### PR TITLE
feat: add PRTS Wiki deep integration (sections, categories, links)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,14 +1,14 @@
 # PRTS-MCP Roadmap
 
-_Last updated: 2026-05-14_
+_Last updated: 2026-05-18_
 
 PRTS-MCP has reached its first stable release. The public tool surface and
 data architecture are now under a compatibility contract.
 
 ## Current Release
 
-- Python: `1.2.0`
-- TypeScript: `1.2.0`
+- Python: `1.3.0`
+- TypeScript: `1.3.0`
 - The public tool surface (12 MCP tools) is frozen in the 1.x line.
   Automated CI checks enforce this.
 - 1.1.0 adds 3 search tools. 1.2.0 adds 2 story summary tools.
@@ -162,11 +162,38 @@ decisions yet; this section captures what's possible.
   LLM-generated long summaries (5~7:1 per-chapter, 10:1 per-event). Three-tier
   fallback ensures graceful degradation when LLM data is unavailable.
 
-## Next Feature: PRTS API Deep Integration
+## 1.3.0: PRTS API Deep Integration
 
-See the [1.2.0 PRTS API Enhancement Candidates](#120-prts-api-enhancement-candidates)
-section above. Categories, sections, search quality, and template parsing are
-all viable targets for the next release cycle.
+Delivered in Python. See [CHANGELOG](python/CHANGELOG.md#130---2026-05-18).
+
+### Added
+
+- `list_prts_sections(page_title)` — section table of contents
+- `get_prts_categories(page_title)` — page category tags
+- `get_prts_links(page_title, direction, limit)` — outbound/inbound links
+
+### Changed
+
+- `read_prts_page` — new `section_index` parameter
+- `search_prts` — new `search_mode`, `filter_technical`; returns `totalhits`
+
+### Deferred
+
+- Template data extraction (`prop=parsetree`) — feasible but complex; defer to
+  1.4.0 after separate prototype validation.
+
+## Next Feature: TS Port of 1.3.0 (TypeScript)
+
+TS implementation now at 1.3.0 — parity with Python achieved.
+
+The next major feature area is Template Data Extraction (`prop=parsetree`),
+deferred from 1.3.0. See "Deferred" in the 1.3.0 section above.
+
+## Template Data Extraction (Future)
+
+Prototype `prop=parsetree` → XML parse → template key-value extraction.
+Decision point after prototype: productize in 1.4.0, or defer further based
+on robustness findings.
 
 ## Detailed Plans
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -164,7 +164,7 @@ decisions yet; this section captures what's possible.
 
 ## 1.3.0: PRTS API Deep Integration
 
-Delivered in Python. See [CHANGELOG](python/CHANGELOG.md#130---2026-05-18).
+Delivered in both Python and TypeScript. See [Python CHANGELOG](python/CHANGELOG.md#130---2026-05-18) and [TS CHANGELOG](ts/CHANGELOG.md#130---2026-05-18).
 
 ### Added
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-05-18
+
+### Added
+
+- **PRTS page table of contents.** `list_prts_sections(page_title)` returns the
+  section index for a wiki page. Each section is labeled with its index (e.g.
+  `[1]`, `[T-1]` for template-transcluded), heading level, and title.
+- **PRTS page categories.** `get_prts_categories(page_title)` returns the
+  category tags for a wiki page (e.g. "干员", "术师干员").
+- **PRTS page links.** `get_prts_links(page_title, direction, limit)` returns
+  outbound links from a page or inbound backlinks to a page, with pagination.
+
+### Changed
+
+- **`read_prts_page` gains `section_index` parameter.** When set, only the
+  specified section's plain-text content is returned instead of the full page.
+  Backwards-compatible: the parameter defaults to `None` (whole page).
+- **`search_prts` enhanced.** New `search_mode` parameter (`text` / `title`),
+  `filter_technical` toggle (default `true`, filters `/spine`, `/data`, etc.
+  technical pages), and `totalhits` count in search results. Backwards-compatible:
+  new parameters have safe defaults.
+
 ## [1.2.0] - 2026-05-14
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "1.2.0"
+version = "1.3.0"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -223,6 +223,9 @@ async def get_links(
             "has_more": len(all_links) > limit,
         }
 
+    if direction != "inbound":
+        raise ValueError(f"无效的 direction 参数：{direction!r}，可选值：outbound、inbound。")
+
     # inbound: use list=backlinks
     params = {
         "action": "query",

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -35,42 +35,94 @@ async def _rate_limit() -> None:
     _last_request_time = asyncio.get_event_loop().time()
 
 
-async def search_prts(query: str, limit: int = 5) -> list[dict]:
-    """Search PRTS wiki and return a list of {title, snippet} dicts."""
+_TECHNICAL_PAGE_PATTERNS = (
+    "/spine",
+    "/data",
+    "/db",
+    "/lua",
+    "/json",
+    "Widget:",
+    "Template:",
+)
+
+
+def _is_technical_page(title: str) -> bool:
+    return any(p in title for p in _TECHNICAL_PAGE_PATTERNS)
+
+
+async def search_prts(
+    query: str,
+    limit: int = 5,
+    search_mode: str = "text",
+    filter_technical: bool = True,
+) -> dict:
+    """Search PRTS wiki.
+
+    Returns:
+        {"totalhits": int, "results": list[dict]} where each result has
+        "title" and "snippet" keys.
+    """
     await _rate_limit()
-    params = {
+    srwhat = "title" if search_mode == "title" else None
+    params: dict = {
         "action": "query",
         "list": "search",
         "srsearch": query,
-        "srlimit": limit,
+        "srlimit": str(limit * 2 if filter_technical else limit),
         "srnamespace": "0",
+        "srinfo": "totalhits",
         "format": "json",
     }
+    if srwhat:
+        params["srwhat"] = srwhat
     async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=15) as client:
         resp = await client.get(PRTS_API_ENDPOINT, params=params)
         resp.raise_for_status()
     data = resp.json()
-    results = []
+    totalhits = data.get("query", {}).get("searchinfo", {}).get("totalhits", 0)
+    results: list[dict] = []
     for item in data.get("query", {}).get("search", []):
+        title = item["title"]
+        if filter_technical and _is_technical_page(title):
+            continue
+        if len(results) >= limit:
+            break
         snippet = strip_wikitext(item.get("snippet", ""))
         snippet = _html.unescape(snippet)
         snippet = _clean_snippet(snippet)
         results.append({
-            "title": item["title"],
+            "title": title,
             "snippet": snippet,
         })
-    return results
+    return {"totalhits": totalhits, "results": results}
 
 
-async def read_page(title: str) -> str:
-    """Fetch rendered plain-text content for a PRTS wiki page."""
+def _strip_html(text: str) -> str:
+    """Remove CSS/JS, HTML tags, entities, and collapse whitespace from parsed output."""
+    text = _CSS_JS_RE.sub("", text)
+    text = _HTML_TAG_RE.sub("", text)
+    text = _HTML_ENTITY_RE.sub(lambda m: _html.unescape(m.group(0)), text)
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+async def read_page(title: str, section_index: int | None = None) -> str:
+    """Fetch rendered plain-text content for a PRTS wiki page.
+
+    Args:
+        title: Wiki page title.
+        section_index: If set, fetch only that section (from prop=sections index).
+    """
     await _rate_limit()
-    params = {
+    params: dict = {
         "action": "parse",
         "page": title,
         "prop": "text",
         "format": "json",
     }
+    if section_index is not None:
+        params["section"] = str(section_index)
     async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=15) as client:
         resp = await client.get(PRTS_API_ENDPOINT, params=params)
         resp.raise_for_status()
@@ -84,16 +136,115 @@ async def read_page(title: str) -> str:
     if not html_text:
         return f"页面 '{title}' 未找到或内容为空。"
 
-    # Remove CSS rules and inline JS that survive HTML stripping as noise
-    text = _CSS_JS_RE.sub("", html_text)
-    # Strip HTML tags
-    text = _HTML_TAG_RE.sub("", text)
-    # Decode remaining HTML entities
-    text = _HTML_ENTITY_RE.sub(lambda m: _html.unescape(m.group(0)), text)
-    # Collapse whitespace
-    text = re.sub(r"[ \t]+", " ", text)
-    text = re.sub(r"\n{3,}", "\n\n", text)
-    return text.strip()
+    return _strip_html(html_text)
+
+
+async def list_sections(title: str) -> list[dict]:
+    """Return the table of contents (sections) for a wiki page.
+
+    Each dict has keys: index, level, line, fromtitle.
+    Template-transcluded sections have index values like "T-1".
+    """
+    await _rate_limit()
+    params = {
+        "action": "parse",
+        "page": title,
+        "prop": "sections",
+        "format": "json",
+    }
+    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=15) as client:
+        resp = await client.get(PRTS_API_ENDPOINT, params=params)
+        resp.raise_for_status()
+    data = resp.json()
+    error = data.get("error", {}).get("info", "")
+    if error:
+        raise ValueError(f"页面 '{title}' 未找到。")
+    sections = data.get("parse", {}).get("sections", [])
+    return [
+        {
+            "index": s.get("index", ""),
+            "level": s.get("level", ""),
+            "line": s.get("line", ""),
+            "fromtitle": s.get("fromtitle", ""),
+        }
+        for s in sections
+    ]
+
+
+async def get_categories(title: str) -> list[str]:
+    """Return the category names for a wiki page."""
+    await _rate_limit()
+    params = {
+        "action": "parse",
+        "page": title,
+        "prop": "categories",
+        "format": "json",
+    }
+    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=15) as client:
+        resp = await client.get(PRTS_API_ENDPOINT, params=params)
+        resp.raise_for_status()
+    data = resp.json()
+    error = data.get("error", {}).get("info", "")
+    if error:
+        raise ValueError(f"页面 '{title}' 未找到。")
+    return [c["*"] for c in data.get("parse", {}).get("categories", [])]
+
+
+async def get_links(
+    title: str,
+    direction: str = "outbound",
+    limit: int = 30,
+) -> dict:
+    """Return outbound or inbound links for a wiki page.
+
+    Returns:
+        {"title": str, "links": list[str], "total": int, "has_more": bool}
+    """
+    await _rate_limit()
+    if direction == "outbound":
+        params = {
+            "action": "parse",
+            "page": title,
+            "prop": "links",
+            "format": "json",
+        }
+        async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=15) as client:
+            resp = await client.get(PRTS_API_ENDPOINT, params=params)
+            resp.raise_for_status()
+        data = resp.json()
+        error = data.get("error", {}).get("info", "")
+        if error:
+            raise ValueError(f"页面 '{title}' 未找到。")
+        all_links = [l["*"] for l in data.get("parse", {}).get("links", [])]
+        return {
+            "title": title,
+            "links": all_links[:limit],
+            "total": len(all_links),
+            "has_more": len(all_links) > limit,
+        }
+
+    # inbound: use list=backlinks
+    params = {
+        "action": "query",
+        "list": "backlinks",
+        "bltitle": title,
+        "bllimit": min(limit, 500),
+        "blnamespace": "0",
+        "format": "json",
+    }
+    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=15) as client:
+        resp = await client.get(PRTS_API_ENDPOINT, params=params)
+        resp.raise_for_status()
+    data = resp.json()
+    backlinks = data.get("query", {}).get("backlinks", [])
+    links = [bl["title"] for bl in backlinks]
+    has_more = "continue" in data
+    return {
+        "title": title,
+        "links": links[:limit],
+        "total": len(links),
+        "has_more": has_more,
+    }
 
 
 def _clean_snippet(snippet: str) -> str:

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -11,7 +11,13 @@ from typing import Annotated, Callable
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
 
-from prts_mcp.api.prts_wiki import search_prts as _search_prts, read_page as _read_page
+from prts_mcp.api.prts_wiki import (
+    search_prts as _search_prts,
+    read_page as _read_page,
+    list_sections as _list_sections,
+    get_categories as _get_categories,
+    get_links as _get_links,
+)
 from prts_mcp.data.operator import (
     get_operator_archives as _get_archives,
     get_operator_voicelines as _get_voicelines,
@@ -43,33 +49,108 @@ _SYNC_RETRY_DELAYS_SECONDS = (30, 120, 600)
 async def search_prts(
     query: Annotated[str, Field(description="搜索关键词，支持中文，如「罗德岛」、「整合运动」。")],
     limit: Annotated[int, Field(default=5, description="返回结果数量上限，默认 5，最大建议不超过 10。")] = 5,
+    search_mode: Annotated[str, Field(default="text", description="搜索模式：text（全文搜索，默认）或 title（仅搜索标题）。")] = "text",
+    filter_technical: Annotated[bool, Field(default=True, description="是否过滤 /spine、/data 等技术页面，默认 True。")] = True,
 ) -> str:
     """搜索 PRTS 明日方舟中文维基词条。
 
-    返回匹配词条的标题和简短摘要列表。这是探索维基的第一步：当需要查找
+    返回匹配词条的标题和简短摘要列表，含匹配总数。这是探索维基的第一步：当需要查找
     不确定的专有名词、干员、关卡或世界观设定时，先用此工具搜索获取准确
     标题，再将标题传入 read_prts_page 获取完整内容。
     """
-    results = await _search_prts(query, limit)
+    if search_mode not in ("text", "title"):
+        return "无效的 search_mode 参数，可选值：text、title。"
+    result = await _search_prts(query, limit, search_mode=search_mode, filter_technical=filter_technical)
+    results = result["results"]
+    totalhits = result["totalhits"]
     if not results:
         return f"未找到与 '{query}' 相关的词条。"
+    header = f"# 搜索 \"{query}\"（共 {totalhits} 条匹配）\n"
     parts = []
     for r in results:
         parts.append(f"**{r['title']}**\n{r['snippet']}")
-    return "\n\n---\n\n".join(parts)
+    return header + "\n\n---\n\n".join(parts)
 
 
 @mcp.tool()
 async def read_prts_page(
     page_title: Annotated[str, Field(description="词条标题，需与维基页面标题完全一致，如「阿米娅」、「整合运动」。建议通过 search_prts 获取准确标题后再传入。")],
+    section_index: Annotated[int | None, Field(default=None, description="可选章节编号（从 list_prts_sections 获取）。不填则返回整页内容；填入编号如 1 则仅返回该节。")] = None,
 ) -> str:
     """读取 PRTS 维基指定词条的纯文本内容。
 
-    返回该词条经过清洗的纯文本，已去除 Wikitext 模板、文件链接和 HTML 标签，
-    内容可能较长。强烈建议先调用 search_prts 确认词条的准确标题，避免因
-    拼写错误导致读取失败。
+    返回该词条经过清洗的纯文本，已去除 CSS、HTML 标签和实体，
+    内容可能较长。强烈建议先调用 list_prts_sections 查看目录结构，
+    再用 section_index 按需读取特定章节，避免整页内容过载。
+    不填 section_index 时返回整页。
     """
-    return await _read_page(page_title)
+    return await _read_page(page_title, section_index=section_index)
+
+
+@mcp.tool()
+async def list_prts_sections(
+    page_title: Annotated[str, Field(description="词条标题，需与维基页面标题完全一致，如「阿米娅」。")],
+) -> str:
+    """列出 PRTS 维基页面的目录（章节列表）。
+
+    返回章节编号、层级和标题，其中以 T- 开头的编号表示该节来自模板嵌入
+    （如角色信息框）。获取编号后可传入 read_prts_page 的 section_index
+    参数按需读取特定章节，避免一次加载整页内容。
+    """
+    try:
+        sections = await _list_sections(page_title)
+    except ValueError as e:
+        return str(e)
+    if not sections:
+        return f"页面 '{page_title}' 没有章节目录。"
+    lines = []
+    for s in sections:
+        lines.append(f"[{s['index']}] L{s['level']} {s['line']}")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_prts_categories(
+    page_title: Annotated[str, Field(description="词条标题，如「阿米娅」、「塔露拉」。")],
+) -> str:
+    """获取 PRTS 维基页面的分类标签。
+
+    返回该页面所属的所有分类，如「干员」「术师干员」「属于罗德岛的干员」。
+    可用于理解页面类型和所属体系，辅助导航和发现相关页面。
+    """
+    try:
+        cats = await _get_categories(page_title)
+    except ValueError as e:
+        return str(e)
+    if not cats:
+        return f"页面 '{page_title}' 没有分类标签。"
+    return "\n".join(f"- {c}" for c in cats)
+
+
+@mcp.tool()
+async def get_prts_links(
+    page_title: Annotated[str, Field(description="词条标题，如「阿米娅」。")],
+    direction: Annotated[str, Field(default="outbound", description="链接方向：outbound（页面引用的链接，默认）或 inbound（引用该页面的链接）。")] = "outbound",
+    limit: Annotated[int, Field(default=30, description="返回链接数量上限，默认 30。")] = 30,
+) -> str:
+    """获取 PRTS 维基页面的相关链接。
+
+    outbound 返回该页面引用的所有其他词条链接；inbound 返回所有引用了该页面的
+    词条链接（反向链接）。可用于探索维基的知识图谱关系。
+    """
+    if direction not in ("outbound", "inbound"):
+        return "无效的 direction 参数，可选值：outbound、inbound。"
+    try:
+        result = await _get_links(page_title, direction=direction, limit=limit)
+    except ValueError as e:
+        return str(e)
+    links = result["links"]
+    if not links:
+        return f"页面 '{page_title}' 没有{'出站' if direction == 'outbound' else '入站'}链接。"
+    total = result["total"]
+    has_more = result["has_more"]
+    suffix = f"\n（共 {total} 条，还有更多）" if has_more else f"\n（共 {total} 条）"
+    return "\n".join(f"- {ln}" for ln in links) + suffix
 
 
 @mcp.tool()

--- a/python/tests/test_tool_surface.py
+++ b/python/tests/test_tool_surface.py
@@ -5,8 +5,11 @@ from pathlib import Path
 
 
 EXPECTED_TOOL_SURFACE = {
-    "search_prts": ("query", "limit"),
-    "read_prts_page": ("page_title",),
+    "search_prts": ("query", "limit", "search_mode", "filter_technical"),
+    "read_prts_page": ("page_title", "section_index"),
+    "list_prts_sections": ("page_title",),
+    "get_prts_categories": ("page_title",),
+    "get_prts_links": ("page_title", "direction", "limit"),
     "get_operator_archives": ("operator_name",),
     "get_operator_voicelines": ("operator_name",),
     "get_operator_basic_info": ("operator_name",),

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-05-18
+
+### Added
+
+- **PRTS page table of contents.** `list_prts_sections(page_title)` returns the
+  section index for a wiki page.
+- **PRTS page categories.** `get_prts_categories(page_title)` returns category
+  tags for a wiki page.
+- **PRTS page links.** `get_prts_links(page_title, direction, limit)` returns
+  outbound links or inbound backlinks with pagination.
+
+### Changed
+
+- **`read_prts_page` gains `section_index` parameter.** Backwards-compatible.
+- **`search_prts` enhanced.** New `search_mode` (`text` / `title`),
+  `filter_technical` toggle, and `totalHits` in results. Backwards-compatible.
+
 ## [1.2.0] - 2026-05-14
 
 ### Added

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP)",
   "type": "module",
   "main": "dist/server.js",

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -290,6 +290,10 @@ export async function getLinks(
     };
   }
 
+  if (direction !== "inbound") {
+    throw new Error(`无效的 direction 参数：${JSON.stringify(direction)}，可选值：outbound、inbound。`);
+  }
+
   // inbound: use list=backlinks
   const data = (await prtsGet({
     action: "query",

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -85,6 +85,33 @@ function cleanSnippet(snippet: string): string {
 }
 
 // ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TECHNICAL_PAGE_PATTERNS = [
+  "/spine",
+  "/data",
+  "/db",
+  "/lua",
+  "/json",
+  "Widget:",
+  "Template:",
+];
+
+function isTechnicalPage(title: string): boolean {
+  return TECHNICAL_PAGE_PATTERNS.some((p) => title.includes(p));
+}
+
+function stripHtml(text: string): string {
+  let out = text.replace(CSS_JS_RE, "");
+  out = out.replace(HTML_TAG_RE, "");
+  out = unescapeHTMLEntities(out);
+  out = out.replace(/[ \t]+/g, " ");
+  out = out.replace(/\n{3,}/g, "\n\n");
+  return out.trim();
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -93,42 +120,71 @@ export interface SearchResult {
   snippet: string;
 }
 
+export interface SearchResponse {
+  totalHits: number;
+  results: SearchResult[];
+}
+
 /**
- * Search PRTS wiki and return a list of { title, snippet } objects.
+ * Search PRTS wiki.
  * Mirrors prts_wiki.search_prts().
  */
 export async function searchPrts(
   query: string,
-  limit = 5
-): Promise<SearchResult[]> {
-  const data = (await prtsGet({
+  limit = 5,
+  searchMode: "text" | "title" = "text",
+  filterTechnical = true,
+): Promise<SearchResponse> {
+  const fetchLimit = filterTechnical ? limit * 2 : limit;
+  const params: Record<string, string | number> = {
     action: "query",
     list: "search",
     srsearch: query,
-    srlimit: limit,
+    srlimit: fetchLimit,
     srnamespace: 0,
+    srinfo: "totalhits",
     format: "json",
-  })) as { query?: { search?: Array<{ title: string; snippet: string }> } };
-
-  return (data.query?.search ?? []).map((item) => {
+  };
+  if (searchMode === "title") {
+    params.srwhat = "title";
+  }
+  const data = (await prtsGet(params)) as {
+    query?: {
+      searchinfo?: { totalhits: number };
+      search?: Array<{ title: string; snippet: string }>;
+    };
+  };
+  const totalHits = data.query?.searchinfo?.totalhits ?? 0;
+  const results: SearchResult[] = [];
+  for (const item of data.query?.search ?? []) {
+    if (filterTechnical && isTechnicalPage(item.title)) continue;
+    if (results.length >= limit) break;
     let snippet = stripWikitext(item.snippet ?? "");
     snippet = unescapeHTMLEntities(snippet);
     snippet = cleanSnippet(snippet);
-    return { title: item.title, snippet };
-  });
+    results.push({ title: item.title, snippet });
+  }
+  return { totalHits, results };
 }
 
 /**
  * Fetch rendered plain-text content for a PRTS wiki page.
  * Mirrors prts_wiki.read_page().
  */
-export async function readPage(title: string): Promise<string> {
-  const data = (await prtsGet({
+export async function readPage(
+  title: string,
+  sectionIndex?: number,
+): Promise<string> {
+  const params: Record<string, string | number> = {
     action: "parse",
     page: title,
     prop: "text",
     format: "json",
-  })) as {
+  };
+  if (sectionIndex !== undefined) {
+    params.section = sectionIndex;
+  }
+  const data = (await prtsGet(params)) as {
     error?: { info?: string };
     parse?: { text?: { "*"?: string } };
   };
@@ -142,14 +198,117 @@ export async function readPage(title: string): Promise<string> {
     return `页面 '${title}' 未找到或内容为空。`;
   }
 
-  // Remove CSS rules and inline JS that survive HTML stripping as noise
-  let text = htmlText.replace(CSS_JS_RE, "");
-  // Strip HTML tags
-  text = text.replace(HTML_TAG_RE, "");
-  // Decode remaining HTML entities
-  text = unescapeHTMLEntities(text);
-  // Collapse whitespace
-  text = text.replace(/[ \t]+/g, " ");
-  text = text.replace(/\n{3,}/g, "\n\n");
-  return text.trim();
+  return stripHtml(htmlText);
+}
+
+/** Mirrors prts_wiki.list_sections(). */
+export async function listSections(
+  title: string,
+): Promise<Array<{ index: string; level: string; line: string; fromTitle: string }>> {
+  const data = (await prtsGet({
+    action: "parse",
+    page: title,
+    prop: "sections",
+    format: "json",
+  })) as {
+    error?: { info?: string };
+    parse?: {
+      sections?: Array<{
+        index: string;
+        level: string;
+        line: string;
+        fromtitle: string;
+      }>;
+    };
+  };
+
+  if (data.error?.info) {
+    throw new Error(`页面 '${title}' 未找到。`);
+  }
+
+  return (data.parse?.sections ?? []).map((s) => ({
+    index: s.index ?? "",
+    level: s.level ?? "",
+    line: s.line ?? "",
+    fromTitle: s.fromtitle ?? "",
+  }));
+}
+
+/** Mirrors prts_wiki.get_categories(). */
+export async function getCategories(title: string): Promise<string[]> {
+  const data = (await prtsGet({
+    action: "parse",
+    page: title,
+    prop: "categories",
+    format: "json",
+  })) as {
+    error?: { info?: string };
+    parse?: { categories?: Array<{ "*": string }> };
+  };
+
+  if (data.error?.info) {
+    throw new Error(`页面 '${title}' 未找到。`);
+  }
+
+  return (data.parse?.categories ?? []).map((c) => c["*"]);
+}
+
+export interface LinksResult {
+  title: string;
+  links: string[];
+  total: number;
+  hasMore: boolean;
+}
+
+/** Mirrors prts_wiki.get_links(). */
+export async function getLinks(
+  title: string,
+  direction: "outbound" | "inbound" = "outbound",
+  limit = 30,
+): Promise<LinksResult> {
+  if (direction === "outbound") {
+    const data = (await prtsGet({
+      action: "parse",
+      page: title,
+      prop: "links",
+      format: "json",
+    })) as {
+      error?: { info?: string };
+      parse?: { links?: Array<{ "*": string }> };
+    };
+
+    if (data.error?.info) {
+      throw new Error(`页面 '${title}' 未找到。`);
+    }
+
+    const allLinks = (data.parse?.links ?? []).map((l) => l["*"]);
+    return {
+      title,
+      links: allLinks.slice(0, limit),
+      total: allLinks.length,
+      hasMore: allLinks.length > limit,
+    };
+  }
+
+  // inbound: use list=backlinks
+  const data = (await prtsGet({
+    action: "query",
+    list: "backlinks",
+    bltitle: title,
+    bllimit: Math.min(limit, 500),
+    blnamespace: 0,
+    format: "json",
+  })) as {
+    continue?: unknown;
+    query?: { backlinks?: Array<{ title: string }> };
+  };
+
+  const backlinks = data.query?.backlinks ?? [];
+  const links = backlinks.map((bl) => bl.title);
+  return {
+    title,
+    links: links.slice(0, limit),
+    total: links.length,
+    hasMore: "continue" in data,
+  };
 }

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -15,7 +15,6 @@ import {
   listSections,
   getCategories,
   getLinks,
-  type SearchResponse,
 } from "./api/prtsWiki.js";
 import { clearOperatorCaches, getOperatorArchives, getOperatorVoicelines, getOperatorBasicInfo } from "./data/operator.js";
 import { searchOperatorData } from "./data/search.js";

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -9,7 +9,14 @@ import { z } from "zod";
 import { ZipStore } from "./data/stores.js";
 
 import { loadConfig, hasStoryData } from "./config.js";
-import { searchPrts, readPage } from "./api/prtsWiki.js";
+import {
+  searchPrts,
+  readPage,
+  listSections,
+  getCategories,
+  getLinks,
+  type SearchResponse,
+} from "./api/prtsWiki.js";
 import { clearOperatorCaches, getOperatorArchives, getOperatorVoicelines, getOperatorBasicInfo } from "./data/operator.js";
 import { searchOperatorData } from "./data/search.js";
 import { syncRelease, syncReleaseArchive } from "./data/sync.js";
@@ -89,21 +96,24 @@ function createMcpServer(): McpServer {
     "search_prts",
     [
       "搜索 PRTS 明日方舟中文维基词条。",
-      "返回匹配词条的标题和简短摘要列表。这是探索维基的第一步：当需要查找不确定的专有名词、干员、关卡或世界观设定时，先用此工具搜索获取准确标题，再将标题传入 read_prts_page 获取完整内容。",
+      "返回匹配词条的标题和简短摘要列表，含匹配总数。这是探索维基的第一步：当需要查找不确定的专有名词、干员、关卡或世界观设定时，先用此工具搜索获取准确标题，再将标题传入 read_prts_page 获取完整内容。",
     ].join(" "),
     {
       query: z.string().describe("搜索关键词，支持中文，如「罗德岛」、「整合运动」。"),
       limit: z.number().int().min(1).max(20).default(5).describe("返回结果数量上限，默认 5，最大建议不超过 10。"),
+      search_mode: z.enum(["text", "title"]).default("text").describe("搜索模式：text（全文搜索，默认）或 title（仅搜索标题）。"),
+      filter_technical: z.boolean().default(true).describe("是否过滤 /spine、/data 等技术页面，默认 true。"),
     },
-    async ({ query, limit }) => {
-      const results = await searchPrts(query, limit);
-      if (results.length === 0) {
+    async ({ query, limit, search_mode, filter_technical }) => {
+      const result = await searchPrts(query, limit, search_mode, filter_technical);
+      if (result.results.length === 0) {
         return { content: [{ type: "text", text: `未找到与 '${query}' 相关的词条。` }] };
       }
-      const text = results
+      const header = `# 搜索 "${query}"（共 ${result.totalHits} 条匹配）\n`;
+      const body = result.results
         .map((r) => `**${r.title}**\n${r.snippet}`)
         .join("\n\n---\n\n");
-      return { content: [{ type: "text", text }] };
+      return { content: [{ type: "text", text: header + body }] };
     }
   );
 
@@ -111,15 +121,91 @@ function createMcpServer(): McpServer {
     "read_prts_page",
     [
       "读取 PRTS 维基指定词条的纯文本内容。",
-      "返回该词条经过清洗的纯文本，已去除 Wikitext 模板、文件链接和 HTML 标签，内容可能较长。",
-      "强烈建议先调用 search_prts 确认词条的准确标题，避免因拼写错误导致读取失败。",
+      "返回该词条经过清洗的纯文本，已去除 CSS、HTML 标签和实体，内容可能较长。",
+      "强烈建议先调用 list_prts_sections 查看目录结构，再用 section_index 按需读取特定章节，避免整页内容过载。",
+      "不填 section_index 时返回整页。",
     ].join(" "),
     {
       page_title: z.string().describe("词条标题，需与维基页面标题完全一致，如「阿米娅」、「整合运动」。建议通过 search_prts 获取准确标题后再传入。"),
+      section_index: z.number().int().optional().describe("可选章节编号（从 list_prts_sections 获取）。不填则返回整页内容；填入编号如 1 则仅返回该节。"),
     },
-    async ({ page_title }) => {
-      const text = await readPage(page_title);
+    async ({ page_title, section_index }) => {
+      const text = await readPage(page_title, section_index);
       return { content: [{ type: "text", text }] };
+    }
+  );
+
+  server.tool(
+    "list_prts_sections",
+    [
+      "列出 PRTS 维基页面的目录（章节列表）。",
+      "返回章节编号、层级和标题，其中以 T- 开头的编号表示该节来自模板嵌入（如角色信息框）。",
+      "获取编号后可传入 read_prts_page 的 section_index 参数按需读取特定章节，避免一次加载整页内容。",
+    ].join(" "),
+    { page_title: z.string().describe("词条标题，需与维基页面标题完全一致，如「阿米娅」。") },
+    async ({ page_title }) => {
+      try {
+        const sections = await listSections(page_title);
+        if (sections.length === 0) {
+          return { content: [{ type: "text", text: `页面 '${page_title}' 没有章节目录。` }] };
+        }
+        const lines = sections.map(
+          (s) => `[${s.index}] L${s.level} ${s.line}`
+        );
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (e) {
+        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+      }
+    }
+  );
+
+  server.tool(
+    "get_prts_categories",
+    [
+      "获取 PRTS 维基页面的分类标签。",
+      "返回该页面所属的所有分类，如「干员」「术师干员」「属于罗德岛的干员」。",
+      "可用于理解页面类型和所属体系，辅助导航和发现相关页面。",
+    ].join(" "),
+    { page_title: z.string().describe("词条标题，如「阿米娅」、「塔露拉」。") },
+    async ({ page_title }) => {
+      try {
+        const cats = await getCategories(page_title);
+        if (cats.length === 0) {
+          return { content: [{ type: "text", text: `页面 '${page_title}' 没有分类标签。` }] };
+        }
+        return { content: [{ type: "text", text: cats.map((c) => `- ${c}`).join("\n") }] };
+      } catch (e) {
+        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+      }
+    }
+  );
+
+  server.tool(
+    "get_prts_links",
+    [
+      "获取 PRTS 维基页面的相关链接。",
+      "outbound 返回该页面引用的所有其他词条链接；inbound 返回所有引用了该页面的词条链接（反向链接）。",
+      "可用于探索维基的知识图谱关系。",
+    ].join(" "),
+    {
+      page_title: z.string().describe("词条标题，如「阿米娅」。"),
+      direction: z.enum(["outbound", "inbound"]).default("outbound").describe("链接方向：outbound（页面引用的链接，默认）或 inbound（引用该页面的链接）。"),
+      limit: z.number().int().min(1).max(100).default(30).describe("返回链接数量上限，默认 30。"),
+    },
+    async ({ page_title, direction, limit }) => {
+      try {
+        const result = await getLinks(page_title, direction, limit);
+        if (result.links.length === 0) {
+          const dirLabel = direction === "outbound" ? "出站" : "入站";
+          return { content: [{ type: "text", text: `页面 '${page_title}' 没有${dirLabel}链接。` }] };
+        }
+        const suffix = result.hasMore
+          ? `\n（共 ${result.total} 条，还有更多）`
+          : `\n（共 ${result.total} 条）`;
+        return { content: [{ type: "text", text: result.links.map((ln) => `- ${ln}`).join("\n") + suffix }] };
+      } catch (e) {
+        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+      }
     }
   );
 

--- a/ts/tests/toolSurface.test.ts
+++ b/ts/tests/toolSurface.test.ts
@@ -6,6 +6,9 @@ import { join } from "node:path";
 const EXPECTED_TOOLS = [
   "search_prts",
   "read_prts_page",
+  "list_prts_sections",
+  "get_prts_categories",
+  "get_prts_links",
   "get_operator_archives",
   "get_operator_voicelines",
   "get_operator_basic_info",


### PR DESCRIPTION
## Summary

Introduce three new MCP tools and enhance two existing tools across both Python and TypeScript implementations.

- **`list_prts_sections`** — table of contents for a wiki page, enabling section-level navigation
- **`get_prts_categories`** — category tags for a wiki page (e.g. "干员", "术师干员")
- **`get_prts_links`** — outbound/inbound link traversal for wiki knowledge graph exploration
- **`read_prts_page`** — new optional `section_index` parameter for reading specific sections
- **`search_prts`** — new `search_mode` (text/title), `filter_technical` toggle, and `totalHits` count

Tool surface: 14 → 17 tools (both implementations).

## Test plan

- [x] Python: 109 tests passing
- [x] TypeScript: 51 tests passing
- [x] Tool surface freeze test updated (both implementations)
- [x] E2E MCP client test: Python stdio — all 5 new capabilities verified
- [x] E2E MCP client test: TypeScript StreamableHTTP — all 17 tools listed, all 5 new capabilities verified

## Verification

```bash
# Python
cd python && pytest tests/ -v  # 109 passed

# TypeScript
cd ts && npm test               # 51 passed
```