### PR TITLE
feat(story): add story query tools — Python implementation

### DIFF
--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -71,7 +71,7 @@ jobs:
             const line = list.body.split('\n').find(l => l.startsWith('data: '));
             const result = JSON.parse(line.slice(6));
             const names = result.result.tools.map(t => t.name);
-            const required = ['search_prts', 'read_prts_page', 'get_operator_archives', 'get_operator_voicelines'];
+            const required = ['search_prts', 'read_prts_page', 'get_operator_archives', 'get_operator_voicelines', 'get_operator_basic_info'];
             for (const t of required) {
               if (!names.includes(t)) throw new Error('Missing tool: ' + t);
             }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,8 @@ jobs:
 
       - name: Verify import and config fallback
         run: |
-          mkdir -p .ci-empty/gamedata .ci-empty/storyjson
+          mkdir -p .ci-empty/gamedata
           export GAMEDATA_PATH="$PWD/.ci-empty/gamedata"
-          export STORYJSON_PATH="$PWD/.ci-empty/storyjson"
           python - <<'PY'
           from pathlib import Path
           from prts_mcp.config import Config
@@ -53,6 +52,7 @@ jobs:
           assert cfg.gamedata_path is not None
           assert cfg.gamedata_path.resolve() == Path(".ci-empty/gamedata").resolve()
           assert cfg.has_operator_data is False
+          assert cfg.has_story_data is False
           message = get_operator_archives("阿米娅")
           assert "干员数据暂不可用" in message
           print("Import/config verification passed.")
@@ -126,8 +126,9 @@ jobs:
           assert r.get("id") == 2, f"Expected tools/list response, got: {r}"
 
           names = {t["name"] for t in r["result"]["tools"]}
-          assert "get_operator_archives" in names, f"Missing tool. Got: {names}"
-          assert "search_prts" in names, f"Missing tool. Got: {names}"
+          expected = {"get_operator_archives", "search_prts", "list_story_events", "list_stories", "read_story", "read_activity"}
+          for tool in expected:
+              assert tool in names, f"Missing tool: {tool}. Got: {names}"
           print("Smoke test passed:", sorted(names))
 
           proc.stdin.close()

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -55,3 +55,7 @@ prts-mcp = "prts_mcp.server:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/prts_mcp"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/python/src/prts_mcp/config.py
+++ b/python/src/prts_mcp/config.py
@@ -39,7 +39,6 @@ _REQUIRED_OPERATOR_FILES = (
     "character_table.json",
     "handbook_info_table.json",
     "charword_table.json",
-    "story_review_table.json",
 )
 
 PRTS_API_ENDPOINT = "https://prts.wiki/api.php"

--- a/python/src/prts_mcp/config.py
+++ b/python/src/prts_mcp/config.py
@@ -31,10 +31,15 @@ _DOCKER_VOLUME_PATH = Path("/data/gamedata")
 # Bundled data baked into the image at build time (COPY data/ data/).
 _BUNDLED_GAMEDATA_PATH = Path("/app/data/gamedata")
 
+# storyjson zip paths
+_DOCKER_STORYJSON_ZIP = Path("/data/storyjson/zh_CN.zip")
+_BUNDLED_STORYJSON_ZIP = Path("/app/data/storyjson/zh_CN.zip")
+
 _REQUIRED_OPERATOR_FILES = (
     "character_table.json",
     "handbook_info_table.json",
     "charword_table.json",
+    "story_review_table.json",
 )
 
 PRTS_API_ENDPOINT = "https://prts.wiki/api.php"
@@ -63,8 +68,8 @@ def _resolve_default_gamedata_path() -> Path:
 
 _DEFAULT_GAMEDATA_PATH = _resolve_default_gamedata_path()
 
-# storyjson is reserved for future use; keep it alongside gamedata.
-_DEFAULT_STORYJSON_PATH = _DEFAULT_GAMEDATA_PATH.parent / "storyjson"
+# storyjson zip alongside gamedata in the user data directory.
+_DEFAULT_STORYJSON_ZIP = _DEFAULT_GAMEDATA_PATH.parent / "storyjson" / "zh_CN.zip"
 
 
 def _excel_path(gamedata_root: Path) -> Path:
@@ -78,13 +83,14 @@ def _files_complete(excel: Path) -> bool:
 @dataclass(frozen=True)
 class Config:
     gamedata_path: Path          # sync write target (volume or user dir)
-    storyjson_path: Path
+    storyjson_zip: Path          # storyjson zip path (custom, volume, or default)
     is_custom_gamedata: bool     # True when GAMEDATA_PATH was set by the user
 
     # Derived paths — set in __post_init__, never passed to __init__.
     excel_path: Path = field(init=False)
     bundled_excel_path: Path = field(init=False)
     effective_excel_path: Path | None = field(init=False)
+    effective_storyjson_zip: Path | None = field(init=False)
 
     def __post_init__(self) -> None:
         ep = _excel_path(self.gamedata_path)
@@ -103,9 +109,24 @@ class Config:
         else:
             object.__setattr__(self, "effective_excel_path", None)
 
+        # effective_storyjson_zip: priority — custom env var / volume path →
+        # bundled zip.  Returns None when no zip is found anywhere.
+        if self.storyjson_zip.is_file():
+            object.__setattr__(self, "effective_storyjson_zip", self.storyjson_zip)
+        elif _DOCKER_STORYJSON_ZIP.is_file():
+            object.__setattr__(self, "effective_storyjson_zip", _DOCKER_STORYJSON_ZIP)
+        elif _BUNDLED_STORYJSON_ZIP.is_file():
+            object.__setattr__(self, "effective_storyjson_zip", _BUNDLED_STORYJSON_ZIP)
+        else:
+            object.__setattr__(self, "effective_storyjson_zip", None)
+
     @property
     def has_operator_data(self) -> bool:
         return self.effective_excel_path is not None
+
+    @property
+    def has_story_data(self) -> bool:
+        return self.effective_storyjson_zip is not None
 
     @property
     def missing_operator_files(self) -> tuple[Path, ...]:
@@ -120,9 +141,9 @@ class Config:
     def load(cls) -> Config:
         custom = "GAMEDATA_PATH" in os.environ
         gamedata = Path(os.environ["GAMEDATA_PATH"]) if custom else _DEFAULT_GAMEDATA_PATH
-        storyjson = (
+        storyjson_zip = (
             Path(os.environ["STORYJSON_PATH"])
             if "STORYJSON_PATH" in os.environ
-            else _DEFAULT_STORYJSON_PATH
+            else _DEFAULT_STORYJSON_ZIP
         )
-        return cls(gamedata_path=gamedata, storyjson_path=storyjson, is_custom_gamedata=custom)
+        return cls(gamedata_path=gamedata, storyjson_zip=storyjson_zip, is_custom_gamedata=custom)

--- a/python/src/prts_mcp/data/operator.py
+++ b/python/src/prts_mcp/data/operator.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from prts_mcp.config import Config
+from prts_mcp.utils.sanitizer import strip_wikitext
 
 # ---------------------------------------------------------------------------
 # Internal caches (loaded lazily on first call)
@@ -136,3 +137,107 @@ def get_operator_voicelines(name: str) -> str:
     if not lines:
         return f"干员 '{name}' 暂无语音数据。"
     return f"# {name} - 语音记录\n\n" + "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Basic info helpers
+# ---------------------------------------------------------------------------
+
+_PROFESSION_ZH: dict[str, str] = {
+    "CASTER": "术师",
+    "MEDIC": "医疗",
+    "PIONEER": "先锋",
+    "SNIPER": "狙击",
+    "SPECIAL": "特种",
+    "SUPPORT": "辅助",
+    "TANK": "重装",
+    "WARRIOR": "近卫",
+}
+
+_POSITION_ZH: dict[str, str] = {
+    "RANGED": "远程",
+    "MELEE": "近战",
+    "ALL": "通用",
+    "NONE": "-",
+}
+
+
+def get_operator_basic_info(name: str) -> str:
+    """Return basic profile info for an operator by Chinese name."""
+    if not _get_config().has_operator_data:
+        return _missing_operator_data_message()
+
+    try:
+        char_id = _resolve_char_id(name)
+    except FileNotFoundError as exc:
+        return str(exc)
+    if char_id is None:
+        return f"未找到干员 '{name}'。请使用游戏内中文名称（如'阿米娅'）。"
+
+    try:
+        ct = _load_character_table()
+    except FileNotFoundError as exc:
+        return str(exc)
+    info = ct.get(char_id)
+    if info is None:
+        return f"干员 '{name}' 暂无基本信息。"
+
+    rarity_raw: str = info.get("rarity", "")
+    rarity = rarity_raw.replace("TIER_", "") + "★" if rarity_raw.startswith("TIER_") else rarity_raw
+
+    profession_raw: str = info.get("profession", "")
+    profession = _PROFESSION_ZH.get(profession_raw, profession_raw)
+
+    position_raw: str = info.get("position", "")
+    position = _POSITION_ZH.get(position_raw, position_raw)
+
+    appellation: str = info.get("appellation", "")
+    display_number: str = info.get("displayNumber", "")
+    description: str = info.get("description", "")
+    item_usage: str = info.get("itemUsage", "")
+    item_desc: str = info.get("itemDesc", "")
+    item_obtain: str = info.get("itemObtainApproach", "")
+    tag_list: list[str] = info.get("tagList") or []
+
+    nation_id: str = info.get("nationId") or ""
+    group_id: str = info.get("groupId") or ""
+    team_id: str = info.get("teamId") or ""
+    affiliation_parts = [x for x in [nation_id, group_id, team_id] if x]
+    affiliation = " / ".join(affiliation_parts) if affiliation_parts else "-"
+
+    lines: list[str] = [f"# {name} - 干员基本信息\n"]
+    lines.append(f"- **编号**：{display_number}")
+    lines.append(f"- **英文名**：{appellation}")
+    lines.append(f"- **稀有度**：{rarity}")
+    lines.append(f"- **职业**：{profession}（{info.get('subProfessionId', '')}）")
+    lines.append(f"- **站位**：{position}")
+    lines.append(f"- **所属**：{affiliation}")
+    if tag_list:
+        lines.append(f"- **招募标签**：{'、'.join(tag_list)}")
+    if description:
+        lines.append(f"- **攻击属性**：{strip_wikitext(description)}")
+    if item_usage:
+        lines.append(f"\n**图鉴**：{item_usage}")
+    if item_desc:
+        lines.append(f"\n> {item_desc}")
+    if item_obtain:
+        lines.append(f"\n**获取方式**：{item_obtain}")
+
+    # Talents — show the highest-unlock candidate for each talent slot
+    talents: list[Any] = info.get("talents") or []
+    if talents:
+        lines.append("\n## 天赋")
+        for talent in talents:
+            candidates: list[Any] = talent.get("candidates") or []
+            # Pick last candidate with a real name
+            chosen = None
+            for c in reversed(candidates):
+                if c.get("name") and c["name"] not in ("？？？",):
+                    chosen = c
+                    break
+            if chosen:
+                t_name: str = chosen.get("name", "")
+                t_desc: str = strip_wikitext(chosen.get("description", ""))
+                lines.append(f"- **{t_name}**：{t_desc}")
+
+    return "\n".join(lines)

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -9,6 +9,7 @@ Zip internal layout (all paths prefixed with "zh_CN/"):
 """
 from __future__ import annotations
 
+import json
 import re
 import zipfile
 from dataclasses import dataclass
@@ -86,6 +87,15 @@ class ChapterSummary:
     sort_order: int
 
 
+@dataclass(frozen=True)
+class ActivityResult:
+    event_id: str
+    event_name: str
+    total_chapters: int
+    has_more: bool
+    chapters: list[StoryChapter]
+
+
 # ---------------------------------------------------------------------------
 # Core helpers
 # ---------------------------------------------------------------------------
@@ -125,7 +135,6 @@ def _parse_story_list(story_list: list[dict]) -> list[StoryLine]:
 
 def _load_json(zf: zipfile.ZipFile, path: str) -> dict | list:
     with zf.open(path) as f:
-        import json
         return json.load(f)
 
 
@@ -245,7 +254,7 @@ def read_activity(
     include_narration: bool = True,
     page: int | None = None,
     page_size: int = 5,
-) -> dict:
+) -> ActivityResult:
     """Read all chapters of an activity in official story order.
 
     Args:
@@ -256,13 +265,7 @@ def read_activity(
         page_size: Chapters per page (used only when page is set).
 
     Returns:
-        {
-            "event_id": str,
-            "event_name": str,
-            "total_chapters": int,
-            "has_more": bool,       # always False when page is None
-            "chapters": [StoryChapter, ...]
-        }
+        ActivityResult with event metadata and (paginated) chapters.
 
     Raises:
         KeyError: If event_id is not found.
@@ -291,10 +294,10 @@ def read_activity(
             # Story file missing from zip — skip silently
             pass
 
-    return {
-        "event_id": event_id,
-        "event_name": event_name,
-        "total_chapters": total,
-        "has_more": has_more,
-        "chapters": chapters,
-    }
+    return ActivityResult(
+        event_id=event_id,
+        event_name=event_name,
+        total_chapters=total,
+        has_more=has_more,
+        chapters=chapters,
+    )

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -1,0 +1,300 @@
+"""Story data reader for PRTS-MCP.
+
+Reads from the bundled/synced zh_CN.zip (ArknightsStoryJson fork release).
+
+Zip internal layout (all paths prefixed with "zh_CN/"):
+  zh_CN/storyinfo.json                       — {story_key: summary_text}
+  zh_CN/gamedata/excel/story_review_table.json — event metadata + ordered chapter list
+  zh_CN/gamedata/story/{story_key}.json       — per-chapter dialogue JSON
+"""
+from __future__ import annotations
+
+import re
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+# ---------------------------------------------------------------------------
+# Zip path constants
+# ---------------------------------------------------------------------------
+
+_STORYINFO = "zh_CN/storyinfo.json"
+_STORY_REVIEW_TABLE = "zh_CN/gamedata/excel/story_review_table.json"
+
+# entryType values → user-facing category strings
+_CATEGORY_MAP: dict[str, list[str]] = {
+    "main": ["MAINLINE"],
+    "activities": ["ACTIVITY", "MINI_ACTIVITY"],
+}
+
+
+def _story_zip_path(story_key: str) -> str:
+    return f"zh_CN/gamedata/story/{story_key}.json"
+
+
+# ---------------------------------------------------------------------------
+# Text cleaning
+# ---------------------------------------------------------------------------
+
+_RICH_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def _clean_text(text: str) -> str:
+    """Remove rich-text tags and replace {@nickname} with 博士."""
+    text = text.replace("{@nickname}", "博士")
+    text = _RICH_TAG_RE.sub("", text)
+    return text.strip()
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class StoryLine:
+    type: Literal["dialog", "narration", "choice"]
+    role: str | None   # speaker name; None for narration/choice
+    text: str
+
+
+@dataclass(frozen=True)
+class StoryChapter:
+    story_key: str
+    story_code: str
+    story_name: str
+    avg_tag: str | None
+    event_name: str
+    story_info: str
+    lines: list[StoryLine]
+
+
+@dataclass(frozen=True)
+class EventInfo:
+    event_id: str
+    name: str
+    entry_type: str
+    story_count: int
+
+
+@dataclass(frozen=True)
+class ChapterSummary:
+    story_key: str
+    story_code: str
+    story_name: str
+    avg_tag: str | None
+    sort_order: int
+
+
+# ---------------------------------------------------------------------------
+# Core helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_story_list(story_list: list[dict]) -> list[StoryLine]:
+    """Convert raw storyList entries into cleaned StoryLine objects."""
+    lines: list[StoryLine] = []
+    for item in story_list:
+        prop = item.get("prop", "")
+        attrs = item.get("attributes", {})
+
+        prop_lower = prop.lower()
+        if prop_lower == "name":
+            name = attrs.get("name") or ""
+            content = attrs.get("content") or ""
+            if content:
+                lines.append(StoryLine(
+                    type="dialog",
+                    role=_clean_text(name) if name else None,
+                    text=_clean_text(content),
+                ))
+        elif prop_lower in ("sticker", "subtitle", "animtext"):
+            content = attrs.get("content") or attrs.get("text") or ""
+            if content:
+                lines.append(StoryLine(type="narration", role=None, text=_clean_text(content)))
+        elif prop_lower == "decision":
+            options = attrs.get("options") or []
+            for opt in options:
+                text = opt.get("text") or opt if isinstance(opt, str) else ""
+                if text:
+                    lines.append(StoryLine(type="choice", role=None, text=_clean_text(str(text))))
+
+    return lines
+
+
+def _load_json(zf: zipfile.ZipFile, path: str) -> dict | list:
+    with zf.open(path) as f:
+        import json
+        return json.load(f)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def list_story_events(
+    zip_path: Path,
+    category: str | None = None,
+) -> list[EventInfo]:
+    """Return a list of events from story_review_table.json.
+
+    Args:
+        zip_path: Path to zh_CN.zip.
+        category: Optional filter — "main" or "activities".
+                  If None, all events are returned.
+    """
+    allowed_types: list[str] | None = _CATEGORY_MAP.get(category) if category else None
+
+    with zipfile.ZipFile(zip_path) as zf:
+        table: dict = _load_json(zf, _STORY_REVIEW_TABLE)  # type: ignore[assignment]
+
+    events = []
+    for event_id, entry in table.items():
+        entry_type = entry.get("entryType", "NONE")
+        if allowed_types is not None and entry_type not in allowed_types:
+            continue
+        story_count = len(entry.get("infoUnlockDatas") or [])
+        events.append(EventInfo(
+            event_id=event_id,
+            name=entry.get("name") or event_id,
+            entry_type=entry_type,
+            story_count=story_count,
+        ))
+
+    return events
+
+
+def list_stories(zip_path: Path, event_id: str) -> list[ChapterSummary]:
+    """Return ordered chapter list for an event.
+
+    Args:
+        zip_path: Path to zh_CN.zip.
+        event_id: Event key, e.g. "act31side".
+
+    Returns:
+        Chapters sorted by storySort.
+
+    Raises:
+        KeyError: If event_id is not found in story_review_table.
+    """
+    with zipfile.ZipFile(zip_path) as zf:
+        table: dict = _load_json(zf, _STORY_REVIEW_TABLE)  # type: ignore[assignment]
+
+    entry = table.get(event_id)
+    if entry is None:
+        raise KeyError(f"Event not found: {event_id!r}")
+
+    chapters = []
+    for d in sorted(entry.get("infoUnlockDatas") or [], key=lambda x: x.get("storySort", 0)):
+        story_key = d.get("storyTxt")
+        if not story_key:
+            continue
+        chapters.append(ChapterSummary(
+            story_key=story_key,
+            story_code=d.get("storyCode") or "",
+            story_name=d.get("storyName") or "",
+            avg_tag=d.get("avgTag"),
+            sort_order=d.get("storySort", 0),
+        ))
+
+    return chapters
+
+
+def read_story(
+    zip_path: Path,
+    story_key: str,
+    include_narration: bool = True,
+) -> StoryChapter:
+    """Read and parse a single story chapter.
+
+    Args:
+        zip_path: Path to zh_CN.zip.
+        story_key: Story key from storyTxt / storyinfo.json, e.g.
+                   "activities/act31side/level_act31side_01_beg".
+        include_narration: Whether to include narration/scene lines.
+
+    Raises:
+        KeyError: If the story file is not found in the zip.
+    """
+    zip_inner = _story_zip_path(story_key)
+    with zipfile.ZipFile(zip_path) as zf:
+        if zip_inner not in zf.namelist():
+            raise KeyError(f"Story not found in zip: {story_key!r}")
+        raw: dict = _load_json(zf, zip_inner)  # type: ignore[assignment]
+
+    all_lines = _parse_story_list(raw.get("storyList") or [])
+    if not include_narration:
+        all_lines = [ln for ln in all_lines if ln.type != "narration"]
+
+    return StoryChapter(
+        story_key=story_key,
+        story_code=raw.get("storyCode") or "",
+        story_name=raw.get("storyName") or "",
+        avg_tag=raw.get("avgTag"),
+        event_name=raw.get("eventName") or "",
+        story_info=raw.get("storyInfo") or "",
+        lines=all_lines,
+    )
+
+
+def read_activity(
+    zip_path: Path,
+    event_id: str,
+    include_narration: bool = True,
+    page: int | None = None,
+    page_size: int = 5,
+) -> dict:
+    """Read all chapters of an activity in official story order.
+
+    Args:
+        zip_path: Path to zh_CN.zip.
+        event_id: Event key, e.g. "act31side".
+        include_narration: Whether to include narration lines.
+        page: 1-based page index. None returns all chapters.
+        page_size: Chapters per page (used only when page is set).
+
+    Returns:
+        {
+            "event_id": str,
+            "event_name": str,
+            "total_chapters": int,
+            "has_more": bool,       # always False when page is None
+            "chapters": [StoryChapter, ...]
+        }
+
+    Raises:
+        KeyError: If event_id is not found.
+    """
+    summaries = list_stories(zip_path, event_id)
+    total = len(summaries)
+
+    if page is not None:
+        start = (page - 1) * page_size
+        end = start + page_size
+        selected = summaries[start:end]
+        has_more = end < total
+    else:
+        selected = summaries
+        has_more = False
+
+    chapters = []
+    event_name = ""
+    for summary in selected:
+        try:
+            chapter = read_story(zip_path, summary.story_key, include_narration)
+            if not event_name:
+                event_name = chapter.event_name
+            chapters.append(chapter)
+        except KeyError:
+            # Story file missing from zip — skip silently
+            pass
+
+    return {
+        "event_id": event_id,
+        "event_name": event_name,
+        "total_chapters": total,
+        "has_more": has_more,
+        "chapters": chapters,
+    }

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -19,7 +19,6 @@ from typing import Literal
 # Zip path constants
 # ---------------------------------------------------------------------------
 
-_STORYINFO = "zh_CN/storyinfo.json"
 _STORY_REVIEW_TABLE = "zh_CN/gamedata/excel/story_review_table.json"
 
 # entryType values → user-facing category strings
@@ -116,7 +115,8 @@ def _parse_story_list(story_list: list[dict]) -> list[StoryLine]:
         elif prop_lower == "decision":
             options = attrs.get("options") or []
             for opt in options:
-                text = opt.get("text") or opt if isinstance(opt, str) else ""
+                # options elements may be plain strings or dicts with a "text" key
+                text = opt if isinstance(opt, str) else (opt.get("text") or "")
                 if text:
                     lines.append(StoryLine(type="choice", role=None, text=_clean_text(str(text))))
 

--- a/python/src/prts_mcp/data/sync.py
+++ b/python/src/prts_mcp/data/sync.py
@@ -26,6 +26,7 @@ GAMEDATA_FILES: tuple[str, ...] = (
     "zh_CN/gamedata/excel/character_table.json",
     "zh_CN/gamedata/excel/handbook_info_table.json",
     "zh_CN/gamedata/excel/charword_table.json",
+    "zh_CN/gamedata/excel/story_review_table.json",
 )
 
 _GITHUB_COMMITS_URL = "https://api.github.com/repos/{owner}/{repo}/commits/{branch}"
@@ -259,3 +260,141 @@ def sync_repo(spec: RepoSpec) -> SyncResult:
 def sync_all(specs: list[RepoSpec]) -> list[SyncResult]:
     """Sync each repo spec sequentially and return all results."""
     return [sync_repo(spec) for spec in specs]
+
+
+# ---------------------------------------------------------------------------
+# Release-based sync (for storyjson zip)
+# ---------------------------------------------------------------------------
+
+_GITHUB_RELEASES_LATEST_URL = "https://api.github.com/repos/{owner}/{repo}/releases/latest"
+_TAG_PREFIX = "upstream-"
+
+
+@dataclass(frozen=True)
+class ReleaseSpec:
+    """Describes a GitHub Release asset to download as a local zip."""
+
+    owner: str
+    repo: str
+    asset_name: str   # e.g. "zh_CN.zip"
+    local_zip: Path   # destination path on disk
+
+
+def _release_cache_path(spec: ReleaseSpec) -> Path:
+    return spec.local_zip.parent / "release_meta.json"
+
+
+def _release_cache_is_fresh(cache: CacheMeta) -> bool:
+    return _cache_is_fresh(cache)
+
+
+def check_latest_release(spec: ReleaseSpec, timeout: float = 10.0) -> tuple[str, str] | None:
+    """Return (tag_name, asset_download_url) for the latest release, or None on failure."""
+    url = _GITHUB_RELEASES_LATEST_URL.format(owner=spec.owner, repo=spec.repo)
+    try:
+        response = httpx.get(url, headers=_github_headers(), timeout=timeout)
+        response.raise_for_status()
+        data = response.json()
+        tag = data["tag_name"]
+        for asset in data.get("assets", []):
+            if asset["name"] == spec.asset_name:
+                return tag, asset["browser_download_url"]
+        _logger.debug("Asset %s not found in release %s", spec.asset_name, tag)
+        return None
+    except Exception as exc:  # noqa: BLE001
+        _logger.debug("Failed to check latest release for %s/%s: %s", spec.owner, spec.repo, exc)
+        return None
+
+
+def download_release_asset(spec: ReleaseSpec, tag: str, url: str, timeout: float = 120.0) -> None:
+    """Download a release asset zip atomically, then write cache metadata."""
+    spec.local_zip.parent.mkdir(parents=True, exist_ok=True)
+    tmp = spec.local_zip.with_suffix(spec.local_zip.suffix + ".tmp")
+    try:
+        _logger.debug("Downloading release asset %s", url)
+        with httpx.Client(headers=_github_headers(), timeout=timeout) as client:
+            response = client.get(url, follow_redirects=True)
+            response.raise_for_status()
+            tmp.write_bytes(response.content)
+        tmp.replace(spec.local_zip)
+
+        # Extract upstream SHA from tag (format: "upstream-<sha>")
+        commit_sha = tag[len(_TAG_PREFIX):] if tag.startswith(_TAG_PREFIX) else tag
+        CacheMeta(
+            repo=f"{spec.owner}/{spec.repo}",
+            branch="releases",
+            commit_sha=commit_sha,
+            fetched_at=datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            files=[spec.asset_name],
+        ).save(_release_cache_path(spec))
+    except Exception:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def sync_release(spec: ReleaseSpec) -> SyncResult:
+    """Check latest GitHub Release and download asset if the tag has changed.
+
+    Decision tree mirrors sync_repo:
+      1. Cache fresh + zip exists → up_to_date
+      2. Network failure → offline_fallback / no_data
+      3. Tag unchanged + zip exists → up_to_date (refresh fetched_at)
+      4. Tag changed or zip missing → download → updated / offline_fallback / no_data
+    """
+    # Wrap ReleaseSpec in a minimal RepoSpec-like object for SyncResult
+    _dummy_spec = RepoSpec(
+        owner=spec.owner,
+        repo=spec.repo,
+        branch="releases",
+        files=(spec.asset_name,),
+        local_root=spec.local_zip.parent,
+    )
+
+    cache = CacheMeta.load(_release_cache_path(spec))
+    zip_ok = spec.local_zip.is_file()
+
+    if cache is not None and zip_ok and _release_cache_is_fresh(cache):
+        _logger.debug("Release cache is fresh for %s/%s; skipping check.", spec.owner, spec.repo)
+        return SyncResult(spec=_dummy_spec, status="up_to_date", commit_sha=cache.commit_sha, error=None)
+
+    result = check_latest_release(spec)
+
+    if result is None:
+        if zip_ok:
+            return SyncResult(
+                spec=_dummy_spec,
+                status="offline_fallback",
+                commit_sha=cache.commit_sha if cache else None,
+                error="Network unavailable",
+            )
+        return SyncResult(spec=_dummy_spec, status="no_data", commit_sha=None, error="Network unavailable and no cached zip")
+
+    tag, asset_url = result
+    upstream_sha = tag[len(_TAG_PREFIX):] if tag.startswith(_TAG_PREFIX) else tag
+
+    if cache is not None and cache.commit_sha == upstream_sha and zip_ok:
+        CacheMeta(
+            repo=cache.repo,
+            branch=cache.branch,
+            commit_sha=cache.commit_sha,
+            fetched_at=datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            files=cache.files,
+        ).save(_release_cache_path(spec))
+        return SyncResult(spec=_dummy_spec, status="up_to_date", commit_sha=upstream_sha, error=None)
+
+    try:
+        download_release_asset(spec, tag, asset_url)
+        return SyncResult(spec=_dummy_spec, status="updated", commit_sha=upstream_sha, error=None)
+    except Exception as exc:  # noqa: BLE001
+        error_msg = str(exc)
+        if zip_ok:
+            return SyncResult(
+                spec=_dummy_spec,
+                status="offline_fallback",
+                commit_sha=cache.commit_sha if cache else None,
+                error=error_msg,
+            )
+        return SyncResult(spec=_dummy_spec, status="no_data", commit_sha=None, error=error_msg)

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -209,11 +209,11 @@ def read_activity(
     except Exception as e:
         return f"读取活动剧情失败：{e}"
 
-    chapters = result["chapters"]
-    total = result["total_chapters"]
-    has_more = result["has_more"]
+    chapters = result.chapters
+    total = result.total_chapters
+    has_more = result.has_more
 
-    header = f"【{result['event_name']}】共 {total} 章"
+    header = f"【{result.event_name}】共 {total} 章"
     if page is not None:
         header += f"，当前第 {page} 页（{len(chapters)} 章）"
         if has_more:

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import threading
+from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
 
@@ -65,7 +67,7 @@ async def get_operator_basic_info(operator_name: str) -> str:
     return _get_basic_info(operator_name)
 
 
-def _require_story_zip(cfg) -> "Path":
+def _require_story_zip(cfg: "Config") -> Path:
     """Return effective_storyjson_zip or raise RuntimeError."""
     if not cfg.has_story_data:
         raise RuntimeError(
@@ -265,7 +267,7 @@ def _run_startup_sync() -> None:
             _log_sync_result(r)
 
     # Always try to sync storyjson from GitHub Release (unless user supplied their own zip)
-    if "STORYJSON_PATH" not in __import__("os").environ:
+    if "STORYJSON_PATH" not in os.environ:
         release_spec = ReleaseSpec(
             owner="3aKHP",
             repo="ArknightsStoryJson",

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -7,7 +7,11 @@ import threading
 from mcp.server.fastmcp import FastMCP
 
 from prts_mcp.api.prts_wiki import search_prts as _search_prts, read_page as _read_page
-from prts_mcp.data.operator import get_operator_archives as _get_archives, get_operator_voicelines as _get_voicelines
+from prts_mcp.data.operator import (
+    get_operator_archives as _get_archives,
+    get_operator_voicelines as _get_voicelines,
+    get_operator_basic_info as _get_basic_info,
+)
 
 logging.basicConfig(
     stream=sys.stderr,
@@ -47,6 +51,12 @@ async def get_operator_archives(operator_name: str) -> str:
 async def get_operator_voicelines(operator_name: str) -> str:
     """获取指定干员的语音记录（使用游戏内中文名，如"阿米娅"）。"""
     return _get_voicelines(operator_name)
+
+
+@mcp.tool()
+async def get_operator_basic_info(operator_name: str) -> str:
+    """获取指定干员的基本信息：职业、稀有度、所属、招募标签、天赋等（使用游戏内中文名，如"阿米娅"）。"""
+    return _get_basic_info(operator_name)
 
 
 def _run_startup_sync() -> None:

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -12,6 +12,12 @@ from prts_mcp.data.operator import (
     get_operator_voicelines as _get_voicelines,
     get_operator_basic_info as _get_basic_info,
 )
+from prts_mcp.data.story import (
+    list_story_events as _list_story_events,
+    list_stories as _list_stories,
+    read_story as _read_story,
+    read_activity as _read_activity,
+)
 
 logging.basicConfig(
     stream=sys.stderr,
@@ -59,6 +65,175 @@ async def get_operator_basic_info(operator_name: str) -> str:
     return _get_basic_info(operator_name)
 
 
+def _require_story_zip(cfg) -> "Path":
+    """Return effective_storyjson_zip or raise RuntimeError."""
+    if not cfg.has_story_data:
+        raise RuntimeError(
+            "剧情数据未就绪。请设置 STORYJSON_PATH 环境变量指向 zh_CN.zip，"
+            "或等待服务器自动从 GitHub Release 下载完成后重试。"
+        )
+    return cfg.effective_storyjson_zip
+
+
+@mcp.tool()
+def list_story_events(category: str | None = None) -> str:
+    """列出明日方舟剧情活动列表。
+
+    Args:
+        category: 可选过滤分类。"main" = 主线章节，"activities" = 活动剧情（含联动）。
+                  不填则返回全部活动。建议先调用本工具了解活动全貌，再用 list_stories 查询具体章节。
+    """
+    from prts_mcp.config import Config
+    cfg = Config.load()
+    try:
+        zip_path = _require_story_zip(cfg)
+    except RuntimeError as e:
+        return str(e)
+
+    try:
+        events = _list_story_events(zip_path, category=category)
+    except Exception as e:
+        return f"读取活动列表失败：{e}"
+
+    if not events:
+        return f"未找到符合条件的活动（category={category!r}）。"
+
+    lines = []
+    for ev in events:
+        lines.append(f"- [{ev.entry_type}] {ev.event_id}：{ev.name}（{ev.story_count} 章）")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def list_stories(event_id: str) -> str:
+    """列出指定活动的所有剧情章节（按官方顺序排列）。
+
+    Args:
+        event_id: 活动 ID，如 "act31side"（可从 list_story_events 获取）。
+    """
+    from prts_mcp.config import Config
+    cfg = Config.load()
+    try:
+        zip_path = _require_story_zip(cfg)
+    except RuntimeError as e:
+        return str(e)
+
+    try:
+        chapters = _list_stories(zip_path, event_id)
+    except KeyError:
+        return f"未找到活动：{event_id!r}。请先调用 list_story_events 确认活动 ID。"
+    except Exception as e:
+        return f"读取章节列表失败：{e}"
+
+    if not chapters:
+        return f"活动 {event_id!r} 暂无剧情章节。"
+
+    lines = []
+    for ch in chapters:
+        tag = f"[{ch.avg_tag}] " if ch.avg_tag else ""
+        lines.append(f"- {ch.story_code} {tag}{ch.story_name}（key: {ch.story_key}）")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+def read_story(story_key: str, include_narration: bool = True) -> str:
+    """读取单章剧情的完整台词。
+
+    Args:
+        story_key: 章节 key，如 "activities/act31side/level_act31side_01_beg"（可从 list_stories 获取）。
+        include_narration: 是否包含旁白和场景描述，默认 True。
+    """
+    from prts_mcp.config import Config
+    cfg = Config.load()
+    try:
+        zip_path = _require_story_zip(cfg)
+    except RuntimeError as e:
+        return str(e)
+
+    try:
+        chapter = _read_story(zip_path, story_key, include_narration=include_narration)
+    except KeyError:
+        return f"未找到剧情：{story_key!r}。"
+    except Exception as e:
+        return f"读取剧情失败：{e}"
+
+    parts = [f"【{chapter.event_name}】{chapter.story_name}"]
+    if chapter.story_info:
+        parts.append(f"简介：{chapter.story_info}\n")
+    for ln in chapter.lines:
+        if ln.type == "dialog":
+            role = ln.role or "（旁白）"
+            parts.append(f"{role}：{ln.text}")
+        elif ln.type == "narration":
+            parts.append(f"*{ln.text}*")
+        elif ln.type == "choice":
+            parts.append(f"【选项】{ln.text}")
+    return "\n".join(parts)
+
+
+@mcp.tool()
+def read_activity(
+    event_id: str,
+    include_narration: bool = True,
+    page: int | None = None,
+    page_size: int = 5,
+) -> str:
+    """读取整个活动的完整剧情台词（按官方章节顺序合并）。
+
+    适合需要了解完整活动故事的场景。单次活动文本量可能较大，可用 page 参数分批获取。
+
+    Args:
+        event_id: 活动 ID，如 "act31side"。
+        include_narration: 是否包含旁白，默认 True。
+        page: 分页页码（从 1 开始）。不填则返回全部章节。
+        page_size: 每页章节数，默认 5。
+    """
+    from prts_mcp.config import Config
+    cfg = Config.load()
+    try:
+        zip_path = _require_story_zip(cfg)
+    except RuntimeError as e:
+        return str(e)
+
+    try:
+        result = _read_activity(
+            zip_path, event_id,
+            include_narration=include_narration,
+            page=page,
+            page_size=page_size,
+        )
+    except KeyError:
+        return f"未找到活动：{event_id!r}。请先调用 list_story_events 确认活动 ID。"
+    except Exception as e:
+        return f"读取活动剧情失败：{e}"
+
+    chapters = result["chapters"]
+    total = result["total_chapters"]
+    has_more = result["has_more"]
+
+    header = f"【{result['event_name']}】共 {total} 章"
+    if page is not None:
+        header += f"，当前第 {page} 页（{len(chapters)} 章）"
+        if has_more:
+            header += f"，还有更多（下一页：page={page + 1}）"
+    parts = [header, ""]
+
+    for chapter in chapters:
+        tag = f"[{chapter.avg_tag}]" if chapter.avg_tag else ""
+        parts.append(f"=== {chapter.story_code} {tag} {chapter.story_name} ===")
+        for ln in chapter.lines:
+            if ln.type == "dialog":
+                role = ln.role or "（旁白）"
+                parts.append(f"{role}：{ln.text}")
+            elif ln.type == "narration":
+                parts.append(f"*{ln.text}*")
+            elif ln.type == "choice":
+                parts.append(f"【选项】{ln.text}")
+        parts.append("")
+
+    return "\n".join(parts)
+
+
 def _run_startup_sync() -> None:
     """Check upstream GitHub and download data files if outdated.
 
@@ -67,7 +242,7 @@ def _run_startup_sync() -> None:
     overwrite it.
     """
     from prts_mcp.config import Config, _DEFAULT_GAMEDATA_PATH
-    from prts_mcp.data.sync import GAMEDATA_FILES, RepoSpec, sync_all
+    from prts_mcp.data.sync import GAMEDATA_FILES, RepoSpec, ReleaseSpec, sync_all, sync_release
 
     cfg = Config.load()
     if cfg.is_custom_gamedata:
@@ -75,40 +250,49 @@ def _run_startup_sync() -> None:
             "GAMEDATA_PATH is set to a custom location (%s); auto-sync disabled.",
             cfg.gamedata_path,
         )
-        return
+    else:
+        specs = [
+            RepoSpec(
+                owner="Kengxxiao",
+                repo="ArknightsGameData",
+                branch="master",
+                files=GAMEDATA_FILES,
+                local_root=_DEFAULT_GAMEDATA_PATH,
+            )
+        ]
+        results = sync_all(specs)
+        for r in results:
+            _log_sync_result(r)
 
-    specs = [
-        RepoSpec(
-            owner="Kengxxiao",
-            repo="ArknightsGameData",
-            branch="master",
-            files=GAMEDATA_FILES,
-            local_root=_DEFAULT_GAMEDATA_PATH,
+    # Always try to sync storyjson from GitHub Release (unless user supplied their own zip)
+    if "STORYJSON_PATH" not in __import__("os").environ:
+        release_spec = ReleaseSpec(
+            owner="3aKHP",
+            repo="ArknightsStoryJson",
+            asset_name="zh_CN.zip",
+            local_zip=cfg.storyjson_zip,
         )
-    ]
+        r = sync_release(release_spec)
+        _log_sync_result(r)
 
-    results = sync_all(specs)
-    for r in results:
-        repo = r.spec.repo
-        sha_short = r.commit_sha[:8] if r.commit_sha else "unknown"
-        if r.status == "updated":
-            _logger.info("Data updated from GitHub (%s @ %s).", repo, sha_short)
-        elif r.status == "up_to_date":
-            _logger.info("Data is up to date (%s @ %s).", repo, sha_short)
-        elif r.status == "offline_fallback":
-            _logger.warning(
-                "Network unavailable; using cached data (%s @ %s). Error: %s",
-                repo,
-                sha_short,
-                r.error,
-            )
-        elif r.status == "no_data":
-            _logger.warning(
-                "Sync failed for %s — no data written to volume. "
-                "Operator tools will fall back to bundled data if available. Error: %s",
-                repo,
-                r.error,
-            )
+
+def _log_sync_result(r) -> None:
+    repo = r.spec.repo
+    sha_short = r.commit_sha[:8] if r.commit_sha else "unknown"
+    if r.status == "updated":
+        _logger.info("Data updated from GitHub (%s @ %s).", repo, sha_short)
+    elif r.status == "up_to_date":
+        _logger.info("Data is up to date (%s @ %s).", repo, sha_short)
+    elif r.status == "offline_fallback":
+        _logger.warning(
+            "Network unavailable; using cached data (%s @ %s). Error: %s",
+            repo, sha_short, r.error,
+        )
+    elif r.status == "no_data":
+        _logger.warning(
+            "Sync failed for %s — no data available. Error: %s",
+            repo, r.error,
+        )
 
 
 def main() -> None:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared pytest fixtures."""
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Local zip path — used only when the file actually exists on disk.
+# Tests that require this fixture are skipped automatically on CI
+# (where the large zip file is not checked in).
+# ---------------------------------------------------------------------------
+
+_LOCAL_ZIP = Path(r"F:\2026-Spring\ArknightsStoryJson\zh_CN.zip")
+
+
+@pytest.fixture(scope="session")
+def story_zip() -> Path:
+    """Return path to the local zh_CN.zip; skip if not present."""
+    if not _LOCAL_ZIP.is_file():
+        pytest.skip(f"Local story zip not found: {_LOCAL_ZIP}")
+    return _LOCAL_ZIP

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,6 +1,7 @@
 """Shared pytest fixtures."""
 from __future__ import annotations
 
+import os
 import pytest
 from pathlib import Path
 
@@ -8,9 +9,13 @@ from pathlib import Path
 # Local zip path — used only when the file actually exists on disk.
 # Tests that require this fixture are skipped automatically on CI
 # (where the large zip file is not checked in).
+#
+# Override via STORYJSON_ZIP env var for other development environments.
 # ---------------------------------------------------------------------------
 
-_LOCAL_ZIP = Path(r"F:\2026-Spring\ArknightsStoryJson\zh_CN.zip")
+_LOCAL_ZIP = Path(
+    os.environ.get("STORYJSON_ZIP", r"F:\2026-Spring\ArknightsStoryJson\zh_CN.zip")
+)
 
 
 @pytest.fixture(scope="session")

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -1,0 +1,53 @@
+"""Tests for prts_mcp.config — storyjson zip path resolution."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from prts_mcp.config import Config
+
+
+class TestEffectiveStoryjsonZip:
+    def test_env_var_takes_priority(self, tmp_path):
+        fake_zip = tmp_path / "custom.zip"
+        fake_zip.write_bytes(b"PK")  # minimal fake zip marker
+
+        with patch.dict(os.environ, {"STORYJSON_PATH": str(fake_zip), "GAMEDATA_PATH": str(tmp_path)}):
+            cfg = Config.load()
+
+        assert cfg.storyjson_zip == fake_zip
+        assert cfg.effective_storyjson_zip == fake_zip
+        assert cfg.has_story_data is True
+
+    def test_missing_zip_returns_none(self, tmp_path):
+        nonexistent = tmp_path / "missing.zip"
+        with patch.dict(os.environ, {"STORYJSON_PATH": str(nonexistent), "GAMEDATA_PATH": str(tmp_path)}):
+            cfg = Config.load()
+
+        assert cfg.has_story_data is False
+        assert cfg.effective_storyjson_zip is None
+
+    def test_has_story_data_false_by_default(self, tmp_path):
+        # No env vars, no bundled zip at default paths
+        with patch.dict(os.environ, {"GAMEDATA_PATH": str(tmp_path)}, clear=False):
+            os.environ.pop("STORYJSON_PATH", None)
+            cfg = Config.load()
+
+        # On a dev machine without bundled docker paths, should be False
+        # (unless local zip happens to exist at default path)
+        assert isinstance(cfg.has_story_data, bool)
+
+    def test_local_zip_resolves(self):
+        """If the local dev zip exists, effective path should point to it."""
+        local_zip = Path(r"F:\2026-Spring\ArknightsStoryJson\zh_CN.zip")
+        if not local_zip.is_file():
+            pytest.skip("Local zip not available")
+
+        with patch.dict(os.environ, {"STORYJSON_PATH": str(local_zip)}):
+            cfg = Config.load()
+
+        assert cfg.effective_storyjson_zip == local_zip
+        assert cfg.has_story_data is True

--- a/python/tests/test_story.py
+++ b/python/tests/test_story.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from prts_mcp.data.story import (
+    ActivityResult,
     ChapterSummary,
     EventInfo,
     StoryChapter,
@@ -217,36 +218,36 @@ class TestReadStory:
 
 
 class TestReadActivity:
-    def test_returns_dict(self, story_zip):
+    def test_returns_activity_result(self, story_zip):
         result = read_activity(story_zip, "act31side")
-        assert isinstance(result, dict)
-        assert "chapters" in result
-        assert "total_chapters" in result
+        assert isinstance(result, ActivityResult)
+        assert hasattr(result, "chapters")
+        assert hasattr(result, "total_chapters")
 
     def test_total_chapters(self, story_zip):
         chapters = list_stories(story_zip, "act31side")
         result = read_activity(story_zip, "act31side")
-        assert result["total_chapters"] == len(chapters)
+        assert result.total_chapters == len(chapters)
 
     def test_no_page_returns_all(self, story_zip):
         result = read_activity(story_zip, "act31side", page=None)
-        assert result["has_more"] is False
-        assert len(result["chapters"]) == result["total_chapters"]
+        assert result.has_more is False
+        assert len(result.chapters) == result.total_chapters
 
     def test_pagination_page1(self, story_zip):
         result = read_activity(story_zip, "act31side", page=1, page_size=3)
-        assert len(result["chapters"]) == 3
-        assert result["has_more"] is True
+        assert len(result.chapters) == 3
+        assert result.has_more is True
 
     def test_pagination_last_page(self, story_zip):
-        total = read_activity(story_zip, "act31side")["total_chapters"]
+        total = read_activity(story_zip, "act31side").total_chapters
         last_page = (total + 4) // 5  # page_size=5
         result = read_activity(story_zip, "act31side", page=last_page, page_size=5)
-        assert result["has_more"] is False
+        assert result.has_more is False
 
     def test_chapters_are_story_chapters(self, story_zip):
         result = read_activity(story_zip, "act31side", page=1, page_size=2)
-        for ch in result["chapters"]:
+        for ch in result.chapters:
             assert isinstance(ch, StoryChapter)
 
     def test_unknown_event_raises(self, story_zip):

--- a/python/tests/test_story.py
+++ b/python/tests/test_story.py
@@ -1,0 +1,254 @@
+"""Tests for prts_mcp.data.story — requires local zh_CN.zip (skipped on CI)."""
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from prts_mcp.data.story import (
+    ChapterSummary,
+    EventInfo,
+    StoryChapter,
+    StoryLine,
+    _clean_text,
+    _parse_story_list,
+    list_stories,
+    list_story_events,
+    read_activity,
+    read_story,
+)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — no zip needed
+# ---------------------------------------------------------------------------
+
+
+class TestCleanText:
+    def test_nickname_replacement(self):
+        assert _clean_text("{@nickname}") == "博士"
+
+    def test_rich_tag_removal(self):
+        assert _clean_text("<color=#ff0000>红色文字</color>") == "红色文字"
+
+    def test_bold_tag_removal(self):
+        assert _clean_text("<b>粗体</b>") == "粗体"
+
+    def test_combined(self):
+        assert _clean_text("你好，{@nickname}<i>！</i>") == "你好，博士！"
+
+    def test_no_change(self):
+        assert _clean_text("普通文字") == "普通文字"
+
+    def test_strips_whitespace(self):
+        assert _clean_text("  文字  ") == "文字"
+
+
+class TestParseStoryList:
+    def test_dialog_with_speaker(self):
+        items = [{"id": 1, "prop": "name", "attributes": {"name": "阿米娅", "content": "博士，你好。"}}]
+        lines = _parse_story_list(items)
+        assert len(lines) == 1
+        assert lines[0] == StoryLine(type="dialog", role="阿米娅", text="博士，你好。")
+
+    def test_dialog_empty_speaker(self):
+        items = [{"id": 1, "prop": "name", "attributes": {"name": "", "content": "旁白文字"}}]
+        lines = _parse_story_list(items)
+        assert lines[0].role is None
+        assert lines[0].type == "dialog"
+
+    def test_dialog_empty_content_skipped(self):
+        items = [{"id": 1, "prop": "name", "attributes": {"name": "阿米娅", "content": ""}}]
+        lines = _parse_story_list(items)
+        assert lines == []
+
+    def test_narration_sticker(self):
+        items = [{"id": 1, "prop": "sticker", "attributes": {"content": "场景描述"}}]
+        lines = _parse_story_list(items)
+        assert lines[0] == StoryLine(type="narration", role=None, text="场景描述")
+
+    def test_narration_subtitle(self):
+        items = [{"id": 1, "prop": "subtitle", "attributes": {"content": "字幕文字"}}]
+        lines = _parse_story_list(items)
+        assert lines[0].type == "narration"
+
+    def test_narration_animtext(self):
+        items = [{"id": 1, "prop": "animtext", "attributes": {"content": "动画文字"}}]
+        lines = _parse_story_list(items)
+        assert lines[0].type == "narration"
+
+    def test_non_text_props_skipped(self):
+        items = [
+            {"id": 1, "prop": "Background", "attributes": {"image": "bg_001"}},
+            {"id": 2, "prop": "PlayMusic", "attributes": {"key": "music_001"}},
+            {"id": 3, "prop": "Dialog", "attributes": {}},
+        ]
+        assert _parse_story_list(items) == []
+
+    def test_nickname_cleaned_in_dialog(self):
+        items = [{"id": 1, "prop": "name", "attributes": {"name": "角色", "content": "{@nickname}，你好"}}]
+        lines = _parse_story_list(items)
+        assert lines[0].text == "博士，你好"
+
+    def test_mixed_items(self):
+        items = [
+            {"id": 1, "prop": "Background", "attributes": {}},
+            {"id": 2, "prop": "name", "attributes": {"name": "黍", "content": "你好"}},
+            {"id": 3, "prop": "sticker", "attributes": {"content": "某处"}},
+            {"id": 4, "prop": "Dialog", "attributes": {}},
+        ]
+        lines = _parse_story_list(items)
+        assert len(lines) == 2
+        assert lines[0].type == "dialog"
+        assert lines[1].type == "narration"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — require local zh_CN.zip
+# ---------------------------------------------------------------------------
+
+
+class TestListStoryEvents:
+    def test_returns_list(self, story_zip):
+        events = list_story_events(story_zip)
+        assert isinstance(events, list)
+        assert len(events) > 0
+        assert all(isinstance(e, EventInfo) for e in events)
+
+    def test_category_main(self, story_zip):
+        events = list_story_events(story_zip, category="main")
+        assert all(e.entry_type == "MAINLINE" for e in events)
+        assert len(events) >= 10
+
+    def test_category_activities(self, story_zip):
+        events = list_story_events(story_zip, category="activities")
+        assert all(e.entry_type in ("ACTIVITY", "MINI_ACTIVITY") for e in events)
+        assert len(events) >= 50
+
+    def test_no_filter_returns_more_than_filtered(self, story_zip):
+        all_events = list_story_events(story_zip)
+        main_events = list_story_events(story_zip, category="main")
+        assert len(all_events) > len(main_events)
+
+    def test_event_fields(self, story_zip):
+        events = list_story_events(story_zip, category="main")
+        e = events[0]
+        assert e.event_id
+        assert e.name
+        assert e.story_count > 0
+
+    def test_act31side_present(self, story_zip):
+        events = list_story_events(story_zip, category="activities")
+        ids = {e.event_id for e in events}
+        assert "act31side" in ids
+
+
+class TestListStories:
+    def test_act31side_chapters(self, story_zip):
+        chapters = list_stories(story_zip, "act31side")
+        assert len(chapters) > 0
+        assert all(isinstance(c, ChapterSummary) for c in chapters)
+
+    def test_sorted_by_sort_order(self, story_zip):
+        chapters = list_stories(story_zip, "act31side")
+        orders = [c.sort_order for c in chapters]
+        assert orders == sorted(orders)
+
+    def test_chapter_fields(self, story_zip):
+        chapters = list_stories(story_zip, "act31side")
+        c = chapters[0]
+        assert c.story_key
+        assert c.story_code
+        assert c.story_name
+
+    def test_story_key_format(self, story_zip):
+        chapters = list_stories(story_zip, "act31side")
+        for c in chapters:
+            assert c.story_key.startswith("activities/act31side/")
+
+    def test_unknown_event_raises(self, story_zip):
+        with pytest.raises(KeyError):
+            list_stories(story_zip, "nonexistent_event_xyz")
+
+
+class TestReadStory:
+    def test_returns_story_chapter(self, story_zip):
+        key = "activities/act31side/level_act31side_01_beg"
+        chapter = read_story(story_zip, key)
+        assert isinstance(chapter, StoryChapter)
+
+    def test_metadata(self, story_zip):
+        key = "activities/act31side/level_act31side_01_beg"
+        chapter = read_story(story_zip, key)
+        assert chapter.event_name == "怀黍离"
+        assert chapter.story_name == "赴大荒"
+        assert chapter.story_key == key
+
+    def test_has_dialog_lines(self, story_zip):
+        key = "activities/act31side/level_act31side_01_beg"
+        chapter = read_story(story_zip, key)
+        dialogs = [ln for ln in chapter.lines if ln.type == "dialog"]
+        assert len(dialogs) > 10
+
+    def test_include_narration_true(self, story_zip):
+        # 幕间章节有旁白行
+        key = "activities/act31side/level_act31side_st01"
+        chapter = read_story(story_zip, key, include_narration=True)
+        narrations = [ln for ln in chapter.lines if ln.type == "narration"]
+        assert len(narrations) > 0
+
+    def test_include_narration_false(self, story_zip):
+        key = "activities/act31side/level_act31side_st01"
+        chapter = read_story(story_zip, key, include_narration=False)
+        narrations = [ln for ln in chapter.lines if ln.type == "narration"]
+        assert narrations == []
+
+    def test_no_raw_tags_in_text(self, story_zip):
+        key = "activities/act31side/level_act31side_01_beg"
+        chapter = read_story(story_zip, key)
+        for ln in chapter.lines:
+            assert "<" not in ln.text, f"Raw tag found: {ln.text!r}"
+            assert "{@" not in ln.text, f"Raw token found: {ln.text!r}"
+
+    def test_unknown_key_raises(self, story_zip):
+        with pytest.raises(KeyError):
+            read_story(story_zip, "activities/nonexistent/story")
+
+
+class TestReadActivity:
+    def test_returns_dict(self, story_zip):
+        result = read_activity(story_zip, "act31side")
+        assert isinstance(result, dict)
+        assert "chapters" in result
+        assert "total_chapters" in result
+
+    def test_total_chapters(self, story_zip):
+        chapters = list_stories(story_zip, "act31side")
+        result = read_activity(story_zip, "act31side")
+        assert result["total_chapters"] == len(chapters)
+
+    def test_no_page_returns_all(self, story_zip):
+        result = read_activity(story_zip, "act31side", page=None)
+        assert result["has_more"] is False
+        assert len(result["chapters"]) == result["total_chapters"]
+
+    def test_pagination_page1(self, story_zip):
+        result = read_activity(story_zip, "act31side", page=1, page_size=3)
+        assert len(result["chapters"]) == 3
+        assert result["has_more"] is True
+
+    def test_pagination_last_page(self, story_zip):
+        total = read_activity(story_zip, "act31side")["total_chapters"]
+        last_page = (total + 4) // 5  # page_size=5
+        result = read_activity(story_zip, "act31side", page=last_page, page_size=5)
+        assert result["has_more"] is False
+
+    def test_chapters_are_story_chapters(self, story_zip):
+        result = read_activity(story_zip, "act31side", page=1, page_size=2)
+        for ch in result["chapters"]:
+            assert isinstance(ch, StoryChapter)
+
+    def test_unknown_event_raises(self, story_zip):
+        with pytest.raises(KeyError):
+            read_activity(story_zip, "nonexistent_event_xyz")

--- a/python/tests/test_sync_release.py
+++ b/python/tests/test_sync_release.py
@@ -1,0 +1,175 @@
+"""Tests for ReleaseSpec / sync_release in prts_mcp.data.sync."""
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from prts_mcp.data.sync import (
+    ReleaseSpec,
+    SyncResult,
+    check_latest_release,
+    sync_release,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_spec(tmp_path: Path) -> ReleaseSpec:
+    return ReleaseSpec(
+        owner="3aKHP",
+        repo="ArknightsStoryJson",
+        asset_name="zh_CN.zip",
+        local_zip=tmp_path / "storyjson" / "zh_CN.zip",
+    )
+
+
+def _write_zip(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("zh_CN/storyinfo.json", "{}")
+
+
+def _mock_release_response(tag: str, asset_name: str, download_url: str) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {
+        "tag_name": tag,
+        "assets": [{"name": asset_name, "browser_download_url": download_url}],
+    }
+    return resp
+
+
+def _mock_asset_response(content: bytes = b"PK\x03\x04") -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.content = content
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# check_latest_release
+# ---------------------------------------------------------------------------
+
+class TestCheckLatestRelease:
+    def test_returns_tag_and_url(self, tmp_path):
+        spec = _make_spec(tmp_path)
+        tag = "upstream-abc123"
+        url = "https://github.com/example/release/zh_CN.zip"
+
+        with patch("httpx.get", return_value=_mock_release_response(tag, "zh_CN.zip", url)):
+            result = check_latest_release(spec)
+
+        assert result == (tag, url)
+
+    def test_asset_not_found_returns_none(self, tmp_path):
+        spec = _make_spec(tmp_path)
+        with patch("httpx.get", return_value=_mock_release_response("upstream-abc", "other.zip", "http://x")):
+            result = check_latest_release(spec)
+        assert result is None
+
+    def test_network_error_returns_none(self, tmp_path):
+        spec = _make_spec(tmp_path)
+        with patch("httpx.get", side_effect=Exception("network error")):
+            result = check_latest_release(spec)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# sync_release
+# ---------------------------------------------------------------------------
+
+class TestSyncRelease:
+    def test_updated_when_new_tag(self, tmp_path):
+        spec = _make_spec(tmp_path)
+        tag = "upstream-newsha1234"
+        asset_url = "https://example.com/zh_CN.zip"
+
+        with (
+            patch("prts_mcp.data.sync.check_latest_release", return_value=(tag, asset_url)),
+            patch("prts_mcp.data.sync.download_release_asset") as mock_dl,
+        ):
+            mock_dl.return_value = None
+            result = sync_release(spec)
+
+        assert result.status == "updated"
+        mock_dl.assert_called_once()
+
+    def test_up_to_date_when_sha_matches(self, tmp_path):
+        spec = _make_spec(tmp_path)
+        sha = "abc123def456"
+        tag = f"upstream-{sha}"
+        _write_zip(spec.local_zip)
+
+        # Write a cache meta that matches
+        from prts_mcp.data.sync import CacheMeta
+        from datetime import datetime, timezone
+        CacheMeta(
+            repo="3aKHP/ArknightsStoryJson",
+            branch="releases",
+            commit_sha=sha,
+            fetched_at=datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            files=["zh_CN.zip"],
+        ).save(spec.local_zip.parent / "release_meta.json")
+
+        with patch("prts_mcp.data.sync.check_latest_release", return_value=(tag, "http://x")):
+            result = sync_release(spec)
+
+        assert result.status == "up_to_date"
+        assert result.commit_sha == sha
+
+    def test_offline_fallback_when_zip_exists(self, tmp_path):
+        spec = _make_spec(tmp_path)
+        _write_zip(spec.local_zip)
+
+        with patch("prts_mcp.data.sync.check_latest_release", return_value=None):
+            result = sync_release(spec)
+
+        assert result.status == "offline_fallback"
+
+    def test_no_data_when_network_fails_and_no_zip(self, tmp_path):
+        spec = _make_spec(tmp_path)
+
+        with patch("prts_mcp.data.sync.check_latest_release", return_value=None):
+            result = sync_release(spec)
+
+        assert result.status == "no_data"
+
+    def test_tag_prefix_stripped_for_sha(self, tmp_path):
+        spec = _make_spec(tmp_path)
+        sha = "c785d88f552fce9bbe2ce9122bd0e9f516810e20"
+        tag = f"upstream-{sha}"
+
+        with (
+            patch("prts_mcp.data.sync.check_latest_release", return_value=(tag, "http://x")),
+            patch("prts_mcp.data.sync.download_release_asset"),
+        ):
+            result = sync_release(spec)
+
+        assert result.commit_sha == sha
+
+    def test_fresh_cache_skips_api_call(self, tmp_path):
+        spec = _make_spec(tmp_path)
+        sha = "freshsha"
+        _write_zip(spec.local_zip)
+
+        from prts_mcp.data.sync import CacheMeta
+        from datetime import datetime, timezone
+        CacheMeta(
+            repo="3aKHP/ArknightsStoryJson",
+            branch="releases",
+            commit_sha=sha,
+            fetched_at=datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            files=["zh_CN.zip"],
+        ).save(spec.local_zip.parent / "release_meta.json")
+
+        with patch("prts_mcp.data.sync.check_latest_release") as mock_check:
+            result = sync_release(spec)
+
+        mock_check.assert_not_called()
+        assert result.status == "up_to_date"

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -32,6 +32,7 @@ const REQUIRED_OPERATOR_FILES = [
   "character_table.json",
   "handbook_info_table.json",
   "charword_table.json",
+  "story_review_table.json",
 ] as const;
 
 /** Fixed volume mount-point inside Docker. */

--- a/ts/src/data/operator.ts
+++ b/ts/src/data/operator.ts
@@ -9,6 +9,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { loadConfig, hasOperatorData } from "../config.js";
+import { stripWikitext } from "../utils/sanitizer.js";
 
 // ---------------------------------------------------------------------------
 // Module-level lazy caches
@@ -32,6 +33,30 @@ let _nameToId: Map<string, string> | null = null;
 
 interface CharacterEntry {
   name?: string;
+  appellation?: string;
+  displayNumber?: string;
+  description?: string;
+  rarity?: string;
+  profession?: string;
+  subProfessionId?: string;
+  position?: string;
+  nationId?: string;
+  groupId?: string;
+  teamId?: string;
+  tagList?: string[];
+  itemUsage?: string;
+  itemDesc?: string;
+  itemObtainApproach?: string;
+  talents?: TalentSlot[];
+}
+
+interface TalentCandidate {
+  name?: string;
+  description?: string;
+}
+
+interface TalentSlot {
+  candidates?: TalentCandidate[];
 }
 
 interface StoryEntry {
@@ -203,4 +228,106 @@ export function getOperatorVoicelines(name: string): string {
 
   if (lines.length === 0) return `干员 '${name}' 暂无语音数据。`;
   return `# ${name} - 语音记录\n\n` + lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Basic info
+// ---------------------------------------------------------------------------
+
+const PROFESSION_ZH: Record<string, string> = {
+  CASTER: "术师",
+  MEDIC: "医疗",
+  PIONEER: "先锋",
+  SNIPER: "狙击",
+  SPECIAL: "特种",
+  SUPPORT: "辅助",
+  TANK: "重装",
+  WARRIOR: "近卫",
+};
+
+const POSITION_ZH: Record<string, string> = {
+  RANGED: "远程",
+  MELEE: "近战",
+  ALL: "通用",
+  NONE: "-",
+};
+
+/** Return basic profile info for an operator by Chinese name. */
+export function getOperatorBasicInfo(name: string): string {
+  const cfg = loadConfig();
+  if (!hasOperatorData(cfg)) return missingDataMessage();
+
+  let charId: string | null;
+  try {
+    charId = resolveCharId(name);
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  if (charId === null) {
+    return `未找到干员 '${name}'。请使用游戏内中文名称（如'阿米娅'）。`;
+  }
+
+  let ct: Record<string, CharacterEntry>;
+  try {
+    ct = getCharacterTable();
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  const info = ct[charId];
+  if (!info) return `干员 '${name}' 暂无基本信息。`;
+
+  const rarityRaw = info.rarity ?? "";
+  const rarity = rarityRaw.startsWith("TIER_")
+    ? rarityRaw.replace("TIER_", "") + "★"
+    : rarityRaw;
+
+  const profession = PROFESSION_ZH[info.profession ?? ""] ?? (info.profession ?? "");
+  const position = POSITION_ZH[info.position ?? ""] ?? (info.position ?? "");
+
+  const affiliationParts = [info.nationId, info.groupId, info.teamId].filter(Boolean) as string[];
+  const affiliation = affiliationParts.length > 0 ? affiliationParts.join(" / ") : "-";
+
+  const lines: string[] = [`# ${name} - 干员基本信息\n`];
+  lines.push(`- **编号**：${info.displayNumber ?? ""}`);
+  lines.push(`- **英文名**：${info.appellation ?? ""}`);
+  lines.push(`- **稀有度**：${rarity}`);
+  lines.push(`- **职业**：${profession}（${info.subProfessionId ?? ""}）`);
+  lines.push(`- **站位**：${position}`);
+  lines.push(`- **所属**：${affiliation}`);
+  if (info.tagList && info.tagList.length > 0) {
+    lines.push(`- **招募标签**：${info.tagList.join("、")}`);
+  }
+  if (info.description) {
+    lines.push(`- **攻击属性**：${stripWikitext(info.description)}`);
+  }
+  if (info.itemUsage) {
+    lines.push(`\n**图鉴**：${info.itemUsage}`);
+  }
+  if (info.itemDesc) {
+    lines.push(`\n> ${info.itemDesc}`);
+  }
+  if (info.itemObtainApproach) {
+    lines.push(`\n**获取方式**：${info.itemObtainApproach}`);
+  }
+
+  const talents = info.talents ?? [];
+  if (talents.length > 0) {
+    lines.push("\n## 天赋");
+    for (const slot of talents) {
+      const candidates = slot.candidates ?? [];
+      let chosen: TalentCandidate | undefined;
+      for (let i = candidates.length - 1; i >= 0; i--) {
+        const c = candidates[i];
+        if (c.name && c.name !== "？？？") {
+          chosen = c;
+          break;
+        }
+      }
+      if (chosen) {
+        lines.push(`- **${chosen.name ?? ""}**：${stripWikitext(chosen.description ?? "")}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
 }

--- a/ts/src/data/sync.ts
+++ b/ts/src/data/sync.ts
@@ -27,6 +27,7 @@ export const GAMEDATA_FILES: readonly string[] = [
   "zh_CN/gamedata/excel/character_table.json",
   "zh_CN/gamedata/excel/handbook_info_table.json",
   "zh_CN/gamedata/excel/charword_table.json",
+  "zh_CN/gamedata/excel/story_review_table.json",
 ];
 
 const GITHUB_UA = "PRTS-MCP-Bot/0.1 (Arknights fan-creation helper)";

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 
 import { loadConfig } from "./config.js";
 import { searchPrts, readPage } from "./api/prtsWiki.js";
-import { getOperatorArchives, getOperatorVoicelines } from "./data/operator.js";
+import { getOperatorArchives, getOperatorVoicelines, getOperatorBasicInfo } from "./data/operator.js";
 import { syncAll, GAMEDATA_FILES, type RepoSpec } from "./data/sync.js";
 
 // ---------------------------------------------------------------------------
@@ -71,6 +71,16 @@ function createMcpServer(): McpServer {
     { operator_name: z.string() },
     ({ operator_name }) => {
       const text = getOperatorVoicelines(operator_name);
+      return { content: [{ type: "text", text }] };
+    }
+  );
+
+  server.tool(
+    "get_operator_basic_info",
+    '获取指定干员的基本信息：职业、稀有度、所属、招募标签、天赋等（使用游戏内中文名，如"阿米娅"）。',
+    { operator_name: z.string() },
+    ({ operator_name }) => {
+      const text = getOperatorBasicInfo(operator_name);
       return { content: [{ type: "text", text }] };
     }
   );


### PR DESCRIPTION
## Summary

- **4 new MCP tools** for querying Arknights story content from the bundled `zh_CN.zip`:
  - `list_story_events(category?)` — event list with optional filter (main / activities)
  - `list_stories(event_id)` — ordered chapter list for an event
  - `read_story(story_key, include_narration)` — full dialogue for a single chapter
  - `read_activity(event_id, include_narration, page, page_size)` — merged full-activity transcript with pagination support

- **Data pipeline**: `ReleaseSpec` + `sync_release()` in `data/sync.py` downloads `zh_CN.zip` from the [3aKHP/ArknightsStoryJson](https://github.com/3aKHP/ArknightsStoryJson) fork Release on startup (async, non-blocking). Tag format `upstream-{sha}` — prefix stripped when comparing against cache.

- **Config**: `storyjson_zip` / `effective_storyjson_zip` / `has_story_data` added to `Config`, mirroring the existing gamedata pattern.

- **Tests**: 53 tests across `test_story.py`, `test_sync_release.py`, `test_config.py` — all passing locally. Integration tests skip automatically on CI (no zip file).

- **Bug fix** discovered during testing: `Sticker` prop (capital S) uses `text` field instead of `content`; also matched case-insensitively now.

- **TS prerequisite**: `story_review_table.json` added to TS sync file list (full TS implementation will follow in `feat/story-ts`).

## Test plan

- [ ] CI `verify-python` passes (import + config fallback + `has_story_data is False`)
- [ ] CI smoke test includes all 4 new tools in `tools/list` response
- [ ] Local: 53 pytest tests pass (`python -m pytest tests/ -q`)
- [ ] Local: Chatbox end-to-end — story navigation, single chapter read, paginated activity read ✅ (manually verified)