### PR TITLE
docs(tools): improve tool descriptions and add parameter-level descriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ prts-mcp.tar
 # TypeScript / Node
 ts/node_modules/
 ts/dist/
+ts/*.tgz
 
 # TS npm bundled data — directories tracked, content downloaded by CI at publish time
 ts/data/*

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -6,9 +6,10 @@ import sys
 import threading
 from pathlib import Path
 
+from typing import Annotated
+
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
-from typing import Annotated
 
 from prts_mcp.api.prts_wiki import search_prts as _search_prts, read_page as _read_page
 from prts_mcp.data.operator import (
@@ -229,7 +230,8 @@ def read_activity(
 
     适合需要了解完整活动故事的场景。返回各章节台词的合并文本，格式与
     read_story 一致，章节间以分隔标题区分。单次活动文本量可能较大，建议
-    使用 page 参数分批获取；返回结果会提示是否还有更多页。
+    使用 page 参数分批获取；返回结果末尾会附上 total_chapters 和 has_more
+    字段，便于判断是否还有后续内容。
     """
     from prts_mcp.config import Config
     cfg = Config.load()

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -7,6 +7,8 @@ import threading
 from pathlib import Path
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field
+from typing import Annotated
 
 from prts_mcp.api.prts_wiki import search_prts as _search_prts, read_page as _read_page
 from prts_mcp.data.operator import (
@@ -32,16 +34,15 @@ mcp = FastMCP("PRTS_Wiki_Assistant")
 
 
 @mcp.tool()
-async def search_prts(query: str, limit: int = 5) -> str:
+async def search_prts(
+    query: Annotated[str, Field(description="搜索关键词，支持中文，如「罗德岛」、「整合运动」。")],
+    limit: Annotated[int, Field(default=5, description="返回结果数量上限，默认 5，最大建议不超过 10。")] = 5,
+) -> str:
     """搜索 PRTS 明日方舟中文维基词条。
 
     返回匹配词条的标题和简短摘要列表。这是探索维基的第一步：当需要查找
     不确定的专有名词、干员、关卡或世界观设定时，先用此工具搜索获取准确
     标题，再将标题传入 read_prts_page 获取完整内容。
-
-    Args:
-        query: 搜索关键词，支持中文，如"罗德岛"、"整合运动"。
-        limit: 返回结果数量上限，默认 5，最大建议不超过 10。
     """
     results = await _search_prts(query, limit)
     if not results:
@@ -53,58 +54,53 @@ async def search_prts(query: str, limit: int = 5) -> str:
 
 
 @mcp.tool()
-async def read_prts_page(page_title: str) -> str:
+async def read_prts_page(
+    page_title: Annotated[str, Field(description="词条标题，需与维基页面标题完全一致，如「阿米娅」、「整合运动」。建议通过 search_prts 获取准确标题后再传入。")],
+) -> str:
     """读取 PRTS 维基指定词条的纯文本内容。
 
     返回该词条经过清洗的纯文本，已去除 Wikitext 模板、文件链接和 HTML 标签，
     内容可能较长。强烈建议先调用 search_prts 确认词条的准确标题，避免因
     拼写错误导致读取失败。
-
-    Args:
-        page_title: 词条标题，需与维基页面标题完全一致，如"阿米娅"、"整合运动"。
-                    建议通过 search_prts 获取准确标题后再传入。
     """
     return await _read_page(page_title)
 
 
 @mcp.tool()
-async def get_operator_archives(operator_name: str) -> str:
+async def get_operator_archives(
+    operator_name: Annotated[str, Field(description="干员的游戏内中文名，如「阿米娅」、「能天使」。")],
+) -> str:
     """获取指定干员的档案资料。
 
     返回干员的客观履历、个人档案（基础档案及解锁档案）等背景故事文本。
     若需查询干员的职业、稀有度等数值信息，请使用 get_operator_basic_info；
     若需查询语音台词，请使用 get_operator_voicelines。
-
-    Args:
-        operator_name: 干员的游戏内中文名，如"阿米娅"、"能天使"。
     """
     return _get_archives(operator_name)
 
 
 @mcp.tool()
-async def get_operator_voicelines(operator_name: str) -> str:
+async def get_operator_voicelines(
+    operator_name: Annotated[str, Field(description="干员的游戏内中文名，如「阿米娅」、「能天使」。")],
+) -> str:
     """获取指定干员的所有语音台词记录。
 
-    返回包含触发条件（如"交谈1"、"晋升后交谈"、"信赖提升后交谈"）及对应
+    返回包含触发条件（如「交谈1」、「晋升后交谈」、「信赖提升后交谈」）及对应
     台词文本的完整列表。此工具仅返回语音文本；若需查询干员背景故事或客观
     履历，请使用 get_operator_archives。
-
-    Args:
-        operator_name: 干员的游戏内中文名，如"阿米娅"、"能天使"。
     """
     return _get_voicelines(operator_name)
 
 
 @mcp.tool()
-async def get_operator_basic_info(operator_name: str) -> str:
+async def get_operator_basic_info(
+    operator_name: Annotated[str, Field(description="干员的游戏内中文名，如「阿米娅」、「能天使」。")],
+) -> str:
     """获取指定干员的基本数值信息。
 
     返回干员的职业、子职业、稀有度（星级）、所属阵营、招募标签、天赋名称
     及描述等结构化信息。适合快速了解干员定位；若需完整背景故事请使用
     get_operator_archives，若需语音台词请使用 get_operator_voicelines。
-
-    Args:
-        operator_name: 干员的游戏内中文名，如"阿米娅"、"能天使"。
     """
     return _get_basic_info(operator_name)
 
@@ -120,15 +116,13 @@ def _require_story_zip(cfg: "Config") -> Path:
 
 
 @mcp.tool()
-def list_story_events(category: str | None = None) -> str:
+def list_story_events(
+    category: Annotated[str | None, Field(default=None, description="可选过滤分类。\"main\" = 主线章节，\"activities\" = 活动剧情（含联动）。不填则返回全部活动。")] = None,
+) -> str:
     """列出明日方舟剧情活动列表。
 
     返回格式：每行 `- [类型] 活动ID：名称（N 章）`，类型为 MAINLINE / ACTIVITY /
     MINI_ACTIVITY 之一。获取活动 ID 后，可调用 list_stories 查看该活动的章节列表。
-
-    Args:
-        category: 可选过滤分类。"main" = 主线章节，"activities" = 活动剧情（含联动）。
-                  不填则返回全部活动。建议先调用本工具了解活动全貌，再用 list_stories 查询具体章节。
     """
     from prts_mcp.config import Config
     cfg = Config.load()
@@ -152,15 +146,14 @@ def list_story_events(category: str | None = None) -> str:
 
 
 @mcp.tool()
-def list_stories(event_id: str) -> str:
+def list_stories(
+    event_id: Annotated[str, Field(description="活动 ID，如 \"act31side\"（可从 list_story_events 获取）。")],
+) -> str:
     """列出指定活动的所有剧情章节（按官方顺序排列）。
 
     返回格式：每行 `- 章节编号 [标签] 章节名（key: story_key）`，其中 story_key
     可直接传入 read_story 读取该章台词。如需一次性读取整个活动，可使用
     read_activity。
-
-    Args:
-        event_id: 活动 ID，如 "act31side"（可从 list_story_events 获取）。
     """
     from prts_mcp.config import Config
     cfg = Config.load()
@@ -187,16 +180,15 @@ def list_stories(event_id: str) -> str:
 
 
 @mcp.tool()
-def read_story(story_key: str, include_narration: bool = True) -> str:
+def read_story(
+    story_key: Annotated[str, Field(description="章节 key，如 \"activities/act31side/level_act31side_01_beg\"（可从 list_stories 获取）。")],
+    include_narration: Annotated[bool, Field(default=True, description="是否包含旁白和场景描述，默认 True。设为 False 可只保留对话台词。")] = True,
+) -> str:
     """读取单章剧情的完整台词。
 
     返回格式：首行为【活动名】章节名，随后按顺序输出对话（`角色：台词`）、
     旁白（`*旁白文本*`）和选项（`【选项】文本`）。story_key 可从 list_stories
     的返回结果中获取。
-
-    Args:
-        story_key: 章节 key，如 "activities/act31side/level_act31side_01_beg"（可从 list_stories 获取）。
-        include_narration: 是否包含旁白和场景描述，默认 True。设为 False 可只保留对话台词。
     """
     from prts_mcp.config import Config
     cfg = Config.load()
@@ -228,22 +220,16 @@ def read_story(story_key: str, include_narration: bool = True) -> str:
 
 @mcp.tool()
 def read_activity(
-    event_id: str,
-    include_narration: bool = True,
-    page: int | None = None,
-    page_size: int = 5,
+    event_id: Annotated[str, Field(description="活动 ID，如 \"act31side\"（可从 list_story_events 获取）。")],
+    include_narration: Annotated[bool, Field(default=True, description="是否包含旁白，默认 True。")] = True,
+    page: Annotated[int | None, Field(default=None, description="分页页码（从 1 开始）。不填则返回全部章节。")] = None,
+    page_size: Annotated[int, Field(default=5, description="每页章节数，默认 5。")] = 5,
 ) -> str:
     """读取整个活动的完整剧情台词（按官方章节顺序合并）。
 
     适合需要了解完整活动故事的场景。返回各章节台词的合并文本，格式与
     read_story 一致，章节间以分隔标题区分。单次活动文本量可能较大，建议
     使用 page 参数分批获取；返回结果会提示是否还有更多页。
-
-    Args:
-        event_id: 活动 ID，如 "act31side"。
-        include_narration: 是否包含旁白，默认 True。
-        page: 分页页码（从 1 开始）。不填则返回全部章节。
-        page_size: 每页章节数，默认 5。
     """
     from prts_mcp.config import Config
     cfg = Config.load()

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -33,7 +33,16 @@ mcp = FastMCP("PRTS_Wiki_Assistant")
 
 @mcp.tool()
 async def search_prts(query: str, limit: int = 5) -> str:
-    """搜索 PRTS 明日方舟中文维基词条。返回匹配的词条标题和摘要。"""
+    """搜索 PRTS 明日方舟中文维基词条。
+
+    返回匹配词条的标题和简短摘要列表。这是探索维基的第一步：当需要查找
+    不确定的专有名词、干员、关卡或世界观设定时，先用此工具搜索获取准确
+    标题，再将标题传入 read_prts_page 获取完整内容。
+
+    Args:
+        query: 搜索关键词，支持中文，如"罗德岛"、"整合运动"。
+        limit: 返回结果数量上限，默认 5，最大建议不超过 10。
+    """
     results = await _search_prts(query, limit)
     if not results:
         return f"未找到与 '{query}' 相关的词条。"
@@ -45,25 +54,58 @@ async def search_prts(query: str, limit: int = 5) -> str:
 
 @mcp.tool()
 async def read_prts_page(page_title: str) -> str:
-    """读取 PRTS 维基指定词条的纯文本内容。"""
+    """读取 PRTS 维基指定词条的纯文本内容。
+
+    返回该词条经过清洗的纯文本，已去除 Wikitext 模板、文件链接和 HTML 标签，
+    内容可能较长。强烈建议先调用 search_prts 确认词条的准确标题，避免因
+    拼写错误导致读取失败。
+
+    Args:
+        page_title: 词条标题，需与维基页面标题完全一致，如"阿米娅"、"整合运动"。
+                    建议通过 search_prts 获取准确标题后再传入。
+    """
     return await _read_page(page_title)
 
 
 @mcp.tool()
 async def get_operator_archives(operator_name: str) -> str:
-    """获取指定干员的档案资料（使用游戏内中文名，如"阿米娅"）。"""
+    """获取指定干员的档案资料。
+
+    返回干员的客观履历、个人档案（基础档案及解锁档案）等背景故事文本。
+    若需查询干员的职业、稀有度等数值信息，请使用 get_operator_basic_info；
+    若需查询语音台词，请使用 get_operator_voicelines。
+
+    Args:
+        operator_name: 干员的游戏内中文名，如"阿米娅"、"能天使"。
+    """
     return _get_archives(operator_name)
 
 
 @mcp.tool()
 async def get_operator_voicelines(operator_name: str) -> str:
-    """获取指定干员的语音记录（使用游戏内中文名，如"阿米娅"）。"""
+    """获取指定干员的所有语音台词记录。
+
+    返回包含触发条件（如"交谈1"、"晋升后交谈"、"信赖提升后交谈"）及对应
+    台词文本的完整列表。此工具仅返回语音文本；若需查询干员背景故事或客观
+    履历，请使用 get_operator_archives。
+
+    Args:
+        operator_name: 干员的游戏内中文名，如"阿米娅"、"能天使"。
+    """
     return _get_voicelines(operator_name)
 
 
 @mcp.tool()
 async def get_operator_basic_info(operator_name: str) -> str:
-    """获取指定干员的基本信息：职业、稀有度、所属、招募标签、天赋等（使用游戏内中文名，如"阿米娅"）。"""
+    """获取指定干员的基本数值信息。
+
+    返回干员的职业、子职业、稀有度（星级）、所属阵营、招募标签、天赋名称
+    及描述等结构化信息。适合快速了解干员定位；若需完整背景故事请使用
+    get_operator_archives，若需语音台词请使用 get_operator_voicelines。
+
+    Args:
+        operator_name: 干员的游戏内中文名，如"阿米娅"、"能天使"。
+    """
     return _get_basic_info(operator_name)
 
 
@@ -80,6 +122,9 @@ def _require_story_zip(cfg: "Config") -> Path:
 @mcp.tool()
 def list_story_events(category: str | None = None) -> str:
     """列出明日方舟剧情活动列表。
+
+    返回格式：每行 `- [类型] 活动ID：名称（N 章）`，类型为 MAINLINE / ACTIVITY /
+    MINI_ACTIVITY 之一。获取活动 ID 后，可调用 list_stories 查看该活动的章节列表。
 
     Args:
         category: 可选过滤分类。"main" = 主线章节，"activities" = 活动剧情（含联动）。
@@ -109,6 +154,10 @@ def list_story_events(category: str | None = None) -> str:
 @mcp.tool()
 def list_stories(event_id: str) -> str:
     """列出指定活动的所有剧情章节（按官方顺序排列）。
+
+    返回格式：每行 `- 章节编号 [标签] 章节名（key: story_key）`，其中 story_key
+    可直接传入 read_story 读取该章台词。如需一次性读取整个活动，可使用
+    read_activity。
 
     Args:
         event_id: 活动 ID，如 "act31side"（可从 list_story_events 获取）。
@@ -141,9 +190,13 @@ def list_stories(event_id: str) -> str:
 def read_story(story_key: str, include_narration: bool = True) -> str:
     """读取单章剧情的完整台词。
 
+    返回格式：首行为【活动名】章节名，随后按顺序输出对话（`角色：台词`）、
+    旁白（`*旁白文本*`）和选项（`【选项】文本`）。story_key 可从 list_stories
+    的返回结果中获取。
+
     Args:
         story_key: 章节 key，如 "activities/act31side/level_act31side_01_beg"（可从 list_stories 获取）。
-        include_narration: 是否包含旁白和场景描述，默认 True。
+        include_narration: 是否包含旁白和场景描述，默认 True。设为 False 可只保留对话台词。
     """
     from prts_mcp.config import Config
     cfg = Config.load()
@@ -182,7 +235,9 @@ def read_activity(
 ) -> str:
     """读取整个活动的完整剧情台词（按官方章节顺序合并）。
 
-    适合需要了解完整活动故事的场景。单次活动文本量可能较大，可用 page 参数分批获取。
+    适合需要了解完整活动故事的场景。返回各章节台词的合并文本，格式与
+    read_story 一致，章节间以分隔标题区分。单次活动文本量可能较大，建议
+    使用 page 参数分批获取；返回结果会提示是否还有更多页。
 
     Args:
         event_id: 活动 ID，如 "act31side"。

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -75,8 +75,14 @@ function createMcpServer(): McpServer {
 
   server.tool(
     "search_prts",
-    "搜索 PRTS 明日方舟中文维基词条。返回匹配的词条标题和摘要。",
-    { query: z.string(), limit: z.number().int().min(1).max(20).default(5) },
+    [
+      "搜索 PRTS 明日方舟中文维基词条。",
+      "返回匹配词条的标题和简短摘要列表。这是探索维基的第一步：当需要查找不确定的专有名词、干员、关卡或世界观设定时，先用此工具搜索获取准确标题，再将标题传入 read_prts_page 获取完整内容。",
+    ].join(" "),
+    {
+      query: z.string().describe("搜索关键词，支持中文，如「罗德岛」、「整合运动」。"),
+      limit: z.number().int().min(1).max(20).default(5).describe("返回结果数量上限，默认 5，最大建议不超过 10。"),
+    },
     async ({ query, limit }) => {
       const results = await searchPrts(query, limit);
       if (results.length === 0) {
@@ -91,8 +97,14 @@ function createMcpServer(): McpServer {
 
   server.tool(
     "read_prts_page",
-    "读取 PRTS 维基指定词条的纯文本内容。",
-    { page_title: z.string() },
+    [
+      "读取 PRTS 维基指定词条的纯文本内容。",
+      "返回该词条经过清洗的纯文本，已去除 Wikitext 模板、文件链接和 HTML 标签，内容可能较长。",
+      "强烈建议先调用 search_prts 确认词条的准确标题，避免因拼写错误导致读取失败。",
+    ].join(" "),
+    {
+      page_title: z.string().describe("词条标题，需与维基页面标题完全一致，如「阿米娅」、「整合运动」。建议通过 search_prts 获取准确标题后再传入。"),
+    },
     async ({ page_title }) => {
       const text = await readPage(page_title);
       return { content: [{ type: "text", text }] };
@@ -101,8 +113,12 @@ function createMcpServer(): McpServer {
 
   server.tool(
     "get_operator_archives",
-    '获取指定干员的档案资料（使用游戏内中文名，如"阿米娅"）。',
-    { operator_name: z.string() },
+    [
+      "获取指定干员的档案资料。",
+      "返回干员的客观履历、个人档案（基础档案及解锁档案）等背景故事文本。",
+      "若需查询干员的职业、稀有度等数值信息，请使用 get_operator_basic_info；若需查询语音台词，请使用 get_operator_voicelines。",
+    ].join(" "),
+    { operator_name: z.string().describe("干员的游戏内中文名，如「阿米娅」、「能天使」。") },
     ({ operator_name }) => {
       const text = getOperatorArchives(operator_name);
       return { content: [{ type: "text", text }] };
@@ -111,8 +127,12 @@ function createMcpServer(): McpServer {
 
   server.tool(
     "get_operator_voicelines",
-    '获取指定干员的语音记录（使用游戏内中文名，如"阿米娅"）。',
-    { operator_name: z.string() },
+    [
+      "获取指定干员的所有语音台词记录。",
+      "返回包含触发条件（如「交谈1」、「晋升后交谈」、「信赖提升后交谈」）及对应台词文本的完整列表。",
+      "此工具仅返回语音文本；若需查询干员背景故事或客观履历，请使用 get_operator_archives。",
+    ].join(" "),
+    { operator_name: z.string().describe("干员的游戏内中文名，如「阿米娅」、「能天使」。") },
     ({ operator_name }) => {
       const text = getOperatorVoicelines(operator_name);
       return { content: [{ type: "text", text }] };
@@ -121,8 +141,12 @@ function createMcpServer(): McpServer {
 
   server.tool(
     "get_operator_basic_info",
-    '获取指定干员的基本信息：职业、稀有度、所属、招募标签、天赋等（使用游戏内中文名，如"阿米娅"）。',
-    { operator_name: z.string() },
+    [
+      "获取指定干员的基本数值信息。",
+      "返回干员的职业、子职业、稀有度（星级）、所属阵营、招募标签、天赋名称及描述等结构化信息。",
+      "适合快速了解干员定位；若需完整背景故事请使用 get_operator_archives，若需语音台词请使用 get_operator_voicelines。",
+    ].join(" "),
+    { operator_name: z.string().describe("干员的游戏内中文名，如「阿米娅」、「能天使」。") },
     ({ operator_name }) => {
       const text = getOperatorBasicInfo(operator_name);
       return { content: [{ type: "text", text }] };
@@ -137,12 +161,10 @@ function createMcpServer(): McpServer {
     "list_story_events",
     [
       "列出明日方舟剧情活动列表。",
-      "category 可选过滤：\"main\"（主线）或 \"activities\"（活动 + 插曲）。",
-      "不传 category 则返回全部条目。",
-      "返回格式：每行 - [类型] 活动ID：名称（N 章）",
+      "返回格式：每行 `- [类型] 活动ID：名称（N 章）`，类型为 MAINLINE / ACTIVITY / MINI_ACTIVITY 之一。",
       "获取活动 ID 后，可调用 list_stories 查看该活动的章节列表。",
     ].join(" "),
-    { category: z.string().optional() },
+    { category: z.string().optional().describe("可选过滤分类。\"main\" = 主线章节，\"activities\" = 活动剧情（含联动）。不填则返回全部活动。") },
     ({ category }) => {
       let zipPath: string;
       try {
@@ -168,12 +190,11 @@ function createMcpServer(): McpServer {
   server.tool(
     "list_stories",
     [
-      "列出指定活动的所有章节，按官方顺序排列。",
-      "event_id 为活动 ID（可从 list_story_events 获取，如 \"act31side\"）。",
-      "返回格式：每行 - 关卡代码 [标签] 章节名（key: 章节key）",
-      "获取章节 key 后，可调用 read_story 阅读具体章节内容。",
+      "列出指定活动的所有剧情章节（按官方顺序排列）。",
+      "返回格式：每行 `- 章节编号 [标签] 章节名（key: story_key）`，其中 story_key 可直接传入 read_story 读取该章台词。",
+      "如需一次性读取整个活动，可使用 read_activity。",
     ].join(" "),
-    { event_id: z.string() },
+    { event_id: z.string().describe("活动 ID，如 \"act31side\"（可从 list_story_events 获取）。") },
     ({ event_id }) => {
       let zipPath: string;
       try {
@@ -211,13 +232,13 @@ function createMcpServer(): McpServer {
   server.tool(
     "read_story",
     [
-      "阅读指定章节的完整剧情内容。",
-      "story_key 为章节 key（可从 list_stories 获取，如 \"activities/act31side/level_act31side_01_beg\"）。",
-      "include_narration 控制是否包含旁白/场景描述（默认 true）。",
+      "读取单章剧情的完整台词。",
+      "返回格式：首行为【活动名】章节名，随后按顺序输出对话（`角色：台词`）、旁白（`*旁白文本*`）和选项（`【选项】文本`）。",
+      "story_key 可从 list_stories 的返回结果中获取。",
     ].join(" "),
     {
-      story_key: z.string(),
-      include_narration: z.boolean().default(true),
+      story_key: z.string().describe("章节 key，如 \"activities/act31side/level_act31side_01_beg\"（可从 list_stories 获取）。"),
+      include_narration: z.boolean().default(true).describe("是否包含旁白和场景描述，默认 true。设为 false 可只保留对话台词。"),
     },
     ({ story_key, include_narration }) => {
       let zipPath: string;
@@ -249,18 +270,15 @@ function createMcpServer(): McpServer {
   server.tool(
     "read_activity",
     [
-      "阅读指定活动的完整剧情（按官方顺序，合并所有章节）。",
-      "event_id 为活动 ID（可从 list_story_events 获取）。",
-      "include_narration 控制是否包含旁白（默认 true）。",
-      "page 为章节分页（从 1 开始），不传则返回全部章节。",
-      "page_size 控制每页章节数（默认 5）。",
-      "返回内容含 total_chapters 和 has_more，便于判断是否还有后续内容。",
+      "读取整个活动的完整剧情台词（按官方章节顺序合并）。",
+      "适合需要了解完整活动故事的场景。返回各章节台词的合并文本，格式与 read_story 一致，章节间以分隔标题区分。",
+      "单次活动文本量可能较大，建议使用 page 参数分批获取；返回结果会提示是否还有更多页。",
     ].join(" "),
     {
-      event_id: z.string(),
-      include_narration: z.boolean().default(true),
-      page: z.number().int().min(1).optional(),
-      page_size: z.number().int().min(1).max(20).default(5),
+      event_id: z.string().describe("活动 ID，如 \"act31side\"（可从 list_story_events 获取）。"),
+      include_narration: z.boolean().default(true).describe("是否包含旁白，默认 true。"),
+      page: z.number().int().min(1).optional().describe("分页页码（从 1 开始）。不填则返回全部章节。"),
+      page_size: z.number().int().min(1).max(20).default(5).describe("每页章节数，默认 5。"),
     },
     ({ event_id, include_narration, page, page_size }) => {
       let zipPath: string;


### PR DESCRIPTION
## 变更内容

对 Python 和 TypeScript 两侧的所有 9 个工具描述进行了改进：

**工具描述改进：**
- 每个工具描述从单行扩展为多句，明确说明返回内容格式、适用场景和与其他工具的关系
- 干员三件套（`get_operator_archives` / `get_operator_voicelines` / `get_operator_basic_info`）互相交叉引用，帮助 LLM 选择正确工具
- `search_prts` + `read_prts_page` 明确了两步工作流
- Story 工具描述统一了返回格式说明

**参数级描述（TS 新增）：**
- 所有参数通过 Zod `.describe()` 添加了说明，包括示例值和取值范围
- 有助于提升 Glama 质量评分和 LLM 工具调用准确率
