### PR TITLE
fix(runtime): harden resource lifecycle

### DIFF
--- a/docs/dev/reports/1.5-runtime-nonfunctional-audit.md
+++ b/docs/dev/reports/1.5-runtime-nonfunctional-audit.md
@@ -1,0 +1,101 @@
+# PRTS-MCP 1.5 Runtime Non-Functional Audit
+
+_Date: 2026-05-28_
+
+## Scope
+
+This audit focused on leak-prone and degradation-prone runtime paths in both
+implementations:
+
+- local dataset store lifecycle, especially zip readers;
+- module-level caches and cache invalidation after auto-sync;
+- startup sync retry timers and network fallback behavior;
+- TypeScript Streamable HTTP session lifecycle;
+- PRTS Wiki network client reuse and rate limiting.
+
+The review was motivated by the previous TypeScript session memory leak fixed
+in 1.4.1. Public MCP tool names and required parameters were intentionally left
+unchanged.
+
+## Findings Fixed
+
+### Python ZipStore Handles
+
+`ZipStore` cached an open `zipfile.ZipFile` for performance, but the zip-path
+story helper functions created transient `ZipStore` instances without a
+deterministic close path. CPython reference cleanup usually closes those files,
+but repeated story reads/searches should not depend on garbage collection.
+
+Fix:
+
+- `ZipStore.close()` closes and clears the cached `ZipFile`.
+- `ZipStore` now supports `with ZipStore(...) as store`.
+- `DirectoryStore.close()` is a no-op and `FallbackStore.close()` propagates to
+  children.
+- Python story zip-path convenience functions use context managers so
+  transient stores are closed after each call.
+
+Coverage:
+
+- store-level tests assert cached zip handles are closed;
+- story wrapper test asserts the transient store close path is used.
+
+### TypeScript Release Zip Fallback Validation
+
+Python `sync_release()` validates cached release zips before treating them as
+usable fallback data. TypeScript `syncRelease()` only checked that the zip file
+existed. A corrupt or incomplete `zh_CN.zip` could therefore be reported as
+`offline_fallback`, delaying recovery until a later tool call failed while
+reading the archive.
+
+Fix:
+
+- `syncRelease()` now runs `validateZip` for existing cached zips when a
+  validator is available.
+- validation failures, including validator exceptions, make the cached zip
+  unusable and return `no_data` when the network is also unavailable.
+
+Coverage:
+
+- tests cover validator-reported missing entries and validator exceptions.
+
+### TypeScript Idle Timer Lifecycle
+
+Startup sync retry timers already call `unref()`. Session idle timers were
+cleaned up on session close/eviction, but they still kept the Node event loop
+alive while pending.
+
+Fix:
+
+- session idle timers now call `unref()` after scheduling.
+
+## Findings Confirmed Acceptable
+
+- **Python `lru_cache(maxsize=1)` table caches** are bounded. GameData startup
+  sync clears operator, enemy, and stage caches after updated data is written.
+- **TypeScript module-level table caches** are bounded singletons and are
+  cleared after updated GameData sync, matching the Python path.
+- **Startup sync retry loops** are bounded to three attempts in both
+  implementations. Python retry timers are daemon threads; TypeScript retry
+  timers are unref'ed.
+- **TypeScript session pool** has a bounded idle eviction path and clears the
+  per-session timer when transports close.
+- **Synchronous release/archive downloads** still buffer the full asset before
+  writing. Current assets are finite release artifacts and writes are atomic;
+  streaming would reduce peak memory but is not required to close a confirmed
+  leak in this pass.
+- **Python PRTS Wiki `httpx.AsyncClient` reuse** keeps a process-wide client for
+  connection pooling. The installed local environment does not currently expose
+  the MCP SDK for verifying a stable FastMCP shutdown hook, so this pass did
+  not add a speculative event-loop shutdown path.
+
+## Residual Risks
+
+- A future Python FastMCP lifecycle hook should close the shared PRTS Wiki
+  `httpx.AsyncClient` explicitly when the SDK is available in the local test
+  environment.
+- If release assets grow substantially, both implementations should revisit
+  streaming downloads to reduce peak memory during sync.
+- Story tools still instantiate one zip store per zip-path wrapper call. The
+  handle is now closed deterministically; a future repository-level story store
+  cache could reduce repeated parse overhead if profiling shows it matters.

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **ZipStore lifecycle hardening.** `ZipStore` now supports explicit
+  `close()` and context-manager use. Zip-path story helpers close their
+  transient stores after each call, avoiding lingering `ZipFile` handles in
+  repeated story reads/searches.
+
 ## [1.5.0] - 2026-05-25
 
 ### Added

--- a/python/src/prts_mcp/data/stores.py
+++ b/python/src/prts_mcp/data/stores.py
@@ -21,6 +21,9 @@ class JsonStore(Protocol):
     def describe(self) -> str:
         ...
 
+    def close(self) -> None:
+        ...
+
 
 def _normalize_path(path: str) -> str:
     normalized = path.replace("\\", "/")
@@ -60,6 +63,9 @@ class DirectoryStore:
     def describe(self) -> str:
         return f"directory:{self.root}"
 
+    def close(self) -> None:
+        return None
+
 
 class ZipStore:
     """Read JSON entries from a zip file."""
@@ -72,6 +78,17 @@ class ZipStore:
         if self._zf is None:
             self._zf = zipfile.ZipFile(self.zip_path)
         return self._zf
+
+    def close(self) -> None:
+        if self._zf is not None:
+            self._zf.close()
+            self._zf = None
+
+    def __enter__(self) -> ZipStore:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self.close()
 
     def exists(self, path: str) -> bool:
         inner_path = _normalize_path(path)
@@ -96,6 +113,13 @@ class ZipStore:
 
     def describe(self) -> str:
         return f"zip:{self.zip_path}"
+
+    def __del__(self) -> None:
+        if getattr(self, "_zf", None) is not None:
+            try:
+                self.close()
+            except Exception:
+                pass
 
 
 class FallbackStore:
@@ -126,3 +150,7 @@ class FallbackStore:
 
     def describe(self) -> str:
         return f"fallback:{self.primary.describe()} -> {self.fallback.describe()}"
+
+    def close(self) -> None:
+        self.primary.close()
+        self.fallback.close()

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -163,7 +163,8 @@ def list_story_events(
     """
     allowed_types: list[str] | None = _CATEGORY_MAP.get(category) if category else None
 
-    return list_story_events_from_store(_story_store(zip_path), category=category)
+    with _story_store(zip_path) as store:
+        return list_story_events_from_store(store, category=category)
 
 
 def list_story_events_from_store(
@@ -203,7 +204,8 @@ def list_stories(zip_path: Path, event_id: str) -> list[ChapterSummary]:
     Raises:
         KeyError: If event_id is not found in story_review_table.
     """
-    return list_stories_from_store(_story_store(zip_path), event_id)
+    with _story_store(zip_path) as store:
+        return list_stories_from_store(store, event_id)
 
 
 def list_stories_from_store(store: JsonStore, event_id: str) -> list[ChapterSummary]:
@@ -246,7 +248,8 @@ def read_story(
     Raises:
         KeyError: If the story file is not found in the zip.
     """
-    return read_story_from_store(_story_store(zip_path), story_key, include_narration=include_narration)
+    with _story_store(zip_path) as store:
+        return read_story_from_store(store, story_key, include_narration=include_narration)
 
 
 def read_story_from_store(
@@ -301,13 +304,14 @@ def read_activity(
     Raises:
         KeyError: If event_id is not found.
     """
-    return read_activity_from_store(
-        _story_store(zip_path),
-        event_id,
-        include_narration=include_narration,
-        page=page,
-        page_size=page_size,
-    )
+    with _story_store(zip_path) as store:
+        return read_activity_from_store(
+            store,
+            event_id,
+            include_narration=include_narration,
+            page=page,
+            page_size=page_size,
+        )
 
 
 def read_activity_from_store(
@@ -385,15 +389,16 @@ def search_stories(
     Convenience wrapper around search_stories_from_store that auto-creates
     a ZipStore from *zip_path*.
     """
-    return search_stories_from_store(
-        _story_store(zip_path),
-        pattern,
-        character=character,
-        line_type=line_type,
-        context_lines=context_lines,
-        max_results=max_results,
-        event_id=event_id,
-    )
+    with _story_store(zip_path) as store:
+        return search_stories_from_store(
+            store,
+            pattern,
+            character=character,
+            line_type=line_type,
+            context_lines=context_lines,
+            max_results=max_results,
+            event_id=event_id,
+        )
 
 
 def search_stories_from_store(
@@ -532,7 +537,8 @@ def get_event_summary(zip_path: Path, event_id: str) -> str:
 
     Convenience wrapper around get_event_summary_from_store.
     """
-    return get_event_summary_from_store(_story_store(zip_path), event_id)
+    with _story_store(zip_path) as store:
+        return get_event_summary_from_store(store, event_id)
 
 
 def get_event_summary_from_store(store: JsonStore, event_id: str) -> str:
@@ -613,7 +619,8 @@ def get_story_summary(zip_path: Path, story_key: str) -> str:
 
     Convenience wrapper around get_story_summary_from_store.
     """
-    return get_story_summary_from_store(_story_store(zip_path), story_key)
+    with _story_store(zip_path) as store:
+        return get_story_summary_from_store(store, story_key)
 
 
 def get_story_summary_from_store(store: JsonStore, story_key: str) -> str:

--- a/python/src/prts_mcp/data/sync.py
+++ b/python/src/prts_mcp/data/sync.py
@@ -486,7 +486,10 @@ def _release_zip_error(spec: ReleaseSpec) -> str | None:
     validator = spec.validate_zip
     if validator is None:
         return None
-    missing = validator(spec.local_zip)
+    try:
+        missing = validator(spec.local_zip)
+    except Exception as exc:  # noqa: BLE001
+        return f"{spec.local_zip.name} is not a valid zip: {exc}"
     if not missing:
         return None
     return "; ".join(str(path) for path in missing[:10])

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -376,12 +376,12 @@ def list_stories(
 
     summaries: dict[str, str] = {}
     if include_summaries:
-        store = ZipStore(zip_path)
         try:
-            if store.exists("zh_CN/storyinfo.json"):
-                raw = store.read_json("zh_CN/storyinfo.json")
-                if isinstance(raw, dict):
-                    summaries = {str(k): str(v) for k, v in raw.items() if v}
+            with ZipStore(zip_path) as store:
+                if store.exists("zh_CN/storyinfo.json"):
+                    raw = store.read_json("zh_CN/storyinfo.json")
+                    if isinstance(raw, dict):
+                        summaries = {str(k): str(v) for k, v in raw.items() if v}
         except Exception:
             pass
 

--- a/python/tests/test_stores.py
+++ b/python/tests/test_stores.py
@@ -66,6 +66,36 @@ class TestZipStore:
         assert store.read_json(FIXTURE_PATH) == FIXTURE_DATA
         assert store.describe().startswith("zip:")
 
+    def test_close_releases_cached_zipfile(self, tmp_path):
+        zip_path = tmp_path / "fixture.zip"
+        write_fixture_zip(zip_path)
+        store = ZipStore(zip_path)
+
+        assert store.exists(FIXTURE_PATH)
+        zf = store._zf
+        assert zf is not None
+        fp = zf.fp
+        assert fp is not None
+
+        store.close()
+
+        assert store._zf is None
+        assert fp.closed
+
+    def test_context_manager_closes_cached_zipfile(self, tmp_path):
+        zip_path = tmp_path / "fixture.zip"
+        write_fixture_zip(zip_path)
+
+        with ZipStore(zip_path) as store:
+            assert store.exists(FIXTURE_PATH)
+            zf = store._zf
+            assert zf is not None
+            fp = zf.fp
+            assert fp is not None
+
+        assert store._zf is None
+        assert fp.closed
+
     def test_missing_entry_raises(self, tmp_path):
         zip_path = tmp_path / "fixture.zip"
         write_fixture_zip(zip_path)
@@ -120,3 +150,30 @@ class TestFallbackStore:
         assert not store.exists(FIXTURE_PATH)
         with pytest.raises(FileNotFoundError):
             store.read_text(FIXTURE_PATH)
+
+    def test_close_propagates_to_child_stores(self, tmp_path):
+        primary_zip = tmp_path / "primary.zip"
+        fallback_zip = tmp_path / "fallback.zip"
+        write_fixture_zip(primary_zip, {"source": "primary"})
+        write_fixture_zip(fallback_zip, {"source": "fallback"})
+        primary = ZipStore(primary_zip)
+        fallback = ZipStore(fallback_zip)
+        store = FallbackStore(primary, fallback)
+
+        assert store.exists(FIXTURE_PATH)
+        assert fallback.exists(FIXTURE_PATH)
+        primary_zf = primary._zf
+        fallback_zf = fallback._zf
+        assert primary_zf is not None
+        assert fallback_zf is not None
+        primary_fp = primary_zf.fp
+        fallback_fp = fallback_zf.fp
+        assert primary_fp is not None
+        assert fallback_fp is not None
+
+        store.close()
+
+        assert primary._zf is None
+        assert fallback._zf is None
+        assert primary_fp.closed
+        assert fallback_fp.closed

--- a/python/tests/test_story_reader_store.py
+++ b/python/tests/test_story_reader_store.py
@@ -153,10 +153,28 @@ def test_public_zip_path_api_still_reads_zip(tmp_path):
     assert chapter.lines[0].text == "你好，博士。"
 
 
+def test_public_zip_path_api_closes_transient_store(tmp_path, monkeypatch):
+    zip_path = tmp_path / "zh_CN.zip"
+    write_story_zip(zip_path)
+    closed_paths: list[Path] = []
+
+    original_close = ZipStore.close
+
+    def tracked_close(self: ZipStore) -> None:
+        closed_paths.append(self.zip_path)
+        original_close(self)
+
+    monkeypatch.setattr(ZipStore, "close", tracked_close)
+
+    chapter = read_story(zip_path, FIRST_STORY_KEY)
+
+    assert chapter.story_code == "TEST-1"
+    assert closed_paths == [zip_path]
+
+
 def test_missing_story_raises_key_error(tmp_path):
     write_story_dir(tmp_path)
     store = DirectoryStore(tmp_path)
 
     with pytest.raises(KeyError):
         read_story_from_store(store, "activities/act_test/missing")
-

--- a/python/tests/test_sync_release.py
+++ b/python/tests/test_sync_release.py
@@ -134,6 +134,23 @@ class TestSyncRelease:
 
         assert result.status == "offline_fallback"
 
+    def test_validator_exception_returns_no_data(self, tmp_path):
+        spec = _make_spec(tmp_path)
+        _write_zip(spec.local_zip)
+        spec = ReleaseSpec(
+            owner=spec.owner,
+            repo=spec.repo,
+            asset_name=spec.asset_name,
+            local_zip=spec.local_zip,
+            validate_zip=lambda _path: (_ for _ in ()).throw(ValueError("bad zip")),
+        )
+
+        with patch("prts_mcp.data.sync.check_latest_release", return_value=None):
+            result = sync_release(spec)
+
+        assert result.status == "no_data"
+        assert result.error == "Network unavailable and no cached zip; cached zip invalid: zh_CN.zip is not a valid zip: bad zip"
+
     def test_no_data_when_network_fails_and_no_zip(self, tmp_path):
         spec = _make_spec(tmp_path)
 

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release zip cache validation parity.** `syncRelease` now treats a cached
+  zip that fails the dataset validator as unusable during network fallback,
+  matching Python behavior and preventing corrupt story archives from being
+  reported as healthy fallback data.
+- **Session timer lifecycle.** Idle-session timers now call `unref()` so they
+  do not keep an otherwise idle Node process alive.
+
 ## [1.5.0] - 2026-05-25
 
 ### Added

--- a/ts/src/data/stores.ts
+++ b/ts/src/data/stores.ts
@@ -7,6 +7,7 @@ export interface JsonStore {
   readText(path: string): string;
   readJson<T = unknown>(path: string): T;
   describe(): string;
+  close(): void;
 }
 
 function normalizePath(path: string): string {
@@ -66,6 +67,10 @@ export class DirectoryStore implements JsonStore {
   describe(): string {
     return `directory:${this.root}`;
   }
+
+  close(): void {
+    // DirectoryStore does not hold open resources.
+  }
 }
 
 export class ZipStore implements JsonStore {
@@ -81,6 +86,10 @@ export class ZipStore implements JsonStore {
       this._zip = new AdmZip(this.zipPath);
     }
     return this._zip;
+  }
+
+  close(): void {
+    this._zip = null;
   }
 
   exists(path: string): boolean {
@@ -140,5 +149,10 @@ export class FallbackStore implements JsonStore {
 
   describe(): string {
     return `fallback:${this.primary.describe()} -> ${this.fallback.describe()}`;
+  }
+
+  close(): void {
+    this.primary.close();
+    this.fallback.close();
   }
 }

--- a/ts/src/data/story.ts
+++ b/ts/src/data/story.ts
@@ -125,6 +125,15 @@ function storyStore(zipPath: string): ZipStore {
   return new ZipStore(zipPath);
 }
 
+function withStoryStore<T>(zipPath: string, read: (store: ZipStore) => T): T {
+  const store = storyStore(zipPath);
+  try {
+    return read(store);
+  } finally {
+    store.close();
+  }
+}
+
 function parseStoryList(
   storyList: RawStoryItem[],
   includeNarration: boolean
@@ -187,7 +196,7 @@ export function listStoryEvents(
   zipPath: string,
   category?: string
 ): EventInfo[] {
-  return listStoryEventsFromStore(storyStore(zipPath), category);
+  return withStoryStore(zipPath, (store) => listStoryEventsFromStore(store, category));
 }
 
 export function listStoryEventsFromStore(
@@ -224,7 +233,7 @@ export function listStories(
   zipPath: string,
   eventId: string
 ): ChapterSummary[] {
-  return listStoriesFromStore(storyStore(zipPath), eventId);
+  return withStoryStore(zipPath, (store) => listStoriesFromStore(store, eventId));
 }
 
 export function listStoriesFromStore(
@@ -268,7 +277,7 @@ export function readStory(
   storyKey: string,
   includeNarration = true
 ): StoryChapter {
-  return readStoryFromStore(storyStore(zipPath), storyKey, includeNarration);
+  return withStoryStore(zipPath, (store) => readStoryFromStore(store, storyKey, includeNarration));
 }
 
 export function readStoryFromStore(
@@ -312,13 +321,13 @@ export function readActivity(
   page?: number,
   pageSize = 5
 ): ActivityResult {
-  return readActivityFromStore(
-    storyStore(zipPath),
+  return withStoryStore(zipPath, (store) => readActivityFromStore(
+    store,
     eventId,
     includeNarration,
     page,
     pageSize,
-  );
+  ));
 }
 
 export function readActivityFromStore(
@@ -392,15 +401,15 @@ export function searchStories(
   maxResults = 30,
   eventId?: string,
 ): string {
-  return searchStoriesFromStore(
-    storyStore(zipPath),
+  return withStoryStore(zipPath, (store) => searchStoriesFromStore(
+    store,
     pattern,
     character,
     lineType,
     contextLines,
     maxResults,
     eventId,
-  );
+  ));
 }
 
 interface SearchResult {
@@ -537,7 +546,7 @@ export function searchStoriesFromStore(
  * Convenience wrapper around getEventSummaryFromStore.
  */
 export function getEventSummary(zipPath: string, eventId: string): string {
-  return getEventSummaryFromStore(storyStore(zipPath), eventId);
+  return withStoryStore(zipPath, (store) => getEventSummaryFromStore(store, eventId));
 }
 
 /**
@@ -625,7 +634,7 @@ export function getEventSummaryFromStore(store: JsonStore, eventId: string): str
  * Convenience wrapper around getStorySummaryFromStore.
  */
 export function getStorySummary(zipPath: string, storyKey: string): string {
-  return getStorySummaryFromStore(storyStore(zipPath), storyKey);
+  return withStoryStore(zipPath, (store) => getStorySummaryFromStore(store, storyKey));
 }
 
 /**

--- a/ts/src/data/sync.ts
+++ b/ts/src/data/sync.ts
@@ -17,7 +17,7 @@ import {
   unlink,
   writeFile,
 } from "node:fs/promises";
-import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import AdmZip from "adm-zip";
 
 // ---------------------------------------------------------------------------
@@ -178,6 +178,17 @@ function filesPresent(spec: RepoSpec): boolean {
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function releaseZipError(spec: ReleaseSpec): string | null {
+  if (!existsSync(spec.localZip)) return "zip file is missing";
+  try {
+    const missing = spec.validateZip?.(spec.localZip) ?? [];
+    if (missing.length === 0) return null;
+    return missing.slice(0, 10).join("; ");
+  } catch (err) {
+    return `${basename(spec.localZip)} is not a valid zip: ${errorMessage(err)}`;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -488,7 +499,8 @@ export async function syncRelease(spec: ReleaseSpec): Promise<SyncResult> {
   };
 
   const cache = await loadReleaseMeta(spec);
-  const zipOk = existsSync(spec.localZip);
+  const zipError = releaseZipError(spec);
+  const zipOk = zipError === null;
 
   if (cache !== null && zipOk && cacheIsFresh(cache)) {
     return { spec: dummySpec, status: "up_to_date", commitSha: cache.commitSha, error: null };
@@ -511,7 +523,11 @@ export async function syncRelease(spec: ReleaseSpec): Promise<SyncResult> {
         return { spec: dummySpec, status: "no_data", commitSha: null, error: errorMessage(err) };
       }
     }
-    return { spec: dummySpec, status: "no_data", commitSha: null, error: "Network unavailable and no cached zip" };
+    const error =
+      existsSync(spec.localZip) && zipError
+        ? `Network unavailable and no cached zip; cached zip invalid: ${zipError}`
+        : "Network unavailable and no cached zip";
+    return { spec: dummySpec, status: "no_data", commitSha: null, error };
   }
 
   const commitSha = latest.tag.startsWith(TAG_PREFIX)

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -427,8 +427,8 @@ function createMcpServer(): McpServer {
         // Load summaries if requested
         let summaries: Record<string, string> = {};
         if (include_summaries) {
+          const store = new ZipStore(zipPath);
           try {
-            const store = new ZipStore(zipPath);
             if (store.exists("zh_CN/storyinfo.json")) {
               const raw = store.readJson<Record<string, unknown>>("zh_CN/storyinfo.json");
               for (const [k, v] of Object.entries(raw)) {
@@ -437,6 +437,8 @@ function createMcpServer(): McpServer {
             }
           } catch {
             // storyinfo.json missing is non-fatal
+          } finally {
+            store.close();
           }
         }
 
@@ -887,6 +889,7 @@ function scheduleSessionTimeout(id: string): void {
       scheduleSessionTimeout(id);
     }
   }, SESSION_IDLE_TIMEOUT_MS);
+  meta.timer.unref();
 }
 
 app.all("/mcp", async (req, res) => {

--- a/ts/tests/stores.test.ts
+++ b/ts/tests/stores.test.ts
@@ -66,6 +66,22 @@ test("ZipStore reads JSON from zip", () => {
   assert.match(store.describe(), /^zip:/);
 });
 
+test("ZipStore close clears cached AdmZip instance", () => {
+  const root = tempRoot();
+  const zipPath = join(root, "fixture.zip");
+  writeFixtureZip(zipPath);
+  const store = new ZipStore(zipPath);
+
+  assert.equal(store.exists(FIXTURE_PATH), true);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assert.ok((store as any)._zip);
+
+  store.close();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assert.equal((store as any)._zip, null);
+});
+
 test("ZipStore reports missing entries and rejects parent paths", () => {
   const root = tempRoot();
   const zipPath = join(root, "fixture.zip");
@@ -119,4 +135,25 @@ test("FallbackStore reports files missing in both stores", () => {
 
   assert.equal(store.exists(FIXTURE_PATH), false);
   assert.throws(() => store.readText(FIXTURE_PATH), /fallback chain/);
+});
+
+test("FallbackStore close propagates to child stores", () => {
+  const root = tempRoot();
+  const primaryZip = join(root, "primary.zip");
+  const fallbackZip = join(root, "fallback.zip");
+  writeFixtureZip(primaryZip, { source: "primary" });
+  writeFixtureZip(fallbackZip, { source: "fallback" });
+  const primary = new ZipStore(primaryZip);
+  const fallback = new ZipStore(fallbackZip);
+  const store = new FallbackStore(primary, fallback);
+
+  assert.equal(store.exists(FIXTURE_PATH), true);
+  assert.equal(fallback.exists(FIXTURE_PATH), true);
+
+  store.close();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assert.equal((primary as any)._zip, null);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  assert.equal((fallback as any)._zip, null);
 });

--- a/ts/tests/story.test.ts
+++ b/ts/tests/story.test.ts
@@ -164,6 +164,27 @@ test("public zip path API still reads zip", () => {
   assert.equal(chapter.lines[0].text, "你好，博士。");
 });
 
+test("public zip path API closes transient store", () => {
+  const root = tempRoot();
+  const zipPath = join(root, "zh_CN.zip");
+  writeStoryZip(zipPath);
+  const originalClose = ZipStore.prototype.close;
+  const closedPaths: string[] = [];
+
+  ZipStore.prototype.close = function closeForTest(this: ZipStore): void {
+    closedPaths.push(this.zipPath);
+    originalClose.call(this);
+  };
+  try {
+    const chapter = readStory(zipPath, FIRST_STORY_KEY);
+
+    assert.equal(chapter.storyCode, "TEST-1");
+    assert.deepEqual(closedPaths, [zipPath]);
+  } finally {
+    ZipStore.prototype.close = originalClose;
+  }
+});
+
 test("missing story raises", () => {
   const root = tempRoot();
   writeStoryDir(root);

--- a/ts/tests/sync.test.ts
+++ b/ts/tests/sync.test.ts
@@ -46,6 +46,84 @@ test("syncRelease returns offline_fallback when network fails but zip exists", a
   });
 });
 
+test("syncRelease treats invalid validated zip as no_data", async () => {
+  const spec = {
+    ...tempSpec(),
+    validateZip: () => ["zh_CN/storyinfo.json"],
+  };
+  mkdirSync(dirname(spec.localZip), { recursive: true });
+  writeFileSync(spec.localZip, "cached");
+
+  await withFetchMock((async () => {
+    throw new Error("network down");
+  }) as typeof fetch, async () => {
+    const result = await syncRelease(spec);
+
+    assert.equal(result.status, "no_data");
+    assert.equal(result.commitSha, null);
+    assert.equal(
+      result.error,
+      "Network unavailable and no cached zip; cached zip invalid: zh_CN/storyinfo.json",
+    );
+  });
+});
+
+test("syncRelease validates zip before fresh-cache fast path", async () => {
+  const spec = {
+    ...tempSpec(),
+    validateZip: () => ["zh_CN/storyinfo.json"],
+  };
+  mkdirSync(dirname(spec.localZip), { recursive: true });
+  writeFileSync(spec.localZip, "cached");
+  writeFileSync(
+    join(dirname(spec.localZip), "release_meta.json"),
+    JSON.stringify({
+      repo: "3aKHP/ArknightsStoryJson",
+      branch: "releases",
+      commitSha: "cached-sha",
+      fetchedAt: new Date().toISOString(),
+      files: ["zh_CN.zip"],
+    }),
+    "utf-8",
+  );
+
+  let fetchCalls = 0;
+  await withFetchMock((async () => {
+    fetchCalls += 1;
+    throw new Error("network down");
+  }) as typeof fetch, async () => {
+    const result = await syncRelease(spec);
+
+    assert.equal(fetchCalls, 1);
+    assert.equal(result.status, "no_data");
+    assert.equal(result.commitSha, null);
+    assert.equal(
+      result.error,
+      "Network unavailable and no cached zip; cached zip invalid: zh_CN/storyinfo.json",
+    );
+  });
+});
+
+test("syncRelease converts zip validation exceptions to no_data", async () => {
+  const spec = {
+    ...tempSpec(),
+    validateZip: () => {
+      throw new Error("bad zip");
+    },
+  };
+  mkdirSync(dirname(spec.localZip), { recursive: true });
+  writeFileSync(spec.localZip, "cached");
+
+  await withFetchMock((async () => {
+    throw new Error("network down");
+  }) as typeof fetch, async () => {
+    const result = await syncRelease(spec);
+
+    assert.equal(result.status, "no_data");
+    assert.match(result.error ?? "", /cached zip invalid: .* is not a valid zip: bad zip/);
+  });
+});
+
 test("syncRelease returns no_data when network fails and no zip exists", async () => {
   const spec = tempSpec();
 


### PR DESCRIPTION
## Summary

- harden Python `ZipStore` with deterministic close/context-manager support and close transient story zip stores
- validate cached TypeScript release zips before treating them as fallback data, including fresh-cache fast path
- unref TypeScript session idle timers and document the runtime non-functional audit

## Verification

- `python/.venv/bin/python.exe -m pytest python/tests/test_stores.py python/tests/test_story_reader_store.py python/tests/test_sync_release.py -q`
- `cd ts; node --import tsx --test "tests/**/*.test.ts"`
- `cd ts; node_modules/.bin/tsc.cmd --noEmit`
- `git diff --check`

## Notes

Python full-suite collection is still blocked in this local venv because `pydantic` is missing. Attempting `python/.venv/bin/python.exe -m pip install -e python` failed due local PyPI SSL certificate verification failure, so the PR records targeted Python coverage plus full TS coverage.

Independent local CR agent found no blocking or high-severity issues. It suggested the TS fresh-cache invalid-zip test, which is included in this PR.