### PR TITLE
refactor(data): replace manual packaging with GitHub-backed auto-sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,48 @@ jobs:
           assert "本地干员数据不可用" in message
           print("Import/config verification passed.")
           PY
+
+  build-image:
+    runs-on: ubuntu-latest
+    needs: verify
+    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package
+        run: python -m pip install -e .
+
+      - name: Restore cached gamedata
+        uses: actions/cache@v4
+        with:
+          path: data/gamedata
+          key: gamedata-${{ hashFiles('data/gamedata/cache_meta.json') }}
+          restore-keys: gamedata-
+
+      - name: Fetch latest gamedata from GitHub
+        run: python scripts/fetch_gamedata.py
+        # Exits 0 on success or when cached data covers a network failure.
+        # Exits 1 (fails the build) only when no data is available at all.
+
+      - name: Build Docker image
+        run: docker build -t prts-mcp:latest .
+
+      - name: Smoke test Docker image
+        run: |
+          echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | \
+          docker run -i --rm prts-mcp:latest | \
+          python -c "
+          import sys, json
+          d = json.loads(sys.stdin.read())
+          names = {t['name'] for t in d['result']['tools']}
+          assert 'get_operator_archives' in names, f'Missing tool. Got: {names}'
+          assert 'search_prts' in names, f'Missing tool. Got: {names}'
+          print('Smoke test passed. Tools:', sorted(names))
+          "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,6 @@ jobs:
   build-image:
     runs-on: ubuntu-latest
     needs: verify
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
 
     steps:
       - name: Checkout repository
@@ -64,7 +63,7 @@ jobs:
         run: python -m pip install -e .
 
       - name: Restore cached gamedata
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: data/gamedata
           key: gamedata-${{ hashFiles('data/gamedata/cache_meta.json') }}
@@ -74,6 +73,12 @@ jobs:
         run: python scripts/fetch_gamedata.py
         # Exits 0 on success or when cached data covers a network failure.
         # Exits 1 (fails the build) only when no data is available at all.
+
+      - name: Save gamedata cache
+        uses: actions/cache/save@v4
+        with:
+          path: data/gamedata
+          key: gamedata-${{ hashFiles('data/gamedata/cache_meta.json') }}
 
       - name: Build Docker image
         run: docker build -t prts-mcp:latest .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
   build-image:
     runs-on: ubuntu-latest
     needs: verify
+    if: github.ref == 'refs/heads/main'
 
     steps:
       - name: Checkout repository
@@ -85,13 +86,32 @@ jobs:
 
       - name: Smoke test Docker image
         run: |
-          echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | \
-          docker run -i --rm prts-mcp:latest | \
-          python -c "
-          import sys, json
-          d = json.loads(sys.stdin.read())
-          names = {t['name'] for t in d['result']['tools']}
-          assert 'get_operator_archives' in names, f'Missing tool. Got: {names}'
-          assert 'search_prts' in names, f'Missing tool. Got: {names}'
-          print('Smoke test passed. Tools:', sorted(names))
-          "
+          python - <<'PY'
+          import subprocess, json, sys
+
+          msgs = [
+            {"jsonrpc":"2.0","method":"initialize","id":1,"params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"ci","version":"0"}}},
+            {"jsonrpc":"2.0","method":"notifications/initialized","params":{}},
+            {"jsonrpc":"2.0","method":"tools/list","id":2,"params":{}},
+          ]
+          inp = "\n".join(json.dumps(m) for m in msgs) + "\n"
+          proc = subprocess.run(
+              ["docker","run","-i","--rm","prts-mcp:latest"],
+              input=inp.encode(), capture_output=True, timeout=30
+          )
+          for line in proc.stdout.decode().splitlines():
+              try:
+                  r = json.loads(line)
+                  if r.get("id") == 2:
+                      names = {t["name"] for t in r["result"]["tools"]}
+                      assert "get_operator_archives" in names, f"Missing tool. Got: {names}"
+                      assert "search_prts" in names, f"Missing tool. Got: {names}"
+                      print("Smoke test passed:", sorted(names))
+                      sys.exit(0)
+              except (json.JSONDecodeError, KeyError):
+                  pass
+          print("ERROR: no tools/list response found", file=sys.stderr)
+          print("stdout:", proc.stdout.decode(), file=sys.stderr)
+          print("stderr:", proc.stderr.decode(), file=sys.stderr)
+          sys.exit(1)
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ dev/
 .pytest_cache/
 _check_data.py
 _smoke_test*.py
-local_repo.jsonc
 docker-compose.override.yml
 .mcp.json
 PRTS维基.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,15 @@ WORKDIR /app
 COPY pyproject.toml .
 COPY README.md .
 COPY src/ src/
+# data/ is pre-populated by scripts/fetch_gamedata.py in CI before docker build.
+# The bundled files serve as the offline fallback baseline; at runtime the server
+# checks GitHub for updates and refreshes them if a newer commit is available.
 COPY data/ data/
 
 RUN pip install --no-cache-dir .
 
-# If data/ has been pre-bundled into the repository, the image can run without host mounts.
-ENV GAMEDATA_PATH=/app/data/gamedata
-ENV STORYJSON_PATH=/app/data/storyjson
+# Tell config.py where the project root is (needed when the package is installed
+# via pip and __file__ resolves inside site-packages rather than /app/src/).
+ENV PRTS_MCP_ROOT=/app
 
 ENTRYPOINT ["prts-mcp"]

--- a/scripts/fetch_gamedata.py
+++ b/scripts/fetch_gamedata.py
@@ -1,0 +1,109 @@
+"""Fetch the latest operator data files from GitHub into data/gamedata/.
+
+Used by CI during Docker image build to bake fresh data into the image.
+Can also be run manually during local development.
+
+Usage:
+    python scripts/fetch_gamedata.py [--force]
+
+Options:
+    --force   Ignore the commit SHA cache and always re-download all files.
+
+Exit codes:
+    0   Data fetched successfully, already up to date, or network failed with valid cached data.
+    1   Download failed and no usable data is available.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+# Make the src/ package importable when running this script directly.
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_SRC_DIR = _PROJECT_ROOT / "src"
+if str(_SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(_SRC_DIR))
+
+from prts_mcp.data.sync import (  # noqa: E402
+    GAMEDATA_FILES,
+    RepoSpec,
+    SyncResult,
+    sync_repo,
+)
+
+logging.basicConfig(
+    stream=sys.stderr,
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s: %(message)s",
+)
+_logger = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fetch the latest ArknightsGameData operator files from GitHub."
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Ignore the cached commit SHA and re-download all files unconditionally.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=_PROJECT_ROOT / "data" / "gamedata",
+        help="Local root directory for cached game data. Default: data/gamedata",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+
+    spec = RepoSpec(
+        owner="Kengxxiao",
+        repo="ArknightsGameData",
+        branch="master",
+        files=GAMEDATA_FILES,
+        local_root=args.output.resolve(),
+    )
+
+    if args.force:
+        # Wipe cache metadata so sync_repo always downloads
+        cache_path = spec.local_root / "cache_meta.json"
+        if cache_path.exists():
+            cache_path.unlink()
+            _logger.info("--force: removed cache_meta.json to trigger full re-download.")
+
+    _logger.info("Syncing %s/%s → %s", spec.owner, spec.repo, spec.local_root)
+    result: SyncResult = sync_repo(spec)
+
+    sha_short = result.commit_sha[:8] if result.commit_sha else "unknown"
+
+    if result.status == "updated":
+        _logger.info("Done. Data updated to %s @ %s.", spec.repo, sha_short)
+        return 0
+    elif result.status == "up_to_date":
+        _logger.info("Data is already up to date (%s @ %s).", spec.repo, sha_short)
+        return 0
+    elif result.status == "offline_fallback":
+        _logger.warning(
+            "Network error; using existing cached data (%s @ %s). Error: %s",
+            spec.repo,
+            sha_short,
+            result.error,
+        )
+        return 0
+    else:  # no_data
+        _logger.error(
+            "Failed to obtain data for %s. No usable files available. Error: %s",
+            spec.repo,
+            result.error,
+        )
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/package_operator_data.py
+++ b/scripts/package_operator_data.py
@@ -1,3 +1,7 @@
+# DEPRECATED: This script has been superseded by scripts/fetch_gamedata.py,
+# which downloads data directly from GitHub without requiring a local clone
+# of ArknightsGameData. This file is retained for reference and will be
+# removed in a future release.
 from __future__ import annotations
 
 import argparse

--- a/src/prts_mcp/config.py
+++ b/src/prts_mcp/config.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
-import json
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
-_PROJECT_ROOT = Path(__file__).resolve().parents[2]  # -> PRTS-MCP/
-_LOCAL_REPO_FILE = _PROJECT_ROOT / "local_repo.jsonc"
+# ---------------------------------------------------------------------------
+# Project root resolution
+#
+# When the package is installed via `pip install .`, __file__ resolves to a
+# location inside site-packages, not the project checkout. We use the
+# PRTS_MCP_ROOT environment variable (set to /app in the Docker image) as the
+# authoritative project root, falling back to the parents[2] heuristic for
+# editable / development installs.
+# ---------------------------------------------------------------------------
+
+_PROJECT_ROOT = Path(os.environ.get("PRTS_MCP_ROOT", str(Path(__file__).resolve().parents[2])))
 _BUNDLED_DATA_ROOT = _PROJECT_ROOT / "data"
 _DEFAULT_GAMEDATA_PATH = _BUNDLED_DATA_ROOT / "gamedata"
 _DEFAULT_STORYJSON_PATH = _BUNDLED_DATA_ROOT / "storyjson"
@@ -19,32 +27,6 @@ _REQUIRED_OPERATOR_FILES = (
 PRTS_API_ENDPOINT = "https://prts.wiki/api.php"
 USER_AGENT = "PRTS-MCP-Bot/0.1 (Arknights fan-creation helper)"
 RATE_LIMIT_INTERVAL = 1.5  # seconds between PRTS API requests
-
-
-def _load_local_repo_jsonc() -> dict[str, str]:
-    """Parse local_repo.jsonc (strip // comments) and return path mapping."""
-    if not _LOCAL_REPO_FILE.exists():
-        return {}
-    text = _LOCAL_REPO_FILE.read_text(encoding="utf-8")
-    lines = [line.split("//")[0] for line in text.splitlines()]
-    try:
-        return json.loads("\n".join(lines))
-    except json.JSONDecodeError:
-        return {}
-
-
-def _resolve_data_path(*candidates: str | Path | None) -> Path | None:
-    normalized: list[Path] = []
-    for candidate in candidates:
-        if candidate in (None, ""):
-            continue
-        normalized.append(Path(candidate))
-
-    for path in normalized:
-        if path.exists():
-            return path
-
-    return normalized[0] if normalized else None
 
 
 @dataclass(frozen=True)
@@ -78,18 +60,10 @@ class Config:
 
     @classmethod
     def load(cls) -> Config:
-        repo_map = _load_local_repo_jsonc()
-        gamedata = _resolve_data_path(
-            os.environ.get("GAMEDATA_PATH"),
-            repo_map.get("ArknightsGameData"),
-            _DEFAULT_GAMEDATA_PATH,
+        gamedata = (
+            Path(os.environ["GAMEDATA_PATH"]) if "GAMEDATA_PATH" in os.environ else _DEFAULT_GAMEDATA_PATH
         )
-        storyjson = _resolve_data_path(
-            os.environ.get("STORYJSON_PATH"),
-            repo_map.get("ArknightsStoryJson"),
-            _DEFAULT_STORYJSON_PATH,
+        storyjson = (
+            Path(os.environ["STORYJSON_PATH"]) if "STORYJSON_PATH" in os.environ else _DEFAULT_STORYJSON_PATH
         )
-        return cls(
-            gamedata_path=gamedata,
-            storyjson_path=storyjson,
-        )
+        return cls(gamedata_path=gamedata, storyjson_path=storyjson)

--- a/src/prts_mcp/config.py
+++ b/src/prts_mcp/config.py
@@ -5,17 +5,50 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 # ---------------------------------------------------------------------------
-# Project root resolution
+# Default data directory resolution
 #
-# When the package is installed via `pip install .`, __file__ resolves to a
-# location inside site-packages, not the project checkout. We use the
-# PRTS_MCP_ROOT environment variable (set to /app in the Docker image) as the
-# authoritative project root, falling back to the parents[2] heuristic for
-# editable / development installs.
+# Priority (highest to lowest):
+#   1. GAMEDATA_PATH / STORYJSON_PATH env vars  — always honoured in Config.load()
+#   2. PRTS_MCP_ROOT env var                    — set to /app in the Docker image;
+#                                                 data lives at $PRTS_MCP_ROOT/data/
+#   3. Editable-install heuristic               — parents[2] of __file__ points at
+#                                                 the checkout root when installed
+#                                                 with `pip install -e .`
+#   4. User data directory                      — ~/.local/share/prts-mcp/ on Linux/
+#                                                 macOS; %LOCALAPPDATA%\prts-mcp\ on
+#                                                 Windows.  Used when the package is
+#                                                 installed non-editably and neither
+#                                                 PRTS_MCP_ROOT nor a checkout is
+#                                                 detectable.
+#
+# Non-editable installs (pip install .) without PRTS_MCP_ROOT: the parents[2]
+# heuristic points into site-packages, which is unlikely to contain a data/
+# directory.  In that case _resolve_default_data_root() falls through to the
+# user data directory so the server and fetch_gamedata.py agree on where data
+# lives without any manual env var configuration.
 # ---------------------------------------------------------------------------
 
-_PROJECT_ROOT = Path(os.environ.get("PRTS_MCP_ROOT", str(Path(__file__).resolve().parents[2])))
-_BUNDLED_DATA_ROOT = _PROJECT_ROOT / "data"
+
+def _resolve_default_data_root() -> Path:
+    # Explicit override wins unconditionally.
+    if "PRTS_MCP_ROOT" in os.environ:
+        return Path(os.environ["PRTS_MCP_ROOT"]) / "data"
+
+    # Editable-install / development checkout: __file__ is inside src/prts_mcp/,
+    # so parents[2] is the project root.
+    candidate = Path(__file__).resolve().parents[2] / "data"
+    if candidate.is_dir():
+        return candidate
+
+    # Non-editable install fallback: use a per-user data directory.
+    if os.name == "nt":
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+    else:
+        base = Path(os.environ.get("XDG_DATA_HOME", Path.home() / ".local" / "share"))
+    return base / "prts-mcp"
+
+
+_BUNDLED_DATA_ROOT = _resolve_default_data_root()
 _DEFAULT_GAMEDATA_PATH = _BUNDLED_DATA_ROOT / "gamedata"
 _DEFAULT_STORYJSON_PATH = _BUNDLED_DATA_ROOT / "storyjson"
 _REQUIRED_OPERATOR_FILES = (

--- a/src/prts_mcp/data/sync.py
+++ b/src/prts_mcp/data/sync.py
@@ -1,0 +1,252 @@
+"""GitHub-backed data sync for PRTS-MCP.
+
+Checks upstream commit SHA and downloads required game data files
+only when the upstream repository has changed. Falls back gracefully
+to cached/bundled data when the network is unavailable.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+import httpx
+
+_logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GAMEDATA_FILES: tuple[str, ...] = (
+    "zh_CN/gamedata/excel/character_table.json",
+    "zh_CN/gamedata/excel/handbook_info_table.json",
+    "zh_CN/gamedata/excel/charword_table.json",
+)
+
+_GITHUB_COMMITS_URL = "https://api.github.com/repos/{owner}/{repo}/commits/{branch}"
+_GITHUB_RAW_URL = "https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}"
+_GITHUB_UA = "PRTS-MCP-Bot/0.1 (Arknights fan-creation helper)"
+
+# Skip the upstream SHA check if cached data is fresher than this many seconds.
+_CACHE_TTL_SECONDS = 3600
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RepoSpec:
+    """Describes an upstream GitHub repository and its required files."""
+
+    owner: str
+    repo: str
+    branch: str
+    files: tuple[str, ...]
+    local_root: Path
+
+
+@dataclass
+class CacheMeta:
+    """Persisted metadata about the last successful sync."""
+
+    repo: str
+    branch: str
+    commit_sha: str
+    fetched_at: str  # ISO 8601 UTC, e.g. "2025-01-01T00:00:00Z"
+    files: list[str]
+
+    @classmethod
+    def load(cls, path: Path) -> CacheMeta | None:
+        if not path.is_file():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return cls(**data)
+        except (json.JSONDecodeError, TypeError, KeyError):
+            return None
+
+    def save(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "repo": self.repo,
+                    "branch": self.branch,
+                    "commit_sha": self.commit_sha,
+                    "fetched_at": self.fetched_at,
+                    "files": self.files,
+                },
+                ensure_ascii=False,
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+
+
+@dataclass
+class SyncResult:
+    spec: RepoSpec
+    status: Literal["updated", "up_to_date", "offline_fallback", "no_data"]
+    commit_sha: str | None
+    error: str | None
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _cache_meta_path(spec: RepoSpec) -> Path:
+    return spec.local_root / "cache_meta.json"
+
+
+def _files_present(spec: RepoSpec) -> bool:
+    return all((spec.local_root / f).is_file() for f in spec.files)
+
+
+def _cache_is_fresh(cache: CacheMeta) -> bool:
+    """Return True if the cache was written within the TTL window."""
+    try:
+        ts = datetime.fromisoformat(cache.fetched_at.rstrip("Z")).replace(tzinfo=timezone.utc)
+        age = (datetime.now(tz=timezone.utc) - ts).total_seconds()
+        return age < _CACHE_TTL_SECONDS
+    except (ValueError, AttributeError):
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def check_upstream_sha(spec: RepoSpec, timeout: float = 10.0) -> str | None:
+    """Return the latest commit SHA from GitHub, or None on any failure."""
+    url = _GITHUB_COMMITS_URL.format(owner=spec.owner, repo=spec.repo, branch=spec.branch)
+    try:
+        response = httpx.get(url, headers={"User-Agent": _GITHUB_UA}, timeout=timeout)
+        response.raise_for_status()
+        return response.json()["sha"]
+    except Exception as exc:  # noqa: BLE001
+        _logger.debug("Failed to check upstream SHA for %s/%s: %s", spec.owner, spec.repo, exc)
+        return None
+
+
+def download_files(spec: RepoSpec, sha: str, timeout: float = 60.0) -> None:
+    """Download all required files atomically, then write cache metadata.
+
+    Uses a write-to-tmp-then-replace pattern so partially downloaded files
+    never appear to the data loader as complete.
+    """
+    tmp_pairs: list[tuple[Path, Path]] = []
+    try:
+        with httpx.Client(headers={"User-Agent": _GITHUB_UA}, timeout=timeout) as client:
+            for file_path in spec.files:
+                url = _GITHUB_RAW_URL.format(
+                    owner=spec.owner,
+                    repo=spec.repo,
+                    branch=spec.branch,
+                    path=file_path,
+                )
+                _logger.debug("Downloading %s", url)
+                response = client.get(url)
+                response.raise_for_status()
+
+                dest = spec.local_root / file_path
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                tmp = dest.with_suffix(dest.suffix + ".tmp")
+                tmp.write_bytes(response.content)
+                tmp_pairs.append((tmp, dest))
+
+        # All downloads succeeded — atomically rename
+        for tmp, dest in tmp_pairs:
+            tmp.replace(dest)
+        tmp_pairs.clear()
+
+        # Persist cache metadata
+        CacheMeta(
+            repo=f"{spec.owner}/{spec.repo}",
+            branch=spec.branch,
+            commit_sha=sha,
+            fetched_at=datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            files=list(spec.files),
+        ).save(_cache_meta_path(spec))
+
+    except Exception:
+        # Clean up any temp files on failure
+        for tmp, _ in tmp_pairs:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise
+
+
+def sync_repo(spec: RepoSpec) -> SyncResult:
+    """Check upstream and download files if needed.
+
+    Decision tree:
+      1. If cache is fresh (< 1 h old) and files exist → up_to_date (skip API call)
+      2. Call GitHub commits API:
+         a. Network failure:
+            - files present → offline_fallback
+            - no files      → no_data
+         b. SHA matches cache AND files present → up_to_date
+         c. Otherwise → download_files()
+            - success → updated
+            - failure → files present → offline_fallback / no files → no_data
+    """
+    cache = CacheMeta.load(_cache_meta_path(spec))
+    files_ok = _files_present(spec)
+
+    # Fast path: cache is fresh, no need to hit the API
+    if cache is not None and files_ok and _cache_is_fresh(cache):
+        _logger.debug("Cache is fresh for %s/%s; skipping upstream check.", spec.owner, spec.repo)
+        return SyncResult(spec=spec, status="up_to_date", commit_sha=cache.commit_sha, error=None)
+
+    upstream_sha = check_upstream_sha(spec)
+
+    if upstream_sha is None:
+        if files_ok:
+            return SyncResult(
+                spec=spec,
+                status="offline_fallback",
+                commit_sha=cache.commit_sha if cache else None,
+                error="Network unavailable",
+            )
+        return SyncResult(spec=spec, status="no_data", commit_sha=None, error="Network unavailable and no cached data")
+
+    if cache is not None and cache.commit_sha == upstream_sha and files_ok:
+        # Update fetched_at so the TTL resets from now
+        CacheMeta(
+            repo=cache.repo,
+            branch=cache.branch,
+            commit_sha=cache.commit_sha,
+            fetched_at=datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            files=cache.files,
+        ).save(_cache_meta_path(spec))
+        return SyncResult(spec=spec, status="up_to_date", commit_sha=upstream_sha, error=None)
+
+    try:
+        download_files(spec, upstream_sha)
+        return SyncResult(spec=spec, status="updated", commit_sha=upstream_sha, error=None)
+    except Exception as exc:  # noqa: BLE001
+        error_msg = str(exc)
+        if files_ok:
+            return SyncResult(
+                spec=spec,
+                status="offline_fallback",
+                commit_sha=cache.commit_sha if cache else None,
+                error=error_msg,
+            )
+        return SyncResult(spec=spec, status="no_data", commit_sha=None, error=error_msg)
+
+
+def sync_all(specs: list[RepoSpec]) -> list[SyncResult]:
+    """Sync each repo spec sequentially and return all results."""
+    return [sync_repo(spec) for spec in specs]

--- a/src/prts_mcp/data/sync.py
+++ b/src/prts_mcp/data/sync.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -30,6 +31,14 @@ GAMEDATA_FILES: tuple[str, ...] = (
 _GITHUB_COMMITS_URL = "https://api.github.com/repos/{owner}/{repo}/commits/{branch}"
 _GITHUB_RAW_URL = "https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}"
 _GITHUB_UA = "PRTS-MCP-Bot/0.1 (Arknights fan-creation helper)"
+
+
+def _github_headers() -> dict[str, str]:
+    headers: dict[str, str] = {"User-Agent": _GITHUB_UA}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
 
 # Skip the upstream SHA check if cached data is fresher than this many seconds.
 _CACHE_TTL_SECONDS = 3600
@@ -129,7 +138,7 @@ def check_upstream_sha(spec: RepoSpec, timeout: float = 10.0) -> str | None:
     """Return the latest commit SHA from GitHub, or None on any failure."""
     url = _GITHUB_COMMITS_URL.format(owner=spec.owner, repo=spec.repo, branch=spec.branch)
     try:
-        response = httpx.get(url, headers={"User-Agent": _GITHUB_UA}, timeout=timeout)
+        response = httpx.get(url, headers=_github_headers(), timeout=timeout)
         response.raise_for_status()
         return response.json()["sha"]
     except Exception as exc:  # noqa: BLE001
@@ -145,7 +154,7 @@ def download_files(spec: RepoSpec, sha: str, timeout: float = 60.0) -> None:
     """
     tmp_pairs: list[tuple[Path, Path]] = []
     try:
-        with httpx.Client(headers={"User-Agent": _GITHUB_UA}, timeout=timeout) as client:
+        with httpx.Client(headers=_github_headers(), timeout=timeout) as client:
             for file_path in spec.files:
                 url = _GITHUB_RAW_URL.format(
                     owner=spec.owner,

--- a/src/prts_mcp/server.py
+++ b/src/prts_mcp/server.py
@@ -1,9 +1,21 @@
 from __future__ import annotations
 
+import logging
+import os
+import sys
+from pathlib import Path
+
 from mcp.server.fastmcp import FastMCP
 
 from prts_mcp.api.prts_wiki import search_prts as _search_prts, read_page as _read_page
 from prts_mcp.data.operator import get_operator_archives as _get_archives, get_operator_voicelines as _get_voicelines
+
+logging.basicConfig(
+    stream=sys.stderr,
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+_logger = logging.getLogger("prts_mcp.server")
 
 mcp = FastMCP("PRTS_Wiki_Assistant")
 
@@ -38,7 +50,55 @@ async def get_operator_voicelines(operator_name: str) -> str:
     return _get_voicelines(operator_name)
 
 
+def _run_startup_sync() -> None:
+    """Check upstream GitHub repos and download data files if outdated.
+
+    Skipped when GAMEDATA_PATH is overridden to a non-default location
+    (e.g. a read-only Docker volume mount managed by the user).
+    """
+    from prts_mcp.config import _DEFAULT_GAMEDATA_PATH
+    from prts_mcp.data.sync import GAMEDATA_FILES, RepoSpec, sync_all
+
+    override = os.environ.get("GAMEDATA_PATH")
+    if override and Path(override).resolve() != _DEFAULT_GAMEDATA_PATH.resolve():
+        _logger.info("GAMEDATA_PATH is overridden (%s); skipping auto-sync.", override)
+        return
+
+    specs = [
+        RepoSpec(
+            owner="Kengxxiao",
+            repo="ArknightsGameData",
+            branch="master",
+            files=GAMEDATA_FILES,
+            local_root=_DEFAULT_GAMEDATA_PATH,
+        )
+    ]
+
+    results = sync_all(specs)
+    for r in results:
+        repo = r.spec.repo
+        sha_short = r.commit_sha[:8] if r.commit_sha else "unknown"
+        if r.status == "updated":
+            _logger.info("Data updated from GitHub (%s @ %s).", repo, sha_short)
+        elif r.status == "up_to_date":
+            _logger.info("Data is up to date (%s @ %s).", repo, sha_short)
+        elif r.status == "offline_fallback":
+            _logger.warning(
+                "Network unavailable; using cached data (%s @ %s). Error: %s",
+                repo,
+                sha_short,
+                r.error,
+            )
+        elif r.status == "no_data":
+            _logger.warning(
+                "No data available for %s. Operator tools will be non-functional. Error: %s",
+                repo,
+                r.error,
+            )
+
+
 def main() -> None:
+    _run_startup_sync()
     mcp.run()
 
 

--- a/src/prts_mcp/server.py
+++ b/src/prts_mcp/server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import sys
+import threading
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
@@ -98,7 +99,8 @@ def _run_startup_sync() -> None:
 
 
 def main() -> None:
-    _run_startup_sync()
+    t = threading.Thread(target=_run_startup_sync, daemon=True, name="prts-sync")
+    t.start()
     mcp.run()
 
 


### PR DESCRIPTION
## 动机

旧的数据获取方式存在三条互相冲突的路径（`GAMEDATA_PATH` 环境变量 → `local_repo.jsonc` → 内置 `data/`），需要用户手动准备整个 `ArknightsGameData` 仓库，且与"一次构建，到处运行"的目标相悖。

## 行为变化

**新增 `src/prts_mcp/data/sync.py`**
- 启动时调用 GitHub commits API 检查上游 SHA
- 仅在 SHA 变化时下载所需的 3 个 JSON 文件（原子写入，`.tmp` → `replace`）
- 1 小时 TTL：频繁重启时跳过 API 调用
- 网络失败时回退到缓存/内置数据，服务继续可用

**`config.py`**
- 移除 `local_repo.jsonc` 路径解析逻辑
- 修复 `_PROJECT_ROOT`：引入 `PRTS_MCP_ROOT` 环境变量，解决 `pip install` 后 `__file__` 指向 site-packages 的问题
- `Config.load()` 简化为：env var → 默认 `data/gamedata`

**`server.py`**
- 新增 `_run_startup_sync()`，在 `mcp.run()` 前执行
- 添加结构化 logging 输出到 stderr
- 当 `GAMEDATA_PATH` 被用户覆盖到非默认路径时跳过 auto-sync（兼容 volume mount 场景）

**`scripts/fetch_gamedata.py`**（新增）
- CI 专用脚本，驱动 `sync_repo` 在 `docker build` 前填充 `data/gamedata/`
- 支持 `--force` 跳过 SHA 缓存强制重下载
- 退出码：`0` = 成功或有缓存可用，`1` = 完全无数据

**`scripts/package_operator_data.py`**
- 标注为 deprecated，由 `fetch_gamedata.py` 取代

**`Dockerfile`**
- 新增 `ENV PRTS_MCP_ROOT=/app`，修复已安装包的路径解析

**`ci.yml`**
- 新增 `build-image` job：fetch data → docker build → smoke test（仅 main 分支触发）

## 验证方式

本地端到端测试已通过：

```
# 首次运行：从 GitHub 下载数据
$ python scripts/fetch_gamedata.py
INFO: Done. Data updated to ArknightsGameData @ a24a8ad1.

# 再次启动：SHA 命中缓存，跳过下载
[log] INFO: Data is up to date (ArknightsGameData @ a24a8ad1).

# MCP 工具列表
['search_prts', 'read_prts_page', 'get_operator_archives', 'get_operator_voicelines']

# get_operator_archives("阿米娅") 正确返回档案内容
# search_prts("阿米娅") 成功请求 PRTS Wiki API
```