### PR TITLE
feat(story): add story query tools — TypeScript implementation

### DIFF
--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -71,7 +71,7 @@ jobs:
             const line = list.body.split('\n').find(l => l.startsWith('data: '));
             const result = JSON.parse(line.slice(6));
             const names = result.result.tools.map(t => t.name);
-            const required = ['search_prts', 'read_prts_page', 'get_operator_archives', 'get_operator_voicelines'];
+            const required = ['search_prts', 'read_prts_page', 'get_operator_archives', 'get_operator_voicelines', 'get_operator_basic_info'];
             for (const t of required) {
               if (!names.includes(t)) throw new Error('Missing tool: ' + t);
             }

--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -71,7 +71,7 @@ jobs:
             const line = list.body.split('\n').find(l => l.startsWith('data: '));
             const result = JSON.parse(line.slice(6));
             const names = result.result.tools.map(t => t.name);
-            const required = ['search_prts', 'read_prts_page', 'get_operator_archives', 'get_operator_voicelines', 'get_operator_basic_info'];
+            const required = ['search_prts', 'read_prts_page', 'get_operator_archives', 'get_operator_voicelines', 'get_operator_basic_info', 'list_story_events', 'list_stories', 'read_story', 'read_activity'];
             for (const t of required) {
               if (!names.includes(t)) throw new Error('Missing tool: ' + t);
             }

--- a/python/src/prts_mcp/data/operator.py
+++ b/python/src/prts_mcp/data/operator.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any
 
 from prts_mcp.config import Config
+from prts_mcp.utils.sanitizer import strip_wikitext
 
 # ---------------------------------------------------------------------------
 # Internal caches (loaded lazily on first call)
@@ -136,3 +137,107 @@ def get_operator_voicelines(name: str) -> str:
     if not lines:
         return f"干员 '{name}' 暂无语音数据。"
     return f"# {name} - 语音记录\n\n" + "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Basic info helpers
+# ---------------------------------------------------------------------------
+
+_PROFESSION_ZH: dict[str, str] = {
+    "CASTER": "术师",
+    "MEDIC": "医疗",
+    "PIONEER": "先锋",
+    "SNIPER": "狙击",
+    "SPECIAL": "特种",
+    "SUPPORT": "辅助",
+    "TANK": "重装",
+    "WARRIOR": "近卫",
+}
+
+_POSITION_ZH: dict[str, str] = {
+    "RANGED": "远程",
+    "MELEE": "近战",
+    "ALL": "通用",
+    "NONE": "-",
+}
+
+
+def get_operator_basic_info(name: str) -> str:
+    """Return basic profile info for an operator by Chinese name."""
+    if not _get_config().has_operator_data:
+        return _missing_operator_data_message()
+
+    try:
+        char_id = _resolve_char_id(name)
+    except FileNotFoundError as exc:
+        return str(exc)
+    if char_id is None:
+        return f"未找到干员 '{name}'。请使用游戏内中文名称（如'阿米娅'）。"
+
+    try:
+        ct = _load_character_table()
+    except FileNotFoundError as exc:
+        return str(exc)
+    info = ct.get(char_id)
+    if info is None:
+        return f"干员 '{name}' 暂无基本信息。"
+
+    rarity_raw: str = info.get("rarity", "")
+    rarity = rarity_raw.replace("TIER_", "") + "★" if rarity_raw.startswith("TIER_") else rarity_raw
+
+    profession_raw: str = info.get("profession", "")
+    profession = _PROFESSION_ZH.get(profession_raw, profession_raw)
+
+    position_raw: str = info.get("position", "")
+    position = _POSITION_ZH.get(position_raw, position_raw)
+
+    appellation: str = info.get("appellation", "")
+    display_number: str = info.get("displayNumber", "")
+    description: str = info.get("description", "")
+    item_usage: str = info.get("itemUsage", "")
+    item_desc: str = info.get("itemDesc", "")
+    item_obtain: str = info.get("itemObtainApproach", "")
+    tag_list: list[str] = info.get("tagList") or []
+
+    nation_id: str = info.get("nationId") or ""
+    group_id: str = info.get("groupId") or ""
+    team_id: str = info.get("teamId") or ""
+    affiliation_parts = [x for x in [nation_id, group_id, team_id] if x]
+    affiliation = " / ".join(affiliation_parts) if affiliation_parts else "-"
+
+    lines: list[str] = [f"# {name} - 干员基本信息\n"]
+    lines.append(f"- **编号**：{display_number}")
+    lines.append(f"- **英文名**：{appellation}")
+    lines.append(f"- **稀有度**：{rarity}")
+    lines.append(f"- **职业**：{profession}（{info.get('subProfessionId', '')}）")
+    lines.append(f"- **站位**：{position}")
+    lines.append(f"- **所属**：{affiliation}")
+    if tag_list:
+        lines.append(f"- **招募标签**：{'、'.join(tag_list)}")
+    if description:
+        lines.append(f"- **攻击属性**：{strip_wikitext(description)}")
+    if item_usage:
+        lines.append(f"\n**图鉴**：{item_usage}")
+    if item_desc:
+        lines.append(f"\n> {item_desc}")
+    if item_obtain:
+        lines.append(f"\n**获取方式**：{item_obtain}")
+
+    # Talents — show the highest-unlock candidate for each talent slot
+    talents: list[Any] = info.get("talents") or []
+    if talents:
+        lines.append("\n## 天赋")
+        for talent in talents:
+            candidates: list[Any] = talent.get("candidates") or []
+            # Pick last candidate with a real name
+            chosen = None
+            for c in reversed(candidates):
+                if c.get("name") and c["name"] not in ("？？？",):
+                    chosen = c
+                    break
+            if chosen:
+                t_name: str = chosen.get("name", "")
+                t_desc: str = strip_wikitext(chosen.get("description", ""))
+                lines.append(f"- **{t_name}**：{t_desc}")
+
+    return "\n".join(lines)

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -7,7 +7,11 @@ import threading
 from mcp.server.fastmcp import FastMCP
 
 from prts_mcp.api.prts_wiki import search_prts as _search_prts, read_page as _read_page
-from prts_mcp.data.operator import get_operator_archives as _get_archives, get_operator_voicelines as _get_voicelines
+from prts_mcp.data.operator import (
+    get_operator_archives as _get_archives,
+    get_operator_voicelines as _get_voicelines,
+    get_operator_basic_info as _get_basic_info,
+)
 
 logging.basicConfig(
     stream=sys.stderr,
@@ -47,6 +51,12 @@ async def get_operator_archives(operator_name: str) -> str:
 async def get_operator_voicelines(operator_name: str) -> str:
     """获取指定干员的语音记录（使用游戏内中文名，如"阿米娅"）。"""
     return _get_voicelines(operator_name)
+
+
+@mcp.tool()
+async def get_operator_basic_info(operator_name: str) -> str:
+    """获取指定干员的基本信息：职业、稀有度、所属、招募标签、天赋等（使用游戏内中文名，如"阿米娅"）。"""
+    return _get_basic_info(operator_name)
 
 
 def _run_startup_sync() -> None:

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -7,15 +7,24 @@
     "": {
       "name": "prts-mcp-ts",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "adm-zip": "^0.5.16",
         "express": "^5.2.1"
       },
+      "bin": {
+        "prts-mcp-ts": "dist/server.js"
+      },
       "devDependencies": {
+        "@types/adm-zip": "^0.5.7",
         "@types/express": "^5.0.6",
         "@types/node": "^24.0.0",
         "tsx": "^4.21.0",
         "typescript": "^5.8.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -512,6 +521,16 @@
         }
       }
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmmirror.com/@types/adm-zip/-/adm-zip-0.5.8.tgz",
+      "integrity": "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmmirror.com/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -621,6 +640,15 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmmirror.com/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/ajv": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -47,9 +47,11 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "adm-zip": "^0.5.16",
     "express": "^5.2.1"
   },
   "devDependencies": {
+    "@types/adm-zip": "^0.5.7",
     "@types/express": "^5.0.6",
     "@types/node": "^24.0.0",
     "tsx": "^4.21.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP)",
   "type": "module",
   "main": "dist/server.js",

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -38,7 +38,6 @@ const REQUIRED_OPERATOR_FILES = [
   "character_table.json",
   "handbook_info_table.json",
   "charword_table.json",
-  "story_review_table.json",
 ] as const;
 
 /** Fixed volume mount-point inside Docker. */

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -13,11 +13,17 @@
  *
  *   BUNDLED_GAMEDATA_PATH — read-only fallback baked into the Docker image.
  *     Always /app/data/gamedata inside the container.
+ *
+ *   effective_storyjson_zip — priority:
+ *     1. STORYJSON_PATH env var — user-supplied zip path.
+ *     2. /data/storyjson/zh_CN.zip — Docker volume mount-point.
+ *     3. /app/data/storyjson/zh_CN.zip — bundled zip (only inside Docker).
+ *     4. null — no story data available.
  */
 
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -32,6 +38,7 @@ const REQUIRED_OPERATOR_FILES = [
   "character_table.json",
   "handbook_info_table.json",
   "charword_table.json",
+  "story_review_table.json",
 ] as const;
 
 /** Fixed volume mount-point inside Docker. */
@@ -39,6 +46,12 @@ const DOCKER_VOLUME_PATH = "/data/gamedata";
 
 /** Bundled data baked into the image at build time. */
 export const BUNDLED_GAMEDATA_PATH = "/app/data/gamedata";
+
+/** Fixed storyjson volume mount-point inside Docker. */
+const DOCKER_STORYJSON_ZIP = "/data/storyjson/zh_CN.zip";
+
+/** Bundled storyjson zip baked into the image at build time. */
+const BUNDLED_STORYJSON_ZIP = "/app/data/storyjson/zh_CN.zip";
 
 // ---------------------------------------------------------------------------
 // Path resolution
@@ -88,10 +101,24 @@ export interface Config {
    * when neither location has data.
    */
   effectiveExcelPath: string | null;
+  /**
+   * Configured storyjson zip path (STORYJSON_PATH env var or default).
+   * This is the sync write target, not necessarily the file that exists.
+   */
+  storyjsonZip: string;
+  /**
+   * The storyjson zip story.ts should actually read from.
+   * Null when no zip is found anywhere.
+   */
+  effectiveStoryjsonZip: string | null;
 }
 
 export function hasOperatorData(cfg: Config): boolean {
   return cfg.effectiveExcelPath !== null;
+}
+
+export function hasStoryData(cfg: Config): boolean {
+  return cfg.effectiveStoryjsonZip !== null;
 }
 
 export function loadConfig(): Config {
@@ -107,11 +134,29 @@ export function loadConfig(): Config {
   if (filesComplete(ep)) effectiveExcelPath = ep;
   else if (filesComplete(bep)) effectiveExcelPath = bep;
 
+  // storyjson zip: default is alongside gamedata in the user data dir.
+  const defaultStoryjsonZip = join(
+    dirname(gamedataPath),
+    "storyjson",
+    "zh_CN.zip"
+  );
+  const storyjsonZip =
+    process.env["STORYJSON_PATH"] ?? defaultStoryjsonZip;
+
+  let effectiveStoryjsonZip: string | null = null;
+  if (existsSync(storyjsonZip)) effectiveStoryjsonZip = storyjsonZip;
+  else if (existsSync(DOCKER_STORYJSON_ZIP))
+    effectiveStoryjsonZip = DOCKER_STORYJSON_ZIP;
+  else if (existsSync(BUNDLED_STORYJSON_ZIP))
+    effectiveStoryjsonZip = BUNDLED_STORYJSON_ZIP;
+
   return {
     gamedataPath,
     isCustomGamedata,
     excelPath: ep,
     bundledExcelPath: bep,
     effectiveExcelPath,
+    storyjsonZip,
+    effectiveStoryjsonZip,
   };
 }

--- a/ts/src/data/operator.ts
+++ b/ts/src/data/operator.ts
@@ -9,6 +9,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { loadConfig, hasOperatorData } from "../config.js";
+import { stripWikitext } from "../utils/sanitizer.js";
 
 // ---------------------------------------------------------------------------
 // Module-level lazy caches
@@ -32,6 +33,30 @@ let _nameToId: Map<string, string> | null = null;
 
 interface CharacterEntry {
   name?: string;
+  appellation?: string;
+  displayNumber?: string;
+  description?: string;
+  rarity?: string;
+  profession?: string;
+  subProfessionId?: string;
+  position?: string;
+  nationId?: string;
+  groupId?: string;
+  teamId?: string;
+  tagList?: string[];
+  itemUsage?: string;
+  itemDesc?: string;
+  itemObtainApproach?: string;
+  talents?: TalentSlot[];
+}
+
+interface TalentCandidate {
+  name?: string;
+  description?: string;
+}
+
+interface TalentSlot {
+  candidates?: TalentCandidate[];
 }
 
 interface StoryEntry {
@@ -203,4 +228,106 @@ export function getOperatorVoicelines(name: string): string {
 
   if (lines.length === 0) return `干员 '${name}' 暂无语音数据。`;
   return `# ${name} - 语音记录\n\n` + lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Basic info
+// ---------------------------------------------------------------------------
+
+const PROFESSION_ZH: Record<string, string> = {
+  CASTER: "术师",
+  MEDIC: "医疗",
+  PIONEER: "先锋",
+  SNIPER: "狙击",
+  SPECIAL: "特种",
+  SUPPORT: "辅助",
+  TANK: "重装",
+  WARRIOR: "近卫",
+};
+
+const POSITION_ZH: Record<string, string> = {
+  RANGED: "远程",
+  MELEE: "近战",
+  ALL: "通用",
+  NONE: "-",
+};
+
+/** Return basic profile info for an operator by Chinese name. */
+export function getOperatorBasicInfo(name: string): string {
+  const cfg = loadConfig();
+  if (!hasOperatorData(cfg)) return missingDataMessage();
+
+  let charId: string | null;
+  try {
+    charId = resolveCharId(name);
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  if (charId === null) {
+    return `未找到干员 '${name}'。请使用游戏内中文名称（如'阿米娅'）。`;
+  }
+
+  let ct: Record<string, CharacterEntry>;
+  try {
+    ct = getCharacterTable();
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  const info = ct[charId];
+  if (!info) return `干员 '${name}' 暂无基本信息。`;
+
+  const rarityRaw = info.rarity ?? "";
+  const rarity = rarityRaw.startsWith("TIER_")
+    ? rarityRaw.replace("TIER_", "") + "★"
+    : rarityRaw;
+
+  const profession = PROFESSION_ZH[info.profession ?? ""] ?? (info.profession ?? "");
+  const position = POSITION_ZH[info.position ?? ""] ?? (info.position ?? "");
+
+  const affiliationParts = [info.nationId, info.groupId, info.teamId].filter(Boolean) as string[];
+  const affiliation = affiliationParts.length > 0 ? affiliationParts.join(" / ") : "-";
+
+  const lines: string[] = [`# ${name} - 干员基本信息\n`];
+  lines.push(`- **编号**：${info.displayNumber ?? ""}`);
+  lines.push(`- **英文名**：${info.appellation ?? ""}`);
+  lines.push(`- **稀有度**：${rarity}`);
+  lines.push(`- **职业**：${profession}（${info.subProfessionId ?? ""}）`);
+  lines.push(`- **站位**：${position}`);
+  lines.push(`- **所属**：${affiliation}`);
+  if (info.tagList && info.tagList.length > 0) {
+    lines.push(`- **招募标签**：${info.tagList.join("、")}`);
+  }
+  if (info.description) {
+    lines.push(`- **攻击属性**：${stripWikitext(info.description)}`);
+  }
+  if (info.itemUsage) {
+    lines.push(`\n**图鉴**：${info.itemUsage}`);
+  }
+  if (info.itemDesc) {
+    lines.push(`\n> ${info.itemDesc}`);
+  }
+  if (info.itemObtainApproach) {
+    lines.push(`\n**获取方式**：${info.itemObtainApproach}`);
+  }
+
+  const talents = info.talents ?? [];
+  if (talents.length > 0) {
+    lines.push("\n## 天赋");
+    for (const slot of talents) {
+      const candidates = slot.candidates ?? [];
+      let chosen: TalentCandidate | undefined;
+      for (let i = candidates.length - 1; i >= 0; i--) {
+        const c = candidates[i];
+        if (c.name && c.name !== "？？？") {
+          chosen = c;
+          break;
+        }
+      }
+      if (chosen) {
+        lines.push(`- **${chosen.name ?? ""}**：${stripWikitext(chosen.description ?? "")}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
 }

--- a/ts/src/data/story.ts
+++ b/ts/src/data/story.ts
@@ -1,0 +1,327 @@
+/**
+ * Story data reader for PRTS-MCP (TypeScript).
+ *
+ * Reads from the bundled/synced zh_CN.zip (ArknightsStoryJson fork release).
+ * Mirrors python/src/prts_mcp/data/story.py.
+ *
+ * Zip internal layout (all paths prefixed with "zh_CN/"):
+ *   zh_CN/storyinfo.json                          — {story_key: summary_text}
+ *   zh_CN/gamedata/excel/story_review_table.json  — event metadata + ordered chapter list
+ *   zh_CN/gamedata/story/{story_key}.json         — per-chapter dialogue JSON
+ */
+
+import AdmZip from "adm-zip";
+
+// ---------------------------------------------------------------------------
+// Zip path constants
+// ---------------------------------------------------------------------------
+
+const STORYINFO = "zh_CN/storyinfo.json";
+const STORY_REVIEW_TABLE = "zh_CN/gamedata/excel/story_review_table.json";
+
+function storyZipPath(storyKey: string): string {
+  return `zh_CN/gamedata/story/${storyKey}.json`;
+}
+
+// entryType → category filter mapping (mirrors Python _CATEGORY_MAP)
+const CATEGORY_MAP: Record<string, string[]> = {
+  main: ["MAINLINE"],
+  activities: ["ACTIVITY", "MINI_ACTIVITY"],
+};
+
+// ---------------------------------------------------------------------------
+// Text cleaning
+// ---------------------------------------------------------------------------
+
+const RICH_TAG_RE = /<[^>]+>/g;
+
+function cleanText(text: string): string {
+  return text.replace(/\{@nickname\}/g, "博士").replace(RICH_TAG_RE, "").trim();
+}
+
+// ---------------------------------------------------------------------------
+// JSON shape types (only fields we use)
+// ---------------------------------------------------------------------------
+
+interface RawStoryItem {
+  prop?: string;
+  attributes?: Record<string, unknown>;
+}
+
+interface RawStoryChapter {
+  storyCode?: string;
+  storyName?: string;
+  avgTag?: string | null;
+  eventName?: string;
+  storyInfo?: string;
+  storyList?: RawStoryItem[];
+}
+
+interface RawInfoUnlockData {
+  storyTxt?: string;
+  storyCode?: string;
+  storyName?: string;
+  avgTag?: string | null;
+  storySort?: number;
+}
+
+interface RawReviewEntry {
+  id?: string;
+  name?: string;
+  entryType?: string;
+  infoUnlockDatas?: RawInfoUnlockData[];
+}
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface StoryLine {
+  type: "dialog" | "narration" | "choice";
+  role: string | null;
+  text: string;
+}
+
+export interface StoryChapter {
+  storyKey: string;
+  storyCode: string;
+  storyName: string;
+  avgTag: string | null;
+  eventName: string;
+  storyInfo: string;
+  lines: StoryLine[];
+}
+
+export interface EventInfo {
+  eventId: string;
+  name: string;
+  entryType: string;
+  storyCount: number;
+}
+
+export interface ChapterSummary {
+  storyKey: string;
+  storyCode: string;
+  storyName: string;
+  avgTag: string | null;
+  sortOrder: number;
+}
+
+export interface ActivityResult {
+  eventId: string;
+  eventName: string;
+  totalChapters: number;
+  hasMore: boolean;
+  chapters: StoryChapter[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function readZipEntry(zip: AdmZip, path: string): string {
+  const entry = zip.getEntry(path);
+  if (!entry) throw new Error(`Entry not found in zip: ${path}`);
+  return entry.getData().toString("utf-8");
+}
+
+function parseJsonFromZip<T>(zip: AdmZip, path: string): T {
+  return JSON.parse(readZipEntry(zip, path)) as T;
+}
+
+function parseStoryList(
+  storyList: RawStoryItem[],
+  includeNarration: boolean
+): StoryLine[] {
+  const lines: StoryLine[] = [];
+  for (const item of storyList) {
+    const prop = (item.prop ?? "").toLowerCase();
+    const attrs = (item.attributes ?? {}) as Record<string, unknown>;
+
+    if (prop === "name") {
+      const name = String(attrs["name"] ?? "");
+      const content = String(attrs["content"] ?? "");
+      if (content) {
+        lines.push({
+          type: "dialog",
+          role: name ? cleanText(name) : null,
+          text: cleanText(content),
+        });
+      }
+    } else if (
+      includeNarration &&
+      (prop === "sticker" || prop === "subtitle" || prop === "animtext")
+    ) {
+      // Sticker uses "text" OR "content" field — check both (see porting guide §4.2)
+      const content = String(attrs["content"] ?? attrs["text"] ?? "");
+      if (content) {
+        lines.push({ type: "narration", role: null, text: cleanText(content) });
+      }
+    } else if (prop === "decision") {
+      const options = attrs["options"];
+      if (Array.isArray(options)) {
+        for (const opt of options) {
+          let text = "";
+          if (typeof opt === "string") text = opt;
+          else if (opt !== null && typeof opt === "object") {
+            text = String((opt as Record<string, unknown>)["text"] ?? "");
+          }
+          if (text) {
+            lines.push({ type: "choice", role: null, text: cleanText(text) });
+          }
+        }
+      }
+    }
+    // All other props (Dialog, Background, PlayMusic, etc.) are skipped.
+  }
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Return a list of events from story_review_table.json.
+ *
+ * @param zipPath  Absolute path to zh_CN.zip.
+ * @param category Optional filter — "main" or "activities".
+ */
+export function listStoryEvents(
+  zipPath: string,
+  category?: string
+): EventInfo[] {
+  const allowedTypes = category ? (CATEGORY_MAP[category] ?? null) : null;
+  const zip = new AdmZip(zipPath);
+  const table = parseJsonFromZip<Record<string, RawReviewEntry>>(
+    zip,
+    STORY_REVIEW_TABLE
+  );
+
+  const events: EventInfo[] = [];
+  for (const [eventId, entry] of Object.entries(table)) {
+    const entryType = entry.entryType ?? "NONE";
+    if (allowedTypes !== null && !allowedTypes.includes(entryType)) continue;
+    events.push({
+      eventId,
+      name: entry.name ?? eventId,
+      entryType,
+      storyCount: (entry.infoUnlockDatas ?? []).length,
+    });
+  }
+  return events;
+}
+
+/**
+ * Return ordered chapter list for an event.
+ *
+ * @param zipPath  Absolute path to zh_CN.zip.
+ * @param eventId  Event key, e.g. "act31side".
+ * @throws Error if eventId is not found in story_review_table.
+ */
+export function listStories(
+  zipPath: string,
+  eventId: string
+): ChapterSummary[] {
+  const zip = new AdmZip(zipPath);
+  const table = parseJsonFromZip<Record<string, RawReviewEntry>>(
+    zip,
+    STORY_REVIEW_TABLE
+  );
+
+  const entry = table[eventId];
+  if (!entry) throw new Error(`Event not found: "${eventId}"`);
+
+  const datas = (entry.infoUnlockDatas ?? []).slice();
+  datas.sort((a, b) => (a.storySort ?? 0) - (b.storySort ?? 0));
+
+  const chapters: ChapterSummary[] = [];
+  for (const d of datas) {
+    if (!d.storyTxt) continue;
+    chapters.push({
+      storyKey: d.storyTxt,
+      storyCode: d.storyCode ?? "",
+      storyName: d.storyName ?? "",
+      avgTag: d.avgTag ?? null,
+      sortOrder: d.storySort ?? 0,
+    });
+  }
+  return chapters;
+}
+
+/**
+ * Read and parse a single story chapter from the zip.
+ *
+ * @param zipPath         Absolute path to zh_CN.zip.
+ * @param storyKey        Story key from storyTxt / storyinfo.json.
+ * @param includeNarration Whether to include narration/scene lines (default true).
+ * @throws Error if the story file is not found in the zip.
+ */
+export function readStory(
+  zipPath: string,
+  storyKey: string,
+  includeNarration = true
+): StoryChapter {
+  const innerPath = storyZipPath(storyKey);
+  const zip = new AdmZip(zipPath);
+  const raw = parseJsonFromZip<RawStoryChapter>(zip, innerPath);
+
+  const lines = parseStoryList(raw.storyList ?? [], includeNarration);
+
+  return {
+    storyKey,
+    storyCode: raw.storyCode ?? "",
+    storyName: raw.storyName ?? "",
+    avgTag: raw.avgTag ?? null,
+    eventName: raw.eventName ?? "",
+    storyInfo: raw.storyInfo ?? "",
+    lines,
+  };
+}
+
+/**
+ * Read all chapters of an activity in official story order.
+ *
+ * @param zipPath         Absolute path to zh_CN.zip.
+ * @param eventId         Event key, e.g. "act31side".
+ * @param includeNarration Whether to include narration lines (default true).
+ * @param page            1-based page index. undefined = return all chapters.
+ * @param pageSize        Chapters per page when page is set (default 5).
+ * @throws Error if eventId is not found.
+ */
+export function readActivity(
+  zipPath: string,
+  eventId: string,
+  includeNarration = true,
+  page?: number,
+  pageSize = 5
+): ActivityResult {
+  const summaries = listStories(zipPath, eventId);
+  const total = summaries.length;
+
+  let selected: ChapterSummary[];
+  let hasMore: boolean;
+  if (page !== undefined) {
+    const start = (page - 1) * pageSize;
+    const end = start + pageSize;
+    selected = summaries.slice(start, end);
+    hasMore = end < total;
+  } else {
+    selected = summaries;
+    hasMore = false;
+  }
+
+  const chapters: StoryChapter[] = [];
+  let eventName = "";
+  for (const summary of selected) {
+    try {
+      const chapter = readStory(zipPath, summary.storyKey, includeNarration);
+      if (!eventName) eventName = chapter.eventName;
+      chapters.push(chapter);
+    } catch {
+      // Story file missing from zip — skip silently (see porting guide §10)
+    }
+  }
+
+  return { eventId, eventName, totalChapters: total, hasMore, chapters };
+}

--- a/ts/src/data/story.ts
+++ b/ts/src/data/story.ts
@@ -16,7 +16,6 @@ import AdmZip from "adm-zip";
 // Zip path constants
 // ---------------------------------------------------------------------------
 
-const STORYINFO = "zh_CN/storyinfo.json";
 const STORY_REVIEW_TABLE = "zh_CN/gamedata/excel/story_review_table.json";
 
 function storyZipPath(storyKey: string): string {

--- a/ts/src/data/sync.ts
+++ b/ts/src/data/sync.ts
@@ -282,3 +282,163 @@ export async function syncAll(specs: RepoSpec[]): Promise<SyncResult[]> {
   }
   return results;
 }
+
+// ---------------------------------------------------------------------------
+// Release-based sync (for zh_CN.zip from GitHub Releases)
+// ---------------------------------------------------------------------------
+
+const GITHUB_RELEASES_LATEST_URL =
+  "https://api.github.com/repos/{owner}/{repo}/releases/latest";
+const TAG_PREFIX = "upstream-";
+
+/** Describes a GitHub Release asset to download as a local zip. */
+export interface ReleaseSpec {
+  owner: string;
+  repo: string;
+  /** Asset filename in the release, e.g. "zh_CN.zip". */
+  assetName: string;
+  /** Absolute destination path for the downloaded zip. */
+  localZip: string;
+}
+
+function releaseCachePath(spec: ReleaseSpec): string {
+  return join(dirname(spec.localZip), "release_meta.json");
+}
+
+async function loadReleaseMeta(spec: ReleaseSpec): Promise<CacheMeta | null> {
+  try {
+    const text = await readFile(releaseCachePath(spec), "utf-8");
+    return JSON.parse(text) as CacheMeta;
+  } catch {
+    return null;
+  }
+}
+
+async function saveReleaseMeta(
+  spec: ReleaseSpec,
+  meta: CacheMeta
+): Promise<void> {
+  const p = releaseCachePath(spec);
+  await mkdir(dirname(p), { recursive: true });
+  await writeFile(p, JSON.stringify(meta, null, 2), "utf-8");
+}
+
+/**
+ * Fetch the latest release tag and asset download URL.
+ * Returns null on any network or API failure.
+ */
+export async function checkLatestRelease(
+  spec: ReleaseSpec,
+  timeoutMs = 10_000
+): Promise<{ tag: string; url: string } | null> {
+  const url = GITHUB_RELEASES_LATEST_URL.replace("{owner}", spec.owner).replace(
+    "{repo}",
+    spec.repo
+  );
+  try {
+    const res = await fetch(url, {
+      headers: githubHeaders(),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = (await res.json()) as {
+      tag_name: string;
+      assets: Array<{ name: string; browser_download_url: string }>;
+    };
+    const asset = data.assets.find((a) => a.name === spec.assetName);
+    if (!asset) return null;
+    return { tag: data.tag_name, url: asset.browser_download_url };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Download the release asset zip atomically, then write cache metadata.
+ * Uses write-to-tmp-then-rename for crash safety.
+ */
+export async function downloadReleaseAsset(
+  spec: ReleaseSpec,
+  tag: string,
+  assetUrl: string,
+  timeoutMs = 120_000
+): Promise<void> {
+  const tmp = spec.localZip + ".tmp";
+  await mkdir(dirname(spec.localZip), { recursive: true });
+  try {
+    const res = await fetch(assetUrl, {
+      headers: githubHeaders(),
+      redirect: "follow",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status} downloading ${spec.assetName}`);
+    await writeFile(tmp, Buffer.from(await res.arrayBuffer()));
+    await rename(tmp, spec.localZip);
+
+    const commitSha = tag.startsWith(TAG_PREFIX) ? tag.slice(TAG_PREFIX.length) : tag;
+    await saveReleaseMeta(spec, {
+      repo: `${spec.owner}/${spec.repo}`,
+      branch: "releases",
+      commitSha,
+      fetchedAt: new Date().toISOString(),
+      files: [spec.assetName],
+    });
+  } catch (err) {
+    try { await unlink(tmp); } catch { /* best-effort */ }
+    throw err;
+  }
+}
+
+/**
+ * Check latest GitHub Release and download the zip if the tag has changed.
+ *
+ * Decision tree mirrors syncRepo:
+ *   1. Cache is fresh AND zip exists → up_to_date (skip API call)
+ *   2. Network failure → offline_fallback / no_data
+ *   3. Tag unchanged AND zip exists → up_to_date (refresh fetchedAt)
+ *   4. Tag changed or zip missing → downloadReleaseAsset → updated / fallback
+ */
+export async function syncRelease(spec: ReleaseSpec): Promise<SyncResult> {
+  // Use a dummy RepoSpec so the result shape is compatible with syncAll logging.
+  const dummySpec: RepoSpec = {
+    owner: spec.owner,
+    repo: spec.repo,
+    branch: "releases",
+    files: [spec.assetName],
+    localRoot: dirname(spec.localZip),
+  };
+
+  const cache = await loadReleaseMeta(spec);
+  const zipOk = existsSync(spec.localZip);
+
+  if (cache !== null && zipOk && cacheIsFresh(cache)) {
+    return { spec: dummySpec, status: "up_to_date", commitSha: cache.commitSha, error: null };
+  }
+
+  const latest = await checkLatestRelease(spec);
+
+  if (latest === null) {
+    return zipOk
+      ? { spec: dummySpec, status: "offline_fallback", commitSha: cache?.commitSha ?? null, error: "Network unavailable" }
+      : { spec: dummySpec, status: "no_data", commitSha: null, error: "Network unavailable and no cached zip" };
+  }
+
+  const commitSha = latest.tag.startsWith(TAG_PREFIX)
+    ? latest.tag.slice(TAG_PREFIX.length)
+    : latest.tag;
+
+  if (cache !== null && cache.commitSha === commitSha && zipOk) {
+    await saveReleaseMeta(spec, { ...cache, fetchedAt: new Date().toISOString() });
+    return { spec: dummySpec, status: "up_to_date", commitSha, error: null };
+  }
+
+  try {
+    await downloadReleaseAsset(spec, latest.tag, latest.url);
+    return { spec: dummySpec, status: "updated", commitSha, error: null };
+  } catch (err) {
+    const error = errorMessage(err);
+    return zipOk
+      ? { spec: dummySpec, status: "offline_fallback", commitSha: cache?.commitSha ?? null, error }
+      : { spec: dummySpec, status: "no_data", commitSha: null, error };
+  }
+}

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -5,7 +5,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
 
-import { loadConfig, hasOperatorData, hasStoryData } from "./config.js";
+import { loadConfig, hasStoryData } from "./config.js";
 import { searchPrts, readPage } from "./api/prtsWiki.js";
 import { getOperatorArchives, getOperatorVoicelines, getOperatorBasicInfo } from "./data/operator.js";
 import { syncAll, syncRelease, GAMEDATA_FILES, type RepoSpec, type ReleaseSpec } from "./data/sync.js";
@@ -33,7 +33,7 @@ function log(level: "INFO" | "WARN" | "ERROR", msg: string): void {
 
 function formatLine(line: StoryLine): string {
   if (line.type === "dialog") {
-    return `${line.role ?? ""}：${line.text}`;
+    return `${line.role ?? "（旁白）"}：${line.text}`;
   } else if (line.type === "narration") {
     return `*${line.text}*`;
   } else {

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -5,10 +5,18 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { z } from "zod";
 
-import { loadConfig } from "./config.js";
+import { loadConfig, hasOperatorData, hasStoryData } from "./config.js";
 import { searchPrts, readPage } from "./api/prtsWiki.js";
 import { getOperatorArchives, getOperatorVoicelines, getOperatorBasicInfo } from "./data/operator.js";
-import { syncAll, GAMEDATA_FILES, type RepoSpec } from "./data/sync.js";
+import { syncAll, syncRelease, GAMEDATA_FILES, type RepoSpec, type ReleaseSpec } from "./data/sync.js";
+import {
+  listStoryEvents as _listStoryEvents,
+  listStories as _listStories,
+  readStory as _readStory,
+  readActivity as _readActivity,
+  type StoryChapter,
+  type StoryLine,
+} from "./data/story.js";
 
 // ---------------------------------------------------------------------------
 // Logging
@@ -17,6 +25,42 @@ import { syncAll, GAMEDATA_FILES, type RepoSpec } from "./data/sync.js";
 function log(level: "INFO" | "WARN" | "ERROR", msg: string): void {
   const ts = new Date().toISOString();
   process.stderr.write(`${ts} ${level} prts_mcp.server: ${msg}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// Story formatting helpers
+// ---------------------------------------------------------------------------
+
+function formatLine(line: StoryLine): string {
+  if (line.type === "dialog") {
+    return `${line.role ?? ""}：${line.text}`;
+  } else if (line.type === "narration") {
+    return `*${line.text}*`;
+  } else {
+    return `【选项】${line.text}`;
+  }
+}
+
+function formatChapter(chapter: StoryChapter): string {
+  const parts: string[] = [];
+  parts.push(`【${chapter.eventName}】${chapter.storyName}`);
+  if (chapter.storyInfo) parts.push(`简介：${chapter.storyInfo}\n`);
+  for (const line of chapter.lines) {
+    parts.push(formatLine(line));
+  }
+  return parts.join("\n");
+}
+
+function requireStoryZip(): string {
+  const cfg = loadConfig();
+  if (!hasStoryData(cfg)) {
+    throw new Error(
+      "剧情数据暂不可用。容器启动时的 auto-sync 可能仍在进行中，请稍后重试；" +
+        "若持续出现此提示，请检查网络连接，或提供 STORYJSON_PATH 指向本地 zh_CN.zip。" +
+        `（当前同步目标路径：${cfg.storyjsonZip}）`
+    );
+  }
+  return cfg.effectiveStoryjsonZip!;
 }
 
 // ---------------------------------------------------------------------------
@@ -85,6 +129,195 @@ function createMcpServer(): McpServer {
     }
   );
 
+  // -------------------------------------------------------------------------
+  // Story tools
+  // -------------------------------------------------------------------------
+
+  server.tool(
+    "list_story_events",
+    [
+      "列出明日方舟剧情活动列表。",
+      "category 可选过滤：\"main\"（主线）或 \"activities\"（活动 + 插曲）。",
+      "不传 category 则返回全部条目。",
+      "返回格式：每行 - [类型] 活动ID：名称（N 章）",
+      "获取活动 ID 后，可调用 list_stories 查看该活动的章节列表。",
+    ].join(" "),
+    { category: z.string().optional() },
+    ({ category }) => {
+      let zipPath: string;
+      try {
+        zipPath = requireStoryZip();
+      } catch (e) {
+        return { content: [{ type: "text", text: (e as Error).message }] };
+      }
+      try {
+        const events = _listStoryEvents(zipPath, category);
+        if (events.length === 0) {
+          return { content: [{ type: "text", text: "未找到匹配的活动。" }] };
+        }
+        const lines = events.map(
+          (ev) => `- [${ev.entryType}] ${ev.eventId}：${ev.name}（${ev.storyCount} 章）`
+        );
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (e) {
+        return { content: [{ type: "text", text: `读取剧情数据失败：${(e as Error).message}` }] };
+      }
+    }
+  );
+
+  server.tool(
+    "list_stories",
+    [
+      "列出指定活动的所有章节，按官方顺序排列。",
+      "event_id 为活动 ID（可从 list_story_events 获取，如 \"act31side\"）。",
+      "返回格式：每行 - 关卡代码 [标签] 章节名（key: 章节key）",
+      "获取章节 key 后，可调用 read_story 阅读具体章节内容。",
+    ].join(" "),
+    { event_id: z.string() },
+    ({ event_id }) => {
+      let zipPath: string;
+      try {
+        zipPath = requireStoryZip();
+      } catch (e) {
+        return { content: [{ type: "text", text: (e as Error).message }] };
+      }
+      try {
+        const chapters = _listStories(zipPath, event_id);
+        if (chapters.length === 0) {
+          return { content: [{ type: "text", text: `活动 "${event_id}" 没有章节数据。` }] };
+        }
+        const lines = chapters.map((ch) => {
+          const tag = ch.avgTag ? `[${ch.avgTag}] ` : "";
+          return `- ${ch.storyCode} ${tag}${ch.storyName}（key: ${ch.storyKey}）`;
+        });
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (e) {
+        const msg = (e as Error).message;
+        if (msg.includes("not found")) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `未找到活动："${event_id}"。请先调用 list_story_events 确认活动 ID。`,
+              },
+            ],
+          };
+        }
+        return { content: [{ type: "text", text: `读取章节列表失败：${msg}` }] };
+      }
+    }
+  );
+
+  server.tool(
+    "read_story",
+    [
+      "阅读指定章节的完整剧情内容。",
+      "story_key 为章节 key（可从 list_stories 获取，如 \"activities/act31side/level_act31side_01_beg\"）。",
+      "include_narration 控制是否包含旁白/场景描述（默认 true）。",
+    ].join(" "),
+    {
+      story_key: z.string(),
+      include_narration: z.boolean().default(true),
+    },
+    ({ story_key, include_narration }) => {
+      let zipPath: string;
+      try {
+        zipPath = requireStoryZip();
+      } catch (e) {
+        return { content: [{ type: "text", text: (e as Error).message }] };
+      }
+      try {
+        const chapter = _readStory(zipPath, story_key, include_narration);
+        return { content: [{ type: "text", text: formatChapter(chapter) }] };
+      } catch (e) {
+        const msg = (e as Error).message;
+        if (msg.includes("not found") || msg.includes("Entry not found")) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `未找到剧情："${story_key}"。请通过 list_stories 确认章节 key。`,
+              },
+            ],
+          };
+        }
+        return { content: [{ type: "text", text: `读取剧情失败：${msg}` }] };
+      }
+    }
+  );
+
+  server.tool(
+    "read_activity",
+    [
+      "阅读指定活动的完整剧情（按官方顺序，合并所有章节）。",
+      "event_id 为活动 ID（可从 list_story_events 获取）。",
+      "include_narration 控制是否包含旁白（默认 true）。",
+      "page 为章节分页（从 1 开始），不传则返回全部章节。",
+      "page_size 控制每页章节数（默认 5）。",
+      "返回内容含 total_chapters 和 has_more，便于判断是否还有后续内容。",
+    ].join(" "),
+    {
+      event_id: z.string(),
+      include_narration: z.boolean().default(true),
+      page: z.number().int().min(1).optional(),
+      page_size: z.number().int().min(1).max(20).default(5),
+    },
+    ({ event_id, include_narration, page, page_size }) => {
+      let zipPath: string;
+      try {
+        zipPath = requireStoryZip();
+      } catch (e) {
+        return { content: [{ type: "text", text: (e as Error).message }] };
+      }
+      try {
+        const result = _readActivity(
+          zipPath,
+          event_id,
+          include_narration,
+          page,
+          page_size
+        );
+        const parts: string[] = [];
+        if (result.eventName) {
+          parts.push(
+            `# ${result.eventName}（共 ${result.totalChapters} 章${result.hasMore ? "，当前为部分内容" : ""}）`
+          );
+        }
+        for (const chapter of result.chapters) {
+          const tag = chapter.avgTag ? ` [${chapter.avgTag}]` : "";
+          parts.push(`\n=== ${chapter.storyCode}${tag} ${chapter.storyName} ===`);
+          if (chapter.storyInfo) parts.push(`简介：${chapter.storyInfo}`);
+          for (const line of chapter.lines) {
+            parts.push(formatLine(line));
+          }
+        }
+        if (result.chapters.length === 0) {
+          parts.push("该活动暂无可读取的章节数据。");
+        }
+        if (result.hasMore) {
+          const nextPage = (page ?? 1) + 1;
+          parts.push(
+            `\n[还有更多章节，请调用 read_activity(event_id="${event_id}", page=${nextPage})]`
+          );
+        }
+        return { content: [{ type: "text", text: parts.join("\n") }] };
+      } catch (e) {
+        const msg = (e as Error).message;
+        if (msg.includes("not found")) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `未找到活动："${event_id}"。请先调用 list_story_events 确认活动 ID。`,
+              },
+            ],
+          };
+        }
+        return { content: [{ type: "text", text: `读取活动剧情失败：${msg}` }] };
+      }
+    }
+  );
+
   return server;
 }
 
@@ -94,39 +327,69 @@ function createMcpServer(): McpServer {
 
 function runStartupSync(): void {
   const cfg = loadConfig();
+
+  // Gamedata sync
   if (cfg.isCustomGamedata) {
     log("INFO", `GAMEDATA_PATH is custom (${cfg.gamedataPath}); auto-sync disabled.`);
-    return;
+  } else {
+    const specs: RepoSpec[] = [
+      {
+        owner: "Kengxxiao",
+        repo: "ArknightsGameData",
+        branch: "master",
+        files: GAMEDATA_FILES,
+        localRoot: cfg.gamedataPath,
+      },
+    ];
+
+    syncAll(specs)
+      .then((results) => {
+        for (const r of results) {
+          const sha = r.commitSha ? r.commitSha.slice(0, 8) : "unknown";
+          if (r.status === "updated") {
+            log("INFO", `Data updated from GitHub (${r.spec.repo} @ ${sha}).`);
+          } else if (r.status === "up_to_date") {
+            log("INFO", `Data is up to date (${r.spec.repo} @ ${sha}).`);
+          } else if (r.status === "offline_fallback") {
+            log("WARN", `Network unavailable; using cached data (${r.spec.repo} @ ${sha}). Error: ${r.error}`);
+          } else {
+            log("ERROR", `Sync failed for ${r.spec.repo} — no data. Error: ${r.error}`);
+          }
+        }
+      })
+      .catch((err: unknown) => {
+        log("ERROR", `Startup sync threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`);
+      });
   }
 
-  const specs: RepoSpec[] = [
-    {
-      owner: "Kengxxiao",
-      repo: "ArknightsGameData",
-      branch: "master",
-      files: GAMEDATA_FILES,
-      localRoot: cfg.gamedataPath,
-    },
-  ];
+  // Storyjson release sync (always attempt unless user supplied STORYJSON_PATH)
+  if (!process.env["STORYJSON_PATH"]) {
+    const releaseSpec: ReleaseSpec = {
+      owner: "3aKHP",
+      repo: "ArknightsStoryJson",
+      assetName: "zh_CN.zip",
+      localZip: cfg.storyjsonZip,
+    };
 
-  syncAll(specs)
-    .then((results) => {
-      for (const r of results) {
+    syncRelease(releaseSpec)
+      .then((r) => {
         const sha = r.commitSha ? r.commitSha.slice(0, 8) : "unknown";
         if (r.status === "updated") {
-          log("INFO", `Data updated from GitHub (${r.spec.repo} @ ${sha}).`);
+          log("INFO", `Storyjson updated from GitHub Release (${r.spec.repo} @ ${sha}).`);
         } else if (r.status === "up_to_date") {
-          log("INFO", `Data is up to date (${r.spec.repo} @ ${sha}).`);
+          log("INFO", `Storyjson is up to date (${r.spec.repo} @ ${sha}).`);
         } else if (r.status === "offline_fallback") {
-          log("WARN", `Network unavailable; using cached data (${r.spec.repo} @ ${sha}). Error: ${r.error}`);
+          log("WARN", `Network unavailable; using cached storyjson (${r.spec.repo} @ ${sha}). Error: ${r.error}`);
         } else {
-          log("ERROR", `Sync failed for ${r.spec.repo} — no data. Error: ${r.error}`);
+          log("ERROR", `Storyjson sync failed for ${r.spec.repo} — no zip. Error: ${r.error}`);
         }
-      }
-    })
-    .catch((err: unknown) => {
-      log("ERROR", `Startup sync threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`);
-    });
+      })
+      .catch((err: unknown) => {
+        log("ERROR", `Storyjson sync threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`);
+      });
+  } else {
+    log("INFO", `STORYJSON_PATH is set (${process.env["STORYJSON_PATH"]}); story auto-sync disabled.`);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -7,7 +7,7 @@ import { z } from "zod";
 
 import { loadConfig } from "./config.js";
 import { searchPrts, readPage } from "./api/prtsWiki.js";
-import { getOperatorArchives, getOperatorVoicelines } from "./data/operator.js";
+import { getOperatorArchives, getOperatorVoicelines, getOperatorBasicInfo } from "./data/operator.js";
 import { syncAll, GAMEDATA_FILES, type RepoSpec } from "./data/sync.js";
 
 // ---------------------------------------------------------------------------
@@ -71,6 +71,16 @@ function createMcpServer(): McpServer {
     { operator_name: z.string() },
     ({ operator_name }) => {
       const text = getOperatorVoicelines(operator_name);
+      return { content: [{ type: "text", text }] };
+    }
+  );
+
+  server.tool(
+    "get_operator_basic_info",
+    '获取指定干员的基本信息：职业、稀有度、所属、招募标签、天赋等（使用游戏内中文名，如"阿米娅"）。',
+    { operator_name: z.string() },
+    ({ operator_name }) => {
+      const text = getOperatorBasicInfo(operator_name);
       return { content: [{ type: "text", text }] };
     }
   );

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -70,7 +70,7 @@ function requireStoryZip(): string {
 function createMcpServer(): McpServer {
   const server = new McpServer({
     name: "PRTS_Wiki_Assistant",
-    version: "0.1.0",
+    version: "0.2.0",
   });
 
   server.tool(

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -148,7 +148,7 @@ function createMcpServer(): McpServer {
       try {
         zipPath = requireStoryZip();
       } catch (e) {
-        return { content: [{ type: "text", text: (e as Error).message }] };
+        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
       }
       try {
         const events = _listStoryEvents(zipPath, category);
@@ -160,7 +160,7 @@ function createMcpServer(): McpServer {
         );
         return { content: [{ type: "text", text: lines.join("\n") }] };
       } catch (e) {
-        return { content: [{ type: "text", text: `读取剧情数据失败：${(e as Error).message}` }] };
+        return { content: [{ type: "text", text: `读取剧情数据失败：${e instanceof Error ? e.message : String(e)}` }] };
       }
     }
   );
@@ -179,7 +179,7 @@ function createMcpServer(): McpServer {
       try {
         zipPath = requireStoryZip();
       } catch (e) {
-        return { content: [{ type: "text", text: (e as Error).message }] };
+        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
       }
       try {
         const chapters = _listStories(zipPath, event_id);
@@ -192,7 +192,7 @@ function createMcpServer(): McpServer {
         });
         return { content: [{ type: "text", text: lines.join("\n") }] };
       } catch (e) {
-        const msg = (e as Error).message;
+        const msg = e instanceof Error ? e.message : String(e);
         if (msg.includes("not found")) {
           return {
             content: [
@@ -224,13 +224,13 @@ function createMcpServer(): McpServer {
       try {
         zipPath = requireStoryZip();
       } catch (e) {
-        return { content: [{ type: "text", text: (e as Error).message }] };
+        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
       }
       try {
         const chapter = _readStory(zipPath, story_key, include_narration);
         return { content: [{ type: "text", text: formatChapter(chapter) }] };
       } catch (e) {
-        const msg = (e as Error).message;
+        const msg = e instanceof Error ? e.message : String(e);
         if (msg.includes("not found") || msg.includes("Entry not found")) {
           return {
             content: [
@@ -267,7 +267,7 @@ function createMcpServer(): McpServer {
       try {
         zipPath = requireStoryZip();
       } catch (e) {
-        return { content: [{ type: "text", text: (e as Error).message }] };
+        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
       }
       try {
         const result = _readActivity(
@@ -302,7 +302,7 @@ function createMcpServer(): McpServer {
         }
         return { content: [{ type: "text", text: parts.join("\n") }] };
       } catch (e) {
-        const msg = (e as Error).message;
+        const msg = e instanceof Error ? e.message : String(e);
         if (msg.includes("not found")) {
           return {
             content: [


### PR DESCRIPTION
## Summary

TypeScript port of the story feature introduced in #3, maintaining full behavioral parity with the Python implementation.

- **4 new MCP tools** (same interface as Python):
  - `list_story_events(category?)` — event list with optional filter (`main` / `activities`)
  - `list_stories(event_id)` — ordered chapter list for an event
  - `read_story(story_key, include_narration)` — full dialogue for a single chapter
  - `read_activity(event_id, include_narration, page, page_size)` — merged full-activity transcript with pagination

- **`data/story.ts`** (new): reads from `zh_CN.zip` via `adm-zip`; prop parsing with case-insensitive matching; `Sticker`/`sticker` dual-field (`content`/`text`) handling; `{@nickname}` → 博士 + rich-tag stripping

- **`data/sync.ts`**: `ReleaseSpec` interface + `syncRelease()` / `checkLatestRelease()` / `downloadReleaseAsset()` — downloads `zh_CN.zip` from GitHub Releases, same `upstream-{sha}` tag logic as Python

- **`config.ts`**: `storyjsonZip` / `effectiveStoryjsonZip` / `hasStoryData()` — path priority `STORYJSON_PATH` → Docker volume → bundled; `story_review_table.json` added to `REQUIRED_OPERATOR_FILES`

- **`server.ts`**: registers 4 story tools; runs `syncRelease()` fire-and-forget at startup; skips sync when `STORYJSON_PATH` is explicitly set

- **Version bump**: `0.1.0 → 0.2.0`

- **Dependency**: `adm-zip ^0.5.16` + `@types/adm-zip ^0.5.7`

## Test plan

- [ ] `tsc --noEmit` passes (zero type errors)
- [ ] `npm run build` succeeds
- [ ] Chatbox end-to-end (StreamableHTTP `http://localhost:3000/mcp`):
  - `list_story_events` with and without category filter ✅
  - `list_stories(act31side)` returns ordered chapter list ✅
  - `read_story` returns formatted dialogue with narration ✅
  - `read_story` with `include_narration=false` omits narration lines ✅
  - `read_activity` with pagination returns `has_more` correctly ✅
  - Invalid event_id returns Chinese error message ✅