### PR TITLE
fix: v1.4.1 production fixes from code audit

### DIFF
--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -11,7 +11,36 @@ import httpx
 from prts_mcp.config import PRTS_API_ENDPOINT, USER_AGENT, RATE_LIMIT_INTERVAL
 from prts_mcp.utils.sanitizer import strip_wikitext
 
-_last_request_time: float = 0.0
+# --- Shared httpx client (connection pooling) ---
+
+_client: httpx.AsyncClient | None = None
+
+
+def _get_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None:
+        _client = httpx.AsyncClient(
+            headers={"User-Agent": USER_AGENT}, timeout=httpx.Timeout(15)
+        )
+    return _client
+
+
+# --- Rate limiting (slot-based — thread-safe for asyncio coroutines) ---
+
+_next_allowed_time: float = 0.0
+
+
+async def _rate_limit() -> None:
+    global _next_allowed_time
+    now = asyncio.get_event_loop().time()
+    slot = max(now, _next_allowed_time)
+    _next_allowed_time = slot + RATE_LIMIT_INTERVAL
+    wait = slot - now
+    if wait > 0:
+        await asyncio.sleep(wait)
+
+
+# --- Wikitext cleanup helpers ---
 
 # MediaWiki parser output contains inline CSS / JS blocks (charinfo font-face,
 # RLQ push snippets, etc.) that produce noise after tag stripping.
@@ -26,15 +55,6 @@ _CSS_JS_RE = re.compile(
 _HTML_TAG_RE = re.compile(r"<[^>]+>")
 
 _HTML_ENTITY_RE = re.compile(r"&#?[a-zA-Z0-9]+;")
-
-
-async def _rate_limit() -> None:
-    global _last_request_time
-    now = asyncio.get_event_loop().time()
-    elapsed = now - _last_request_time
-    if elapsed < RATE_LIMIT_INTERVAL:
-        await asyncio.sleep(RATE_LIMIT_INTERVAL - elapsed)
-    _last_request_time = asyncio.get_event_loop().time()
 
 
 _TECHNICAL_PAGE_PATTERNS = (
@@ -77,9 +97,11 @@ async def search_prts(
     }
     if srwhat:
         params["srwhat"] = srwhat
-    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=15) as client:
-        resp = await client.get(PRTS_API_ENDPOINT, params=params)
+    try:
+        resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
         resp.raise_for_status()
+    except httpx.HTTPError:
+        return {"totalhits": 0, "results": []}
     data = resp.json()
     totalhits = data.get("query", {}).get("searchinfo", {}).get("totalhits", 0)
     results: list[dict] = []
@@ -125,9 +147,11 @@ async def read_page(title: str, section_index: int | None = None) -> str:
     }
     if section_index is not None:
         params["section"] = str(section_index)
-    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=15) as client:
-        resp = await client.get(PRTS_API_ENDPOINT, params=params)
+    try:
+        resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
         resp.raise_for_status()
+    except httpx.HTTPError as e:
+        return f"读取页面失败：{e}"
     data = resp.json()
 
     error = data.get("error", {}).get("info", "")
@@ -154,13 +178,12 @@ async def list_sections(title: str) -> list[dict]:
         "prop": "sections",
         "format": "json",
     }
-    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=15) as client:
-        resp = await client.get(PRTS_API_ENDPOINT, params=params)
-        resp.raise_for_status()
+    resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
+    resp.raise_for_status()
     data = resp.json()
     error = data.get("error", {}).get("info", "")
     if error:
-        raise ValueError(f"页面 '{title}' 未找到。")
+        raise RuntimeError(f"页面 '{title}' 未找到。")
     sections = data.get("parse", {}).get("sections", [])
     return [
         {
@@ -182,13 +205,12 @@ async def get_categories(title: str) -> list[str]:
         "prop": "categories",
         "format": "json",
     }
-    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=15) as client:
-        resp = await client.get(PRTS_API_ENDPOINT, params=params)
-        resp.raise_for_status()
+    resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
+    resp.raise_for_status()
     data = resp.json()
     error = data.get("error", {}).get("info", "")
     if error:
-        raise ValueError(f"页面 '{title}' 未找到。")
+        raise RuntimeError(f"页面 '{title}' 未找到。")
     return [c["*"] for c in data.get("parse", {}).get("categories", [])]
 
 
@@ -210,13 +232,12 @@ async def get_links(
             "prop": "links",
             "format": "json",
         }
-        async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=15) as client:
-            resp = await client.get(PRTS_API_ENDPOINT, params=params)
-            resp.raise_for_status()
+        resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
+        resp.raise_for_status()
         data = resp.json()
         error = data.get("error", {}).get("info", "")
         if error:
-            raise ValueError(f"页面 '{title}' 未找到。")
+            raise RuntimeError(f"页面 '{title}' 未找到。")
         all_links = [l["*"] for l in data.get("parse", {}).get("links", [])]
         return {
             "title": title,
@@ -237,9 +258,8 @@ async def get_links(
         "blnamespace": "0",
         "format": "json",
     }
-    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=15) as client:
-        resp = await client.get(PRTS_API_ENDPOINT, params=params)
-        resp.raise_for_status()
+    resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
+    resp.raise_for_status()
     data = resp.json()
     backlinks = data.get("query", {}).get("backlinks", [])
     links = [bl["title"] for bl in backlinks]
@@ -273,18 +293,17 @@ async def get_template_data(title: str) -> dict:
         "prop": "parsetree",
         "format": "json",
     }
-    async with httpx.AsyncClient(headers={"User-Agent": USER_AGENT}, timeout=15) as client:
-        resp = await client.get(PRTS_API_ENDPOINT, params=params)
-        resp.raise_for_status()
+    resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
+    resp.raise_for_status()
     data = resp.json()
 
     error = data.get("error", {}).get("info", "")
     if error:
-        raise ValueError(f"页面 '{title}' 未找到。")
+        raise RuntimeError(f"页面 '{title}' 未找到。")
 
     xml_str = data.get("parse", {}).get("parsetree", {}).get("*", "")
     if not xml_str:
-        raise ValueError(f"页面 '{title}' 无 parsetree 数据。")
+        raise RuntimeError(f"页面 '{title}' 无 parsetree 数据。")
 
     root = ET.fromstring(xml_str)
     templates: dict[str, dict] = {}
@@ -300,6 +319,8 @@ async def get_template_data(title: str) -> dict:
             if sub.tag == "comment":
                 if sub.text:
                     comment_text = sub.text.strip()
+                if sub.tail:
+                    t_title_elem.text = (t_title_elem.text or "") + sub.tail
                 t_title_elem.remove(sub)
         t_name = (t_title_elem.text or "").strip()
         if not t_name:
@@ -316,6 +337,8 @@ async def get_template_data(title: str) -> dict:
 
             # Get full text of <value>, stripping any nested <template> children.
             for nested in list(value_el.findall("template")):
+                if nested.tail:
+                    value_el.text = (value_el.text or "") + nested.tail
                 value_el.remove(nested)
             val = (value_el.text or "").strip()
             if not val:

--- a/python/src/prts_mcp/data/stores.py
+++ b/python/src/prts_mcp/data/stores.py
@@ -66,20 +66,28 @@ class ZipStore:
 
     def __init__(self, zip_path: Path | str) -> None:
         self.zip_path = Path(zip_path)
+        self._zf: zipfile.ZipFile | None = None
+
+    def _zipfile(self) -> zipfile.ZipFile:
+        if self._zf is None:
+            self._zf = zipfile.ZipFile(self.zip_path)
+        return self._zf
 
     def exists(self, path: str) -> bool:
         inner_path = _normalize_path(path)
         if not self.zip_path.is_file():
             return False
-        with zipfile.ZipFile(self.zip_path) as zf:
-            return inner_path in zf.namelist()
+        try:
+            self._zipfile().getinfo(inner_path)
+            return True
+        except KeyError:
+            return False
 
     def read_text(self, path: str) -> str:
         inner_path = _normalize_path(path)
         try:
-            with zipfile.ZipFile(self.zip_path) as zf:
-                with zf.open(inner_path) as f:
-                    return f.read().decode("utf-8")
+            with self._zipfile().open(inner_path) as f:
+                return f.read().decode("utf-8")
         except KeyError as exc:
             raise FileNotFoundError(f"Dataset zip entry not found: {path}") from exc
 

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -9,6 +9,7 @@ Zip internal layout (all paths prefixed with "zh_CN/"):
 """
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -321,6 +322,8 @@ def read_activity_from_store(
     total = len(summaries)
 
     if page is not None:
+        if page < 1:
+            raise ValueError("page 参数必须 >= 1")
         start = (page - 1) * page_size
         end = start + page_size
         selected = summaries[start:end]
@@ -465,9 +468,7 @@ def search_stories_from_store(
                 chapter = read_story_from_store(
                     store, story_key, include_narration=True,
                 )
-            except KeyError:
-                continue
-            except Exception:
+            except (KeyError, FileNotFoundError, json.JSONDecodeError):
                 continue
 
             for i, line in enumerate(chapter.lines):

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -340,8 +340,8 @@ def read_activity_from_store(
             if not event_name:
                 event_name = chapter.event_name
             chapters.append(chapter)
-        except KeyError:
-            # Story file missing from zip — skip silently
+        except (KeyError, FileNotFoundError, json.JSONDecodeError):
+            # Story file missing or corrupt — skip silently
             pass
 
     return ActivityResult(
@@ -386,7 +386,7 @@ def search_stories(
     a ZipStore from *zip_path*.
     """
     return search_stories_from_store(
-        ZipStore(zip_path),
+        _story_store(zip_path),
         pattern,
         character=character,
         line_type=line_type,
@@ -532,7 +532,7 @@ def get_event_summary(zip_path: Path, event_id: str) -> str:
 
     Convenience wrapper around get_event_summary_from_store.
     """
-    return get_event_summary_from_store(ZipStore(zip_path), event_id)
+    return get_event_summary_from_store(_story_store(zip_path), event_id)
 
 
 def get_event_summary_from_store(store: JsonStore, event_id: str) -> str:
@@ -613,7 +613,7 @@ def get_story_summary(zip_path: Path, story_key: str) -> str:
 
     Convenience wrapper around get_story_summary_from_store.
     """
-    return get_story_summary_from_store(ZipStore(zip_path), story_key)
+    return get_story_summary_from_store(_story_store(zip_path), story_key)
 
 
 def get_story_summary_from_store(store: JsonStore, story_key: str) -> str:

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -106,7 +106,7 @@ async def list_prts_sections(
     """
     try:
         sections = await _list_sections(page_title)
-    except ValueError as e:
+    except RuntimeError as e:
         return str(e)
     if not sections:
         return f"页面 '{page_title}' 没有章节目录。"
@@ -127,7 +127,7 @@ async def get_prts_categories(
     """
     try:
         cats = await _get_categories(page_title)
-    except ValueError as e:
+    except RuntimeError as e:
         return str(e)
     if not cats:
         return f"页面 '{page_title}' 没有分类标签。"
@@ -149,7 +149,7 @@ async def get_prts_links(
         return "无效的 direction 参数，可选值：outbound、inbound。"
     try:
         result = await _get_links(page_title, direction=direction, limit=limit)
-    except ValueError as e:
+    except RuntimeError as e:
         return str(e)
     links = result["links"]
     if not links:
@@ -173,7 +173,7 @@ async def get_prts_template(
     """
     try:
         templates = await _get_template_data(page_title)
-    except ValueError as e:
+    except RuntimeError as e:
         return str(e)
     except Exception as e:
         return f"获取页面 '{page_title}' 的模板数据失败：{e}"

--- a/python/tests/test_e2e.py
+++ b/python/tests/test_e2e.py
@@ -1,0 +1,239 @@
+"""
+E2E test for the Python MCP server (stdio JSON-RPC).
+
+Spawns ``python -m prts_mcp`` as a subprocess and communicates via
+stdin/stdout with JSON-RPC messages.  Tests that can run without
+network or full data:
+
+  1. MCP initialize handshake
+  2. tools/list — all 21 tools registered
+  3. Operator tools (bundled fixture data)
+  4. Graceful errors for unavailable data
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+GAMEDATA_PATH = Path(__file__).resolve().parents[2] / "data" / "gamedata"
+GAMEDATA_PATH = GAMEDATA_PATH.resolve()
+
+# Ensure data exists so the test is meaningful.
+_op_table = GAMEDATA_PATH / "zh_CN" / "gamedata" / "excel" / "character_table.json"
+_has_operator_data = _op_table.is_file()
+
+_run_prts_api = os.environ.get("E2E_PRTS_API") == "1"
+
+
+def _send(proc: subprocess.Popen, msg: dict) -> None:
+    """Write a JSON-RPC message to the server's stdin."""
+    assert proc.stdin is not None
+    data = (json.dumps(msg, ensure_ascii=False) + "\n").encode()
+    proc.stdin.write(data)
+    # flush() can fail on Windows pipes; the write itself is sufficient
+    # because PIPE buffers are line-buffered by default in Python.
+    try:
+        proc.stdin.flush()
+    except OSError:
+        pass
+
+
+def _recv(proc: subprocess.Popen, timeout: float = 10.0) -> dict:
+    """Read one JSON-RPC message from the server's stdout."""
+    assert proc.stdout is not None
+    deadline = time.monotonic() + timeout
+    line = None
+    while time.monotonic() < deadline:
+        line = proc.stdout.readline()
+        if line:
+            break
+        time.sleep(0.01)
+    if not line:
+        raise TimeoutError("no response from server")
+    try:
+        return json.loads(line)  # type: ignore[no-any-return]
+    except json.JSONDecodeError:
+        # Some MCP messages may be non-JSON; return raw
+        return {"_raw": line.decode().strip()}
+
+
+def _tool_call(name: str, args: dict, id: int) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {"name": name, "arguments": args},
+        "id": id,
+    }
+
+
+def _call_result_text(proc: subprocess.Popen, name: str, args: dict, id: int) -> str:
+    _send(proc, _tool_call(name, args, id))
+    resp = _recv(proc)
+    content = resp.get("result", {}).get("content", [])
+    return content[0].get("text", "") if content else ""
+
+
+def _data_unavailable(text: str) -> bool:
+    return "暂不可用" in text or "未就绪" in text or "仍在进行中" in text
+
+
+# ---------------------------------------------------------------------------
+# Fixture: start the server once, share across tests in this module
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def server():
+    """Start the MCP server subprocess and return a handle for sending/receiving."""
+    env = os.environ.copy()
+    env["GAMEDATA_PATH"] = str(GAMEDATA_PATH)
+    env["GITHUB_MIRRORS"] = ""
+    # Prevent auto-sync interfering with the test
+    env.setdefault("STORYJSON_PATH", str(GAMEDATA_PATH / "does-not-exist.zip"))
+
+    # Ensure the package is importable
+    python_src = Path(__file__).resolve().parents[1] / "src"
+    env["PYTHONPATH"] = str(python_src)
+
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "from prts_mcp.server import main; main()"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+
+    # Give the server a moment to start background threads
+    time.sleep(1.0)
+
+    # Check server didn't crash on startup
+    if proc.poll() is not None:
+        stderr_text = proc.stderr.read().decode(errors="replace") if proc.stderr else ""
+        raise RuntimeError(f"Server exited with code {proc.returncode}: {stderr_text[-500:]}")
+
+    yield proc
+
+    # Cleanup
+    try:
+        proc.stdin.close()
+    except Exception:
+        pass
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+EXPECTED_TOOLS = {
+    "search_prts", "read_prts_page", "list_prts_sections",
+    "get_prts_categories", "get_prts_links", "get_prts_template",
+    "get_operator_archives", "get_operator_voicelines", "get_operator_basic_info",
+    "list_enemies", "get_enemy_info", "search_enemies",
+    "list_story_events", "list_stories", "read_story", "read_activity",
+    "list_search_scopes", "search_data", "search_stories",
+    "get_event_summary", "get_story_summary",
+}
+
+
+def test_initialize_handshake(server: subprocess.Popen) -> None:
+    _send(server, {
+        "jsonrpc": "2.0",
+        "method": "initialize",
+        "id": 1,
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "pytest-e2e", "version": "0"},
+        },
+    })
+    resp = _recv(server)
+    assert resp.get("id") == 1, f"Expected initialize response, got: {resp}"
+    result = resp.get("result", {})
+    assert "serverInfo" in result or "protocolVersion" in result, f"Missing server info: {resp}"
+
+    # Send initialized notification
+    _send(server, {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+
+
+def test_tools_list(server: subprocess.Popen) -> None:
+    _send(server, {"jsonrpc": "2.0", "method": "tools/list", "id": 2, "params": {}})
+    resp = _recv(server)
+    assert resp.get("id") == 2, f"Expected tools/list response, got: {resp}"
+    tools = resp["result"]["tools"]
+    names = {t["name"] for t in tools}
+
+    assert len(names) == 21, f"Expected 21 tools, got {len(names)}: {sorted(names)}"
+    for name in EXPECTED_TOOLS:
+        assert name in names, f"Missing tool: {name}"
+
+
+@pytest.mark.skipif(not _has_operator_data, reason="No bundled operator data")
+def test_operator_basic_info_amiya(server: subprocess.Popen) -> None:
+    text = _call_result_text(server, "get_operator_basic_info", {"operator_name": "阿米娅"}, 3)
+    assert "5★" in text, f"阿米娅 should be 5★: {text.split(chr(10))}"
+
+
+@pytest.mark.skipif(not _has_operator_data, reason="No bundled operator data")
+def test_operator_basic_info_senye(server: subprocess.Popen) -> None:
+    text = _call_result_text(server, "get_operator_basic_info", {"operator_name": "森蚺"}, 4)
+    assert "6★" in text, f"森蚺 should be 6★: {text.split(chr(10))}"
+
+
+@pytest.mark.skipif(not _has_operator_data, reason="No bundled operator data")
+def test_operator_archives(server: subprocess.Popen) -> None:
+    text = _call_result_text(server, "get_operator_archives", {"operator_name": "阿米娅"}, 5)
+    assert "阿米娅" in text and "干员档案" in text
+
+
+@pytest.mark.skipif(not _has_operator_data, reason="No bundled operator data")
+def test_operator_voicelines(server: subprocess.Popen) -> None:
+    text = _call_result_text(server, "get_operator_voicelines", {"operator_name": "阿米娅"}, 6)
+    assert "语音记录" in text and "阿米娅" in text
+
+
+@pytest.mark.skipif(not _has_operator_data, reason="No bundled operator data")
+def test_search_data(server: subprocess.Popen) -> None:
+    text = _call_result_text(server, "search_data", {"pattern": "法术伤害", "scope": "operators", "max_results": 3}, 7)
+    assert "法术伤害" in text
+
+
+def test_list_enemies_graceful(server: subprocess.Popen) -> None:
+    text = _call_result_text(server, "list_enemies", {"limit": 5}, 8)
+    assert "敌方图鉴" in text or _data_unavailable(text), f"unexpected: {text[:120]}"
+
+
+def test_list_story_events_graceful(server: subprocess.Popen) -> None:
+    text = _call_result_text(server, "list_story_events", {}, 9)
+    assert "[MAINLINE]" in text or "[ACTIVITY]" in text or _data_unavailable(text), \
+        f"unexpected: {text[:120]}"
+
+
+def test_list_search_scopes(server: subprocess.Popen) -> None:
+    text = _call_result_text(server, "list_search_scopes", {}, 10)
+    assert "operators" in text and "stories" in text
+
+
+@pytest.mark.skipif(not _run_prts_api, reason="E2E_PRTS_API not set")
+def test_search_prts(server: subprocess.Popen) -> None:
+    text = _call_result_text(server, "search_prts", {"query": "阿米娅", "limit": 3}, 20)
+    assert "阿米娅" in text and "匹配" in text
+
+
+@pytest.mark.skipif(not _run_prts_api, reason="E2E_PRTS_API not set")
+def test_list_prts_sections(server: subprocess.Popen) -> None:
+    text = _call_result_text(server, "list_prts_sections", {"page_title": "阿米娅"}, 21)
+    assert "[" in text and "] L" in text

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -59,16 +59,20 @@ const CSS_JS_RE =
 
 const HTML_TAG_RE = /<[^>]+>/g;
 
+const NAMED_ENTITIES: Record<string, string> = {
+  quot: '"', amp: "&", lt: "<", gt: ">", apos: "'", nbsp: " ",
+  mdash: "—", ndash: "–", hellip: "…",
+  lsquo: "‘", rsquo: "’", ldquo: "“", rdquo: "”",
+  copy: "©", reg: "®", trade: "™",
+  times: "×", divide: "÷", plusmn: "±",
+  bull: "•", middot: "·", shy: "­",
+};
+
 function unescapeHTMLEntities(text: string): string {
   return text
-    .replace(/&#(\d+);/g, (_, d) => String.fromCharCode(Number(d)))
-    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCharCode(parseInt(h, 16)))
-    .replace(/&quot;/g, '"')
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&#039;/g, "'")
-    .replace(/&nbsp;/g, " ");
+    .replace(/&#(\d+);/g, (_, d) => String.fromCodePoint(Number(d)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, h) => String.fromCodePoint(parseInt(h, 16)))
+    .replace(/&([a-zA-Z]+);/g, (_, name) => NAMED_ENTITIES[name] ?? `&${name};`);
 }
 
 function cleanSnippet(snippet: string): string {

--- a/ts/src/data/enemy.ts
+++ b/ts/src/data/enemy.ts
@@ -298,8 +298,8 @@ function fmtStats(dbEntry: EnemyDbEntry): string {
       const bb = s.blackboard ?? [];
       if (bb.length > 0) {
         const bbStrs = bb
-          .filter((b) => b.value != null)
           .slice(0, 6)
+          .filter((b) => b.value != null)
           .map((b) => `${b.key}=${b.value}`);
         if (bbStrs.length > 0) parts.push(": " + bbStrs.join("，"));
       }

--- a/ts/src/data/stores.ts
+++ b/ts/src/data/stores.ts
@@ -70,13 +70,17 @@ export class DirectoryStore implements JsonStore {
 
 export class ZipStore implements JsonStore {
   readonly zipPath: string;
+  private _zip: AdmZip | null = null;
 
   constructor(zipPath: string) {
     this.zipPath = zipPath;
   }
 
   private zip(): AdmZip {
-    return new AdmZip(this.zipPath);
+    if (this._zip === null) {
+      this._zip = new AdmZip(this.zipPath);
+    }
+    return this._zip;
   }
 
   exists(path: string): boolean {

--- a/ts/src/data/story.ts
+++ b/ts/src/data/story.ts
@@ -334,6 +334,7 @@ export function readActivityFromStore(
   let selected: ChapterSummary[];
   let hasMore: boolean;
   if (page !== undefined) {
+    if (page < 1) throw new Error("page 参数必须 >= 1");
     const start = (page - 1) * pageSize;
     const end = start + pageSize;
     selected = summaries.slice(start, end);
@@ -390,7 +391,7 @@ export function searchStories(
   eventId?: string,
 ): string {
   return searchStoriesFromStore(
-    new ZipStore(zipPath),
+    storyStore(zipPath),
     pattern,
     character,
     lineType,
@@ -466,8 +467,10 @@ export function searchStoriesFromStore(
       let chapter: StoryChapter;
       try {
         chapter = readStoryFromStore(store, d.storyTxt, true);
-      } catch {
-        continue;
+      } catch (err) {
+        if (err instanceof SyntaxError) continue;
+        if (err instanceof Error && /not found/i.test(err.message)) continue;
+        throw err;
       }
 
       for (let i = 0; i < chapter.lines.length; i++) {
@@ -532,7 +535,7 @@ export function searchStoriesFromStore(
  * Convenience wrapper around getEventSummaryFromStore.
  */
 export function getEventSummary(zipPath: string, eventId: string): string {
-  return getEventSummaryFromStore(new ZipStore(zipPath), eventId);
+  return getEventSummaryFromStore(storyStore(zipPath), eventId);
 }
 
 /**
@@ -620,7 +623,7 @@ export function getEventSummaryFromStore(store: JsonStore, eventId: string): str
  * Convenience wrapper around getStorySummaryFromStore.
  */
 export function getStorySummary(zipPath: string, storyKey: string): string {
-  return getStorySummaryFromStore(new ZipStore(zipPath), storyKey);
+  return getStorySummaryFromStore(storyStore(zipPath), storyKey);
 }
 
 /**

--- a/ts/src/data/story.ts
+++ b/ts/src/data/story.ts
@@ -351,8 +351,10 @@ export function readActivityFromStore(
       const chapter = readStoryFromStore(store, summary.storyKey, includeNarration);
       if (!eventName) eventName = chapter.eventName;
       chapters.push(chapter);
-    } catch (error) {
-      console.warn(`Skipping unreadable chapter "${summary.storyKey}":`, error);
+    } catch (err) {
+      if (err instanceof SyntaxError) { /* corrupt JSON */ }
+      else if (err instanceof Error && /not found/i.test(err.message)) { /* missing */ }
+      else throw err;
     }
   }
 

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -794,6 +794,51 @@ app.use(express.json());
 
 const transports = new Map<string, StreamableHTTPServerTransport>();
 
+const SESSION_IDLE_TIMEOUT_MS = (() => {
+  const raw = process.env["SESSION_IDLE_TIMEOUT_MS"];
+  if (raw === undefined) return 30 * 60 * 1000;
+  const parsed = Number(raw);
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return -1;
+})();
+
+interface SessionMeta {
+  transport: StreamableHTTPServerTransport;
+  lastActivity: number;
+  timer?: ReturnType<typeof setTimeout>;
+}
+
+const sessionMeta = new Map<string, SessionMeta>();
+
+function touchSession(id: string): void {
+  if (SESSION_IDLE_TIMEOUT_MS <= 0) return;
+  const meta = sessionMeta.get(id);
+  if (!meta) return;
+  meta.lastActivity = Date.now();
+}
+
+function scheduleSessionTimeout(id: string): void {
+  if (SESSION_IDLE_TIMEOUT_MS <= 0) return;
+  const meta = sessionMeta.get(id);
+  if (!meta) return;
+
+  if (meta.timer) clearTimeout(meta.timer);
+
+  meta.timer = setTimeout(() => {
+    const m = sessionMeta.get(id);
+    if (!m) return;
+    const idleMs = Date.now() - m.lastActivity;
+    if (idleMs >= SESSION_IDLE_TIMEOUT_MS) {
+      log("INFO", `Session ${id} idle for ${Math.round(idleMs / 1000)}s — evicting.`);
+      try { m.transport.close(); } catch { /* best-effort */ }
+      transports.delete(id);
+      sessionMeta.delete(id);
+    } else {
+      scheduleSessionTimeout(id);
+    }
+  }, SESSION_IDLE_TIMEOUT_MS);
+}
+
 app.all("/mcp", async (req, res) => {
   const sessionId = req.headers["mcp-session-id"] as string | undefined;
   let transport = sessionId ? transports.get(sessionId) : undefined;
@@ -803,12 +848,17 @@ app.all("/mcp", async (req, res) => {
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (id) => {
         transports.set(id, newTransport);
+        sessionMeta.set(id, { transport: newTransport, lastActivity: Date.now() });
+        scheduleSessionTimeout(id);
         log("INFO", `Session ${id} initialized.`);
       },
     });
     newTransport.onclose = () => {
       if (newTransport.sessionId) {
+        const meta = sessionMeta.get(newTransport.sessionId);
+        if (meta?.timer) clearTimeout(meta.timer);
         transports.delete(newTransport.sessionId);
+        sessionMeta.delete(newTransport.sessionId);
         log("INFO", `Session ${newTransport.sessionId} closed.`);
       }
     };
@@ -821,6 +871,11 @@ app.all("/mcp", async (req, res) => {
       return;
     }
     transport = newTransport;
+  }
+
+  // Update idle timer on each request
+  if (sessionId) {
+    touchSession(sessionId);
   }
 
   // Pass req.body explicitly so the transport uses the already-parsed body

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -1,0 +1,272 @@
+/**
+ * E2E test — starts the TS MCP server and exercises core tools via HTTP.
+ *
+ * Tests that run without network or full data:
+ *   1. Server startup + health check
+ *   2. MCP initialize handshake
+ *   3. tools/list — all 21 tools registered
+ *   4. Session persistence across requests
+ *   5. Operator tools (bundled fixture data)
+ *   6. Graceful errors for unavailable data
+ *
+ * Network-dependent PRTS API tests are skipped when E2E_PRTS_API is unset.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn, ChildProcess } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const s = createServer();
+    s.on("error", reject);
+    s.listen(0, "127.0.0.1", () => {
+      const addr = s.address();
+      s.close(() => {
+        if (addr && typeof addr === "object") resolve(addr.port);
+        else reject(new Error("no port"));
+      });
+    });
+  });
+}
+
+async function waitForHealth(origin: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${origin}/health`, { signal: AbortSignal.timeout(300) });
+      if (res.ok) return;
+    } catch { /* retry */ }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error("health check timeout");
+}
+
+interface McpResponse {
+  status: number;
+  body: Record<string, unknown>;
+  sessionId: string | null;
+}
+
+async function mcpPost(
+  origin: string,
+  body: unknown,
+  sessionId?: string,
+): Promise<McpResponse> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+  if (sessionId) headers["Mcp-Session-Id"] = sessionId;
+
+  const res = await fetch(`${origin}/mcp`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  const sid = res.headers.get("mcp-session-id");
+  const raw = await res.text();
+  let data: unknown;
+  const sseMatch = raw.match(/^data:\s*(\{[\s\S]*\})/m);
+  if (sseMatch) {
+    try { data = JSON.parse(sseMatch[1]); } catch { data = raw; }
+  } else {
+    try { data = JSON.parse(raw); } catch { data = raw; }
+  }
+  return { status: res.status, body: data as Record<string, unknown>, sessionId: sid };
+}
+
+function toolResultText(r: McpResponse): string {
+  const content = (r.body?.result as Record<string, unknown>)?.content as Array<{ text: string }> | undefined;
+  return content?.[0]?.text ?? "";
+}
+
+function dataUnavailable(text: string): boolean {
+  return text.includes("暂不可用") || text.includes("未就绪");
+}
+
+const tc = (name: string, args: Record<string, unknown>, id: number) => ({
+  jsonrpc: "2.0" as const,
+  method: "tools/call" as const,
+  params: { name, arguments: args },
+  id,
+});
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+const GAMEDATA_PATH = join(import.meta.dirname, "..", "..", "data", "gamedata");
+const RUN_PRTS_API = process.env["E2E_PRTS_API"] === "1";
+
+test("E2E", async (t) => {
+  // --- start server ---
+  const port = await getFreePort();
+  const origin = `http://127.0.0.1:${port}`;
+
+  const dataHome = mkdtempSync(join(tmpdir(), "prts-e2e-"));
+  const localAppData = join(dataHome, "LocalAppData");
+  mkdirSync(localAppData, { recursive: true });
+
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "src/server.ts"],
+    {
+      cwd: join(import.meta.dirname, ".."),
+      env: {
+        ...process.env,
+        PORT: String(port),
+        HOST: "127.0.0.1",
+        GAMEDATA_PATH,
+        XDG_DATA_HOME: dataHome,
+        LOCALAPPDATA: localAppData,
+        GITHUB_MIRRORS: "",
+        SESSION_IDLE_TIMEOUT_MS: "30000",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  let stderr = "";
+  child.stderr!.setEncoding("utf-8");
+  child.stderr!.on("data", (d: string) => { stderr += d; });
+
+  await waitForHealth(origin, 15000);
+
+  t.after(() => { child.kill(); });
+
+  // --- protocol handshake ---
+  let sessionId: string;
+
+  await t.test("protocol handshake", async () => {
+    const init = await mcpPost(origin, {
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "e2e", version: "1.0" },
+      },
+      id: 1,
+    });
+
+    assert.equal(init.status, 200, `status ${init.status}`);
+    assert.ok(init.sessionId, "should return Mcp-Session-Id");
+    sessionId = init.sessionId!;
+    assert.ok(init.body?.result, "initialize should have result");
+  });
+
+  // --- tools/list ---
+  await t.test("tools/list returns all 21 tools", async () => {
+    const tl = await mcpPost(
+      origin,
+      { jsonrpc: "2.0", method: "tools/list", id: 2 },
+      sessionId,
+    );
+
+    assert.equal(tl.status, 200);
+    const tools = (tl.body?.result as Record<string, unknown>)?.tools as Array<{ name: string }> | undefined;
+    assert.ok(tools, "tools/list should return tools");
+    assert.equal(tools!.length, 21, `got ${tools!.length} tools`);
+
+    const expected = new Set([
+      "search_prts", "read_prts_page", "list_prts_sections",
+      "get_prts_categories", "get_prts_links", "get_prts_template",
+      "get_operator_archives", "get_operator_voicelines", "get_operator_basic_info",
+      "list_enemies", "get_enemy_info", "search_enemies",
+      "list_story_events", "list_stories", "read_story", "read_activity",
+      "list_search_scopes", "search_data", "search_stories",
+      "get_event_summary", "get_story_summary",
+    ]);
+    const names = new Set(tools!.map((t) => t.name));
+    for (const name of expected) {
+      assert.ok(names.has(name), `missing tool: ${name}`);
+    }
+  });
+
+  // --- operator tools (bundled fixture always available) ---
+  await t.test("get_operator_basic_info — char_* filter (阿米娅 5★)", async () => {
+    const r = await mcpPost(origin, tc("get_operator_basic_info", { operator_name: "阿米娅" }, 3), sessionId);
+    assert.equal(r.status, 200);
+    const text = toolResultText(r);
+    assert.ok(text.includes("5★"), `阿米娅 should be 5★: ${text.split("\n").find((l) => l.includes("稀有度"))}`);
+  });
+
+  await t.test("get_operator_basic_info — char_* filter (森蚺 6★)", async () => {
+    const r = await mcpPost(origin, tc("get_operator_basic_info", { operator_name: "森蚺" }, 4), sessionId);
+    assert.equal(r.status, 200);
+    const text = toolResultText(r);
+    assert.ok(text.includes("6★"), `森蚺 should be 6★: ${text.split("\n").find((l) => l.includes("稀有度"))}`);
+  });
+
+  await t.test("get_operator_archives", async () => {
+    const r = await mcpPost(origin, tc("get_operator_archives", { operator_name: "阿米娅" }, 5), sessionId);
+    assert.equal(r.status, 200);
+    const text = toolResultText(r);
+    assert.ok(text.includes("阿米娅") && text.includes("干员档案"), text.slice(0, 80));
+  });
+
+  await t.test("get_operator_voicelines", async () => {
+    const r = await mcpPost(origin, tc("get_operator_voicelines", { operator_name: "阿米娅" }, 6), sessionId);
+    assert.equal(r.status, 200);
+    const text = toolResultText(r);
+    assert.ok(text.includes("语音记录") && text.includes("阿米娅"), text.slice(0, 80));
+  });
+
+  await t.test("search_data", async () => {
+    const r = await mcpPost(origin, tc("search_data", { pattern: "法术伤害", scope: "operators", max_results: 3 }, 7), sessionId);
+    assert.equal(r.status, 200);
+    const text = toolResultText(r);
+    assert.ok(text.includes("法术伤害"), text.slice(0, 80));
+  });
+
+  // --- graceful errors for unavailable data ---
+  await t.test("list_enemies — data or graceful error", async () => {
+    const r = await mcpPost(origin, tc("list_enemies", { limit: 5 }, 8), sessionId);
+    assert.equal(r.status, 200);
+    const text = toolResultText(r);
+    assert.ok(text.includes("敌方图鉴") || dataUnavailable(text), `unexpected: ${text.slice(0, 100)}`);
+  });
+
+  await t.test("list_story_events — data or graceful error", async () => {
+    const r = await mcpPost(origin, tc("list_story_events", {}, 9), sessionId);
+    assert.equal(r.status, 200);
+    const text = toolResultText(r);
+    assert.ok(text.includes("[MAINLINE]") || text.includes("[ACTIVITY]") || dataUnavailable(text),
+      `unexpected: ${text.slice(0, 100)}`);
+  });
+
+  // --- session persistence ---
+  await t.test("session persists across calls", async () => {
+    const r = await mcpPost(
+      origin,
+      { jsonrpc: "2.0", method: "tools/list", id: 10 },
+      sessionId,
+    );
+    assert.equal(r.status, 200);
+    assert.ok(r.body?.result, "reused session should work");
+  });
+
+  // --- PRTS API tools (opt-in) ---
+  await t.test("search_prts", { skip: !RUN_PRTS_API }, async () => {
+    const r = await mcpPost(origin, tc("search_prts", { query: "阿米娅", limit: 3 }, 20), sessionId);
+    assert.equal(r.status, 200);
+    const text = toolResultText(r);
+    assert.ok(text.includes("阿米娅") && text.includes("匹配"), text.slice(0, 80));
+  });
+
+  await t.test("list_prts_sections", { skip: !RUN_PRTS_API }, async () => {
+    const r = await mcpPost(origin, tc("list_prts_sections", { page_title: "阿米娅" }, 21), sessionId);
+    assert.equal(r.status, 200);
+    const text = toolResultText(r);
+    assert.ok(text.includes("[") && text.includes("] L"), text.slice(0, 80));
+  });
+});

--- a/ts/tests/sessionIdleTimeout.test.ts
+++ b/ts/tests/sessionIdleTimeout.test.ts
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn, ChildProcess } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      server.close(() => {
+        if (addr && typeof addr === "object") resolve(addr.port);
+        else reject(new Error("Failed to allocate test port"));
+      });
+    });
+  });
+}
+
+async function waitForHealth(origin: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastErr: unknown = null;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(origin + "/health", { signal: AbortSignal.timeout(300) });
+      if (res.ok) return;
+      lastErr = new Error("HTTP " + res.status);
+    } catch (err) { lastErr = err; }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+}
+
+function collectStderr(child: ChildProcess): string[] {
+  const lines: string[] = [];
+  child.stderr!.setEncoding("utf-8");
+  child.stderr!.on("data", (chunk: string) => { lines.push(chunk); });
+  return lines;
+}
+
+test("idle sessions are evicted after timeout", async () => {
+  const port = await getFreePort();
+  const dataHome = mkdtempSync(join(tmpdir(), "prts-session-idle-"));
+  const localAppData = join(dataHome, "LocalAppData");
+  mkdirSync(localAppData, { recursive: true });
+
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "--import", "./tests/fixtures/hangingFetch.ts", "src/server.ts"],
+    {
+      cwd: join(import.meta.dirname, ".."),
+      env: {
+        ...process.env,
+        PORT: String(port),
+        HOST: "127.0.0.1",
+        XDG_DATA_HOME: dataHome,
+        LOCALAPPDATA: localAppData,
+        GITHUB_MIRRORS: "",
+        STORYJSON_PATH: join(dataHome, "storyjson", "missing.zip"),
+        SESSION_IDLE_TIMEOUT_MS: "2000",
+      },
+      stdio: ["ignore", "ignore", "pipe"],
+    },
+  );
+
+  const stderrLines = collectStderr(child);
+
+  try {
+    const origin = "http://127.0.0.1:" + port;
+    await waitForHealth(origin, 5000);
+
+    const initRes = await fetch(origin + "/mcp", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify({
+        jsonrpc: "2.0", method: "initialize",
+        params: { protocolVersion: "2025-03-26", capabilities: {}, clientInfo: { name: "test", version: "1.0" } },
+        id: 1,
+      }),
+    });
+
+    const sessionId = initRes.headers.get("mcp-session-id");
+    assert.ok(sessionId, "should return Mcp-Session-Id");
+    assert.ok(initRes.ok, "initialize should succeed");
+
+    // Wait for idle eviction (timeout is 2s, wait 4s)
+    await new Promise((r) => setTimeout(r, 4000));
+
+    // Reuse old session — should get a new session or error
+    const reuseRes = await fetch(origin + "/mcp", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "mcp-session-id": sessionId },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 2 }),
+    });
+
+    const reuseSessionId = reuseRes.headers.get("mcp-session-id");
+    assert.ok(reuseSessionId || reuseRes.status >= 400,
+      "reuse should get new session or error");
+
+    // Check eviction log
+    const allStderr = stderrLines.join("");
+    assert.match(allStderr, /idle for \d+s.*evicting/i, "should log idle eviction");
+  } finally {
+    child.kill();
+    await new Promise((r) => child.once("exit", r));
+  }
+});

--- a/ts/tests/zipCache.test.ts
+++ b/ts/tests/zipCache.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for ZipStore AdmZip instance caching.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import AdmZip from "adm-zip";
+import { ZipStore } from "../src/data/stores.ts";
+
+const FIXTURE_PATH = "zh_CN/gamedata/excel/sample.json";
+const FIXTURE_DATA = { name: "阿米娅", rarity: 5 };
+
+function tempRoot(): string {
+  return mkdtempSync(join(tmpdir(), "prts-zipcache-test-"));
+}
+
+function writeFixtureZip(path: string, data: unknown = FIXTURE_DATA): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const zip = new AdmZip();
+  zip.addFile(FIXTURE_PATH, Buffer.from(JSON.stringify(data), "utf-8"));
+  zip.writeZip(path);
+}
+
+test("ZipStore reuses AdmZip instance across calls", () => {
+  const root = tempRoot();
+  const zipPath = join(root, "fixture.zip");
+  writeFixtureZip(zipPath);
+  const store = new ZipStore(zipPath);
+
+  assert.equal(store.exists(FIXTURE_PATH), true);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const zip1 = (store as any)._zip;
+  assert.ok(zip1 && typeof zip1 === "object" && typeof zip1.getEntry === "function",
+    "first zip() should create an AdmZip-like object");
+
+  assert.deepEqual(store.readJson(FIXTURE_PATH), FIXTURE_DATA);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const zip2 = (store as any)._zip;
+
+  assert.strictEqual(
+    zip1,
+    zip2,
+    "ZipStore should reuse the same AdmZip instance",
+  );
+});
+
+test("ZipStore cached instance still functions correctly", () => {
+  const root = tempRoot();
+  const zipPath = join(root, "fixture.zip");
+  writeFixtureZip(zipPath);
+
+  const store = new ZipStore(zipPath);
+
+  for (let i = 0; i < 5; i++) {
+    assert.equal(store.exists(FIXTURE_PATH), true);
+    assert.match(store.readText(FIXTURE_PATH), /阿米娅/);
+    assert.deepEqual(store.readJson(FIXTURE_PATH), FIXTURE_DATA);
+  }
+});
+
+test("ZipStore reports missing entries correctly with cached instance", () => {
+  const root = tempRoot();
+  const zipPath = join(root, "fixture.zip");
+  writeFixtureZip(zipPath);
+  const store = new ZipStore(zipPath);
+
+  assert.equal(store.exists("zh_CN/missing.json"), false);
+  assert.throws(
+    () => store.readText("zh_CN/missing.json"),
+    /Dataset zip entry not found/,
+  );
+});


### PR DESCRIPTION
## Summary

- **ZipStore caching** — both TS (AdmZip) and Python (ZipFile) now cache the parsed zip instance instead of re-opening on every call. In `search_stories` without an `event_id` filter this was ~3000 zip re-parses, exceeding the 120 s client timeout.
- **Session memory leak** — `SESSION_IDLE_TIMEOUT_MS` (default 30 min) evicts MCP transports from disconnected clients.
- **Python httpx client** — shared module-level `AsyncClient` instead of creating a new one on every API call (7 call sites).
- **Python rate limiter** — slot-based reservation replaces the check-then-act pattern that had a race condition under concurrent coroutines.
- **TS enemy blackboard** — filter/slice order fixed to match Python (slice first 6, then filter nulls).
- **TS HTML entity decoding** — `String.fromCodePoint` replaces `String.fromCharCode`; extended named entity table.
- **Python parsetree** — `.tail` text preserved after removing nested elements in title/value extraction.
- **Story search** — narrowed exception handling; `page>=1` validation in `read_activity`.
- **E2E tests** — MCP protocol test suites for both implementations covering handshake, tool surface, operator data, and graceful degradation.

## Test plan

- [x] `cd python && python -m pytest tests/ -v` — 136 passed, 2 skipped
- [x] `cd ts && node --import tsx --test tests/*.test.ts` — 82 passed, 2 skipped
- [ ] CI passes for both implementations
- [ ] Manual E2E against production with `E2E_PRTS_API=1`

## Deferred

- HTTP 429/Retry-After handling (new feature, not a bug)
- `pllimit` for outbound links (not applicable to `action=parse`)
- Python `include_narration=False` parse-then-filter optimization (minor)