### PR TITLE
fix(ts): return spec-compliant 404 for stale sessions with LLM-friendly message

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,8 @@ PRTS-MCP is past 1.0. The public tool surface and data architecture are under a 
 
 ## Current Release
 
-- Python: `1.4.1`
-- TypeScript: `1.4.1`
+- Python: `1.4.2`
+- TypeScript: `1.4.2`
 - 21 public MCP tools, frozen in the 1.x line (CI-enforced).
 - See [migration guide](docs/migration-0.x-to-1.0.md) for the
   0.x → 1.0 transition.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,13 +1,13 @@
 # PRTS-MCP 项目状态
 
-_Last updated: 2026-05-19_
+_Last updated: 2026-05-25_
 
 ## 当前版本
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 1.4.1 | stable |
-| TypeScript | 1.4.1 | stable |
+| Python | 1.4.2 | stable |
+| TypeScript | 1.4.2 | stable |
 
 - 公共工具面：21 个 MCP 工具（1.x 冻结）
 - 兼容性合约：1.x 期间工具名和必填参数不变

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-05-25
+
+### Changed
+
+- **Version sync with TS 1.4.2.** No Python-side changes — the session pool
+  fix in this release applies only to the TypeScript Streamable HTTP transport.
+  Python's stdio transport is not affected by the stale-session issue.
+
 ## [1.4.1] - 2026-05-19
 
 ### Fixed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "1.4.1"
+version = "1.4.2"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [1.4.2] - 2026-05-25
+
+### Fixed
+
+- **Session pool 400 on stale session ID.** When a client reuses a session ID
+  that was evicted by idle timeout or lost across server restart, the server
+  now returns a spec-compliant 404 (error code `-32002`) with an
+  LLM-actionable message instead of the previous 400 "Server not initialized".
+  Initialize requests with a stale session ID auto-recover (strip old ID,
+  treat as fresh handshake) — an intentional relaxation of MCP Streamable
+  HTTP §3.2 for clients that don't retry with a fresh handshake on error.
+
+### Changed
+
+- **Session idle timeout default extended** from 30 minutes to 24 hours,
+  reducing the chance of session eviction during normal interactive use.
+  Configurable via `SESSION_IDLE_TIMEOUT_MS` env var.
+- **Session idle timeout test** tightened to assert exact 404 status and
+  error code, plus a new sub-test for init auto-recovery path.
+
 ## [1.4.1] - 2026-05-19
 
 ### Fixed

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP)",
   "type": "module",
   "main": "dist/server.js",

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -796,7 +796,7 @@ const transports = new Map<string, StreamableHTTPServerTransport>();
 
 const SESSION_IDLE_TIMEOUT_MS = (() => {
   const raw = process.env["SESSION_IDLE_TIMEOUT_MS"];
-  if (raw === undefined) return 30 * 60 * 1000;
+  if (raw === undefined) return 24 * 60 * 60 * 1000;
   const parsed = Number(raw);
   if (Number.isFinite(parsed) && parsed > 0) return parsed;
   return -1;
@@ -844,6 +844,38 @@ app.all("/mcp", async (req, res) => {
   let transport = sessionId ? transports.get(sessionId) : undefined;
 
   if (!transport) {
+    // Stale session ID: evicted by idle timeout or lost across restart.
+    // Per MCP Streamable HTTP spec §3.2, unrecognized session IDs MUST
+    // receive 404 regardless of request type.  We intentionally relax this
+    // for initialize requests: stripping the old ID and treating it as a
+    // fresh handshake gives broken/non-retrying clients (e.g. Chatbox) a
+    // zero-error recovery path.  Non-init requests get the spec-mandated
+    // 404 with an LLM-actionable message.
+    if (sessionId) {
+      const isInit =
+        req.method === "POST" &&
+        !Array.isArray(req.body) &&
+        req.body?.method === "initialize";
+      if (!isInit) {
+        log("INFO", `Session ${sessionId} not found; returning 404.`);
+        res.status(404).json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32002,
+            message:
+              "MCP session lost (server may have restarted for data sync). " +
+              "Please ask the user to disconnect and reconnect the MCP server " +
+              "in the client settings — typically by toggling the MCP connection " +
+              "off and on, or restarting the client application.",
+          },
+          id: (req.body as Record<string, unknown> | undefined)?.id ?? null,
+        });
+        return;
+      }
+      delete req.headers["mcp-session-id"];
+      log("INFO", `Session ${sessionId} not found; allowing re-initialization.`);
+    }
+
     const newTransport = new StreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (id) => {

--- a/ts/tests/sessionIdleTimeout.test.ts
+++ b/ts/tests/sessionIdleTimeout.test.ts
@@ -89,16 +89,54 @@ test("idle sessions are evicted after timeout", async () => {
     // Wait for idle eviction (timeout is 2s, wait 4s)
     await new Promise((r) => setTimeout(r, 4000));
 
-    // Reuse old session — should get a new session or error
+    // --- non-init request with stale session → 404 JSON-RPC error ---
     const reuseRes = await fetch(origin + "/mcp", {
       method: "POST",
       headers: { "Content-Type": "application/json", "mcp-session-id": sessionId },
       body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 2 }),
     });
 
-    const reuseSessionId = reuseRes.headers.get("mcp-session-id");
-    assert.ok(reuseSessionId || reuseRes.status >= 400,
-      "reuse should get new session or error");
+    assert.equal(reuseRes.status, 404, "non-init stale session should return 404");
+    assert.equal(
+      reuseRes.headers.get("content-type")?.split(";")[0],
+      "application/json",
+    );
+    const reuseBody = await reuseRes.json() as Record<string, unknown>;
+    assert.equal(reuseBody.jsonrpc, "2.0", "should be valid JSON-RPC");
+    assert.equal(reuseBody.id, 2, "should preserve request id");
+    assert.ok(reuseBody.error, "should include error object");
+    const err = reuseBody.error as Record<string, unknown>;
+    assert.equal(err.code, -32002, "error code should be -32002");
+    assert.ok(
+      typeof err.message === "string" && err.message.includes("MCP session lost"),
+      "error message should mention session loss",
+    );
+
+    // --- initialize request with stale session → auto-recovery ---
+    const reinitRes = await fetch(origin + "/mcp", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "mcp-session-id": sessionId,
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "test-reinit", version: "1.0" },
+        },
+        id: 3,
+      }),
+    });
+
+    assert.equal(reinitRes.status, 200, "init with stale session should auto-recover");
+    assert.ok(reinitRes.ok, "initialize should succeed");
+    const newSessionId = reinitRes.headers.get("mcp-session-id");
+    assert.ok(newSessionId, "should return a new session ID");
+    assert.notEqual(newSessionId, sessionId, "new session ID should differ from old one");
 
     // Check eviction log
     const allStderr = stderrLines.join("");


### PR DESCRIPTION
## Summary

- Fixes a consistently reproducible 400 error in the TypeScript Streamable HTTP transport when clients reuse a session ID that was evicted by idle timeout or lost across server restart.
- Initialize requests with stale session IDs now auto-recover (old ID stripped, treated as fresh handshake). Non-init requests receive a spec-compliant 404 with an LLM-actionable error message that instructs the LLM to prompt the user to reconnect.
- `SESSION_IDLE_TIMEOUT_MS` default extended from 30 min to 24 h to reduce eviction frequency during normal use.
- Python implementation is unaffected (stdio transport has no session pool).

## Test plan

- [x] `ts/tests/sessionIdleTimeout.test.ts` — idle eviction + stale session reuse
- [x] `ts/tests/e2e.test.ts` — full MCP protocol handshake, session persistence, all 21 tools
- [x] TypeScript full suite: 82 passed, 0 failed, 2 skipped (PRTS network)
- [x] Python full suite: 136 passed, 0 failed, 2 skipped (PRTS network)
- [x] Manual testing with Chatbox — confirmed 404 response format and LLM-friendly message content