### PR TITLE
docs: prepare 1.0.0-alpha.2 prerelease

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This repository contains two independent implementations for different deploymen
 
 | Area | Python | TypeScript | 1.0 policy |
 |------|--------|------------|------------|
-| Current line | `1.0.0-alpha.1` | `1.0.0-alpha.1` | Alpha releases are cut from the same commit when possible |
+| Current line | `1.0.0-alpha.2` | `1.0.0-alpha.2` | Alpha releases are cut from the same commit when possible |
 | MCP tools | Same public tool names and required parameters | Same public tool names and required parameters | Tool names and required parameters stay stable through 1.0 |
 | GameData | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | Custom paths disable auto-sync |
 | Story data | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | Custom zip paths disable auto-sync |
@@ -88,7 +88,7 @@ Published Docker images and the npm package include bundled fallback game/story 
 
 | 范围 | Python | TypeScript | 1.0 策略 |
 |------|--------|------------|----------|
-| 当前版本线 | `1.0.0-alpha.1` | `1.0.0-alpha.1` | Alpha 尽量从同一 commit 发布 |
+| 当前版本线 | `1.0.0-alpha.2` | `1.0.0-alpha.2` | Alpha 尽量从同一 commit 发布 |
 | MCP 工具 | 相同工具名和必填参数 | 相同工具名和必填参数 | 1.0 期间保持工具名和必填参数稳定 |
 | 干员数据 | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | 自定义路径会禁用自动同步 |
 | 剧情数据 | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | 自定义 zip 会禁用自动同步 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # PRTS-MCP Roadmap
 
-_Last updated: 2026-05-03_
+_Last updated: 2026-05-04_
 
 PRTS-MCP is moving from a fast-evolving dual implementation project toward a
 stable 1.0 architecture. The next major release is planned as a compatibility
@@ -8,10 +8,13 @@ and data-layer milestone rather than a new-feature sprint.
 
 ## Current Alpha Release
 
-- Python: `1.0.0-alpha.1`
-- TypeScript: `1.0.0-alpha.1`
+- Python: `1.0.0-alpha.2`
+- TypeScript: `1.0.0-alpha.2`
 - Main purpose: validate the 1.0 data reader architecture, aligned public tool
   surface, and release packaging path before the stable 1.0 line.
+- alpha.2 adds cross-implementation parity for startup-sync hardening:
+  bounded retry on transient network failures and post-download zip
+  integrity validation for the storyjson Release asset.
 - Bundled fallback data policy:
   - Docker images include CI-prewarmed fallback data.
   - npm releases include CI-prewarmed fallback data.
@@ -73,6 +76,11 @@ support future feature work without duplicating sync and parsing paths.
 
 ### `1.0.0-alpha.2`: Sync and Storage Consolidation
 
+- Status: ready for prerelease tagging from the current `main` commit.
+- Added bounded retry for `offline_fallback` / `no_data` startup-sync
+  results on the Python side (TypeScript already had it).
+- Added post-download zip integrity validation for the storyjson Release
+  asset on the TypeScript side (Python already had it).
 - Normalize release metadata, cache freshness, and fallback decisions.
 - Decide which datasets remain zip-backed at runtime and which are extracted.
 - Verify Docker and npm bundled fallback data through CI package inspection.

--- a/docs/dev/plans/1.0-development-roadmap.md
+++ b/docs/dev/plans/1.0-development-roadmap.md
@@ -74,6 +74,11 @@ Python and TypeScript currently expose the same intended tool surface:
 
 ### `1.0.0-alpha.2`
 
+- Status: ready for prerelease tagging from the current `main` commit.
+- Added bounded retry loop for Python startup sync, matching the existing
+  TypeScript behavior.
+- Added post-download zip integrity validation for the TypeScript storyjson
+  Release asset, matching the existing Python behavior.
 - Consolidate sync/cache metadata behavior around dataset specs.
 - Decide whether gamedata should remain extracted in the transition or become
   zip-first behind the reader abstraction.

--- a/docs/migration-0.x-to-1.0.md
+++ b/docs/migration-0.x-to-1.0.md
@@ -1,6 +1,6 @@
 # Migration Guide: 0.x to 1.0
 
-_Status: 1.0.0-alpha.1_
+_Status: 1.0.0-alpha.2_
 
 PRTS-MCP 1.0 keeps the public MCP tool surface stable while normalizing the
 internal data layer.

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.0-alpha.2] - 2026-05-04
+
 ### Added
 
 - Bounded retry loop for startup sync: `offline_fallback` and `no_data`
@@ -14,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   giving up until the next process start. Matches the existing TypeScript
   behavior so both implementations recover from transient network failures
   without manual restart.
+- The first sync attempt is wrapped in `_run_initial_sync`, so an
+  unexpected exception in `sync_release` / `sync_release_archive` no longer
+  kills the daemon sync thread; it is logged and treated as retry-needed,
+  matching the TypeScript `.catch(() => true)` baseline.
 
 ## [1.0.0-alpha.1] - 2026-05-03
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.0-alpha.2] - 2026-05-04
+
 ### Added
 
 - Post-download zip integrity validation for the storyjson Release asset:

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "1.0.0-alpha.1",
+      "version": "1.0.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP)",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Follows the same shape as the alpha.1 prep commit (`6165183`): bumps versions, stamps dated CHANGELOG sections, and refreshes status-of-alpha lines so tagging `python/v1.0.0-alpha.2` / `ts/v1.0.0-alpha.2` on the merge commit produces coherent release notes and package metadata.

- `python/pyproject.toml`: `1.0.0-alpha.1` → `1.0.0-alpha.2`
- `ts/package.json` + regenerated `ts/package-lock.json`: same bump
- Both CHANGELOGs: `[Unreleased]` → `[1.0.0-alpha.2] - 2026-05-04`, with the `_run_initial_sync` exception wrapper folded into the Python entry
- `ROADMAP.md`: "Current Alpha Release" bumped; alpha.2 section marked ready for tagging with the two parity items it delivered
- `docs/dev/plans/1.0-development-roadmap.md`: alpha.2 status updated
- `docs/migration-0.x-to-1.0.md`: status line bumped
- `README.md`: compatibility matrix bumped (EN + ZH)

No code changes.

## Test plan

- [x] `python -m pytest tests/` — 83/83 (includes the 2 new `_run_initial_sync` tests merged via PR #11)
- [x] `npm test` — 24/24
- [x] Validator sanity: `STORY_ZH_CN.validate_zip` accepts the fork's latest `zh_CN.zip` with 0 missing entries, so alpha.2's stricter TS validator will not reject real-world assets.
- [ ] After merge: tag `python/v1.0.0-alpha.2` and `ts/v1.0.0-alpha.2` on the merge commit, which triggers pre-release PyPI / npm alpha / GHCR / GitHub release workflows.