### PR TITLE
fix(operator): filter non-operator entries from name lookup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,136 @@
+---
+project: "PRTS-MCP"
+branch: "main"
+---
+
+# CLAUDE.md — AI 协作者说明
+
+PRTS-MCP 是面向明日方舟同人创作的 MCP Server，包含 Python（stdio）和 TypeScript（Streamable HTTP）两套独立实现。
+本文件记录**每次会话必读**的工作流。
+
+## 相关文档
+
+| 想看... | 去哪里 |
+|---|---|
+| 项目现状、版本状态、仓库结构 | [`STATUS.md`](STATUS.md) |
+| 代码规范、反模式、已知陷阱 | [`docs/dev/STYLE.md`](docs/dev/STYLE.md) |
+| 路线图与未来规划 | [`ROADMAP.md`](ROADMAP.md) |
+| 外部贡献者指南 | [`CONTRIBUTING.md`](CONTRIBUTING.md) |
+| Python 实现 | [`python/`](python/) |
+| TypeScript 实现 | [`ts/`](ts/) |
+
+动手写代码前先读 `docs/dev/STYLE.md`；不确定项目欠什么时查 `STATUS.md`。
+
+---
+
+## 启动准则
+
+三条硬规则：
+
+- **需明确指令才 Commit**。对话里讨论到"要提交"不算指令，必须出现"请提交 / 请 commit / 请开 PR"这类明确祈使句
+- **一般不在 main 直接工作**，但**允许例外**：大 PR merge 完后的 chore/docs 级小修补（补一个版本号遗漏、改 typo）可以直接在 main 上。feat/fix/refactor 级一律走分支
+- **不主动 push**。即使刚 commit 完，也等用户说"请推"
+
+## 分支命名
+
+`<type>/v<version>-<topic>`，type 用 Conventional Commits 的类型。例：
+- `chore/v1.4.0-housekeeping`
+- `feat/v1.4.0-template-extraction`
+- `fix/v1.3.1-search-crash`
+
+## 单次迭代循环
+
+一个大修改（从"你决定要做 X"到"main 合进 X"）的标准循环：
+
+1. **对齐计划**：动手前用 1-2 段话描述打算做什么、拆成几个 commit、可能的风险。等用户点头
+2. **拉分支**：按上面的命名约定
+3. **动手**：按 commit 主题分批提交，每个中间 commit 都能独立编译（bisect-friendly）
+4. **本地验证**：
+   - Python: `cd python && python -m pytest tests/ -v`
+   - TypeScript: `cd ts && npm test && npm run typecheck`
+   - 双实现同步改动时两边都要跑
+5. **推分支 + 开 PR**：PR body 包含 Summary / Test plan / 未尽事宜三段
+6. **独立 CR**：spawn 子代理做独立 review（见下文）
+7. **应对 CR**：blocking 和 should-fix 处理掉，推到同分支；nits 酌情
+8. **人类 merge**：Claude 不做 merge，等用户确认
+9. **本地清扫**：`git checkout main && git pull && git branch -d <branch> && git remote prune origin`
+
+## Commit 规范
+
+严格遵守 [Conventional Commits](https://www.conventionalcommits.org/)。
+
+格式：`<type>(<scope>): <subject>`
+
+- **type**：`feat` / `fix` / `refactor` / `docs` / `chore` / `test` / `style` / `perf`
+- **scope** 常用：`python` / `ts` / `sync` / `wiki` / `operator` / `story` / `search` / `ci` / `docker`
+- **subject** 小写、祈使、≤72 字符、无句号
+
+多行 body 用 HEREDOC：
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat(wiki): add template data extraction via prop=parsetree
+
+Detailed explanation...
+EOF
+)"
+```
+
+不使用 `--amend`（除非用户明确要求）；pre-commit hook 失败时不加 `--no-verify`。
+
+## 独立 CR 规范
+
+**每个 PR 都应被一个独立子代理审阅一次**——子代理看不到我们的讨论过程，从 code-only 视角会发现我们共同忽略的东西。
+
+**调用方式**：spawn 一个 `general-purpose` 子代理，prompt 要点：
+- 明确说明审阅者视角独立、要 critical
+- 提供 PR URL、分支名、基于的主线
+- 列出 PR 自述（代理不看 PR 描述会默认相信提交信息）
+- 给具体的审查清单（见下方）
+- 要求结构化输出：**Blocking / Should-fix / Nits / Verified claims**
+
+**审查清单**：
+- 实现一致性：Python 和 TS 两套实现是否行为一致（工具名、参数、输出格式）
+- 数据流：新增数据源是否经过 store 抽象层，sync 路径是否正确
+- 错误处理：缺失数据/网络失败时是否有优雅降级
+- 测试覆盖：新功能是否有对应测试
+- 版本一致性：`pyproject.toml` / `package.json` / `CHANGELOG.md` 是否同步更新
+- 公共 API：工具参数是否向后兼容（1.x 兼容性合约）
+
+**CR 返回后的处理**：
+- Blocking 必修；Should-fix 原则上都做，除非有充分理由推迟
+- 修完推到同分支，给评论者明确回复
+- 涉及架构决策的分歧先同步用户再动
+
+## 版本同步清单
+
+每次版本号变更时，需同步更新以下文件：
+
+| 文件 | 内容 |
+|------|------|
+| `python/pyproject.toml` | `version` 字段 |
+| `ts/package.json` | `version` 字段 |
+| `python/CHANGELOG.md` | 新版本条目 |
+| `ts/CHANGELOG.md` | 新版本条目 |
+| `ROADMAP.md` | 当前版本号 |
+
+涉及用户可见行为变化时，顺手更新 `README.md`。
+
+## 双实现开发规则
+
+本项目 Python 和 TypeScript 是**独立实现**，不是翻译关系。规则：
+
+- 改了一个实现的工具行为，**必须检查**另一个实现是否有对应改动
+- 公共工具名、必填参数、输出格式在两套实现间必须一致（CI 有 tool surface 测试）
+- 新工具建议先在一个实现中完成，验证后再移植到另一个
+- 两套实现各有独立的 CHANGELOG，版本号尽量同步
+
+## 已知陷阱
+
+- PRTS Wiki `action=query&prop=extracts` 会丢失模板渲染内容，必须用 `action=parse&prop=text`
+- MediaWiki 搜索默认扫描所有 namespace，需加 `srnamespace=0`
+- PRTS 的 `/spine`、`/data` 等技术页面在主命名空间，需客户端过滤
+- story_review_table.json 顶层直接是 `{event_id: entry}`，不是嵌套在某个 key 下
+- ArknightsStoryJson zip 内所有路径以 `zh_CN/` 为前缀
+- `GITHUB_MIRRORS` 配置的代理 URL 不要带尾部斜杠
+- Python 的 `httpx` 和 TS 的 `fetch` 行为不完全一致（重试、超时），sync 逻辑不要假设相同

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ This repository contains two independent implementations for different deploymen
 
 | Area | Python | TypeScript | 1.0 policy |
 |------|--------|------------|------------|
-| Current line | `1.2.0` | `1.2.0` | Stable releases are cut from the same commit when possible |
-| MCP tools | Same 12 public tool names and required parameters | Same 12 public tool names and required parameters | Tool names and required parameters stay stable through 1.x |
+| Current line | `1.3.0` | `1.3.0` | Stable releases are cut from the same commit when possible |
+| MCP tools | Same 17 public tool names and required parameters | Same 17 public tool names and required parameters | Tool names and required parameters stay stable through 1.x |
 | GameData | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | Custom paths disable auto-sync |
 | Story data | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | Custom zip paths disable auto-sync |
 | Bundled fallback data | Docker image only | Docker image and published npm package | PyPI remains data-light |
@@ -56,6 +56,9 @@ Both implementations expose the same tool set:
 | `list_search_scopes` | List available search domains (operators, stories) with descriptions |
 | `search_data(pattern, scope, max_results)` | Full-text regex search across operator names, descriptions, archives, and voice lines |
 | `search_stories(pattern, character?, line_type?, context_lines?, max_results?, event_id?)` | Full-text regex search across story dialogue, narration, and choice lines with filtering |
+| `list_prts_sections(page_title)` | Section table of contents for a wiki page |
+| `get_prts_categories(page_title)` | Category tags for a wiki page |
+| `get_prts_links(page_title, direction, limit)` | Outbound links or inbound backlinks with pagination |
 
 ### Quick Start
 
@@ -93,8 +96,8 @@ Published Docker images and the npm package include bundled fallback game/story 
 
 | 范围 | Python | TypeScript | 1.0 策略 |
 |------|--------|------------|----------|
-| 当前版本线 | `1.2.0` | `1.2.0` | 稳定发布尽量从同一 commit 发布 |
-| MCP 工具 | 相同的 12 个工具名和必填参数 | 相同的 12 个工具名和必填参数 | 1.x 期间保持工具名和必填参数稳定 |
+| 当前版本线 | `1.3.0` | `1.3.0` | 稳定发布尽量从同一 commit 发布 |
+| MCP 工具 | 相同的 17 个工具名和必填参数 | 相同的 17 个工具名和必填参数 | 1.x 期间保持工具名和必填参数稳定 |
 | 干员数据 | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | 自定义路径会禁用自动同步 |
 | 剧情数据 | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | 自定义 zip 会禁用自动同步 |
 | bundled 兜底数据 | Docker 镜像 | Docker 镜像和正式 npm 包 | PyPI 继续保持轻量 |
@@ -121,6 +124,9 @@ Published Docker images and the npm package include bundled fallback game/story 
 | `list_search_scopes` | 列出可搜索的数据域（干员、剧情）及其内容类型 |
 | `search_data(pattern, scope, max_results)` | 在干员名称、描述、档案、语音中执行全文正则搜索 |
 | `search_stories(pattern, character?, line_type?, context_lines?, max_results?, event_id?)` | 在剧情台词中执行全文正则搜索，支持按角色和台词类型过滤 |
+| `list_prts_sections(page_title)` | 获取词条的章节目录 |
+| `get_prts_categories(page_title)` | 获取词条的分类标签 |
+| `get_prts_links(page_title, direction, limit)` | 获取词条的出链或入链，支持分页 |
 
 ### 快速开始
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,9 +9,9 @@ data architecture are now under a compatibility contract.
 
 - Python: `1.3.0`
 - TypeScript: `1.3.0`
-- The public tool surface (12 MCP tools) is frozen in the 1.x line.
+- The public tool surface (17 MCP tools) is frozen in the 1.x line.
   Automated CI checks enforce this.
-- 1.1.0 adds 3 search tools. 1.2.0 adds 2 story summary tools.
+- 1.1.0 adds 3 search tools. 1.2.0 adds 2 story summary tools. 1.3.0 adds 3 PRTS Wiki deep integration tools.
 - A migration guide covers behavioral changes for users upgrading from 0.x.
 
 ## 1.x Patch Policy

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,0 +1,94 @@
+# PRTS-MCP 项目状态
+
+_Last updated: 2026-05-18_
+
+## 当前版本
+
+| 实现 | 版本 | 状态 |
+|------|------|------|
+| Python | 1.3.0 | stable |
+| TypeScript | 1.3.0 | stable |
+
+- 公共工具面：17 个 MCP 工具（1.x 冻结）
+- 兼容性合约：1.x 期间工具名和必填参数不变
+
+## 仓库结构
+
+```
+PRTS-MCP/
+├── python/                 # Python 实现 (stdio, FastMCP)
+│   ├── src/prts_mcp/       # 源码
+│   │   ├── server.py       # MCP 工具注册 + 启动同步
+│   │   ├── config.py       # 路径解析、环境变量
+│   │   ├── api/            # PRTS Wiki MediaWiki API 客户端
+│   │   ├── data/           # 干员/剧情/搜索/同步/store 抽象
+│   │   └── utils/          # wikitext 清洗等工具
+│   ├── tests/              # pytest 测试
+│   ├── pyproject.toml      # 包元数据、依赖
+│   └── CHANGELOG.md
+├── ts/                     # TypeScript 实现 (Streamable HTTP, Express)
+│   ├── src/                # 源码，结构对齐 python/
+│   ├── tests/              # node --test 测试
+│   ├── package.json
+│   └── CHANGELOG.md
+├── data/                   # 共享数据（gamedata zip 等）
+├── docs/                   # 文档
+│   ├── dev/                # 开发者文档
+│   ├── admin/              # 管理员文档
+│   └── user/               # 用户文档
+├── dev/                    # 本地开发草稿（.gitignore 排除）
+├── .github/workflows/      # CI/CD
+│   ├── ci.yml              # 双实现测试
+│   ├── cd.yml              # Python PyPI 发布
+│   └── cd-ts.yml           # TS npm + Docker 发布
+├── CLAUDE.md               # AI 协作说明（本会话必读）
+├── ROADMAP.md              # 路线图
+├── STATUS.md               # 本文件
+└── README.md               # 面向用户的说明
+```
+
+## 数据源
+
+| 数据源 | 用途 | 同步方式 |
+|--------|------|----------|
+| [ArknightsGameData](https://github.com/3aKHP/ArknightsGameData) | 干员档案/语音/基础信息 | GitHub Release `zh_CN-excel.zip` |
+| [ArknightsStoryJson](https://github.com/3aKHP/ArknightsStoryJson) | 剧情台词 | GitHub Release `zh_CN.zip` |
+| [PRTS Wiki API](https://prts.wiki/api.php) | 世界观词条/阵营设定 | 实时 HTTP 请求 |
+
+## 工具清单 (17)
+
+| # | 工具 | 数据源 | 版本 |
+|---|------|--------|------|
+| 1 | `search_prts` | PRTS Wiki | 0.1.0 |
+| 2 | `read_prts_page` | PRTS Wiki | 0.1.0 |
+| 3 | `get_operator_archives` | GameData | 0.1.0 |
+| 4 | `get_operator_voicelines` | GameData | 0.1.0 |
+| 5 | `get_operator_basic_info` | GameData | 0.1.0 |
+| 6 | `list_story_events` | StoryJson | 0.3.0 |
+| 7 | `list_stories` | StoryJson | 0.3.0 |
+| 8 | `read_story` | StoryJson | 0.3.0 |
+| 9 | `read_activity` | StoryJson | 0.3.0 |
+| 10 | `list_search_scopes` | 混合 | 1.1.0 |
+| 11 | `search_data` | GameData | 1.1.0 |
+| 12 | `search_stories` | StoryJson | 1.1.0 |
+| 13 | `get_event_summary` | StoryJson | 1.2.0 |
+| 14 | `get_story_summary` | StoryJson | 1.2.0 |
+| 15 | `list_prts_sections` | PRTS Wiki | 1.3.0 |
+| 16 | `get_prts_categories` | PRTS Wiki | 1.3.0 |
+| 17 | `get_prts_links` | PRTS Wiki | 1.3.0 |
+
+## 遗留 TODO
+
+- [ ] Template Data Extraction (`prop=parsetree`) — 1.4.0 候选，需先原型验证
+- [ ] PRTS 搜索结果中 redirect 页面自动解析（MediaWiki API 限制）
+- [ ] PRTS 搜索结果中 `/spine`、`/data` 等技术页面的更精确过滤
+
+## 最近发布
+
+| 版本 | 日期 | 亮点 |
+|------|------|------|
+| 1.3.0 | 2026-05-18 | PRTS 深度集成：章节列表、分类标签、链接遍历 |
+| 1.2.0 | 2026-05-14 | 剧情摘要工具 + LLM 管线 |
+| 1.1.1 | 2026-05-14 | PRTS API 修复（parse 替代 extracts） |
+| 1.1.0 | 2026-05-14 | 全文搜索工具 |
+| 1.0.0 | 2026-05-13 | 稳定版，工具面冻结 |

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -1,0 +1,321 @@
+# 代码规范与架构 — PRTS-MCP
+
+面向所有协作者（人类与 AI）。本文件记录代码架构硬原则、反模式、CHANGELOG 规则、测试规范以及历史陷阱。
+
+日常工作流见 [`../../CLAUDE.md`](../../CLAUDE.md)；项目现状见 [`../../STATUS.md`](../../STATUS.md)。
+
+---
+
+## 代码规范与架构
+
+**项目维护者对代码架构和模块化解耦要求很高**。上帝文件和面条代码是底线问题，在它们出现之前就要阻止。以下是硬性原则，不是"nice to have"。
+
+### 文件大小与职责
+
+- **单一职责**：一个文件只干一件事。`operator.py` 只负责干员数据读取，不混进搜索逻辑；`sanitizer.py` 只管 wikitext 清洗，不放 API 调用
+- **文件长度预警线**：源文件超过 ~300 行就要问"这能不能拆"
+- **模块边界**：`data/` 只做数据读写和格式化，不混进 HTTP 请求；`api/` 只做 PRTS Wiki API 调用；`server.py` 只做工具注册和启动编排
+
+### 分层纪律
+
+```
+server.py/ts          ←  MCP 工具注册、启动同步编排
+api/                  ←  PRTS Wiki MediaWiki API 客户端
+data/                 ←  干员/剧情/搜索/同步/store 抽象
+data/stores           ←  DirectoryStore / ZipStore 底层读写
+utils/                ←  跨领域纯函数（wikitext 清洗等）
+config.py/ts          ←  路径解析、环境变量
+```
+
+**允许的依赖方向**：`server → api, data, config` / `data → stores, utils, config` / `api → utils`。
+**禁止**：`stores` 依赖 `data`；`utils` 依赖 `api` 或 `data`；`config` 依赖任何其他模块。
+
+### 抽象层
+
+- 所有数据读写经过 `stores.py` / `stores.ts` 的 `DirectoryStore` / `ZipStore`
+- 不要直接在工具函数里 `open()` / `readFileSync()` 读 JSON
+- 新数据源先加 dataset spec，再实现 reader
+
+### 抽取的触发条件
+
+遇到以下任一情况**立即**抽成独立单元，不要等下次 PR：
+
+- 同一个公式/逻辑在 ≥2 个地方出现
+- 一个函数超过 ~50 行或嵌套超过 3 层
+- 一段逻辑有明显的"状态 + 更新 + 查询"三要素（→ 独立类/模块）
+- 一段逻辑需要单独测试（→ 独立纯函数）
+
+### 模块化 vs 过度抽象
+
+不要为了抽而抽。**单次使用、少于 10 行、语义清晰**的内联代码不需要抽。判断基准："如果我明天给这块代码写单测或者重用它，现在的形状会让我想重写吗？"——会就抽，不会就留着。
+
+### 命名与样式
+
+- 公开 API 必须有 docstring / JSDoc，说明 **what + why**，不说 **how**
+- 不写"废话注释"（`# increment i by 1`）；非显而易见的约束必须注释
+- 错误消息用中文，面向最终用户（MCP 客户端会直接展示给用户）
+
+### 错误处理
+
+- 缺失数据：返回人类可读的中文错误消息，不要抛裸异常
+- 网络失败：sync 模块负责重试和降级，工具函数不自己重试
+- 用户输入错误：在工具函数入口验证，返回明确提示
+
+### 公共 API 约束（1.x 兼容性合约）
+
+- 工具名、必填参数、输出格式在 1.x 期间不得破坏性变更
+- 新参数必须有安全默认值（向后兼容）
+- 两套实现的工具签名必须一致
+
+### 触及现有坏味道时
+
+遵循"**童子军规则**"：
+
+- **离开比到来时更干净一点**。改一个函数顺手把它的命名、缩进、局部变量换掉
+- **不做"顺便大重构"**：看到面条不代表可以在 bugfix PR 里顺手拆。**专门开一个 `refactor` PR**，说明动机、范围、验证方式
+- **拆一个坏文件的 PR，不要再顺便加新功能**。保持重构 PR 的 diff 尽量只在移动代码
+
+### 常见反模式（见到就阻止）
+
+这些不要在本仓库出现：
+
+- 千行以上的单文件
+- 工具函数里直接读文件（绕过 store 抽象）
+- `Utils.py` / `helpers.ts` 杂物堆——按主题拆专用模块
+- 同一份常量在多个文件散落（必须走 config 或顶层常量）
+- 跨层调用（data 模块里直接发起 HTTP 请求）
+- 两套实现的行为不一致（工具名、参数、输出格式）
+
+### 何时是重构 PR 的好时机
+
+- 准备在某个模块加新功能，发现"得先清理才能干净地加"——**先开一个 refactor PR，merge 后再开 feature PR**
+- 子代理 CR 里连续两次指出同一类坏味道
+- 文件大小、嵌套深度跨过预警线
+
+---
+
+## Python 规范
+
+### 风格
+
+- 遵守 PEP 8；最大行宽 88 字符（与 black 默认一致）
+- 类型注解：所有公开函数签名必须有类型注解，内部函数酌情
+- 使用 `from __future__ import annotations` 延迟注解求值
+- 字符串：单引号或双引号均可，同一文件内保持一致
+- 导入顺序：标准库 → 第三方 → 本地模块，用空行分隔
+
+### 类型
+
+```python
+# 好：用 dict[str, Any] 而非 Dict[str, Any]（3.10+）
+def _load_json(filename: str) -> dict[str, Any]: ...
+
+# 好：Optional 用 X | None
+def get_operator(name: str | None) -> dict[str, Any] | None: ...
+```
+
+### 缓存
+
+- 只读数据表用 `@lru_cache(maxsize=1)` 惰性加载
+- 数据被 sync 更新后，调用 `clear_operator_caches()` 清缓存
+- 不要缓存 `Config`，它需要反映 sync 后的路径变化
+
+### MCP 工具注册
+
+```python
+# server.py 中的模式：本地函数用 _ 前缀，MCP 工具是薄包装
+from prts_mcp.data.operator import get_operator_archives as _get_archives
+
+@mcp.tool()
+async def get_operator_archives(
+    operator_name: Annotated[str, Field(description="干员中文名，如「阿米娅」。")],
+) -> str:
+    """获取干员的档案资料。"""
+    return _get_archives(operator_name)
+```
+
+- 工具函数是薄包装：参数验证 + 委托给 data/api 模块
+- `description` 用中文，面向最终用户
+- 不要在工具函数里做业务逻辑
+
+### 测试
+
+- 测试文件：`python/tests/test_<module>.py`
+- 使用 pytest fixtures，共享 fixture 放 `conftest.py`
+- 大型测试数据（zip 文件）通过 `story_zip` fixture 按需 skip
+- 运行：`cd python && python -m pytest tests/ -v`
+
+---
+
+## TypeScript 规范
+
+### 风格
+
+- 遵守 ESLint recommended rules
+- 使用 ESM (`"type": "module"`)
+- 文件名：`camelCase.ts`（与 Python 的 `snake_case.py` 对应）
+- 类型：优先 `interface` 定义数据形状，`type` 用于联合/交叉类型
+- 导入：使用 `.js` 扩展名（ESM 要求）
+
+### 类型
+
+```typescript
+// 好：interface 定义 JSON 结构
+interface CharacterEntry {
+  name?: string;
+  appellation?: string;
+  rarity?: string;
+  // ...
+}
+
+// 好：module-level 惰性缓存
+let _characterTable: TableCache<Record<string, CharacterEntry>> = null;
+```
+
+- 只定义实际使用的字段，不要为整个 JSON 定义完整类型
+- `null` = 未加载，`undefined` = 加载失败
+
+### 缓存
+
+- 模块级 `let` 变量 + `clearXxxCaches()` 函数
+- 不要用 `Map` 做简单缓存（除非需要 LRU 或多 key）
+- Config 不缓存：`loadConfig()` 每次调用重新读取
+
+### MCP 工具注册
+
+```typescript
+// server.ts 中的模式
+import { getOperatorArchives as _getArchives } from "./data/operator.js";
+
+server.tool(
+  "get_operator_archives",
+  "获取干员的档案资料。",
+  { operator_name: z.string().describe("干员中文名，如「阿米娅」。") },
+  async ({ operator_name }) => ({ content: [{ type: "text", text: _getArchives(operator_name) }] }),
+);
+```
+
+### 测试
+
+- 测试文件：`ts/tests/<module>.test.ts`
+- 使用 Node.js 内置 `node:test` + `node:assert`
+- 共享 fixture 放 `ts/tests/fixtures/`
+- 运行：`cd ts && npm test`
+
+---
+
+## 两套实现的对应关系
+
+Python 和 TypeScript 不是翻译关系，但文件结构和模块职责应保持对齐：
+
+| Python | TypeScript | 职责 |
+|--------|-----------|------|
+| `server.py` | `server.ts` | MCP 工具注册、启动同步 |
+| `config.py` | `config.ts` | 路径解析、环境变量 |
+| `data/stores.py` | `data/stores.ts` | DirectoryStore / ZipStore 抽象 |
+| `data/operator.py` | `data/operator.ts` | 干员数据读取和格式化 |
+| `data/story.py` | `data/story.ts` | 剧情数据读取和格式化 |
+| `data/search.py` | `data/search.ts` | 全文搜索 |
+| `data/sync.py` | `data/sync.ts` | GitHub Release 同步 |
+| `data/datasets.py` | `data/datasets.ts` | 数据集 spec 定义 |
+| `api/prts_wiki.py` | `api/prtsWiki.ts` | PRTS MediaWiki API 客户端 |
+| `utils/sanitizer.py` | `utils/sanitizer.ts` | Wikitext 清洗 |
+
+TS 文件头注释应注明对应的 Python 文件：`Mirrors python/src/prts_mcp/data/operator.py.`
+
+---
+
+## 版本号与发布
+
+遵循 [SemVer](https://semver.org/)。预发布用 `-alpha.N` / `-beta.N` / `-rc.N` 后缀。
+
+**版本号需要同步更新的地方**：
+
+| 文件 | 内容 |
+|------|------|
+| `python/pyproject.toml` | `version` 字段 |
+| `ts/package.json` | `version` 字段 |
+| `python/CHANGELOG.md` | 新版本条目 |
+| `ts/CHANGELOG.md` | 新版本条目 |
+| `ROADMAP.md` | 当前版本号 |
+
+tag 名带 `v` 前缀：`v1.4.0`。含 `-` 后缀的 tag 会被 CD workflow 识别为 prerelease。
+
+---
+
+## CHANGELOG 规则
+
+遵循 [Keep a Changelog](https://keepachangelog.com/) 规范。**英文撰写**。
+
+**核心原则：面向用户描述变更，不记 commit 细节（不写哈希、不抄 commit message）。**
+
+变更分类（仅列出有内容的分类）：**Added** / **Changed** / **Deprecated** / **Removed** / **Fixed** / **Security**。
+
+### 日常开发
+
+每个模块级改动（feat / fix / refactor）在 `## [Unreleased]` 段落对应分类下追加一行。小型 chore / docs / style 无需改 CHANGELOG。
+
+### 准备发版（打 tag 前）
+
+1. 将 `## [Unreleased]` 改为 `## [X.Y.Z] - YYYY-MM-DD`
+2. 在其上方插入新的空 `## [Unreleased]` 段
+
+---
+
+## 测试与构建
+
+### 常用命令
+
+```bash
+# Python
+cd python && python -m pytest tests/ -v          # 全量单测
+cd python && python -m pytest tests/ -v -k test_xxx  # 单个测试
+
+# TypeScript
+cd ts && npm test                                  # 全量单测
+cd ts && npm run typecheck                         # 类型检查
+cd ts && npm run build                             # 编译
+```
+
+### 测试规范
+
+- 新增的数据处理逻辑**必须**带单测
+- Python 用 pytest，位于 `python/tests/`
+- TS 用 Node.js 内置 `node:test`，位于 `ts/tests/`
+- 大型 fixture（zip 文件）通过环境变量或 skip 机制按需启用
+- 涉及 PRTS Wiki API 的测试用 mock/fixture，不要在 CI 中打真实 API
+
+### 双实现验证
+
+改动一个实现时，**必须检查**另一个实现是否有对应改动：
+
+- 工具名、参数名、输出格式
+- 错误消息内容
+- 数据处理逻辑（如 wikitext 清洗规则、搜索过滤条件）
+
+---
+
+## 已知陷阱（踩过的坑）
+
+避免重复踩，按主题记录。
+
+### PRTS Wiki API
+
+- `action=query&prop=extracts` 丢失模板内容，**必须**用 `action=parse&prop=text`
+- MediaWiki 搜索需 `srnamespace=0`，否则技术页面污染结果
+- PRTS `/spine`、`/data` 页面在主命名空间（ns=0），需客户端 `filter_technical` 过滤
+- `action=parse&prop=sections` 返回的 `index` 可能是 `T-N` 格式（模板转译），不只是纯数字
+- Free-text snippets 从 MediaWiki 搜索索引提取，天然不精确；唯一可靠方式是 `action=parse` 获取完整渲染内容
+
+### 数据格式
+
+- `story_review_table.json` 顶层直接是 `{event_id: entry}`，不是嵌套在某个 key 下
+- ArknightsStoryJson zip 内所有路径以 `zh_CN/` 为前缀
+- `character_table.json` 用干员 ID（如 `char_002_amiya`）作 key，不是中文名
+
+### 网络与同步
+
+- `GITHUB_MIRRORS` 代理 URL 不要带尾部斜杠
+- Python `httpx` 和 TS `fetch` 行为不完全一致（重试、超时策略），sync 逻辑不要假设相同
+- TS `adm-zip` 和 Python `zipfile` 对损坏 zip 的容错不同，sync 里的完整性检查两边都要有
+- GitHub API 匿名请求有严格限速，建议配置 `GITHUB_TOKEN`

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Operator name-to-ID collision.** `_build_name_to_id()` in `operator.py` now
+  filters to `char_*` entries only, preventing `trap_*` and `token_*` entries from
+  silently overwriting real operator IDs when they share the same Chinese name.
+  Fixes `get_operator_basic_info`, `get_operator_archives`,
+  `get_operator_voicelines`, and `search_data` for affected operators (阿米娅,
+  森蚺, 狮蝎, 佩佩, 断罪者, etc.).
+
 ## [1.3.0] - 2026-05-18
 
 ### Added

--- a/python/src/prts_mcp/data/operator.py
+++ b/python/src/prts_mcp/data/operator.py
@@ -65,7 +65,8 @@ def _load_charword_table() -> dict[str, Any]:
 def _build_name_to_id() -> dict[str, str]:
     """Map operator Chinese name -> charId."""
     ct = _load_character_table()
-    return {info["name"]: cid for cid, info in ct.items() if info.get("name")}
+    return {info["name"]: cid for cid, info in ct.items()
+            if info.get("name") and cid.startswith("char_")}
 
 
 def _resolve_char_id(name: str) -> str | None:

--- a/python/tests/test_operator_data.py
+++ b/python/tests/test_operator_data.py
@@ -81,3 +81,38 @@ class TestOperatorDataRefresh:
             clear_operator_caches()
 
             assert operator._load_character_table.cache_info().currsize == 0
+
+
+class TestNameToId:
+    def test_trap_entry_with_same_name_does_not_override_operator(self, tmp_path):
+        """Regression: trap_* and token_* entries must not shadow char_* entries."""
+        import json
+        excel = tmp_path / "zh_CN" / "gamedata" / "excel"
+        excel.mkdir(parents=True)
+        (excel / "character_table.json").write_text(
+            json.dumps(
+                {
+                    "char_002_amiya": {"name": "阿米娅", "rarity": "TIER_5", "profession": "CASTER"},
+                    "trap_999_amiya_fake": {"name": "阿米娅", "rarity": "TIER_1", "profession": "TRAP"},
+                },
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        (excel / "handbook_info_table.json").write_text(
+            json.dumps({"handbookDict": {"char_002_amiya": {"storyTextAudio": []}}}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        (excel / "charword_table.json").write_text(
+            json.dumps({"charWords": {}}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        (excel / "story_review_table.json").write_text("{}", encoding="utf-8")
+
+        with patch.dict(os.environ, {"GAMEDATA_PATH": str(tmp_path)}, clear=False):
+            os.environ.pop("STORYJSON_PATH", None)
+            clear_operator_caches()
+
+            info = get_operator_basic_info("阿米娅")
+            assert "5★" in info, f"Expected 5★ from char_*, got: {info}"
+            assert "TRAP" not in info, f"TRAP entry leaked into result: {info}"

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Operator name-to-ID collision.** `resolveCharId()` and `searchOperatorData()`
+  now filter to `char_*` entries only, preventing `trap_*` and `token_*` entries
+  from silently overwriting real operator IDs when they share the same Chinese
+  name. Fixes `get_operator_basic_info`, `get_operator_archives`,
+  `get_operator_voicelines`, and `search_data` for affected operators (阿米娅,
+  森蚺, 狮蝎, 佩佩, 断罪者, etc.).
+
 ## [1.3.0] - 2026-05-18
 
 ### Added

--- a/ts/src/data/operator.ts
+++ b/ts/src/data/operator.ts
@@ -152,7 +152,7 @@ export function resolveCharId(name: string): string | null {
     const ct = getCharacterTable();
     _nameToId = new Map(
       Object.entries(ct)
-        .filter(([, info]) => info.name)
+        .filter(([cid, info]) => info.name && cid.startsWith("char_"))
         .map(([cid, info]) => [info.name!, cid])
     );
   }

--- a/ts/src/data/search.ts
+++ b/ts/src/data/search.ts
@@ -9,7 +9,6 @@ import {
   getCharacterTable,
   getHandbookTable,
   getCharwordTable,
-  resolveCharId,
 } from "./operator.js";
 
 // Reuse types from operator.ts
@@ -75,7 +74,7 @@ export function searchOperatorData(pattern: string, maxResults = 30): string {
   // Build name → id and charId → voice entries index
   const nameToId = new Map<string, string>();
   for (const [cid, info] of Object.entries(ct)) {
-    if (info.name) nameToId.set(info.name, cid);
+    if (info.name && cid.startsWith("char_")) nameToId.set(info.name, cid);
   }
 
   const charidToVoices = new Map<string, CharwordEntry[]>();

--- a/ts/tests/operator.test.ts
+++ b/ts/tests/operator.test.ts
@@ -107,3 +107,36 @@ test("operator data is incomplete when a required file is not a file", async () 
 
   assert.match(operator.getOperatorBasicInfo("阿米娅"), /干员数据暂不可用/);
 });
+
+test("trap entry with same name does not override operator", async () => {
+  const root = tempGamedataRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  delete process.env["STORYJSON_PATH"];
+
+  const excel = join(root, "zh_CN", "gamedata", "excel");
+  mkdirSync(excel, { recursive: true });
+  writeFileSync(
+    join(excel, "character_table.json"),
+    JSON.stringify({
+      char_002_amiya: { name: "阿米娅", rarity: "TIER_5", profession: "CASTER" },
+      trap_999_amiya_fake: { name: "阿米娅", rarity: "TIER_1", profession: "TRAP" },
+    }),
+    "utf-8",
+  );
+  writeFileSync(
+    join(excel, "handbook_info_table.json"),
+    JSON.stringify({ handbookDict: { char_002_amiya: { storyTextAudio: [] } } }),
+    "utf-8",
+  );
+  writeFileSync(
+    join(excel, "charword_table.json"),
+    JSON.stringify({ charWords: {} }),
+    "utf-8",
+  );
+  writeFileSync(join(excel, "story_review_table.json"), "{}", "utf-8");
+
+  const operator = await loadOperatorModule();
+  const info = operator.getOperatorBasicInfo("阿米娅");
+  assert.match(info, /5★/);
+  assert.doesNotMatch(info, /TRAP/);
+});


### PR DESCRIPTION
## Summary

- `_build_name_to_id()` / `resolveCharId()` used a plain dict/Map where `trap_*` / `token_*` entries silently overwrote real `char_*` operator entries when they shared the same Chinese name.
- **Fix**: filter to `char_*` prefix only in the name→ID mapping. This is a 1-character-key filter change in both implementations.
- **Affected tools**: `get_operator_basic_info`, `get_operator_archives`, `get_operator_voicelines`, `search_data`, `search_stories` — all five now identify the correct operator.
- **Confirmed on production**: Amiya and at least 7 other operators (森蚺, 狮蝎, 佩佩, 断罪者, etc.) were returning 1★/TRAP data instead of their real profiles.

## Test plan

- [x] Python: 110/110 tests pass (added regression test: TRAP same-name collision)
- [x] TypeScript: 52/52 tests pass (added same regression test)
- [x] Production endpoint confirmed the bug via direct MCP calls
- [x] Both implementations verified locally with pytest and node --test