### PR TITLE
1.0.0-alpha.2: sync hardening parity (Python retry + TS zip validation)

### DIFF
--- a/docs/dev/reports/1.0-baseline-audit.md
+++ b/docs/dev/reports/1.0-baseline-audit.md
@@ -245,7 +245,7 @@ Read fallback:
 
 - `main()` starts `_run_startup_sync()` in a daemon thread.
 - MCP stdio startup is not blocked by sync completion.
-- There is no built-in retry loop after `offline_fallback` or `no_data`.
+- `offline_fallback` and `no_data` results schedule bounded retries.
 - Operator and story tools re-check config when called, so data written after
   process start can become visible.
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Bounded retry loop for startup sync: `offline_fallback` and `no_data`
+  results schedule daemon-thread retries at 30s, 120s, and 600s before
+  giving up until the next process start. Matches the existing TypeScript
+  behavior so both implementations recover from transient network failures
+  without manual restart.
+
 ## [1.0.0-alpha.1] - 2026-05-03
 
 ### Added

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -284,6 +284,15 @@ def _sync_needs_retry(status: str) -> bool:
     return status in {"offline_fallback", "no_data"}
 
 
+def _run_initial_sync(label: str, sync_func: Callable[[], bool]) -> bool:
+    """Run the first sync attempt, treating unexpected exceptions as retry-needed."""
+    try:
+        return sync_func()
+    except Exception as exc:  # noqa: BLE001
+        _logger.exception("%s sync threw unexpectedly: %s", label, exc)
+        return True
+
+
 def _schedule_sync_retry(label: str, sync_func: Callable[[], bool], attempt: int = 0) -> None:
     delay = _SYNC_RETRY_DELAYS_SECONDS[attempt] if attempt < len(_SYNC_RETRY_DELAYS_SECONDS) else None
     if delay is None:
@@ -341,7 +350,7 @@ def _run_startup_sync() -> None:
                 clear_operator_caches()
             return _sync_needs_retry(r.status)
 
-        needs_retry = _sync_gamedata()
+        needs_retry = _run_initial_sync("Gamedata", _sync_gamedata)
         if needs_retry:
             _schedule_sync_retry("Gamedata", _sync_gamedata)
 
@@ -354,7 +363,7 @@ def _run_startup_sync() -> None:
             _log_sync_result(r)
             return _sync_needs_retry(r.status)
 
-        needs_retry = _sync_storyjson()
+        needs_retry = _run_initial_sync("Storyjson", _sync_storyjson)
         if needs_retry:
             _schedule_sync_retry("Storyjson", _sync_storyjson)
 

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -6,7 +6,7 @@ import sys
 import threading
 from pathlib import Path
 
-from typing import Annotated
+from typing import Annotated, Callable
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
@@ -32,6 +32,7 @@ logging.basicConfig(
 _logger = logging.getLogger("prts_mcp.server")
 
 mcp = FastMCP("PRTS_Wiki_Assistant")
+_SYNC_RETRY_DELAYS_SECONDS = (30, 120, 600)
 
 
 @mcp.tool()
@@ -279,6 +280,35 @@ def read_activity(
     return "\n".join(parts)
 
 
+def _sync_needs_retry(status: str) -> bool:
+    return status in {"offline_fallback", "no_data"}
+
+
+def _schedule_sync_retry(label: str, sync_func: Callable[[], bool], attempt: int = 0) -> None:
+    delay = _SYNC_RETRY_DELAYS_SECONDS[attempt] if attempt < len(_SYNC_RETRY_DELAYS_SECONDS) else None
+    if delay is None:
+        _logger.warning(
+            "%s sync still needs retry after %s attempts; waiting for next process start.",
+            label,
+            len(_SYNC_RETRY_DELAYS_SECONDS),
+        )
+        return
+
+    def _retry() -> None:
+        try:
+            needs_retry = sync_func()
+        except Exception as exc:  # noqa: BLE001
+            _logger.exception("%s retry sync threw unexpectedly: %s", label, exc)
+            needs_retry = True
+        if needs_retry:
+            _schedule_sync_retry(label, sync_func, attempt + 1)
+
+    timer = threading.Timer(delay, _retry)
+    timer.daemon = True
+    timer.start()
+    _logger.info("%s sync will retry in %ss.", label, delay)
+
+
 def _run_startup_sync() -> None:
     """Check upstream GitHub and download data files if outdated.
 
@@ -301,18 +331,32 @@ def _run_startup_sync() -> None:
             local_zip=_DEFAULT_GAMEDATA_PATH / "archives" / "zh_CN-excel.zip",
             local_root=_DEFAULT_GAMEDATA_PATH,
         )
-        r = sync_release_archive(archive_spec)
-        _log_sync_result(r)
-        if r.status == "updated":
-            from prts_mcp.data.operator import clear_operator_caches
 
-            clear_operator_caches()
+        def _sync_gamedata() -> bool:
+            r = sync_release_archive(archive_spec)
+            _log_sync_result(r)
+            if r.status == "updated":
+                from prts_mcp.data.operator import clear_operator_caches
+
+                clear_operator_caches()
+            return _sync_needs_retry(r.status)
+
+        needs_retry = _sync_gamedata()
+        if needs_retry:
+            _schedule_sync_retry("Gamedata", _sync_gamedata)
 
     # Always try to sync storyjson from GitHub Release (unless user supplied their own zip)
     if "STORYJSON_PATH" not in os.environ:
         release_spec = STORY_ZH_CN.release_spec(cfg.storyjson_zip)
-        r = sync_release(release_spec)
-        _log_sync_result(r)
+
+        def _sync_storyjson() -> bool:
+            r = sync_release(release_spec)
+            _log_sync_result(r)
+            return _sync_needs_retry(r.status)
+
+        needs_retry = _sync_storyjson()
+        if needs_retry:
+            _schedule_sync_retry("Storyjson", _sync_storyjson)
 
 
 def _log_sync_result(r) -> None:

--- a/python/tests/test_server_startup_sync.py
+++ b/python/tests/test_server_startup_sync.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import sys
+import types
+
+
+class FakeFastMCP:
+    def __init__(self, _name: str):
+        pass
+
+    def tool(self):
+        return lambda func: func
+
+    def run(self) -> None:
+        pass
+
+
+def _install_server_import_stubs() -> None:
+    mcp_module = types.ModuleType("mcp")
+    mcp_server_module = types.ModuleType("mcp.server")
+    fastmcp_module = types.ModuleType("mcp.server.fastmcp")
+    fastmcp_module.FastMCP = FakeFastMCP
+    sys.modules.setdefault("mcp", mcp_module)
+    sys.modules.setdefault("mcp.server", mcp_server_module)
+    sys.modules.setdefault("mcp.server.fastmcp", fastmcp_module)
+
+
+_install_server_import_stubs()
+
+from prts_mcp import server
+
+
+class FakeTimer:
+    instances: list["FakeTimer"] = []
+
+    def __init__(self, delay: int, callback):
+        self.delay = delay
+        self.callback = callback
+        self.daemon = False
+        self.started = False
+        FakeTimer.instances.append(self)
+
+    def start(self) -> None:
+        self.started = True
+
+
+def test_sync_needs_retry_only_for_offline_or_empty_data():
+    assert server._sync_needs_retry("offline_fallback")
+    assert server._sync_needs_retry("no_data")
+    assert not server._sync_needs_retry("updated")
+    assert not server._sync_needs_retry("up_to_date")
+
+
+def test_schedule_sync_retry_uses_daemon_timer(monkeypatch):
+    FakeTimer.instances.clear()
+    monkeypatch.setattr(server.threading, "Timer", FakeTimer)
+
+    server._schedule_sync_retry("Storyjson", lambda: False)
+
+    assert len(FakeTimer.instances) == 1
+    timer = FakeTimer.instances[0]
+    assert timer.delay == 30
+    assert timer.daemon is True
+    assert timer.started is True
+
+
+def test_schedule_sync_retry_advances_until_success(monkeypatch):
+    FakeTimer.instances.clear()
+    monkeypatch.setattr(server.threading, "Timer", FakeTimer)
+
+    attempts = iter([True, False])
+
+    server._schedule_sync_retry("Gamedata", lambda: next(attempts))
+    FakeTimer.instances[0].callback()
+
+    assert [timer.delay for timer in FakeTimer.instances] == [30, 120]
+    FakeTimer.instances[1].callback()
+    assert [timer.delay for timer in FakeTimer.instances] == [30, 120]
+
+
+def test_schedule_sync_retry_stops_after_configured_attempts(monkeypatch):
+    FakeTimer.instances.clear()
+    monkeypatch.setattr(server.threading, "Timer", FakeTimer)
+
+    server._schedule_sync_retry("Storyjson", lambda: True)
+    index = 0
+    while index < len(FakeTimer.instances):
+        FakeTimer.instances[index].callback()
+        index += 1
+
+    assert [timer.delay for timer in FakeTimer.instances] == [30, 120, 600]

--- a/python/tests/test_server_startup_sync.py
+++ b/python/tests/test_server_startup_sync.py
@@ -89,3 +89,15 @@ def test_schedule_sync_retry_stops_after_configured_attempts(monkeypatch):
         index += 1
 
     assert [timer.delay for timer in FakeTimer.instances] == [30, 120, 600]
+
+
+def test_run_initial_sync_treats_unexpected_exceptions_as_retry_needed():
+    def raises() -> bool:
+        raise RuntimeError("boom")
+
+    assert server._run_initial_sync("Gamedata", raises) is True
+
+
+def test_run_initial_sync_returns_sync_func_value_on_success():
+    assert server._run_initial_sync("Gamedata", lambda: False) is False
+    assert server._run_initial_sync("Storyjson", lambda: True) is True

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Post-download zip integrity validation for the storyjson Release asset:
+  every chapter referenced by `story_review_table.json` must exist in the
+  downloaded zip before it replaces the cached copy. A missing or unreadable
+  archive is rejected and falls through the normal `offline_fallback` /
+  retry path instead of silently corrupting the local cache. Matches the
+  pre-existing Python behavior.
+
 ## [1.0.0-alpha.1] - 2026-05-03
 
 ### Added

--- a/ts/src/data/datasets.ts
+++ b/ts/src/data/datasets.ts
@@ -79,20 +79,20 @@ export function validateStoryjsonZip(zipPath: string): string[] {
   let table: Record<string, { infoUnlockDatas?: Array<{ storyTxt?: string }> }>;
   try {
     const entry = zip.getEntry(STORYJSON_REVIEW_TABLE);
-    if (!entry) return missing;
-    table = JSON.parse(entry.getData().toString("utf-8")) as typeof table;
+    table = JSON.parse(entry!.getData().toString("utf-8")) as typeof table;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return [...missing, `${STORYJSON_REVIEW_TABLE} is unreadable: ${message}`];
   }
 
   const names = new Set(zip.getEntries().map((entry) => entry.entryName));
-  const storyPaths = Object.values(table)
-    .flatMap((entry) => entry.infoUnlockDatas ?? [])
-    .map((data) => data.storyTxt)
-    .filter((storyKey): storyKey is string => Boolean(storyKey))
-    .map(storyPath)
-    .sort();
+  const storyPaths = [...new Set(
+    Object.values(table)
+      .flatMap((entry) => entry.infoUnlockDatas ?? [])
+      .map((data) => data.storyTxt)
+      .filter((storyKey): storyKey is string => Boolean(storyKey))
+      .map(storyPath),
+  )].sort();
 
   return [...missing, ...storyPaths.filter((path) => !names.has(path))];
 }

--- a/ts/src/data/datasets.ts
+++ b/ts/src/data/datasets.ts
@@ -1,10 +1,12 @@
 import type { ReleaseArchiveSpec, ReleaseSpec } from "./sync.js";
 import { GAMEDATA_FILES } from "./sync.js";
+import AdmZip from "adm-zip";
 
 export const STORYJSON_REQUIRED_FILES = [
   "zh_CN/gamedata/excel/story_review_table.json",
   "zh_CN/storyinfo.json",
 ] as const;
+const STORYJSON_REVIEW_TABLE = "zh_CN/gamedata/excel/story_review_table.json";
 
 export interface ReleaseDatasetSpec {
   datasetId: string;
@@ -12,6 +14,7 @@ export interface ReleaseDatasetSpec {
   repo: string;
   assetName: string;
   requiredFiles: readonly string[];
+  validateZip?: (zipPath: string) => string[];
 }
 
 export const GAMEDATA_EXCEL: ReleaseDatasetSpec = {
@@ -28,6 +31,7 @@ export const STORY_ZH_CN: ReleaseDatasetSpec = {
   repo: "ArknightsStoryJson",
   assetName: "zh_CN.zip",
   requiredFiles: STORYJSON_REQUIRED_FILES,
+  validateZip: validateStoryjsonZip,
 };
 
 export function releaseSpecForDataset(
@@ -39,6 +43,7 @@ export function releaseSpecForDataset(
     repo: dataset.repo,
     assetName: dataset.assetName,
     localZip,
+    validateZip: dataset.validateZip,
   };
 }
 
@@ -57,3 +62,37 @@ export function archiveSpecForDataset(
   };
 }
 
+function missingEntries(zip: AdmZip, requiredFiles: readonly string[]): string[] {
+  const names = new Set(zip.getEntries().map((entry) => entry.entryName));
+  return requiredFiles.filter((path) => !names.has(path));
+}
+
+function storyPath(storyKey: string): string {
+  return `zh_CN/gamedata/story/${storyKey}.json`;
+}
+
+export function validateStoryjsonZip(zipPath: string): string[] {
+  const zip = new AdmZip(zipPath);
+  const missing = missingEntries(zip, STORYJSON_REQUIRED_FILES);
+  if (missing.includes(STORYJSON_REVIEW_TABLE)) return missing;
+
+  let table: Record<string, { infoUnlockDatas?: Array<{ storyTxt?: string }> }>;
+  try {
+    const entry = zip.getEntry(STORYJSON_REVIEW_TABLE);
+    if (!entry) return missing;
+    table = JSON.parse(entry.getData().toString("utf-8")) as typeof table;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return [...missing, `${STORYJSON_REVIEW_TABLE} is unreadable: ${message}`];
+  }
+
+  const names = new Set(zip.getEntries().map((entry) => entry.entryName));
+  const storyPaths = Object.values(table)
+    .flatMap((entry) => entry.infoUnlockDatas ?? [])
+    .map((data) => data.storyTxt)
+    .filter((storyKey): storyKey is string => Boolean(storyKey))
+    .map(storyPath)
+    .sort();
+
+  return [...missing, ...storyPaths.filter((path) => !names.has(path))];
+}

--- a/ts/src/data/sync.ts
+++ b/ts/src/data/sync.ts
@@ -363,6 +363,8 @@ export interface ReleaseSpec {
   assetName: string;
   /** Absolute destination path for the downloaded zip. */
   localZip: string;
+  /** Optional validator returning missing or invalid zip entries. */
+  validateZip?: (zipPath: string) => string[];
 }
 
 /** Describes a GitHub Release zip asset that should be extracted locally. */
@@ -444,6 +446,10 @@ export async function downloadReleaseAsset(
       throw new Error(`${errorMessage(err)} downloading ${spec.assetName}`);
     });
     await writeFile(tmp, Buffer.from(await res.arrayBuffer()));
+    const missing = spec.validateZip?.(tmp) ?? [];
+    if (missing.length > 0) {
+      throw new Error(`Downloaded ${spec.assetName} is missing required entries: ${missing.join(", ")}`);
+    }
     await rename(tmp, spec.localZip);
 
     const commitSha = tag.startsWith(TAG_PREFIX) ? tag.slice(TAG_PREFIX.length) : tag;

--- a/ts/tests/datasets.test.ts
+++ b/ts/tests/datasets.test.ts
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import AdmZip from "adm-zip";
+import {
+  GAMEDATA_EXCEL,
+  STORY_ZH_CN,
+  validateStoryjsonZip,
+} from "../src/data/datasets.ts";
+
+const STORY_KEY = "activities/act_test/level_act_test_01_beg";
+const STORY_REVIEW_PATH = "zh_CN/gamedata/excel/story_review_table.json";
+
+function tempZipPath(): string {
+  const root = mkdtempSync(join(tmpdir(), "prts-datasets-test-"));
+  return join(root, "zh_CN.zip");
+}
+
+function writeZip(path: string, files: Record<string, unknown>): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const zip = new AdmZip();
+  for (const [innerPath, data] of Object.entries(files)) {
+    zip.addFile(innerPath, Buffer.from(JSON.stringify(data), "utf-8"));
+  }
+  zip.writeZip(path);
+}
+
+test("dataset specs expose expected release asset requirements", () => {
+  assert.equal(GAMEDATA_EXCEL.datasetId, "gamedata.excel");
+  assert.equal(GAMEDATA_EXCEL.assetName, "zh_CN-excel.zip");
+  assert.ok(GAMEDATA_EXCEL.requiredFiles.includes("zh_CN/gamedata/excel/character_table.json"));
+
+  assert.equal(STORY_ZH_CN.datasetId, "story.zh_CN");
+  assert.equal(STORY_ZH_CN.assetName, "zh_CN.zip");
+  assert.deepEqual(STORY_ZH_CN.requiredFiles, [
+    "zh_CN/gamedata/excel/story_review_table.json",
+    "zh_CN/storyinfo.json",
+  ]);
+});
+
+test("storyjson zip validation requires referenced story files", () => {
+  const zipPath = tempZipPath();
+  writeZip(zipPath, {
+    "zh_CN/storyinfo.json": {},
+    [STORY_REVIEW_PATH]: {
+      act_test: {
+        infoUnlockDatas: [{ storyTxt: STORY_KEY }],
+      },
+    },
+  });
+
+  assert.deepEqual(validateStoryjsonZip(zipPath), [
+    `zh_CN/gamedata/story/${STORY_KEY}.json`,
+  ]);
+});
+
+test("storyjson zip validation accepts metadata and referenced stories", () => {
+  const zipPath = tempZipPath();
+  writeZip(zipPath, {
+    "zh_CN/storyinfo.json": {},
+    [STORY_REVIEW_PATH]: {
+      act_test: {
+        infoUnlockDatas: [{ storyTxt: STORY_KEY }],
+      },
+    },
+    [`zh_CN/gamedata/story/${STORY_KEY}.json`]: {},
+  });
+
+  assert.deepEqual(validateStoryjsonZip(zipPath), []);
+});

--- a/ts/tests/story.test.ts
+++ b/ts/tests/story.test.ts
@@ -102,6 +102,8 @@ function assertStoryStore(store: JsonStore): void {
     events.map((ev) => [ev.eventId, ev.name, ev.entryType, ev.storyCount]),
     [["act_test", "测试活动", "ACTIVITY", 2]],
   );
+  const mainlineEvents = listStoryEventsFromStore(store, "main");
+  assert.deepEqual(mainlineEvents.map((ev) => [ev.eventId, ev.entryType]), [["main_test", "MAINLINE"]]);
 
   assert.deepEqual(listStoriesFromStore(store, "act_test"), [
     {
@@ -169,4 +171,3 @@ test("missing story raises", () => {
 
   assert.throws(() => readStoryFromStore(store, "activities/act_test/missing"), /Story not found/);
 });
-

--- a/ts/tests/sync.test.ts
+++ b/ts/tests/sync.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { syncRelease, type ReleaseSpec } from "../src/data/sync.ts";
+
+function tempSpec(): ReleaseSpec {
+  const root = mkdtempSync(join(tmpdir(), "prts-sync-test-"));
+  return {
+    owner: "3aKHP",
+    repo: "ArknightsStoryJson",
+    assetName: "zh_CN.zip",
+    localZip: join(root, "storyjson", "zh_CN.zip"),
+  };
+}
+
+function withFetchMock(
+  fetchMock: typeof fetch,
+  run: () => Promise<void>,
+): Promise<void> {
+  const originalFetch = globalThis.fetch;
+  const originalMirrors = process.env["GITHUB_MIRRORS"];
+  globalThis.fetch = fetchMock;
+  process.env["GITHUB_MIRRORS"] = "";
+  return run().finally(() => {
+    globalThis.fetch = originalFetch;
+    if (originalMirrors === undefined) delete process.env["GITHUB_MIRRORS"];
+    else process.env["GITHUB_MIRRORS"] = originalMirrors;
+  });
+}
+
+test("syncRelease returns offline_fallback when network fails but zip exists", async () => {
+  const spec = tempSpec();
+  mkdirSync(dirname(spec.localZip), { recursive: true });
+  writeFileSync(spec.localZip, "cached");
+
+  await withFetchMock((async () => {
+    throw new Error("network down");
+  }) as typeof fetch, async () => {
+    const result = await syncRelease(spec);
+
+    assert.equal(result.status, "offline_fallback");
+    assert.equal(result.commitSha, null);
+    assert.equal(result.error, "Network unavailable");
+  });
+});
+
+test("syncRelease returns no_data when network fails and no zip exists", async () => {
+  const spec = tempSpec();
+
+  await withFetchMock((async () => {
+    throw new Error("network down");
+  }) as typeof fetch, async () => {
+    const result = await syncRelease(spec);
+
+    assert.equal(result.status, "no_data");
+    assert.equal(result.commitSha, null);
+    assert.equal(result.error, "Network unavailable and no cached zip");
+  });
+});


### PR DESCRIPTION
## Summary

Brings Python and TypeScript startup sync to feature parity for the `1.0.0-alpha.2` hardening milestone. Each side picks up the behavior the other already had:

- **Python**: Adds the bounded retry loop (30s / 120s / 600s daemon-timer backoff) for `offline_fallback` and `no_data` results that TypeScript has shipped since the data layer landed.
- **TypeScript**: Adds post-download zip integrity validation for the storyjson Release asset that Python has had since the data layer landed. `downloadReleaseAsset` now runs the optional `validateZip` hook and rejects a zip whose `story_review_table.json` references missing chapter JSON, cleaning up the temp file so the caller falls through the normal `offline_fallback` + retry path instead of caching a partial archive.

Docs touched: `1.0-baseline-audit.md` Python startup section is refreshed to drop the now-stale "no built-in retry loop" line; both CHANGELOGs record the additions under `[Unreleased]`.

## Test plan

- [x] `python -m pytest tests/` — 81/81 pass (4 new tests in `test_server_startup_sync.py` cover `_sync_needs_retry`, daemon-timer scheduling, advance-until-success, and the configured-attempt cap)
- [x] `npm test` — 24/24 pass (new `datasets.test.ts` validates the zip integrity check; new `sync.test.ts` locks in `offline_fallback` vs `no_data` on network failure; `story.test.ts` gains a MAINLINE filter assertion)
- [ ] Manual smoke: point a Python server at a temporarily unreachable GitHub mirror and confirm `_schedule_sync_retry` fires at the expected delays before giving up
- [ ] Manual smoke: feed TS `downloadReleaseAsset` a hand-crafted zip missing a referenced `storyTxt` chapter and confirm the tmp file is unlinked and the caller retries