### PR TITLE
feat(python): add 1.0 data reader layer

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,12 +31,7 @@ jobs:
       - name: Check tag matches package version
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#python/v}"
-          PKG_VERSION=$(python -c "import importlib.metadata; print(importlib.metadata.version('prts-mcp'))")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "::error::Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION) in pyproject.toml"
-            exit 1
-          fi
-          echo "Version check passed: $TAG_VERSION"
+          python -c "import importlib.metadata, re, sys; normalize=lambda v: re.sub(r'-(a|alpha|b|beta|rc)\.?', lambda m: {'alpha': 'a', 'beta': 'b'}.get(m.group(1), m.group(1)), v); tag=normalize(sys.argv[1]); pkg=normalize(importlib.metadata.version('prts-mcp')); print(f'Version check passed: {tag}') if tag == pkg else (print(f'::error::Tag version ({tag}) does not match package version ({pkg}) in pyproject.toml'), sys.exit(1))" "$TAG_VERSION"
 
       - name: Verify import and config fallback
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check tag matches package version
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#python/v}"
-          python -c "import importlib.metadata, re, sys; normalize=lambda v: re.sub(r'-(a|alpha|b|beta|rc)\.?', lambda m: {'alpha': 'a', 'beta': 'b'}.get(m.group(1), m.group(1)), v); tag=normalize(sys.argv[1]); pkg=normalize(importlib.metadata.version('prts-mcp')); print(f'Version check passed: {tag}') if tag == pkg else (print(f'::error::Tag version ({tag}) does not match package version ({pkg}) in pyproject.toml'), sys.exit(1))" "$TAG_VERSION"
+          python -c "import importlib.metadata, re, sys; normalize=lambda v: re.sub(r'-(alpha|beta|rc|a|b)\.?', lambda m: {'alpha': 'a', 'beta': 'b'}.get(m.group(1), m.group(1)), v); tag=normalize(sys.argv[1]); pkg=normalize(importlib.metadata.version('prts-mcp')); print(f'Version check passed: {tag}') if tag == pkg else (print(f'::error::Tag version ({tag}) does not match package version ({pkg}) in pyproject.toml'), sys.exit(1))" "$TAG_VERSION"
 
       - name: Verify import and config fallback
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "python/v[0-9]*.[0-9]*.[0-9]*"
+      - "python/v[0-9]*.[0-9]*.[0-9]*-*"
 
 jobs:
   verify:
@@ -106,6 +107,9 @@ jobs:
             --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify bundled package data
+        run: python python/scripts/check_package_data.py --data-root data
 
       - name: Resolve image name and version
         id: image

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository contains two independent implementations for different deploymen
 
 | Area | Python | TypeScript | 1.0 policy |
 |------|--------|------------|------------|
-| Current line | `1.0.0-alpha.1` | `1.0.0-alpha.1` | Alpha releases are cut from the same commit when possible |
+| Current line | `1.0.0-alpha.1` | `0.3.3` | Alpha releases are cut from the same commit when possible |
 | MCP tools | Same public tool names and required parameters | Same public tool names and required parameters | Tool names and required parameters stay stable through 1.0 |
 | GameData | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | Custom paths disable auto-sync |
 | Story data | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | Custom zip paths disable auto-sync |
@@ -88,7 +88,7 @@ Published Docker images and the npm package include bundled fallback game/story 
 
 | 范围 | Python | TypeScript | 1.0 策略 |
 |------|--------|------------|----------|
-| 当前版本线 | `1.0.0-alpha.1` | `1.0.0-alpha.1` | Alpha 尽量从同一 commit 发布 |
+| 当前版本线 | `1.0.0-alpha.1` | `0.3.3` | Alpha 尽量从同一 commit 发布 |
 | MCP 工具 | 相同工具名和必填参数 | 相同工具名和必填参数 | 1.0 期间保持工具名和必填参数稳定 |
 | 干员数据 | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | 自定义路径会禁用自动同步 |
 | 剧情数据 | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | 自定义 zip 会禁用自动同步 |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ This repository contains two independent implementations for different deploymen
 | [`python/`](python/) | Python 3.10+ | stdio | Local Claude Desktop / Claude Code, Docker |
 | [`ts/`](ts/) | TypeScript / Node.js | Streamable HTTP | Self-hosted server, remote HTTP access |
 
+### 1.0 Compatibility Matrix
+
+| Area | Python | TypeScript | 1.0 policy |
+|------|--------|------------|------------|
+| Current line | `1.0.0-alpha.1` | `1.0.0-alpha.1` | Alpha releases are cut from the same commit when possible |
+| MCP tools | Same public tool names and required parameters | Same public tool names and required parameters | Tool names and required parameters stay stable through 1.0 |
+| GameData | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | Custom paths disable auto-sync |
+| Story data | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | Custom zip paths disable auto-sync |
+| Bundled fallback data | Docker image only | Docker image and published npm package | PyPI remains data-light |
+
+See [`docs/migration-0.x-to-1.0.md`](docs/migration-0.x-to-1.0.md) for the
+0.x to 1.0 migration notes.
+
 ### Tools
 
 Both implementations expose the same tool set:
@@ -70,6 +83,18 @@ Published Docker images and the npm package include bundled fallback game/story 
 |------|------|----------|----------|
 | [`python/`](python/) | Python 3.10+ | stdio | Claude Desktop / Claude Code 本地接入、Docker |
 | [`ts/`](ts/) | TypeScript / Node.js | Streamable HTTP | 个人服务器部署，供他人通过 HTTP 调用 |
+
+### 1.0 兼容矩阵
+
+| 范围 | Python | TypeScript | 1.0 策略 |
+|------|--------|------------|----------|
+| 当前版本线 | `1.0.0-alpha.1` | `1.0.0-alpha.1` | Alpha 尽量从同一 commit 发布 |
+| MCP 工具 | 相同工具名和必填参数 | 相同工具名和必填参数 | 1.0 期间保持工具名和必填参数稳定 |
+| 干员数据 | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | 自定义路径会禁用自动同步 |
+| 剧情数据 | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | 自定义 zip 会禁用自动同步 |
+| bundled 兜底数据 | Docker 镜像 | Docker 镜像和正式 npm 包 | PyPI 继续保持轻量 |
+
+0.x 到 1.0 的迁移说明见 [`docs/migration-0.x-to-1.0.md`](docs/migration-0.x-to-1.0.md)。
 
 ### 工具集
 

--- a/docs/dev/reports/1.0-baseline-audit.md
+++ b/docs/dev/reports/1.0-baseline-audit.md
@@ -1,0 +1,324 @@
+# PRTS-MCP 1.0 Baseline Audit
+
+_Date: 2026-05-03_
+
+## Scope
+
+This report satisfies Phase 0 of the 1.0 architecture plan. It records the
+current data-access baseline before implementation changes begin.
+
+No code behavior was changed for this audit.
+
+## Development Constraints Confirmed
+
+- Phase 0 is documentation-only.
+- Story summary tooling is deferred and should not be implemented as part of
+  the initial 1.0 data-layer migration.
+- Python and TypeScript implementation work should start from the same commit
+  head, then proceed on separate branches with separate PRs and code reviews.
+- Python startup sync must remain asynchronous and non-blocking. Waiting and
+  retry behavior may be added only if it preserves non-blocking startup.
+
+## Public Tool Surface
+
+Both implementations are intended to preserve these current MCP tools:
+
+- `search_prts`
+- `read_prts_page`
+- `get_operator_archives`
+- `get_operator_voicelines`
+- `get_operator_basic_info`
+- `list_story_events`
+- `list_stories`
+- `read_story`
+- `read_activity`
+
+The 1.0 reader migration must not rename tools or change required parameters.
+
+## Required JSON Paths
+
+### Game Data Excel
+
+These files are required by the current operator data path and sync checks:
+
+- `zh_CN/gamedata/excel/character_table.json`
+- `zh_CN/gamedata/excel/handbook_info_table.json`
+- `zh_CN/gamedata/excel/charword_table.json`
+- `zh_CN/gamedata/excel/story_review_table.json`
+
+Current operator tools directly use:
+
+- `character_table.json`
+- `handbook_info_table.json`
+- `charword_table.json`
+
+`story_review_table.json` is included in the required game-data bundle and is
+also present inside the story archive.
+
+### Story JSON
+
+These paths are expected inside `zh_CN.zip`:
+
+- `zh_CN/storyinfo.json`
+- `zh_CN/gamedata/excel/story_review_table.json`
+- `zh_CN/gamedata/story/{story_key}.json`
+
+Current story tools directly use:
+
+- `zh_CN/gamedata/excel/story_review_table.json`
+- `zh_CN/gamedata/story/{story_key}.json`
+
+`zh_CN/storyinfo.json` is documented as available but is not currently consumed
+by public story tools.
+
+## Current Data Flow
+
+### Game Data
+
+- Source: `3aKHP/ArknightsGameData` GitHub Release asset
+  `zh_CN-excel.zip`.
+- Runtime sync downloads the archive and extracts it into an
+  ArknightsGameData-compatible directory layout.
+- Operator parsing reads unpacked JSON files from the effective excel
+  directory.
+
+### Story Data
+
+- Source: `3aKHP/ArknightsStoryJson` GitHub Release asset `zh_CN.zip`.
+- Runtime sync downloads the zip archive.
+- Story parsing reads JSON entries directly from the zip.
+
+### PRTS Wiki
+
+- Source: PRTS MediaWiki API.
+- This path is network-backed and separate from local dataset storage.
+
+## Fallback Order
+
+### Python Game Data
+
+Defined in `python/src/prts_mcp/config.py`.
+
+Write target:
+
+1. `GAMEDATA_PATH`, when set by the user. This disables game-data auto-sync.
+2. `/data/gamedata`, when `PRTS_MCP_ROOT=/app` inside Docker.
+3. Per-user data directory:
+   - Windows: `%LOCALAPPDATA%/prts-mcp/gamedata`
+   - Linux/macOS: `$XDG_DATA_HOME/prts-mcp/gamedata` or
+     `~/.local/share/prts-mcp/gamedata`
+
+Read fallback:
+
+1. Complete excel files under the write target.
+2. Bundled Docker fallback at `/app/data/gamedata`.
+3. No operator data.
+
+### Python Story Data
+
+Defined in `python/src/prts_mcp/config.py`.
+
+Configured sync/read target:
+
+1. `STORYJSON_PATH`, when set by the user. This disables story auto-sync.
+2. Default zip next to the game-data directory:
+   `{gamedata_parent}/storyjson/zh_CN.zip`.
+
+Read fallback:
+
+1. Configured `storyjson_zip`.
+2. Docker volume zip at `/data/storyjson/zh_CN.zip`.
+3. Bundled Docker fallback at `/app/data/storyjson/zh_CN.zip`.
+4. No story data.
+
+### TypeScript Game Data
+
+Defined in `ts/src/config.ts`.
+
+Write target:
+
+1. `GAMEDATA_PATH`, when set by the user. This disables game-data auto-sync.
+2. `/data/gamedata`, when `PRTS_MCP_ROOT=/app` inside Docker.
+3. Per-user data directory:
+   - Windows: `%LOCALAPPDATA%/prts-mcp/gamedata`
+   - Linux/macOS: `$XDG_DATA_HOME/prts-mcp/gamedata` or
+     `~/.local/share/prts-mcp/gamedata`
+
+Read fallback:
+
+1. Complete excel files under the write target.
+2. Bundled package fallback at `<package_root>/data/gamedata`.
+3. No operator data.
+
+### TypeScript Story Data
+
+Defined in `ts/src/config.ts`.
+
+Configured sync/read target:
+
+1. `STORYJSON_PATH`, when set by the user. This disables story auto-sync.
+2. Default zip next to the game-data directory:
+   `{gamedata_parent}/storyjson/zh_CN.zip`.
+
+Read fallback:
+
+1. Configured `storyjsonZip`.
+2. Docker volume zip at `/data/storyjson/zh_CN.zip`.
+3. Bundled package fallback at `<package_root>/data/storyjson/zh_CN.zip`.
+4. No story data.
+
+## Direct Filesystem And Zip Access
+
+### Python Runtime Reads
+
+- `python/src/prts_mcp/config.py`
+  - Checks whether required excel files and story zip files exist.
+  - Resolves effective game-data and story-data paths.
+- `python/src/prts_mcp/data/operator.py`
+  - Directly reads unpacked JSON files with `Path.read_text()`.
+  - Caches `character_table.json`, `handbook_info_table.json`, and
+    `charword_table.json`.
+- `python/src/prts_mcp/data/story.py`
+  - Directly opens `zh_CN.zip` with `zipfile.ZipFile`.
+  - Reads `story_review_table.json` and per-story chapter JSON from zip
+    entries.
+- `python/src/prts_mcp/server.py`
+  - Resolves config at tool-call time for story tools.
+  - Starts game-data and story-data sync in a daemon thread.
+
+### Python Runtime Writes
+
+- `python/src/prts_mcp/data/sync.py`
+  - Writes `cache_meta.json` for file-based repo sync.
+  - Writes `release_meta.json` next to release-asset zip files.
+  - Downloads release zips with write-to-temp then replace.
+  - Extracts release archives into the local game-data root with path-safety
+    checks.
+- `python/src/prts_mcp/server.py`
+  - Calls `sync_release_archive()` for game data unless `GAMEDATA_PATH` is set.
+  - Calls `sync_release()` for story data unless `STORYJSON_PATH` is set.
+
+### Python Scripts
+
+- `python/scripts/fetch_gamedata.py`
+  - User-facing and CI-facing prewarm helper.
+  - Downloads `zh_CN-excel.zip` and extracts it under `data/gamedata` by
+    default, or a caller-provided output path.
+- `python/scripts/package_operator_data.py`
+  - Deprecated compatibility script.
+  - Copies three operator JSON files from an existing ArknightsGameData
+    checkout.
+
+### TypeScript Runtime Reads
+
+- `ts/src/config.ts`
+  - Checks whether required excel files and story zip files exist.
+  - Resolves effective package, Docker, and user-data paths.
+- `ts/src/data/operator.ts`
+  - Directly reads unpacked JSON files with `readFileSync()`.
+  - Caches `character_table.json`, `handbook_info_table.json`, and
+    `charword_table.json`.
+- `ts/src/data/story.ts`
+  - Directly opens `zh_CN.zip` with `AdmZip`.
+  - Reads `story_review_table.json` and per-story chapter JSON from zip
+    entries.
+- `ts/src/server.ts`
+  - Resolves config at tool-call time for story tools.
+  - Starts HTTP service before running startup sync.
+
+### TypeScript Runtime Writes
+
+- `ts/src/data/sync.ts`
+  - Writes `cache_meta.json` for file-based repo sync.
+  - Writes `release_meta.json` next to release-asset zip files.
+  - Downloads release zips with write-to-temp then rename.
+  - Extracts release archives into the local game-data root with path-safety
+    checks.
+- `ts/src/server.ts`
+  - Calls `syncReleaseArchive()` for game data unless `GAMEDATA_PATH` is set.
+  - Calls `syncRelease()` for story data unless `STORYJSON_PATH` is set.
+  - Schedules retry attempts for `offline_fallback` and `no_data` results.
+
+## Startup Sync Baseline
+
+### Python
+
+- `main()` starts `_run_startup_sync()` in a daemon thread.
+- MCP stdio startup is not blocked by sync completion.
+- There is no built-in retry loop after `offline_fallback` or `no_data`.
+- Operator and story tools re-check config when called, so data written after
+  process start can become visible.
+
+### TypeScript
+
+- Express starts listening before `runStartupSync()` is invoked.
+- Startup sync is asynchronous and does not block `/health` or `/mcp` startup.
+- `offline_fallback` and `no_data` results schedule bounded retries.
+- Operator and story tools re-check config when called, so data written after
+  process start can become visible.
+
+## Package Content Expectations
+
+### Docker Images
+
+- Python Dockerfile copies repo-level `data/` into `/app/data/`.
+- TypeScript Dockerfile copies repo-level `data/` into `/app/data/`.
+- CI/CD prewarms repo-level `data/gamedata` with
+  `python/scripts/fetch_gamedata.py`.
+- CI/CD downloads `zh_CN.zip` into repo-level `data/storyjson`.
+- Docker containers use `/data/gamedata` and `/data/storyjson` as writable
+  runtime volumes, with `/app/data` as read-only bundled fallback.
+
+### npm Package
+
+- `ts/package.json` includes `dist/` and `data/` in package files.
+- TypeScript CD prewarms `ts/data/gamedata` and downloads
+  `ts/data/storyjson/zh_CN.zip` before `npm publish`.
+- Local `npm pack` without prewarm may contain only placeholder data
+  directories; docs already warn about this.
+
+### PyPI Package
+
+- `python/pyproject.toml` packages only `src/prts_mcp`.
+- PyPI distributions do not include repo-level bundled game/story data.
+- Direct `pip install prts-mcp` relies on startup auto-sync or user-provided
+  `GAMEDATA_PATH` / `STORYJSON_PATH`.
+
+## Current Test Coverage
+
+### Python
+
+- Operator tests cover:
+  - data written after an initial miss becomes visible in the same process
+  - core operator tools read a minimal fixture
+  - explicit cache clearing
+- Story tests cover:
+  - text cleanup and raw story-list parsing without zip data
+  - integration behavior when a local `zh_CN.zip` fixture is available
+- Sync tests cover release download, archive extraction, fallback behavior, and
+  unsafe zip path rejection.
+
+### TypeScript
+
+- Operator tests cover:
+  - data written after an initial miss becomes visible in the same process
+  - core operator tools read a minimal fixture
+  - explicit cache clearing
+  - incomplete required-file detection
+- Startup test covers:
+  - HTTP server listens before a hanging background fetch completes
+- TypeScript story behavior currently has no dedicated visible unit test file.
+
+## Migration Notes For Phase 1+
+
+- Add reader/store abstractions without changing public tool names or
+  parameters.
+- Keep `GAMEDATA_PATH` and `STORYJSON_PATH` semantics intact.
+- Preserve current output formatting while migrating parser internals.
+- Do not introduce runtime network requirements when user-provided or bundled
+  data is present.
+- Keep Python and TypeScript reader behavior aligned through small shared
+  fixture expectations.
+- Treat `storyinfo.json` as available data but not part of required 1.0 tool
+  behavior unless a later design decision explicitly includes it.
+

--- a/docs/dev/reports/1.0-beta-hardening.md
+++ b/docs/dev/reports/1.0-beta-hardening.md
@@ -1,0 +1,40 @@
+# PRTS-MCP 1.0 Beta Hardening Checklist
+
+_Date: 2026-05-03_
+
+## Public Surface Freeze
+
+The 1.0 line freezes these public MCP tool names and required parameters:
+
+| Tool | Required parameters |
+|------|---------------------|
+| `search_prts` | `query` |
+| `read_prts_page` | `page_title` |
+| `get_operator_archives` | `operator_name` |
+| `get_operator_voicelines` | `operator_name` |
+| `get_operator_basic_info` | `operator_name` |
+| `list_story_events` | none |
+| `list_stories` | `event_id` |
+| `read_story` | `story_key` |
+| `read_activity` | `event_id` |
+
+Optional parameters may continue to exist, but removing or renaming any current
+parameter requires a migration note before 1.0 final.
+
+## Automated Checks Added
+
+- Python tool function signatures are frozen by `python/tests/test_tool_surface.py`.
+- TypeScript tool registration names are frozen by `ts/tests/toolSurface.test.ts`.
+- Package fallback data is checked by `python/scripts/check_package_data.py`.
+- Python and TypeScript release workflows now match pre-release tags such as:
+  - `python/v1.0.0-alpha.1`
+  - `ts/v1.0.0-alpha.1`
+
+## Release Readiness Notes
+
+- Docker images must contain bundled `data/gamedata` and `data/storyjson/zh_CN.zip`.
+- Published npm packages must contain prewarmed `ts/data/gamedata` and
+  `ts/data/storyjson/zh_CN.zip`.
+- PyPI wheels must remain data-light.
+- Story summary tooling remains deferred.
+

--- a/docs/dev/reports/1.0-beta-hardening.md
+++ b/docs/dev/reports/1.0-beta-hardening.md
@@ -24,11 +24,9 @@ parameter requires a migration note before 1.0 final.
 ## Automated Checks Added
 
 - Python tool function signatures are frozen by `python/tests/test_tool_surface.py`.
-- TypeScript tool registration names are frozen by `ts/tests/toolSurface.test.ts`.
 - Package fallback data is checked by `python/scripts/check_package_data.py`.
-- Python and TypeScript release workflows now match pre-release tags such as:
+- Python release workflows now match pre-release tags such as:
   - `python/v1.0.0-alpha.1`
-  - `ts/v1.0.0-alpha.1`
 
 ## Release Readiness Notes
 
@@ -37,4 +35,3 @@ parameter requires a migration note before 1.0 final.
   `ts/data/storyjson/zh_CN.zip`.
 - PyPI wheels must remain data-light.
 - Story summary tooling remains deferred.
-

--- a/docs/migration-0.x-to-1.0.md
+++ b/docs/migration-0.x-to-1.0.md
@@ -1,0 +1,46 @@
+# Migration Guide: 0.x to 1.0
+
+_Status: 1.0.0-alpha.1_
+
+PRTS-MCP 1.0 keeps the public MCP tool surface stable while normalizing the
+internal data layer.
+
+## What Stays Compatible
+
+- Existing MCP tool names are unchanged.
+- Existing required tool parameters are unchanged.
+- `GAMEDATA_PATH` still disables GameData auto-sync and points to an
+  ArknightsGameData-compatible root.
+- `STORYJSON_PATH` still disables story auto-sync and points to `zh_CN.zip`.
+- `GITHUB_TOKEN` and `GITHUB_MIRRORS` keep the same runtime meanings.
+- Docker and npm releases continue to include bundled fallback data prepared by
+  CI.
+- PyPI remains data-light and relies on startup auto-sync or user-provided data
+  paths.
+
+## Internal Changes
+
+- Operator and story parsers now read through a small store abstraction.
+- Directory-backed, zip-backed, and fallback stores share the same conceptual
+  API across Python and TypeScript.
+- Runtime sync code is being consolidated around dataset specs for:
+  - `gamedata.excel`
+  - `story.zh_CN`
+
+These changes should not require client configuration changes.
+
+## Upgrade Notes
+
+1. Upgrade the Python package or TypeScript package as usual.
+2. Keep existing `GAMEDATA_PATH`, `STORYJSON_PATH`, `GITHUB_TOKEN`, and
+   `GITHUB_MIRRORS` settings if you already use them.
+3. For Docker deployments, keep mounting `gamedata` and `storyjson` volumes as
+   before.
+4. If you publish local npm tarballs manually, prewarm `ts/data/` first or
+   expect only placeholder fallback data in the tarball.
+
+## Deferred
+
+Story summary tools are not part of the initial 1.0 migration. They may be
+considered after the reader layer is stable.
+

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.0-alpha.1] - 2026-05-03
+
+### Added
+
+- Added a shared local dataset reader layer with directory, zip, and fallback stores.
+- Added dataset specs for GameData excel and story JSON Release assets.
+- Added bundled package-data verification for Docker and npm release pipelines.
+
+### Changed
+
+- Operator and story parsers now read through the new store abstraction while preserving
+  current MCP tool names, parameters, and output formatting.
+- Runtime sync setup now consumes dataset specs instead of repeating Release metadata in
+  server startup code and prewarm scripts.
+
 ## [0.4.2] - 2026-05-03
 
 ### Changed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "0.4.2"
+version = "1.0.0-alpha.1"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/scripts/check_package_data.py
+++ b/python/scripts/check_package_data.py
@@ -1,0 +1,66 @@
+"""Verify bundled fallback data before Docker or npm packaging."""
+from __future__ import annotations
+
+import argparse
+import sys
+import zipfile
+from pathlib import Path
+
+_PYTHON_DIR = Path(__file__).resolve().parents[1]
+_REPO_ROOT = _PYTHON_DIR.parent
+_SRC_DIR = _PYTHON_DIR / "src"
+if str(_SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(_SRC_DIR))
+
+from prts_mcp.data.datasets import GAMEDATA_EXCEL, STORY_ZH_CN  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check bundled PRTS-MCP data files.")
+    parser.add_argument(
+        "--data-root",
+        type=Path,
+        default=_REPO_ROOT / "data",
+        help="Directory containing gamedata/ and storyjson/. Default: repo data/.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    data_root = args.data_root.resolve()
+    gamedata_root = data_root / "gamedata"
+    story_zip = data_root / "storyjson" / STORY_ZH_CN.asset_name
+
+    missing = [path for path in GAMEDATA_EXCEL.required_files if not (gamedata_root / path).is_file()]
+    if missing:
+        print("Missing bundled gamedata files:", file=sys.stderr)
+        for path in missing:
+            print(f" - {gamedata_root / path}", file=sys.stderr)
+        return 1
+
+    if not story_zip.is_file():
+        print(f"Missing bundled story zip: {story_zip}", file=sys.stderr)
+        return 1
+
+    try:
+        with zipfile.ZipFile(story_zip) as zf:
+            names = set(zf.namelist())
+            missing_entries = [path for path in STORY_ZH_CN.required_files if path not in names]
+    except zipfile.BadZipFile:
+        print(f"Bundled story zip is not a valid zip: {story_zip}", file=sys.stderr)
+        return 1
+
+    if missing_entries:
+        print("Missing bundled story zip entries:", file=sys.stderr)
+        for path in missing_entries:
+            print(f" - {path}", file=sys.stderr)
+        return 1
+
+    print(f"Package data check passed: {data_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/python/scripts/check_package_data.py
+++ b/python/scripts/check_package_data.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import argparse
 import sys
-import zipfile
 from pathlib import Path
 
 _PYTHON_DIR = Path(__file__).resolve().parents[1]
@@ -43,16 +42,10 @@ def main() -> int:
         print(f"Missing bundled story zip: {story_zip}", file=sys.stderr)
         return 1
 
-    try:
-        with zipfile.ZipFile(story_zip) as zf:
-            names = set(zf.namelist())
-            missing_entries = [path for path in STORY_ZH_CN.required_files if path not in names]
-    except zipfile.BadZipFile:
-        print(f"Bundled story zip is not a valid zip: {story_zip}", file=sys.stderr)
-        return 1
+    missing_entries = STORY_ZH_CN.validate_zip(story_zip)
 
     if missing_entries:
-        print("Missing bundled story zip entries:", file=sys.stderr)
+        print("Invalid bundled story zip entries:", file=sys.stderr)
         for path in missing_entries:
             print(f" - {path}", file=sys.stderr)
         return 1
@@ -63,4 +56,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/python/scripts/fetch_gamedata.py
+++ b/python/scripts/fetch_gamedata.py
@@ -27,7 +27,8 @@ _SRC_DIR = _PYTHON_DIR / "src"
 if str(_SRC_DIR) not in sys.path:
     sys.path.insert(0, str(_SRC_DIR))
 
-from prts_mcp.data.sync import GAMEDATA_FILES, ReleaseArchiveSpec, SyncResult, sync_release_archive  # noqa: E402
+from prts_mcp.data.datasets import GAMEDATA_EXCEL  # noqa: E402
+from prts_mcp.data.sync import SyncResult, sync_release_archive  # noqa: E402
 
 logging.basicConfig(
     stream=sys.stderr,
@@ -64,13 +65,9 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
 
-    spec = ReleaseArchiveSpec(
-        owner="3aKHP",
-        repo="ArknightsGameData",
-        asset_name="zh_CN-excel.zip",
+    spec = GAMEDATA_EXCEL.archive_spec(
         local_zip=(args.archive_cache or args.output / "archives" / "zh_CN-excel.zip").resolve(),
         local_root=args.output.resolve(),
-        required_files=GAMEDATA_FILES,
     )
 
     if args.force:

--- a/python/src/prts_mcp/data/datasets.py
+++ b/python/src/prts_mcp/data/datasets.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from pathlib import Path
+from zipfile import BadZipFile, ZipFile
 
 from prts_mcp.data.sync import GAMEDATA_FILES, ReleaseArchiveSpec, ReleaseSpec
 
@@ -10,6 +12,7 @@ STORYJSON_REQUIRED_FILES: tuple[str, ...] = (
     "zh_CN/gamedata/excel/story_review_table.json",
     "zh_CN/storyinfo.json",
 )
+STORYJSON_REVIEW_TABLE = "zh_CN/gamedata/excel/story_review_table.json"
 
 
 @dataclass(frozen=True)
@@ -26,6 +29,7 @@ class ReleaseDatasetSpec:
             repo=self.repo,
             asset_name=self.asset_name,
             local_zip=local_zip,
+            validate_zip=self.validate_zip,
         )
 
     def archive_spec(self, *, local_zip: Path, local_root: Path) -> ReleaseArchiveSpec:
@@ -37,6 +41,45 @@ class ReleaseDatasetSpec:
             local_root=local_root,
             required_files=self.required_files,
         )
+
+    def validate_zip(self, zip_path: Path) -> list[str]:
+        """Return missing or invalid zip entries for this dataset."""
+        try:
+            with ZipFile(zip_path) as zf:
+                return validate_storyjson_zip(zf) if self is STORY_ZH_CN else _missing_entries(zf, self.required_files)
+        except BadZipFile:
+            return [f"{zip_path} is not a valid zip"]
+
+
+def _missing_entries(zf: ZipFile, required_files: tuple[str, ...]) -> list[str]:
+    names = set(zf.namelist())
+    return [path for path in required_files if path not in names]
+
+
+def _story_path(story_key: str) -> str:
+    return f"zh_CN/gamedata/story/{story_key}.json"
+
+
+def validate_storyjson_zip(zf: ZipFile) -> list[str]:
+    """Validate story metadata and referenced chapter JSON entries."""
+    missing = _missing_entries(zf, STORYJSON_REQUIRED_FILES)
+    if STORYJSON_REVIEW_TABLE in missing:
+        return missing
+
+    try:
+        table = json.loads(zf.read(STORYJSON_REVIEW_TABLE).decode("utf-8"))
+    except (KeyError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return [*missing, f"{STORYJSON_REVIEW_TABLE} is unreadable: {exc}"]
+
+    names = set(zf.namelist())
+    story_paths = sorted({
+        _story_path(story_key)
+        for entry in table.values()
+        for data in (entry.get("infoUnlockDatas") or [])
+        if (story_key := data.get("storyTxt"))
+    })
+    missing.extend(path for path in story_paths if path not in names)
+    return missing
 
 
 GAMEDATA_EXCEL = ReleaseDatasetSpec(
@@ -54,4 +97,3 @@ STORY_ZH_CN = ReleaseDatasetSpec(
     asset_name="zh_CN.zip",
     required_files=STORYJSON_REQUIRED_FILES,
 )
-

--- a/python/src/prts_mcp/data/datasets.py
+++ b/python/src/prts_mcp/data/datasets.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from prts_mcp.data.sync import GAMEDATA_FILES, ReleaseArchiveSpec, ReleaseSpec
+
+
+STORYJSON_REQUIRED_FILES: tuple[str, ...] = (
+    "zh_CN/gamedata/excel/story_review_table.json",
+    "zh_CN/storyinfo.json",
+)
+
+
+@dataclass(frozen=True)
+class ReleaseDatasetSpec:
+    dataset_id: str
+    owner: str
+    repo: str
+    asset_name: str
+    required_files: tuple[str, ...]
+
+    def release_spec(self, local_zip: Path) -> ReleaseSpec:
+        return ReleaseSpec(
+            owner=self.owner,
+            repo=self.repo,
+            asset_name=self.asset_name,
+            local_zip=local_zip,
+        )
+
+    def archive_spec(self, *, local_zip: Path, local_root: Path) -> ReleaseArchiveSpec:
+        return ReleaseArchiveSpec(
+            owner=self.owner,
+            repo=self.repo,
+            asset_name=self.asset_name,
+            local_zip=local_zip,
+            local_root=local_root,
+            required_files=self.required_files,
+        )
+
+
+GAMEDATA_EXCEL = ReleaseDatasetSpec(
+    dataset_id="gamedata.excel",
+    owner="3aKHP",
+    repo="ArknightsGameData",
+    asset_name="zh_CN-excel.zip",
+    required_files=GAMEDATA_FILES,
+)
+
+STORY_ZH_CN = ReleaseDatasetSpec(
+    dataset_id="story.zh_CN",
+    owner="3aKHP",
+    repo="ArknightsStoryJson",
+    asset_name="zh_CN.zip",
+    required_files=STORYJSON_REQUIRED_FILES,
+)
+

--- a/python/src/prts_mcp/data/operator.py
+++ b/python/src/prts_mcp/data/operator.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-import json
 from functools import lru_cache
-from pathlib import Path
 from typing import Any
 
 from prts_mcp.config import Config
+from prts_mcp.data.stores import DirectoryStore
 from prts_mcp.utils.sanitizer import strip_wikitext
 
 def _get_config() -> Config:
@@ -31,34 +30,35 @@ def _missing_operator_data_message() -> str:
     )
 
 
-def _load_json(path: Path) -> dict[str, Any]:
-    if not path.is_file():
+def _operator_store() -> DirectoryStore:
+    ep = _get_config().effective_excel_path
+    assert ep is not None
+    return DirectoryStore(ep)
+
+
+def _load_json(filename: str) -> dict[str, Any]:
+    store = _operator_store()
+    if not store.exists(filename):
         raise FileNotFoundError(
-            f"干员数据文件不存在：{path}。"
+            f"干员数据文件不存在：{store.root / filename}。"
             "数据目录可能为空，或挂载路径有误（GAMEDATA_PATH 应指向 ArknightsGameData 仓库根目录）。"
         )
-    return json.loads(path.read_text(encoding="utf-8"))
+    return store.read_json(filename)
 
 
 @lru_cache(maxsize=1)
 def _load_character_table() -> dict[str, Any]:
-    ep = _get_config().effective_excel_path
-    assert ep is not None
-    return _load_json(ep / "character_table.json")
+    return _load_json("character_table.json")
 
 
 @lru_cache(maxsize=1)
 def _load_handbook_table() -> dict[str, Any]:
-    ep = _get_config().effective_excel_path
-    assert ep is not None
-    return _load_json(ep / "handbook_info_table.json")
+    return _load_json("handbook_info_table.json")
 
 
 @lru_cache(maxsize=1)
 def _load_charword_table() -> dict[str, Any]:
-    ep = _get_config().effective_excel_path
-    assert ep is not None
-    return _load_json(ep / "charword_table.json")
+    return _load_json("charword_table.json")
 
 
 @lru_cache(maxsize=1)

--- a/python/src/prts_mcp/data/stores.py
+++ b/python/src/prts_mcp/data/stores.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+from typing import Any, Protocol
+
+
+class JsonStore(Protocol):
+    """Minimal JSON reader interface for local dataset storage."""
+
+    def exists(self, path: str) -> bool:
+        ...
+
+    def read_text(self, path: str) -> str:
+        ...
+
+    def read_json(self, path: str) -> Any:
+        ...
+
+    def describe(self) -> str:
+        ...
+
+
+def _normalize_path(path: str) -> str:
+    normalized = path.replace("\\", "/").lstrip("/")
+    parts = [part for part in normalized.split("/") if part not in ("", ".")]
+    if any(part == ".." for part in parts):
+        raise ValueError(f"Unsafe dataset path: {path!r}")
+    return "/".join(parts)
+
+
+class DirectoryStore:
+    """Read JSON files from a directory root."""
+
+    def __init__(self, root: Path | str) -> None:
+        self.root = Path(root)
+
+    def _resolve(self, path: str) -> Path:
+        root = self.root.resolve()
+        target = (self.root / _normalize_path(path)).resolve()
+        if not target.is_relative_to(root):
+            raise ValueError(f"Unsafe dataset path: {path!r}")
+        return target
+
+    def exists(self, path: str) -> bool:
+        return self._resolve(path).is_file()
+
+    def read_text(self, path: str) -> str:
+        target = self._resolve(path)
+        if not target.is_file():
+            raise FileNotFoundError(f"Dataset file not found: {path}")
+        return target.read_text(encoding="utf-8")
+
+    def read_json(self, path: str) -> Any:
+        return json.loads(self.read_text(path))
+
+    def describe(self) -> str:
+        return f"directory:{self.root}"
+
+
+class ZipStore:
+    """Read JSON entries from a zip file."""
+
+    def __init__(self, zip_path: Path | str) -> None:
+        self.zip_path = Path(zip_path)
+
+    def exists(self, path: str) -> bool:
+        inner_path = _normalize_path(path)
+        if not self.zip_path.is_file():
+            return False
+        with zipfile.ZipFile(self.zip_path) as zf:
+            return inner_path in zf.namelist()
+
+    def read_text(self, path: str) -> str:
+        inner_path = _normalize_path(path)
+        try:
+            with zipfile.ZipFile(self.zip_path) as zf:
+                with zf.open(inner_path) as f:
+                    return f.read().decode("utf-8")
+        except KeyError as exc:
+            raise FileNotFoundError(f"Dataset zip entry not found: {path}") from exc
+
+    def read_json(self, path: str) -> Any:
+        return json.loads(self.read_text(path))
+
+    def describe(self) -> str:
+        return f"zip:{self.zip_path}"
+
+
+class FallbackStore:
+    """Read from primary storage first, then fall back to bundled storage."""
+
+    def __init__(self, primary: JsonStore, fallback: JsonStore) -> None:
+        self.primary = primary
+        self.fallback = fallback
+
+    def _store_for(self, path: str) -> JsonStore | None:
+        if self.primary.exists(path):
+            return self.primary
+        if self.fallback.exists(path):
+            return self.fallback
+        return None
+
+    def exists(self, path: str) -> bool:
+        return self._store_for(path) is not None
+
+    def read_text(self, path: str) -> str:
+        store = self._store_for(path)
+        if store is None:
+            raise FileNotFoundError(f"Dataset file not found in fallback chain: {path}")
+        return store.read_text(path)
+
+    def read_json(self, path: str) -> Any:
+        return json.loads(self.read_text(path))
+
+    def describe(self) -> str:
+        return f"fallback:{self.primary.describe()} -> {self.fallback.describe()}"
+

--- a/python/src/prts_mcp/data/stores.py
+++ b/python/src/prts_mcp/data/stores.py
@@ -23,7 +23,9 @@ class JsonStore(Protocol):
 
 
 def _normalize_path(path: str) -> str:
-    normalized = path.replace("\\", "/").lstrip("/")
+    normalized = path.replace("\\", "/")
+    if normalized.startswith("/"):
+        raise ValueError(f"Unsafe dataset path: {path!r}")
     parts = [part for part in normalized.split("/") if part not in ("", ".")]
     if any(part == ".." for part in parts):
         raise ValueError(f"Unsafe dataset path: {path!r}")
@@ -116,4 +118,3 @@ class FallbackStore:
 
     def describe(self) -> str:
         return f"fallback:{self.primary.describe()} -> {self.fallback.describe()}"
-

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -9,12 +9,12 @@ Zip internal layout (all paths prefixed with "zh_CN/"):
 """
 from __future__ import annotations
 
-import json
 import re
-import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
+
+from prts_mcp.data.stores import JsonStore, ZipStore
 
 # ---------------------------------------------------------------------------
 # Zip path constants
@@ -133,9 +133,12 @@ def _parse_story_list(story_list: list[dict]) -> list[StoryLine]:
     return lines
 
 
-def _load_json(zf: zipfile.ZipFile, path: str) -> dict | list:
-    with zf.open(path) as f:
-        return json.load(f)
+def _story_store(zip_path: Path) -> ZipStore:
+    return ZipStore(zip_path)
+
+
+def _load_json(store: JsonStore, path: str) -> dict | list:
+    return store.read_json(path)
 
 
 # ---------------------------------------------------------------------------
@@ -156,8 +159,16 @@ def list_story_events(
     """
     allowed_types: list[str] | None = _CATEGORY_MAP.get(category) if category else None
 
-    with zipfile.ZipFile(zip_path) as zf:
-        table: dict = _load_json(zf, _STORY_REVIEW_TABLE)  # type: ignore[assignment]
+    return list_story_events_from_store(_story_store(zip_path), category=category)
+
+
+def list_story_events_from_store(
+    store: JsonStore,
+    category: str | None = None,
+) -> list[EventInfo]:
+    """Return a list of events from story_review_table.json using a JSON store."""
+    allowed_types: list[str] | None = _CATEGORY_MAP.get(category) if category else None
+    table: dict = _load_json(store, _STORY_REVIEW_TABLE)  # type: ignore[assignment]
 
     events = []
     for event_id, entry in table.items():
@@ -188,8 +199,12 @@ def list_stories(zip_path: Path, event_id: str) -> list[ChapterSummary]:
     Raises:
         KeyError: If event_id is not found in story_review_table.
     """
-    with zipfile.ZipFile(zip_path) as zf:
-        table: dict = _load_json(zf, _STORY_REVIEW_TABLE)  # type: ignore[assignment]
+    return list_stories_from_store(_story_store(zip_path), event_id)
+
+
+def list_stories_from_store(store: JsonStore, event_id: str) -> list[ChapterSummary]:
+    """Return ordered chapter list for an event using a JSON store."""
+    table: dict = _load_json(store, _STORY_REVIEW_TABLE)  # type: ignore[assignment]
 
     entry = table.get(event_id)
     if entry is None:
@@ -227,11 +242,19 @@ def read_story(
     Raises:
         KeyError: If the story file is not found in the zip.
     """
-    zip_inner = _story_zip_path(story_key)
-    with zipfile.ZipFile(zip_path) as zf:
-        if zip_inner not in zf.namelist():
-            raise KeyError(f"Story not found in zip: {story_key!r}")
-        raw: dict = _load_json(zf, zip_inner)  # type: ignore[assignment]
+    return read_story_from_store(_story_store(zip_path), story_key, include_narration=include_narration)
+
+
+def read_story_from_store(
+    store: JsonStore,
+    story_key: str,
+    include_narration: bool = True,
+) -> StoryChapter:
+    """Read and parse a single story chapter using a JSON store."""
+    story_path = _story_zip_path(story_key)
+    if not store.exists(story_path):
+        raise KeyError(f"Story not found in store: {story_key!r}")
+    raw: dict = _load_json(store, story_path)  # type: ignore[assignment]
 
     all_lines = _parse_story_list(raw.get("storyList") or [])
     if not include_narration:
@@ -270,7 +293,24 @@ def read_activity(
     Raises:
         KeyError: If event_id is not found.
     """
-    summaries = list_stories(zip_path, event_id)
+    return read_activity_from_store(
+        _story_store(zip_path),
+        event_id,
+        include_narration=include_narration,
+        page=page,
+        page_size=page_size,
+    )
+
+
+def read_activity_from_store(
+    store: JsonStore,
+    event_id: str,
+    include_narration: bool = True,
+    page: int | None = None,
+    page_size: int = 5,
+) -> ActivityResult:
+    """Read all chapters of an activity in official story order using a JSON store."""
+    summaries = list_stories_from_store(store, event_id)
     total = len(summaries)
 
     if page is not None:
@@ -286,7 +326,7 @@ def read_activity(
     event_name = ""
     for summary in selected:
         try:
-            chapter = read_story(zip_path, summary.story_key, include_narration)
+            chapter = read_story_from_store(store, summary.story_key, include_narration)
             if not event_name:
                 event_name = chapter.event_name
             chapters.append(chapter)

--- a/python/src/prts_mcp/data/sync.py
+++ b/python/src/prts_mcp/data/sync.py
@@ -14,7 +14,7 @@ import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Literal
+from typing import Callable, Literal
 
 import httpx
 
@@ -329,6 +329,7 @@ class ReleaseSpec:
     repo: str
     asset_name: str   # e.g. "zh_CN.zip"
     local_zip: Path   # destination path on disk
+    validate_zip: Callable[[Path], list[str]] | None = None
 
 
 @dataclass(frozen=True)
@@ -376,6 +377,10 @@ def download_release_asset(spec: ReleaseSpec, tag: str, url: str, timeout: float
         _logger.debug("Downloading release asset %s", url)
         response = _get_cascading(url, timeout=timeout, headers=_github_headers(), follow_redirects=True)
         tmp.write_bytes(response.content)
+        if spec.validate_zip is not None:
+            missing = spec.validate_zip(tmp)
+            if missing:
+                raise ValueError("Downloaded release asset is invalid: " + "; ".join(missing[:10]))
         tmp.replace(spec.local_zip)
 
         # Extract upstream SHA from tag (format: "upstream-<sha>")
@@ -414,7 +419,8 @@ def sync_release(spec: ReleaseSpec) -> SyncResult:
     )
 
     cache = CacheMeta.load(_release_cache_path(spec))
-    zip_ok = spec.local_zip.is_file()
+    zip_error = _release_zip_error(spec)
+    zip_ok = zip_error is None
 
     if cache is not None and zip_ok and _release_cache_is_fresh(cache):
         _logger.debug("Release cache is fresh for %s/%s; skipping check.", spec.owner, spec.repo)
@@ -439,7 +445,10 @@ def sync_release(spec: ReleaseSpec) -> SyncResult:
                 return SyncResult(spec=_dummy_spec, status="updated", commit_sha="unknown", error=None)
             except Exception as exc:  # noqa: BLE001
                 return SyncResult(spec=_dummy_spec, status="no_data", commit_sha=None, error=str(exc))
-        return SyncResult(spec=_dummy_spec, status="no_data", commit_sha=None, error="Network unavailable and no cached zip")
+        error = "Network unavailable and no cached zip"
+        if spec.local_zip.is_file() and zip_error:
+            error += f"; cached zip invalid: {zip_error}"
+        return SyncResult(spec=_dummy_spec, status="no_data", commit_sha=None, error=error)
 
     tag, asset_url = result
     upstream_sha = tag[len(_TAG_PREFIX):] if tag.startswith(_TAG_PREFIX) else tag
@@ -467,6 +476,18 @@ def sync_release(spec: ReleaseSpec) -> SyncResult:
                 error=error_msg,
             )
         return SyncResult(spec=_dummy_spec, status="no_data", commit_sha=None, error=error_msg)
+
+
+def _release_zip_error(spec: ReleaseSpec) -> str | None:
+    if not spec.local_zip.is_file():
+        return "zip file is missing"
+    validator = spec.validate_zip
+    if validator is None:
+        return None
+    missing = validator(spec.local_zip)
+    if not missing:
+        return None
+    return "; ".join(str(path) for path in missing[:10])
 
 
 def _archive_files_present(spec: ReleaseArchiveSpec) -> bool:

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -287,7 +287,8 @@ def _run_startup_sync() -> None:
     overwrite it.
     """
     from prts_mcp.config import Config, _DEFAULT_GAMEDATA_PATH
-    from prts_mcp.data.sync import GAMEDATA_FILES, ReleaseArchiveSpec, ReleaseSpec, sync_release, sync_release_archive
+    from prts_mcp.data.datasets import GAMEDATA_EXCEL, STORY_ZH_CN
+    from prts_mcp.data.sync import sync_release, sync_release_archive
 
     cfg = Config.load()
     if cfg.is_custom_gamedata:
@@ -296,13 +297,9 @@ def _run_startup_sync() -> None:
             cfg.gamedata_path,
         )
     else:
-        archive_spec = ReleaseArchiveSpec(
-            owner="3aKHP",
-            repo="ArknightsGameData",
-            asset_name="zh_CN-excel.zip",
+        archive_spec = GAMEDATA_EXCEL.archive_spec(
             local_zip=_DEFAULT_GAMEDATA_PATH / "archives" / "zh_CN-excel.zip",
             local_root=_DEFAULT_GAMEDATA_PATH,
-            required_files=GAMEDATA_FILES,
         )
         r = sync_release_archive(archive_spec)
         _log_sync_result(r)
@@ -313,12 +310,7 @@ def _run_startup_sync() -> None:
 
     # Always try to sync storyjson from GitHub Release (unless user supplied their own zip)
     if "STORYJSON_PATH" not in os.environ:
-        release_spec = ReleaseSpec(
-            owner="3aKHP",
-            repo="ArknightsStoryJson",
-            asset_name="zh_CN.zip",
-            local_zip=cfg.storyjson_zip,
-        )
+        release_spec = STORY_ZH_CN.release_spec(cfg.storyjson_zip)
         r = sync_release(release_spec)
         _log_sync_result(r)
 

--- a/python/tests/test_dataset_specs.py
+++ b/python/tests/test_dataset_specs.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import zipfile
+
+from prts_mcp.data.datasets import STORY_ZH_CN
+
+
+def test_storyjson_zip_requires_referenced_story_files(tmp_path):
+    zip_path = tmp_path / "zh_CN.zip"
+    story_key = "activities/act_test/level_act_test_01_beg"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("zh_CN/storyinfo.json", "{}")
+        zf.writestr(
+            "zh_CN/gamedata/excel/story_review_table.json",
+            json.dumps(
+                {
+                    "act_test": {
+                        "infoUnlockDatas": [
+                            {"storyTxt": story_key},
+                        ],
+                    },
+                }
+            ),
+        )
+
+    assert STORY_ZH_CN.validate_zip(zip_path) == [
+        f"zh_CN/gamedata/story/{story_key}.json",
+    ]
+
+
+def test_storyjson_zip_accepts_required_metadata_and_story_files(tmp_path):
+    zip_path = tmp_path / "zh_CN.zip"
+    story_key = "activities/act_test/level_act_test_01_beg"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("zh_CN/storyinfo.json", "{}")
+        zf.writestr(
+            "zh_CN/gamedata/excel/story_review_table.json",
+            json.dumps(
+                {
+                    "act_test": {
+                        "infoUnlockDatas": [
+                            {"storyTxt": story_key},
+                        ],
+                    },
+                }
+            ),
+        )
+        zf.writestr(f"zh_CN/gamedata/story/{story_key}.json", "{}")
+
+    assert STORY_ZH_CN.validate_zip(zip_path) == []

--- a/python/tests/test_operator_data.py
+++ b/python/tests/test_operator_data.py
@@ -43,9 +43,35 @@ class TestOperatorDataRefresh:
         with patch.dict(os.environ, {"GAMEDATA_PATH": str(tmp_path)}, clear=False):
             os.environ.pop("STORYJSON_PATH", None)
 
-            assert "阿米娅的档案文本" in get_operator_archives("阿米娅")
-            assert "博士，今天也请多指教" in get_operator_voicelines("阿米娅")
-            assert "情绪吸收" in get_operator_basic_info("阿米娅")
+            assert get_operator_archives("阿米娅") == (
+                "# 阿米娅 - 干员档案\n\n"
+                "### 档案资料一\n"
+                "阿米娅的档案文本。"
+            )
+            assert get_operator_voicelines("阿米娅") == (
+                "# 阿米娅 - 语音记录\n\n"
+                "**任命助理**: 博士，今天也请多指教。"
+            )
+            assert get_operator_basic_info("阿米娅") == (
+                "# 阿米娅 - 干员基本信息\n\n"
+                "- **编号**：R001\n"
+                "- **英文名**：Amiya\n"
+                "- **稀有度**：5★\n"
+                "- **职业**：术师（corecaster）\n"
+                "- **站位**：远程\n"
+                "- **所属**：rhodes\n"
+                "- **招募标签**：输出、支援\n"
+                "- **攻击属性**：法术伤害\n"
+                "\n"
+                "**图鉴**：罗德岛的公开领袖。\n"
+                "\n"
+                "> 阿米娅的信物。\n"
+                "\n"
+                "**获取方式**：主线获得\n"
+                "\n"
+                "## 天赋\n"
+                "- **情绪吸收**：攻击回复技力"
+            )
 
     def test_table_caches_can_be_cleared_explicitly(self, tmp_path):
         write_minimal_gamedata(tmp_path)

--- a/python/tests/test_stores.py
+++ b/python/tests/test_stores.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from prts_mcp.data.stores import DirectoryStore, FallbackStore, ZipStore
+
+
+FIXTURE_PATH = "zh_CN/gamedata/excel/sample.json"
+FIXTURE_DATA = {"name": "阿米娅", "rarity": 5}
+
+
+def write_fixture_dir(root: Path, data: dict = FIXTURE_DATA) -> None:
+    target = root / FIXTURE_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+
+def write_fixture_zip(path: Path, data: dict = FIXTURE_DATA) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr(FIXTURE_PATH, json.dumps(data, ensure_ascii=False))
+
+
+class TestDirectoryStore:
+    def test_reads_json_from_directory(self, tmp_path):
+        write_fixture_dir(tmp_path)
+        store = DirectoryStore(tmp_path)
+
+        assert store.exists(FIXTURE_PATH)
+        assert "阿米娅" in store.read_text(FIXTURE_PATH)
+        assert store.read_json(FIXTURE_PATH) == FIXTURE_DATA
+        assert store.describe().startswith("directory:")
+
+    def test_missing_file_raises(self, tmp_path):
+        store = DirectoryStore(tmp_path)
+
+        assert not store.exists(FIXTURE_PATH)
+        with pytest.raises(FileNotFoundError):
+            store.read_text(FIXTURE_PATH)
+
+    def test_rejects_parent_path(self, tmp_path):
+        store = DirectoryStore(tmp_path)
+
+        with pytest.raises(ValueError):
+            store.exists("../outside.json")
+
+
+class TestZipStore:
+    def test_reads_json_from_zip(self, tmp_path):
+        zip_path = tmp_path / "fixture.zip"
+        write_fixture_zip(zip_path)
+        store = ZipStore(zip_path)
+
+        assert store.exists(FIXTURE_PATH)
+        assert "阿米娅" in store.read_text(FIXTURE_PATH)
+        assert store.read_json(FIXTURE_PATH) == FIXTURE_DATA
+        assert store.describe().startswith("zip:")
+
+    def test_missing_entry_raises(self, tmp_path):
+        zip_path = tmp_path / "fixture.zip"
+        write_fixture_zip(zip_path)
+        store = ZipStore(zip_path)
+
+        assert not store.exists("zh_CN/missing.json")
+        with pytest.raises(FileNotFoundError):
+            store.read_text("zh_CN/missing.json")
+
+    def test_rejects_parent_path(self, tmp_path):
+        store = ZipStore(tmp_path / "fixture.zip")
+
+        with pytest.raises(ValueError):
+            store.exists("../outside.json")
+
+
+class TestFallbackStore:
+    def test_prefers_primary_store(self, tmp_path):
+        primary = tmp_path / "primary"
+        fallback = tmp_path / "fallback"
+        write_fixture_dir(primary, {"source": "primary"})
+        write_fixture_dir(fallback, {"source": "fallback"})
+
+        store = FallbackStore(DirectoryStore(primary), DirectoryStore(fallback))
+
+        assert store.exists(FIXTURE_PATH)
+        assert store.read_json(FIXTURE_PATH) == {"source": "primary"}
+        assert store.describe().startswith("fallback:")
+
+    def test_reads_fallback_when_primary_missing(self, tmp_path):
+        primary = tmp_path / "primary"
+        fallback = tmp_path / "fallback"
+        write_fixture_dir(fallback, {"source": "fallback"})
+
+        store = FallbackStore(DirectoryStore(primary), DirectoryStore(fallback))
+
+        assert store.exists(FIXTURE_PATH)
+        assert store.read_json(FIXTURE_PATH) == {"source": "fallback"}
+
+    def test_missing_in_both_raises(self, tmp_path):
+        store = FallbackStore(
+            DirectoryStore(tmp_path / "primary"),
+            DirectoryStore(tmp_path / "fallback"),
+        )
+
+        assert not store.exists(FIXTURE_PATH)
+        with pytest.raises(FileNotFoundError):
+            store.read_text(FIXTURE_PATH)
+

--- a/python/tests/test_stores.py
+++ b/python/tests/test_stores.py
@@ -48,6 +48,12 @@ class TestDirectoryStore:
         with pytest.raises(ValueError):
             store.exists("../outside.json")
 
+    def test_rejects_absolute_path(self, tmp_path):
+        store = DirectoryStore(tmp_path)
+
+        with pytest.raises(ValueError):
+            store.exists("/zh_CN/gamedata/excel/sample.json")
+
 
 class TestZipStore:
     def test_reads_json_from_zip(self, tmp_path):
@@ -74,6 +80,12 @@ class TestZipStore:
 
         with pytest.raises(ValueError):
             store.exists("../outside.json")
+
+    def test_rejects_absolute_path(self, tmp_path):
+        store = ZipStore(tmp_path / "fixture.zip")
+
+        with pytest.raises(ValueError):
+            store.exists("/zh_CN/gamedata/excel/sample.json")
 
 
 class TestFallbackStore:
@@ -108,4 +120,3 @@ class TestFallbackStore:
         assert not store.exists(FIXTURE_PATH)
         with pytest.raises(FileNotFoundError):
             store.read_text(FIXTURE_PATH)
-

--- a/python/tests/test_story_reader_store.py
+++ b/python/tests/test_story_reader_store.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from prts_mcp.data.stores import DirectoryStore, ZipStore
+from prts_mcp.data.story import (
+    ChapterSummary,
+    StoryChapter,
+    list_stories_from_store,
+    list_story_events_from_store,
+    read_activity_from_store,
+    read_story,
+    read_story_from_store,
+)
+
+
+STORY_REVIEW_PATH = "zh_CN/gamedata/excel/story_review_table.json"
+FIRST_STORY_KEY = "activities/act_test/level_act_test_01_beg"
+SECOND_STORY_KEY = "activities/act_test/level_act_test_02_end"
+
+
+def story_path(story_key: str) -> str:
+    return f"zh_CN/gamedata/story/{story_key}.json"
+
+
+def story_files() -> dict[str, object]:
+    return {
+        STORY_REVIEW_PATH: {
+            "act_test": {
+                "name": "测试活动",
+                "entryType": "ACTIVITY",
+                "infoUnlockDatas": [
+                    {
+                        "storyTxt": SECOND_STORY_KEY,
+                        "storyCode": "TEST-2",
+                        "storyName": "终章",
+                        "avgTag": "END",
+                        "storySort": 2,
+                    },
+                    {
+                        "storyTxt": FIRST_STORY_KEY,
+                        "storyCode": "TEST-1",
+                        "storyName": "开端",
+                        "avgTag": "BEG",
+                        "storySort": 1,
+                    },
+                ],
+            },
+            "main_test": {
+                "name": "测试主线",
+                "entryType": "MAINLINE",
+                "infoUnlockDatas": [],
+            },
+        },
+        story_path(FIRST_STORY_KEY): {
+            "storyCode": "TEST-1",
+            "storyName": "开端",
+            "avgTag": "BEG",
+            "eventName": "测试活动",
+            "storyInfo": "测试简介",
+            "storyList": [
+                {"prop": "name", "attributes": {"name": "阿米娅", "content": "你好，{@nickname}。"}},
+                {"prop": "sticker", "attributes": {"content": "<b>场景描述</b>"}},
+                {"prop": "decision", "attributes": {"options": ["选项一"]}},
+            ],
+        },
+        story_path(SECOND_STORY_KEY): {
+            "storyCode": "TEST-2",
+            "storyName": "终章",
+            "avgTag": "END",
+            "eventName": "测试活动",
+            "storyInfo": "",
+            "storyList": [
+                {"prop": "name", "attributes": {"name": "博士", "content": "结束。"}},
+            ],
+        },
+    }
+
+
+def write_story_dir(root: Path) -> None:
+    for path, data in story_files().items():
+        target = root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+
+def write_story_zip(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as zf:
+        for inner_path, data in story_files().items():
+            zf.writestr(inner_path, json.dumps(data, ensure_ascii=False))
+
+
+@pytest.mark.parametrize("store_kind", ["directory", "zip"])
+def test_story_tools_read_from_store(tmp_path, store_kind):
+    if store_kind == "directory":
+        write_story_dir(tmp_path)
+        store = DirectoryStore(tmp_path)
+    else:
+        zip_path = tmp_path / "zh_CN.zip"
+        write_story_zip(zip_path)
+        store = ZipStore(zip_path)
+
+    events = list_story_events_from_store(store, category="activities")
+    assert [(ev.event_id, ev.name, ev.entry_type, ev.story_count) for ev in events] == [
+        ("act_test", "测试活动", "ACTIVITY", 2)
+    ]
+
+    chapters = list_stories_from_store(store, "act_test")
+    assert chapters == [
+        ChapterSummary(
+            story_key=FIRST_STORY_KEY,
+            story_code="TEST-1",
+            story_name="开端",
+            avg_tag="BEG",
+            sort_order=1,
+        ),
+        ChapterSummary(
+            story_key=SECOND_STORY_KEY,
+            story_code="TEST-2",
+            story_name="终章",
+            avg_tag="END",
+            sort_order=2,
+        ),
+    ]
+
+    chapter = read_story_from_store(store, FIRST_STORY_KEY)
+    assert isinstance(chapter, StoryChapter)
+    assert chapter.story_name == "开端"
+    assert [line.text for line in chapter.lines] == ["你好，博士。", "场景描述", "选项一"]
+
+    dialogs_only = read_story_from_store(store, FIRST_STORY_KEY, include_narration=False)
+    assert [line.type for line in dialogs_only.lines] == ["dialog", "choice"]
+
+    activity = read_activity_from_store(store, "act_test", page=1, page_size=1)
+    assert activity.event_name == "测试活动"
+    assert activity.total_chapters == 2
+    assert activity.has_more is True
+    assert [chapter.story_key for chapter in activity.chapters] == [FIRST_STORY_KEY]
+
+
+def test_public_zip_path_api_still_reads_zip(tmp_path):
+    zip_path = tmp_path / "zh_CN.zip"
+    write_story_zip(zip_path)
+
+    chapter = read_story(zip_path, FIRST_STORY_KEY)
+
+    assert chapter.story_code == "TEST-1"
+    assert chapter.lines[0].text == "你好，博士。"
+
+
+def test_missing_story_raises_key_error(tmp_path):
+    write_story_dir(tmp_path)
+    store = DirectoryStore(tmp_path)
+
+    with pytest.raises(KeyError):
+        read_story_from_store(store, "activities/act_test/missing")
+

--- a/python/tests/test_tool_surface.py
+++ b/python/tests/test_tool_surface.py
@@ -18,6 +18,8 @@ EXPECTED_TOOL_SURFACE = {
 
 
 def test_python_tool_function_signatures_are_frozen() -> None:
+    # Alpha hardening intentionally freezes required and optional parameters.
+    # Relax this before 1.0 final if additive optional parameters become policy.
     source = Path(__file__).parents[1] / "src" / "prts_mcp" / "server.py"
     module = ast.parse(source.read_text(encoding="utf-8"))
     functions = {

--- a/python/tests/test_tool_surface.py
+++ b/python/tests/test_tool_surface.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+EXPECTED_TOOL_SURFACE = {
+    "search_prts": ("query", "limit"),
+    "read_prts_page": ("page_title",),
+    "get_operator_archives": ("operator_name",),
+    "get_operator_voicelines": ("operator_name",),
+    "get_operator_basic_info": ("operator_name",),
+    "list_story_events": ("category",),
+    "list_stories": ("event_id",),
+    "read_story": ("story_key", "include_narration"),
+    "read_activity": ("event_id", "include_narration", "page", "page_size"),
+}
+
+
+def test_python_tool_function_signatures_are_frozen() -> None:
+    source = Path(__file__).parents[1] / "src" / "prts_mcp" / "server.py"
+    module = ast.parse(source.read_text(encoding="utf-8"))
+    functions = {
+        node.name: node
+        for node in module.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+    for name, expected_params in EXPECTED_TOOL_SURFACE.items():
+        fn = functions[name]
+        params = [arg.arg for arg in fn.args.args]
+        assert tuple(params) == expected_params


### PR DESCRIPTION
## Summary
- add Python dataset specs and directory/zip/fallback stores for the 1.0 data layer
- migrate Python operator and story parsers behind the store abstraction while preserving tool names, parameters, and output formatting
- add Phase 0/Phase 6 docs, 0.x migration notes, package data checks, and Python 1.0.0-alpha.1 release prep

## Scope
This PR is the Python-line PR cut from the shared base commit `9152a89`. It intentionally does not include the TypeScript implementation changes.

## Verification
- `F:\2026-Spring\PRTS-MCP\python\.venv\bin\python.exe -m pytest python\tests`
- `F:\2026-Spring\PRTS-MCP\python\.venv\bin\python.exe -m compileall python\src python\scripts`

## Notes
- `python/scripts/check_package_data.py --data-root data` fails locally unless `data/storyjson/zh_CN.zip` has been prewarmed; CI/CD downloads it before running the check.
