### PR TITLE
fix: add operator memoir discovery and optimize search indexes (v1.6.1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# Codex Instructions for PRTS-MCP
+
+This file is intentionally repo-local so a fresh Codex session starts with the
+known-good runtime on this Windows workstation.
+
+## Startup Reads
+
+- Read `CLAUDE.md` and `docs/dev/STYLE.md` before non-trivial code changes.
+- Use `STATUS.md` for current project shape and version state.
+- Use `ROADMAP.md` / `ROADMAP.zh-CN.md` when planning feature work.
+
+## Runtime Environment
+
+- Shell: prefer `C:\Program Files\PowerShell\7\pwsh.exe` with UTF-8 output.
+- Python: use `E:\Anaconda3\envs\python311\python.exe` for this repo.
+- Do not use ambient `python` from PATH for validation. On this machine it
+  resolves to MSYS/WindowsApps before the intended conda environment.
+- Do not use `python\.venv` for Python MCP tests. It was created from MSYS
+  Python 3.12 and currently lacks the real `mcp` runtime dependency.
+- For local-source Python imports, set `PYTHONPATH` to
+  `F:\2026-Spring\PRTS-MCP\python\src`.
+- Node: use the Volta Node image already selected by `ts/package.json`
+  (`node` currently resolves to Node 24.14.0; project requires Node >=22).
+- In PowerShell, use `npm.cmd` / `npx.cmd` instead of bare `npm` / `npx`.
+  Bare commands resolve to Volta-generated `.ps1` shims first on this host, and
+  those shims can fail while the `.cmd` shims work.
+
+## Quick Verification
+
+Run the repo-local environment audit first when a session starts or when command
+behavior looks suspicious:
+
+```powershell
+.\scripts\check-runtime.ps1
+```
+
+Run the full validation set before merging runtime-sensitive changes:
+
+```powershell
+.\scripts\check-runtime.ps1 -Full
+```
+
+Equivalent manual commands:
+
+```powershell
+Push-Location python
+& 'E:\Anaconda3\envs\python311\python.exe' -m pytest tests -q
+Pop-Location
+
+Push-Location ts
+npm.cmd test
+npm.cmd run typecheck
+Pop-Location
+```
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,4 +52,3 @@ npm.cmd test
 npm.cmd run typecheck
 Pop-Location
 ```
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,32 @@ PRTS-MCP 是面向明日方舟同人创作的 MCP Server，包含 Python（stdio
 
 ---
 
+## 本机运行时环境（Windows）
+
+本仓库在当前 Windows 主机上的已验证入口：
+
+- Shell：优先使用 `C:\Program Files\PowerShell\7\pwsh.exe`，文本输出按 UTF-8 处理
+- Python：使用 `E:\Anaconda3\envs\python311\python.exe`
+- Python 本地源码导入：需要 `PYTHONPATH=F:\2026-Spring\PRTS-MCP\python\src`
+- TypeScript：使用 Volta 选中的 Node 24.14.0（项目要求 Node >=22）
+- PowerShell 下运行 npm 命令时用 `npm.cmd` / `npx.cmd`，不要直接用 `npm` / `npx`
+
+快速检查：
+
+```powershell
+.\scripts\check-runtime.ps1
+```
+
+完整验证：
+
+```powershell
+.\scripts\check-runtime.ps1 -Full
+```
+
+当前仓库内的 `python/.venv` 来自 MSYS Python 3.12，且缺少 `mcp` 运行时依赖，不作为本机验证环境使用。
+
+---
+
 ## 启动准则
 
 三条硬规则：
@@ -45,8 +71,9 @@ PRTS-MCP 是面向明日方舟同人创作的 MCP Server，包含 Python（stdio
 2. **拉分支**：按上面的命名约定
 3. **动手**：按 commit 主题分批提交，每个中间 commit 都能独立编译（bisect-friendly）
 4. **本地验证**：
-   - Python: `cd python && python -m pytest tests/ -v`
-   - TypeScript: `cd ts && npm test && npm run typecheck`
+   - Windows 本机一键验证：`.\scripts\check-runtime.ps1 -Full`
+   - Python: `cd python && E:\Anaconda3\envs\python311\python.exe -m pytest tests -q`
+   - TypeScript: `cd ts && npm.cmd test && npm.cmd run typecheck`
    - 双实现同步改动时两边都要跑
 5. **推分支 + 开 PR**：PR body 包含 Summary / Test plan / 未尽事宜三段
 6. **独立 CR**：spawn 子代理做独立 review（见下文）

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,16 +1,16 @@
 # PRTS-MCP 项目状态
 
-_Last updated: 2026-05-28_
+_Last updated: 2026-06-03_
 
 ## 当前版本
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 1.6.0 | release candidate |
-| TypeScript | 1.6.0 | release candidate |
+| Python | 1.6.1 | release candidate |
+| TypeScript | 1.6.1 | release candidate |
 
-- 当前发版候选：29 个 MCP 工具（1.6.0，新增关卡敌人融合与物品/材料域）
-- 当前稳定发布：24 个 MCP 工具（1.5.0）
+- 当前发版候选：30 个 MCP 工具（1.6.1，新增干员密录发现与搜索缓存优化）
+- 当前稳定发布：29 个 MCP 工具（1.6.0）
 - 兼容性合约：1.x 期间既有工具名和必填参数不变；minor 版本允许新增工具和可选参数
 
 ## 仓库结构
@@ -90,6 +90,7 @@ PRTS-MCP/
 | 27 | `list_items` | GameData | 1.6.0 |
 | 28 | `get_item_info` | GameData | 1.6.0 |
 | 29 | `search_items` | GameData | 1.6.0 |
+| 30 | `get_operator_memoirs` | StoryJson | 1.6.1 |
 
 ## 遗留 TODO
 
@@ -100,6 +101,7 @@ PRTS-MCP/
 
 | 版本 | 日期 | 亮点 |
 |------|------|------|
+| 1.6.1 | 2026-06-03 | 干员密录发现 + 搜索缓存优化（30 工具） |
 | 1.6.0 | 2026-05-28 | 关卡敌人融合 + 物品/材料域（29 工具） |
 | 1.5.0 | 2026-05-25 | 关卡数据域：list_stages、get_stage_info、search_stages（24 工具） |
 | 1.4.2 | 2026-05-25 | 修复 Streamable HTTP session pool 400 错误 |

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Operator memoir discovery.** New `get_operator_memoirs(operator_name)` tool
   resolves operator Chinese name to memoir story keys via `chardict.json`,
   enabling LLM agents to find and read operator memoir (干员密录) dialogue.
+- This new tool is treated as a one-off patch-line exception because it exposes
+  story data that already existed in the synced StoryJson archive but was not
+  discoverable through the public tool surface.
 - `list_story_events(category="memoirs")` now exposes 372 previously hidden
   operator memoir events.
 - Operator memoir dialogue is now indexed by `search_stories`.

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,7 +4,33 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.6.1] - 2026-06-03
+
+### Added
+
+- **Operator memoir discovery.** New `get_operator_memoirs(operator_name)` tool
+  resolves operator Chinese name to memoir story keys via `chardict.json`,
+  enabling LLM agents to find and read operator memoir (干员密录) dialogue.
+- `list_story_events(category="memoirs")` now exposes 372 previously hidden
+  operator memoir events.
+- Operator memoir dialogue is now indexed by `search_stories`.
+
+### Changed
+
+- Search tools backed by local game/story data now reuse cached search records
+  instead of rebuilding parsed text on every call, substantially improving
+  repeated full-story and full-table regex searches.
+- Enemy search records now include `enemyTags` in searchable text.
+
+### Fixed
+
+- Story search now caps `max_results` and `context_lines` consistently to
+  prevent oversized MCP responses from long-running full-dataset searches.
+- `search_stages` and `search_items` now enforce `max_results` bounds (1–100)
+  for parity with other search tools.
+- `list_story_events` and `search_stories` no longer ignore entries with
+  `entryType: "NONE"` when those entries have valid story data (was the
+  root cause of memoirs being undiscoverable).
 
 ## [1.6.0] - 2026-05-28
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "1.6.0"
+version = "1.6.1"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/src/prts_mcp/data/enemy.py
+++ b/python/src/prts_mcp/data/enemy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any
 
@@ -16,10 +17,17 @@ def clear_enemy_caches() -> None:
     _load_enemy_handbook.cache_clear()
     _load_enemy_database.cache_clear()
     _build_enemy_name_to_id.cache_clear()
+    _enemy_search_records.cache_clear()
 
 
 _HANDBOOK_FILE = "enemy_handbook_table.json"
 _DATABASE_FILE = "enemy_database.json"
+
+
+@dataclass(frozen=True)
+class _EnemySearchRecord:
+    info: dict[str, Any]
+    search_text: str
 
 
 def _missing_data_message() -> str:
@@ -383,27 +391,24 @@ def search_enemies(pattern: str, max_results: int = 30) -> str:
     """Regex search across enemy names and descriptions."""
     if not _has_enemy_data():
         return _missing_data_message()
+    if max_results < 1:
+        return "max_results 必须 >= 1。"
+    if max_results > 100:
+        return "max_results 必须 <= 100。"
 
     try:
         regex = re.compile(pattern, re.IGNORECASE)
     except re.error as exc:
         return f"正则表达式无效：{exc}"
 
+    matches: list[dict] = []
     try:
-        raw = _load_enemy_handbook()
+        records = _enemy_search_records()
     except FileNotFoundError as exc:
         return str(exc)
-
-    ed = raw.get("enemyData", {})
-    matches: list[dict] = []
-    for _eid, info in ed.items():
-        if info.get("hideInHandbook"):
-            continue
-        name = info.get("name") or ""
-        desc = info.get("description") or ""
-        ability = info.get("ability") or ""
-        if regex.search(f"{name} {desc} {ability}"):
-            matches.append(info)
+    for record in records:
+        if regex.search(record.search_text):
+            matches.append(record.info)
         if len(matches) >= max_results:
             break
 
@@ -415,3 +420,21 @@ def search_enemies(pattern: str, max_results: int = 30) -> str:
         lines.append(_fmt_enemy(info))
         lines.append("")
     return "\n".join(lines).strip()
+
+
+@lru_cache(maxsize=1)
+def _enemy_search_records() -> tuple[_EnemySearchRecord, ...]:
+    raw = _load_enemy_handbook()
+    ed = raw.get("enemyData", {})
+    records: list[_EnemySearchRecord] = []
+    for _eid, info in ed.items():
+        if info.get("hideInHandbook"):
+            continue
+        search_text = " ".join([
+            info.get("name") or "",
+            info.get("description") or "",
+            info.get("ability") or "",
+            " ".join(info.get("enemyTags") or []),
+        ])
+        records.append(_EnemySearchRecord(info=info, search_text=search_text))
+    return tuple(records)

--- a/python/src/prts_mcp/data/item.py
+++ b/python/src/prts_mcp/data/item.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
 from functools import lru_cache
 from typing import Any
 
@@ -36,6 +37,13 @@ _CATEGORY_ALIASES: dict[str, str] = {
     "NONE": "NONE",
     "其他": "NONE",
 }
+
+
+@dataclass(frozen=True)
+class _ItemSearchRecord:
+    item_id: str
+    info: dict[str, Any]
+    search_text: str
 
 
 def _get_config() -> Config:
@@ -108,6 +116,7 @@ def _build_item_lookup() -> dict[str, str]:
 def clear_item_caches() -> None:
     _load_items.cache_clear()
     _build_item_lookup.cache_clear()
+    _item_search_records.cache_clear()
 
 
 def get_item_name_by_id(item_id: str) -> str | None:
@@ -280,15 +289,10 @@ def search_items(pattern: str, max_results: int = 30) -> str:
     except (FileNotFoundError, RuntimeError, TypeError) as exc:
         return _missing_data_message() + f"（{exc}）"
 
-    results: list[tuple[str, dict[str, Any]]] = []
-    for item_id, info in sorted(entries, key=lambda kv: (kv[1].get("sortId", 999999), kv[0])):
-        search_text = " ".join(
-            str(info.get(field) or "")
-            for field in ("name", "description", "usage", "obtainApproach", "classifyType", "itemType")
-        )
-        search_text += f" {item_id}"
-        if regex.search(search_text):
-            results.append((item_id, info))
+    results: list[_ItemSearchRecord] = []
+    for record in _item_search_records():
+        if regex.search(record.search_text):
+            results.append(record)
             if len(results) >= max_results:
                 break
 
@@ -296,7 +300,9 @@ def search_items(pattern: str, max_results: int = 30) -> str:
         return f"未找到匹配 '{pattern}' 的物品。"
 
     lines = [f"# 搜索结果：{pattern}（共 {len(results)} 个）"]
-    for item_id, info in results:
+    for record in results:
+        item_id = record.item_id
+        info = record.info
         item_name = info.get("name") or "（无名）"
         classify = _classify_label(str(info.get("classifyType") or ""))
         item_type = info.get("itemType") or "-"
@@ -309,3 +315,20 @@ def search_items(pattern: str, max_results: int = 30) -> str:
         if obtain:
             lines.append(f"- **获取方式**：{obtain}")
     return "\n".join(lines)
+
+
+@lru_cache(maxsize=1)
+def _item_search_records() -> tuple[_ItemSearchRecord, ...]:
+    records: list[_ItemSearchRecord] = []
+    entries = sorted(_visible_items(), key=lambda kv: (kv[1].get("sortId", 999999), kv[0]))
+    for item_id, info in entries:
+        search_text = " ".join(
+            str(info.get(field) or "")
+            for field in ("name", "description", "usage", "obtainApproach", "classifyType", "itemType")
+        )
+        records.append(_ItemSearchRecord(
+            item_id=item_id,
+            info=info,
+            search_text=f"{search_text} {item_id}",
+        ))
+    return tuple(records)

--- a/python/src/prts_mcp/data/item.py
+++ b/python/src/prts_mcp/data/item.py
@@ -284,13 +284,12 @@ def search_items(pattern: str, max_results: int = 30) -> str:
     except re.error as exc:
         return f"正则表达式无效：{exc}"
 
+    results: list[_ItemSearchRecord] = []
     try:
-        entries = _visible_items()
+        records = _item_search_records()
     except (FileNotFoundError, RuntimeError, TypeError) as exc:
         return _missing_data_message() + f"（{exc}）"
-
-    results: list[_ItemSearchRecord] = []
-    for record in _item_search_records():
+    for record in records:
         if regex.search(record.search_text):
             results.append(record)
             if len(results) >= max_results:

--- a/python/src/prts_mcp/data/operator.py
+++ b/python/src/prts_mcp/data/operator.py
@@ -17,6 +17,7 @@ def clear_operator_caches() -> None:
     _load_handbook_table.cache_clear()
     _load_charword_table.cache_clear()
     _build_name_to_id.cache_clear()
+    # Lazy import to break circular dependency (search imports from operator).
     try:
         from prts_mcp.data.search import clear_search_caches
 

--- a/python/src/prts_mcp/data/operator.py
+++ b/python/src/prts_mcp/data/operator.py
@@ -17,6 +17,12 @@ def clear_operator_caches() -> None:
     _load_handbook_table.cache_clear()
     _load_charword_table.cache_clear()
     _build_name_to_id.cache_clear()
+    try:
+        from prts_mcp.data.search import clear_search_caches
+
+        clear_search_caches()
+    except ImportError:
+        pass
 
 
 def _missing_operator_data_message() -> str:

--- a/python/src/prts_mcp/data/search.py
+++ b/python/src/prts_mcp/data/search.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
+from functools import lru_cache
 
 from prts_mcp.config import Config
 from prts_mcp.data.operator import (
@@ -14,11 +16,29 @@ from prts_mcp.data.operator import (
 from prts_mcp.utils.sanitizer import strip_wikitext
 
 
+@dataclass(frozen=True)
+class _OperatorSearchRecord:
+    operator: str
+    category: str
+    field: str
+    text: str
+
+
+def clear_search_caches() -> None:
+    """Clear cached cross-table search records."""
+    _operator_search_records.cache_clear()
+
+
 def search_operator_data(pattern: str, max_results: int = 30) -> str:
     """Search operator names, archive texts, and voice lines by regex.
 
     Case-insensitive.  Returns a formatted multi-block string.
     """
+    if max_results < 1:
+        return "max_results 必须 >= 1。"
+    if max_results > 100:
+        return "max_results 必须 <= 100。"
+
     config = Config.load()
     if not config.has_operator_data:
         return (
@@ -33,83 +53,12 @@ def search_operator_data(pattern: str, max_results: int = 30) -> str:
     except re.error as exc:
         return f"正则表达式无效：{exc}"
 
-    ct = _load_character_table()
-    handbook = _load_handbook_table().get("handbookDict", {})
-    charwords = _load_charword_table().get("charWords", {})
-    name_to_id = _build_name_to_id()
-
-    # Build charId → voice entries index once to avoid O(n×m) nested loops
-    charid_to_voices: dict[str, list[dict]] = {}
-    for entry in charwords.values():
-        cid = entry.get("charId")
-        if cid and entry.get("voiceText"):
-            charid_to_voices.setdefault(cid, []).append(entry)
-
-    results: list[dict] = []
-
-    for name, char_id in name_to_id.items():
-        if len(results) >= max_results:
-            break
-        info = ct.get(char_id)
-        if info is None:
-            continue
-
-        # --- basic: operator name ---
-        if regex.search(name):
-            results.append({
-                "operator": name,
-                "category": "basic",
-                "field": "干员名称",
-                "text": name,
-            })
+    results: list[_OperatorSearchRecord] = []
+    for record in _operator_search_records():
+        if regex.search(record.text):
+            results.append(record)
             if len(results) >= max_results:
                 break
-
-        # --- basic: description ---
-        desc = info.get("description") or ""
-        if desc:
-            cleaned = strip_wikitext(desc)
-            if regex.search(cleaned):
-                results.append({
-                    "operator": name,
-                    "category": "basic",
-                    "field": "攻击属性",
-                    "text": cleaned,
-                })
-                if len(results) >= max_results:
-                    break
-
-        # --- archives ---
-        hb_entry = handbook.get(char_id)
-        if hb_entry:
-            for story in hb_entry.get("storyTextAudio", []):
-                if len(results) >= max_results:
-                    break
-                title = story.get("storyTitle", "")
-                for s in story.get("stories", []):
-                    if len(results) >= max_results:
-                        break
-                    text = s.get("storyText", "")
-                    if text and regex.search(text):
-                        results.append({
-                            "operator": name,
-                            "category": "archives",
-                            "field": title,
-                            "text": text,
-                        })
-
-        # --- voicelines ---
-        if char_id in charid_to_voices:
-            for v in charid_to_voices[char_id]:
-                if len(results) >= max_results:
-                    break
-                if regex.search(v["voiceText"]):
-                    results.append({
-                        "operator": name,
-                        "category": "voicelines",
-                        "field": v.get("voiceTitle", "未知"),
-                        "text": v["voiceText"],
-                    })
 
     if not results:
         return f"未找到匹配 '{pattern}' 的干员数据。"
@@ -118,9 +67,69 @@ def search_operator_data(pattern: str, max_results: int = 30) -> str:
     for r in results:
         blocks.append(
             f"\n---\n\n"
-            f"[operators/{r['category']}/{r['operator']}]\n"
-            f"匹配：{r['field']}\n"
-            f"{r['text']}"
+            f"[operators/{r.category}/{r.operator}]\n"
+            f"匹配：{r.field}\n"
+            f"{r.text}"
         )
 
     return "".join(blocks)
+
+
+@lru_cache(maxsize=1)
+def _operator_search_records() -> tuple[_OperatorSearchRecord, ...]:
+    ct = _load_character_table()
+    handbook = _load_handbook_table().get("handbookDict", {})
+    charwords = _load_charword_table().get("charWords", {})
+    name_to_id = _build_name_to_id()
+
+    charid_to_voices: dict[str, list[dict]] = {}
+    for entry in charwords.values():
+        cid = entry.get("charId")
+        if cid and entry.get("voiceText"):
+            charid_to_voices.setdefault(cid, []).append(entry)
+
+    records: list[_OperatorSearchRecord] = []
+    for name, char_id in name_to_id.items():
+        info = ct.get(char_id)
+        if info is None:
+            continue
+
+        records.append(_OperatorSearchRecord(
+            operator=name,
+            category="basic",
+            field="干员名称",
+            text=name,
+        ))
+
+        desc = info.get("description") or ""
+        if desc:
+            records.append(_OperatorSearchRecord(
+                operator=name,
+                category="basic",
+                field="攻击属性",
+                text=strip_wikitext(desc),
+            ))
+
+        hb_entry = handbook.get(char_id)
+        if hb_entry:
+            for story in hb_entry.get("storyTextAudio", []):
+                title = story.get("storyTitle", "")
+                for s in story.get("stories", []):
+                    text = s.get("storyText", "")
+                    if text:
+                        records.append(_OperatorSearchRecord(
+                            operator=name,
+                            category="archives",
+                            field=title,
+                            text=text,
+                        ))
+
+        for v in charid_to_voices.get(char_id, []):
+            records.append(_OperatorSearchRecord(
+                operator=name,
+                category="voicelines",
+                field=v.get("voiceTitle", "未知"),
+                text=v["voiceText"],
+            ))
+
+    return tuple(records)

--- a/python/src/prts_mcp/data/stage.py
+++ b/python/src/prts_mcp/data/stage.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re as _re
+from dataclasses import dataclass as _dataclass
 from functools import lru_cache as _lru_cache
 
 from prts_mcp.config import Config as _Config
@@ -30,6 +31,13 @@ _DIFFICULTY_LABELS: dict[str, str] = {
     "FOUR_STAR": "突袭",
     "SIX_STAR": "六星",
 }
+
+
+@_dataclass(frozen=True)
+class _StageSearchRecord:
+    stage_id: str
+    entry: dict
+    search_text: str
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -164,6 +172,7 @@ def _zone_display(zone_id: str) -> str:
 def clear_stage_caches() -> None:
     _load_stage_table.cache_clear()
     _load_zone_table.cache_clear()
+    _stage_search_records.cache_clear()
 
 
 # ---------------------------------------------------------------------------
@@ -322,19 +331,10 @@ def search_stages(pattern: str, max_results: int = 30) -> str:
     except (FileNotFoundError, TypeError) as e:
         return _missing_data_message() + f"（{e}）"
 
-    matched: list[dict] = []
-    for sid, entry in sorted(stages.items()):
-        search_text = (
-            (entry.get("name") or "")
-            + " "
-            + (entry.get("code") or "")
-            + " "
-            + _clean_description(entry.get("description") or "")
-            + " "
-            + (entry.get("stageType") or "")
-        )
-        if regex.search(search_text):
-            matched.append(entry)
+    matched: list[_StageSearchRecord] = []
+    for record in _stage_search_records():
+        if regex.search(record.search_text):
+            matched.append(record)
             if len(matched) >= max_results:
                 break
 
@@ -342,7 +342,8 @@ def search_stages(pattern: str, max_results: int = 30) -> str:
         return f"未找到匹配 '{pattern}' 的关卡。"
 
     lines = [f"# 搜索结果：{pattern}（共 {len(matched)} 个）"]
-    for e in matched:
+    for record in matched:
+        e = record.entry
         name = e.get("name") or "（无名）"
         code = e.get("code") or "?"
         t_label = _stage_type_label(e.get("stageType", ""))
@@ -353,7 +354,7 @@ def search_stages(pattern: str, max_results: int = 30) -> str:
         raw_desc = e.get("description") or ""
         cdesc = _clean_description(raw_desc)
 
-        sid = e.get("stageId", "")
+        sid = record.stage_id
         lines.append(f"\n## {name} [{t_label}] {code}（id: {sid}）")
         lines.append(f"- **区域**：{zd}")
         lines.append(f"- **难度**：{d_label}")
@@ -362,3 +363,22 @@ def search_stages(pattern: str, max_results: int = 30) -> str:
             lines.append(f"- **描述**：{cdesc[:120]}{'...' if len(cdesc) > 120 else ''}")
 
     return "\n".join(lines)
+
+
+@_lru_cache(maxsize=1)
+def _stage_search_records() -> tuple[_StageSearchRecord, ...]:
+    records: list[_StageSearchRecord] = []
+    for sid, entry in sorted(_load_stage_table().items()):
+        search_text = " ".join([
+            entry.get("name") or "",
+            entry.get("code") or "",
+            _clean_description(entry.get("description") or ""),
+            entry.get("stageType") or "",
+            sid,
+        ])
+        records.append(_StageSearchRecord(
+            stage_id=sid,
+            entry=entry,
+            search_text=search_text,
+        ))
+    return tuple(records)

--- a/python/src/prts_mcp/data/stage.py
+++ b/python/src/prts_mcp/data/stage.py
@@ -326,13 +326,12 @@ def search_stages(pattern: str, max_results: int = 30) -> str:
     except _re.error as e:
         return f"正则表达式无效：{e}"
 
+    matched: list[_StageSearchRecord] = []
     try:
-        stages = _load_stage_table()
+        records = _stage_search_records()
     except (FileNotFoundError, TypeError) as e:
         return _missing_data_message() + f"（{e}）"
-
-    matched: list[_StageSearchRecord] = []
-    for record in _stage_search_records():
+    for record in records:
         if regex.search(record.search_text):
             matched.append(record)
             if len(matched) >= max_results:

--- a/python/src/prts_mcp/data/stage_enemy.py
+++ b/python/src/prts_mcp/data/stage_enemy.py
@@ -43,6 +43,7 @@ def clear_stage_enemy_caches() -> None:
     _load_enemy_handbook.cache_clear()
     _load_enemy_database.cache_clear()
     _build_enemy_name_to_id.cache_clear()
+    _enemy_appearance_index.cache_clear()
 
 
 @lru_cache(maxsize=1)
@@ -253,10 +254,14 @@ def get_stage_enemies(stage_id: str) -> str:
 
 
 def _find_enemy_appearances(enemy_id: str) -> list[tuple[str, int]]:
-    appearances: list[tuple[str, int]] = []
-    stages = _load_stage_table()
+    return _enemy_appearance_index().get(enemy_id, [])
+
+
+@lru_cache(maxsize=1)
+def _enemy_appearance_index() -> dict[str, list[tuple[str, int]]]:
+    appearances: dict[str, list[tuple[str, int]]] = {}
     store = _levels_store()
-    for stage_id, stage in stages.items():
+    for stage_id, stage in _load_stage_table().items():
         level_id = stage.get("levelId")
         if not level_id:
             continue
@@ -266,9 +271,8 @@ def _find_enemy_appearances(enemy_id: str) -> list[tuple[str, int]]:
         level = store.read_json(path)
         if not isinstance(level, dict):
             continue
-        count = _spawn_counts(level).get(enemy_id)
-        if count:
-            appearances.append((stage_id, count))
+        for enemy_id, count in _spawn_counts(level).items():
+            appearances.setdefault(enemy_id, []).append((stage_id, count))
     return appearances
 
 

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -712,6 +712,9 @@ def _build_story_search_index(store: JsonStore) -> _StorySearchIndex:
         )
         if not datas:
             continue
+        # Only include NONE entries that are operator memoirs
+        if entry.get("entryType", "NONE") == "NONE" and not _is_memoir_event(ev_id):
+            continue
         event_ids.add(ev_id)
         for d in datas:
             story_key = d.get("storyTxt")

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -11,11 +11,12 @@ from __future__ import annotations
 
 import json
 import re
+from functools import lru_cache
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-from prts_mcp.data.stores import JsonStore, ZipStore
+from prts_mcp.data.stores import DirectoryStore, JsonStore, ZipStore
 
 # ---------------------------------------------------------------------------
 # Zip path constants
@@ -25,11 +26,13 @@ _STORY_REVIEW_TABLE = "zh_CN/gamedata/excel/story_review_table.json"
 _STORYINFO = "zh_CN/storyinfo.json"
 _SUMMARIES = "zh_CN/summaries.json"
 _EVENT_SUMMARIES = "zh_CN/event_summaries.json"
+_CHARDICT = "zh_CN/chardict.json"
 
 # entryType values → user-facing category strings
 _CATEGORY_MAP: dict[str, list[str]] = {
     "main": ["MAINLINE"],
     "activities": ["ACTIVITY", "MINI_ACTIVITY"],
+    "memoirs": ["NONE"],
 }
 
 
@@ -42,6 +45,7 @@ def _story_zip_path(story_key: str) -> str:
 # ---------------------------------------------------------------------------
 
 _RICH_TAG_RE = re.compile(r"<[^>]+>")
+_MEMOIR_EVENT_RE = re.compile(r"^story_([a-z0-9_]+)_set_\d+$")
 
 
 def _clean_text(text: str) -> str:
@@ -98,6 +102,51 @@ class ActivityResult:
     total_chapters: int
     has_more: bool
     chapters: list[StoryChapter]
+
+
+@dataclass(frozen=True)
+class MemoirChapter:
+    event_id: str
+    story_key: str
+    story_code: str
+    story_name: str
+
+
+@dataclass(frozen=True)
+class OperatorMemoirResult:
+    operator_name: str
+    internal_code: str
+    operator_id: str
+    total_chapters: int
+    chapters: list[MemoirChapter]
+
+
+@dataclass(frozen=True)
+class _StorySearchChapter:
+    event_id: str
+    story_code: str
+    lines: tuple[StoryLine, ...]
+
+
+@dataclass(frozen=True)
+class _StorySearchRecord:
+    chapter_index: int
+    line_index: int
+    line: StoryLine
+
+
+@dataclass(frozen=True)
+class _StorySearchIndex:
+    event_ids: frozenset[str]
+    chapters: tuple[_StorySearchChapter, ...]
+    records: tuple[_StorySearchRecord, ...]
+
+
+def clear_story_caches() -> None:
+    """Clear cached story search indexes after story data changes."""
+    global _chardict_cache
+    _cached_story_search_index.cache_clear()
+    _chardict_cache = None
 
 
 # ---------------------------------------------------------------------------
@@ -178,8 +227,13 @@ def list_story_events_from_store(
     events = []
     for event_id, entry in table.items():
         entry_type = entry.get("entryType", "NONE")
-        if allowed_types is not None and entry_type not in allowed_types:
-            continue
+        if allowed_types is not None:
+            if allowed_types == ["NONE"]:
+                # "memoirs" category: NONE entries whose event_id matches memoir pattern
+                if not _is_memoir_event(event_id):
+                    continue
+            elif entry_type not in allowed_types:
+                continue
         story_count = len(entry.get("infoUnlockDatas") or [])
         events.append(EventInfo(
             event_id=event_id,
@@ -357,10 +411,112 @@ def read_activity_from_store(
     )
 
 
+_chardict_cache: dict[str, dict[str, str]] | None = None
+
+
+def _load_chardict(store: JsonStore) -> dict[str, dict[str, str]]:
+    """Load chardict.json from the story store (cached at module level)."""
+    global _chardict_cache
+    if _chardict_cache is not None:
+        return _chardict_cache
+    if not store.exists(_CHARDICT):
+        _chardict_cache = {}
+        return _chardict_cache
+    try:
+        data: dict = _load_json(store, _CHARDICT)  # type: ignore[assignment]
+        _chardict_cache = {str(k): v for k, v in data.items() if isinstance(v, dict)}
+    except (KeyError, FileNotFoundError, json.JSONDecodeError):
+        _chardict_cache = {}
+    return _chardict_cache
+
+
+def _resolve_operator_code(
+    chardict: dict[str, dict[str, str]],
+    operator_name: str,
+) -> str | None:
+    """Reverse lookup: operator display name -> internal code (e.g. '能天使' -> 'angel')."""
+    for code, info in chardict.items():
+        if info.get("name") == operator_name:
+            return code
+    return None
+
+
+def _is_memoir_event(event_id: str) -> bool:
+    """Check if an event_id matches the memoir pattern story_{code}_set_N."""
+    return bool(_MEMOIR_EVENT_RE.match(event_id))
+
+
+def get_operator_memoirs(
+    zip_path: Path,
+    operator_name: str,
+) -> OperatorMemoirResult:
+    """Return all memoir chapters for an operator by Chinese name.
+
+    Raises:
+        KeyError: If the operator is not found in chardict or has no memoirs.
+    """
+    with _story_store(zip_path) as store:
+        return get_operator_memoirs_from_store(store, operator_name)
+
+
+def get_operator_memoirs_from_store(
+    store: JsonStore,
+    operator_name: str,
+) -> OperatorMemoirResult:
+    """Return all memoir chapters for an operator by Chinese name using a JSON store."""
+    chardict = _load_chardict(store)
+    if not chardict:
+        raise KeyError("chardict.json 未在 story zip 中找到。")
+
+    code = _resolve_operator_code(chardict, operator_name)
+    if code is None:
+        raise KeyError(
+            f"未找到干员名称 '{operator_name}' 对应的内部代码。请使用游戏内中文名称。"
+        )
+
+    char_info = chardict[code]
+    operator_id = char_info.get("id", "")
+
+    table: dict = _load_json(store, _STORY_REVIEW_TABLE)  # type: ignore[assignment]
+    prefix = f"story_{code}_set_"
+    memoir_events = sorted(
+        (eid for eid in table if eid.startswith(prefix)),
+        key=lambda eid: int(eid.rsplit("_", 1)[-1]) if eid.rsplit("_", 1)[-1].isdigit() else 0,
+    )
+
+    if not memoir_events:
+        raise KeyError(f"干员 '{operator_name}' (code={code}) 暂无密录数据。")
+
+    chapters: list[MemoirChapter] = []
+    for event_id in memoir_events:
+        entry = table[event_id]
+        datas = sorted(
+            entry.get("infoUnlockDatas") or [],
+            key=lambda x: x.get("storySort", 0),
+        )
+        for d in datas:
+            story_key = d.get("storyTxt")
+            if not story_key:
+                continue
+            chapters.append(MemoirChapter(
+                event_id=event_id,
+                story_key=story_key,
+                story_code=d.get("storyCode", ""),
+                story_name=d.get("storyName", ""),
+            ))
+
+    return OperatorMemoirResult(
+        operator_name=operator_name,
+        internal_code=code,
+        operator_id=operator_id,
+        total_chapters=len(chapters),
+        chapters=chapters,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Search helpers
 # ---------------------------------------------------------------------------
-
 
 def _format_story_line(line: StoryLine) -> str:
     """Format a single StoryLine for display in search results."""
@@ -424,6 +580,15 @@ def search_stories_from_store(
     Returns:
         Formatted multi-block search result string.
     """
+    if max_results < 1:
+        return "max_results 必须 >= 1。"
+    if max_results > 100:
+        return "max_results 必须 <= 100。"
+    if context_lines < 0:
+        return "context_lines 必须 >= 0。"
+    if context_lines > 5:
+        return "context_lines 必须 <= 5。"
+
     try:
         regex = re.compile(pattern, re.IGNORECASE)
     except re.error as exc:
@@ -432,78 +597,45 @@ def search_stories_from_store(
     if line_type is not None and line_type not in _VALID_LINE_TYPES:
         return f"无效的 line_type：{line_type!r}，可选值：{', '.join(sorted(_VALID_LINE_TYPES))}"
 
-    # --- build active event list --------------------------------------------------
     try:
-        table: dict = _load_json(store, _STORY_REVIEW_TABLE)
+        index = _story_search_index(store)
     except Exception as exc:
         return f"读取剧情数据索引失败：{exc}"
 
-    # Respect the same category semantics as list_story_events
-    active_events: list[tuple[str, dict]] = []
-    for ev_id, entry in table.items():
-        if event_id is not None and ev_id != event_id:
-            continue
-        if entry.get("entryType", "NONE") == "NONE":
-            continue
-        active_events.append((ev_id, entry))
-
-    if event_id is not None and not active_events:
+    if event_id is not None and event_id not in index.event_ids:
         return f"未找到匹配的活动：{event_id!r}。"
 
     results: list[dict] = []
 
-    for ev_id, entry in active_events:
+    for record in index.records:
         if len(results) >= max_results:
             break
 
-        datas = sorted(
-            entry.get("infoUnlockDatas") or [],
-            key=lambda x: x.get("storySort", 0),
-        )
-
-        for d in datas:
-            if len(results) >= max_results:
-                break
-            story_key = d.get("storyTxt")
-            if not story_key:
+        chapter = index.chapters[record.chapter_index]
+        line = record.line
+        if event_id is not None and chapter.event_id != event_id:
+            continue
+        if character is not None:
+            if line.type != "dialog" or (line.role or "").lower() != character.lower():
                 continue
-            story_code = d.get("storyCode", "")
+        if line_type is not None and line.type != line_type:
+            continue
+        if not regex.search(line.text):
+            continue
 
-            try:
-                chapter = read_story_from_store(
-                    store, story_key, include_narration=True,
-                )
-            except (KeyError, FileNotFoundError, json.JSONDecodeError):
-                continue
+        start = max(0, record.line_index - context_lines)
+        end = min(len(chapter.lines), record.line_index + context_lines + 1)
+        ctx_parts: list[str] = []
+        for j in range(start, end):
+            prefix = ">>> " if j == record.line_index else "    "
+            ctx_parts.append(prefix + _format_story_line(chapter.lines[j]))
 
-            for i, line in enumerate(chapter.lines):
-                if len(results) >= max_results:
-                    break
-
-                # --- filters ---
-                if character is not None:
-                    if line.type != "dialog" or (line.role or "").lower() != character.lower():
-                        continue
-                if line_type is not None and line.type != line_type:
-                    continue
-
-                if not regex.search(line.text):
-                    continue
-
-                # --- context collection ---
-                start = max(0, i - context_lines)
-                end = min(len(chapter.lines), i + context_lines + 1)
-                ctx_parts: list[str] = []
-                for j in range(start, end):
-                    prefix = ">>> " if j == i else "    "
-                    ctx_parts.append(prefix + _format_story_line(chapter.lines[j]))
-
-                results.append({
-                    "event_id": ev_id,
-                    "story_code": story_code,
-                    "line_number": i + 1,
-                    "context": "\n".join(ctx_parts),
-                })
+        results.append({
+            "event_id": chapter.event_id,
+            "story_code": chapter.story_code,
+            "line_number": record.line_index + 1,
+            "context": "\n".join(ctx_parts),
+        })
 
     if not results:
         filter_desc = "。".join(
@@ -525,6 +657,87 @@ def search_stories_from_store(
         )
 
     return "\n".join(parts)
+
+
+def _story_search_index(store: JsonStore) -> _StorySearchIndex:
+    descriptor = _story_store_descriptor(store)
+    if descriptor is None:
+        return _build_story_search_index(store)
+    return _cached_story_search_index(descriptor)
+
+
+def _story_store_descriptor(store: JsonStore) -> tuple[str, str, int, int] | None:
+    if isinstance(store, ZipStore):
+        path = store.zip_path.resolve()
+        if not path.is_file():
+            return None
+        stat = path.stat()
+        return ("zip", str(path), stat.st_size, stat.st_mtime_ns)
+    if isinstance(store, DirectoryStore):
+        root = store.root.resolve()
+        review = root / _STORY_REVIEW_TABLE
+        if not review.is_file():
+            return None
+        stat = review.stat()
+        return ("directory", str(root), stat.st_size, stat.st_mtime_ns)
+    return None
+
+
+@lru_cache(maxsize=4)
+def _cached_story_search_index(
+    descriptor: tuple[str, str, int, int],
+) -> _StorySearchIndex:
+    kind, source, _size, _mtime_ns = descriptor
+    store: JsonStore
+    if kind == "zip":
+        store = ZipStore(source)
+    else:
+        store = DirectoryStore(source)
+    try:
+        return _build_story_search_index(store)
+    finally:
+        store.close()
+
+
+def _build_story_search_index(store: JsonStore) -> _StorySearchIndex:
+    table: dict = _load_json(store, _STORY_REVIEW_TABLE)  # type: ignore[assignment]
+    event_ids: set[str] = set()
+    chapters: list[_StorySearchChapter] = []
+    records: list[_StorySearchRecord] = []
+
+    for ev_id, entry in table.items():
+        datas = sorted(
+            entry.get("infoUnlockDatas") or [],
+            key=lambda x: x.get("storySort", 0),
+        )
+        if not datas:
+            continue
+        event_ids.add(ev_id)
+        for d in datas:
+            story_key = d.get("storyTxt")
+            if not story_key:
+                continue
+            try:
+                chapter = read_story_from_store(store, story_key, include_narration=True)
+            except (KeyError, FileNotFoundError, json.JSONDecodeError):
+                continue
+            chapter_index = len(chapters)
+            indexed_chapter = _StorySearchChapter(
+                event_id=ev_id,
+                story_code=d.get("storyCode", ""),
+                lines=tuple(chapter.lines),
+            )
+            chapters.append(indexed_chapter)
+            records.extend(
+                _StorySearchRecord(chapter_index=chapter_index, line_index=i, line=line)
+                for i, line in enumerate(indexed_chapter.lines)
+            )
+
+    return _StorySearchIndex(
+        event_ids=frozenset(event_ids),
+        chapters=tuple(chapters),
+        records=tuple(records),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -144,9 +144,8 @@ class _StorySearchIndex:
 
 def clear_story_caches() -> None:
     """Clear cached story search indexes after story data changes."""
-    global _chardict_cache
     _cached_story_search_index.cache_clear()
-    _chardict_cache = None
+    _cached_chardict.cache_clear()
 
 
 # ---------------------------------------------------------------------------
@@ -411,27 +410,59 @@ def read_activity_from_store(
     )
 
 
-_chardict_cache: dict[str, dict[str, object]] | None = None
-
-
 def _load_chardict(store: JsonStore) -> dict[str, dict[str, object]]:
-    """Load chardict.json from the story store (cached at module level)."""
-    global _chardict_cache
-    if _chardict_cache is not None:
-        return _chardict_cache
+    """Load chardict.json from the story store."""
+    descriptor = _chardict_store_descriptor(store)
+    if descriptor is not None:
+        return _cached_chardict(descriptor)
     if not store.exists(_CHARDICT):
-        _chardict_cache = {}
-        return _chardict_cache
+        return {}
+    return _read_chardict_from_store(store)
+
+
+def _read_chardict_from_store(store: JsonStore) -> dict[str, dict[str, object]]:
     try:
         data: dict = _load_json(store, _CHARDICT)  # type: ignore[assignment]
-        _chardict_cache = {str(k): v for k, v in data.items() if isinstance(v, dict)}
+        return {str(k): v for k, v in data.items() if isinstance(v, dict)}
     except (KeyError, FileNotFoundError, json.JSONDecodeError):
-        _chardict_cache = {}
-    return _chardict_cache
+        return {}
+
+
+def _chardict_store_descriptor(store: JsonStore) -> tuple[str, str, int, int] | None:
+    if isinstance(store, ZipStore):
+        path = store.zip_path.resolve()
+        if not path.is_file():
+            return None
+        stat = path.stat()
+        return ("zip", str(path), stat.st_size, stat.st_mtime_ns)
+    if isinstance(store, DirectoryStore):
+        root = store.root.resolve()
+        chardict = root / _CHARDICT
+        if not chardict.is_file():
+            return None
+        stat = chardict.stat()
+        return ("directory", str(root), stat.st_size, stat.st_mtime_ns)
+    return None
+
+
+@lru_cache(maxsize=4)
+def _cached_chardict(
+    descriptor: tuple[str, str, int, int],
+) -> dict[str, dict[str, object]]:
+    kind, source, _size, _mtime_ns = descriptor
+    store: JsonStore
+    if kind == "zip":
+        store = ZipStore(source)
+    else:
+        store = DirectoryStore(source)
+    try:
+        return _read_chardict_from_store(store)
+    finally:
+        store.close()
 
 
 def _resolve_operator_code(
-    chardict: dict[str, dict[str, str]],
+    chardict: dict[str, dict[str, object]],
     operator_name: str,
 ) -> str | None:
     """Reverse lookup: operator display name -> internal code (e.g. '能天使' -> 'angel')."""

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -411,10 +411,10 @@ def read_activity_from_store(
     )
 
 
-_chardict_cache: dict[str, dict[str, str]] | None = None
+_chardict_cache: dict[str, dict[str, object]] | None = None
 
 
-def _load_chardict(store: JsonStore) -> dict[str, dict[str, str]]:
+def _load_chardict(store: JsonStore) -> dict[str, dict[str, object]]:
     """Load chardict.json from the story store (cached at module level)."""
     global _chardict_cache
     if _chardict_cache is not None:

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -287,7 +287,7 @@ def get_enemy_info(
 @mcp.tool()
 def search_enemies(
     pattern: Annotated[str, Field(description="正则表达式模式，如 '萨卡兹|骑士'。")],
-    max_results: Annotated[int, Field(default=30, description="返回结果数量上限，默认 30。")] = 30,
+    max_results: Annotated[int, Field(default=30, ge=1, le=100, description="返回结果数量上限，默认 30。")] = 30,
 ) -> str:
     """在敌人图鉴中进行全文正则搜索。
 
@@ -352,7 +352,7 @@ def get_stage_info(
 @mcp.tool()
 def search_stages(
     pattern: Annotated[str, Field(description="正则表达式搜索模式，大小写不敏感。例如 'H10'、'切尔诺伯格'。")],
-    max_results: Annotated[int, Field(default=30, description="最多返回条数，默认 30。")] = 30,
+    max_results: Annotated[int, Field(default=30, ge=1, le=100, description="最多返回条数，默认 30。")] = 30,
 ) -> str:
     """在关卡数据库中执行全文正则搜索。
 
@@ -389,7 +389,7 @@ def get_item_info(
 @mcp.tool()
 def search_items(
     pattern: Annotated[str, Field(description="正则表达式搜索模式，如「源岩|装置」。")],
-    max_results: Annotated[int, Field(default=30, description="返回结果数量上限，默认 30。")] = 30,
+    max_results: Annotated[int, Field(default=30, ge=1, le=100, description="返回结果数量上限，默认 30。")] = 30,
 ) -> str:
     """在物品/材料数据中进行全文正则搜索。
 
@@ -677,8 +677,8 @@ def search_stories(
     pattern: Annotated[str, Field(description="正则表达式搜索模式，大小写不敏感。")],
     character: Annotated[str | None, Field(default=None, description="按说话角色名过滤（仅匹配 dialog 行），如「博士」、「阿米娅」。")] = None,
     line_type: Annotated[str | None, Field(default=None, description="台词类型过滤：dialog（对话）、narration（旁白）、choice（选项）。")] = None,
-    context_lines: Annotated[int, Field(default=1, description="匹配行前后的上下文行数，默认 1。设 0 则只返回匹配行本身。")] = 1,
-    max_results: Annotated[int, Field(default=30, description="最多返回条数，默认 30。")] = 30,
+    context_lines: Annotated[int, Field(default=1, ge=0, le=5, description="匹配行前后的上下文行数，默认 1。设 0 则只返回匹配行本身。")] = 1,
+    max_results: Annotated[int, Field(default=30, ge=1, le=100, description="最多返回条数，默认 30。")] = 30,
     event_id: Annotated[str | None, Field(default=None, description="限定活动 ID，如「act31side」。不填则搜索全部活动。")] = None,
 ) -> str:
     """在剧情台词中执行全文正则搜索，支持角色和台词类型过滤。

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -54,6 +54,7 @@ from prts_mcp.data.story import (
     search_stories as _search_stories,
     get_event_summary as _get_event_summary,
     get_story_summary as _get_story_summary,
+    get_operator_memoirs as _get_operator_memoirs,
 )
 
 logging.basicConfig(
@@ -399,12 +400,13 @@ def search_items(
 
 @mcp.tool()
 def list_story_events(
-    category: Annotated[str | None, Field(default=None, description="可选过滤分类。\"main\" = 主线章节，\"activities\" = 活动剧情（含联动）。不填则返回全部活动。")] = None,
+    category: Annotated[str | None, Field(default=None, description="可选过滤分类。\"main\" = 主线章节，\"activities\" = 活动剧情（含联动），\"memoirs\" = 干员密录。不填则返回全部活动。")] = None,
 ) -> str:
     """列出明日方舟剧情活动列表。
 
     返回格式：每行 `- [类型] 活动ID：名称（N 章）`，类型为 MAINLINE / ACTIVITY /
-    MINI_ACTIVITY 之一。获取活动 ID 后，可调用 list_stories 查看该活动的章节列表。
+    MINI_ACTIVITY / NONE 之一。获取活动 ID 后，可调用 list_stories 查看该活动的章节列表。
+    category=\"memoirs\" 可列出所有干员密录。
     """
     from prts_mcp.config import Config
     cfg = Config.load()
@@ -645,7 +647,9 @@ def list_search_scopes() -> str:
         "- enemies：敌人图鉴（名称、威胁等级、描述、属性）。\n"
         "  使用 list_enemies / get_enemy_info / search_enemies 查询。\n"
         "- items：物品/材料（名称、描述、用途、掉落、商店关联）。\n"
-        "  使用 list_items / get_item_info / search_items 查询。"
+        "  使用 list_items / get_item_info / search_items 查询。\n"
+        "- memoirs：干员密录剧情，可通过 get_operator_memoirs 按干员名查找。\n"
+        "  获取 story_key 后使用 read_story 读取完整台词。"
     )
 
 
@@ -702,6 +706,39 @@ def search_stories(
         )
     except Exception as e:
         return f"剧情搜索失败：{e}"
+
+
+@mcp.tool()
+def get_operator_memoirs(
+    operator_name: Annotated[str, Field(description="干员的游戏内中文名，如「阿米娅」、「能天使」。")],
+) -> str:
+    """根据干员名称查询干员密录剧情。
+
+    返回干员的密录章节列表，包含章节 key（story_key）和元数据。
+    获取 story_key 后可传入 read_story 读取密录台词。
+    若需先查找正确的干员名称，可使用 search_data 搜索干员数据。
+    """
+    from prts_mcp.config import Config
+    cfg = Config.load()
+    try:
+        zip_path = _require_story_zip(cfg)
+    except RuntimeError as e:
+        return str(e)
+
+    try:
+        result = _get_operator_memoirs(zip_path, operator_name)
+    except KeyError as e:
+        return str(e)
+    except Exception as e:
+        return f"查询干员密录失败：{e}"
+
+    lines = [
+        f"# {result.operator_name}（code: {result.internal_code}，id: {result.operator_id}）",
+        f"共 {result.total_chapters} 章密录\n",
+    ]
+    for ch in result.chapters:
+        lines.append(f"- {ch.story_code} {ch.story_name}（key: {ch.story_key}）")
+    return "\n".join(lines)
 
 
 def _sync_needs_retry(status: str) -> bool:
@@ -833,6 +870,10 @@ def _run_startup_sync() -> None:
         def _sync_storyjson() -> bool:
             r = sync_release(release_spec)
             _log_sync_result(r)
+            if r.status == "updated":
+                from prts_mcp.data.story import clear_story_caches
+
+                clear_story_caches()
             return _sync_needs_retry(r.status)
 
         needs_retry = _run_initial_sync(

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -657,7 +657,7 @@ def list_search_scopes() -> str:
 def search_data(
     pattern: Annotated[str, Field(description="正则表达式搜索模式，大小写不敏感。例如「博士」、「法术伤害」。")],
     scope: Annotated[str, Field(default="operators", description="搜索域，目前支持 \"operators\"。")] = "operators",
-    max_results: Annotated[int, Field(default=30, description="最多返回条数，默认 30。")] = 30,
+    max_results: Annotated[int, Field(default=30, ge=1, le=100, description="最多返回条数，默认 30。")] = 30,
 ) -> str:
     """在干员数据中执行全文正则搜索。
 

--- a/python/tests/test_e2e.py
+++ b/python/tests/test_e2e.py
@@ -149,6 +149,7 @@ EXPECTED_TOOLS = {
     "list_story_events", "list_stories", "read_story", "read_activity",
     "list_search_scopes", "search_data", "search_stories",
     "get_event_summary", "get_story_summary",
+    "get_operator_memoirs",
 }
 
 
@@ -179,7 +180,7 @@ def test_tools_list(server: subprocess.Popen) -> None:
     tools = resp["result"]["tools"]
     names = {t["name"] for t in tools}
 
-    assert len(names) == 29, f"Expected 29 tools, got {len(names)}: {sorted(names)}"
+    assert len(names) == 30, f"Expected 30 tools, got {len(names)}: {sorted(names)}"
     for name in EXPECTED_TOOLS:
         assert name in names, f"Missing tool: {name}"
 

--- a/python/tests/test_search.py
+++ b/python/tests/test_search.py
@@ -243,3 +243,15 @@ class TestSearchStories:
         store = _story_store(store_kind, tmp_path)
         result = search_stories_from_store(store, ".", context_lines=6)
         assert "context_lines 必须 <= 5" in result
+
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_max_results_lower_bound(self, tmp_path: Path, store_kind: str) -> None:
+        store = _story_store(store_kind, tmp_path)
+        result = search_stories_from_store(store, ".", max_results=0)
+        assert "max_results 必须 >= 1" in result
+
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_context_lines_lower_bound(self, tmp_path: Path, store_kind: str) -> None:
+        store = _story_store(store_kind, tmp_path)
+        result = search_stories_from_store(store, ".", context_lines=-1)
+        assert "context_lines 必须 >= 0" in result

--- a/python/tests/test_search.py
+++ b/python/tests/test_search.py
@@ -155,6 +155,10 @@ class TestSearchOperatorData:
         result = search_operator_data(".", max_results=2)
         assert "共 2 条" in result
 
+    def test_max_results_cap(self) -> None:
+        result = search_operator_data(".", max_results=101)
+        assert "max_results 必须 <= 100" in result
+
 
 # ---------------------------------------------------------------------------
 # Story search tests
@@ -227,3 +231,15 @@ class TestSearchStories:
         store = _story_store(store_kind, tmp_path)
         result = search_stories_from_store(store, ".", line_type="invalid")
         assert "无效的 line_type" in result
+
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_max_results_cap(self, tmp_path: Path, store_kind: str) -> None:
+        store = _story_store(store_kind, tmp_path)
+        result = search_stories_from_store(store, ".", max_results=101)
+        assert "max_results 必须 <= 100" in result
+
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_context_lines_cap(self, tmp_path: Path, store_kind: str) -> None:
+        store = _story_store(store_kind, tmp_path)
+        result = search_stories_from_store(store, ".", context_lines=6)
+        assert "context_lines 必须 <= 5" in result

--- a/scripts/check-runtime.ps1
+++ b/scripts/check-runtime.ps1
@@ -1,0 +1,168 @@
+[CmdletBinding()]
+param(
+    [switch]$Full
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+$OutputEncoding = [Console]::OutputEncoding = [Text.UTF8Encoding]::new()
+
+$RepoRoot = Split-Path -Parent $PSScriptRoot
+$Python = if ($env:PRTS_MCP_PYTHON) {
+    $env:PRTS_MCP_PYTHON
+} else {
+    "E:\Anaconda3\envs\python311\python.exe"
+}
+$PythonSrc = Join-Path $RepoRoot "python\src"
+$PythonVenv = Join-Path $RepoRoot "python\.venv\bin\python.exe"
+$TsDir = Join-Path $RepoRoot "ts"
+
+$Failures = 0
+$Warnings = 0
+
+function Invoke-Required {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][scriptblock]$Script
+    )
+
+    Write-Host ""
+    Write-Host "== $Name =="
+    try {
+        & $Script
+        Write-Host "[OK] $Name"
+    } catch {
+        $script:Failures += 1
+        Write-Host "[FAIL] $Name"
+        Write-Host $_.Exception.Message
+    }
+}
+
+function Invoke-Warning {
+    param(
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    $script:Warnings += 1
+    Write-Host "[WARN] $Message"
+}
+
+Write-Host "Repo root: $RepoRoot"
+Write-Host "Python: $Python"
+
+Invoke-Required "PowerShell 7+" {
+    $version = $PSVersionTable.PSVersion
+    Write-Host "PowerShell $version"
+    if ($version.Major -lt 7) {
+        throw "Use C:\Program Files\PowerShell\7\pwsh.exe for this repo."
+    }
+}
+
+Invoke-Required "Python runtime" {
+    if (-not (Test-Path -LiteralPath $Python)) {
+        throw "Missing Python interpreter: $Python"
+    }
+
+    $probe = @'
+import importlib.metadata as md
+import sys
+
+import mcp
+import pydantic
+import pytest
+
+print(sys.executable)
+print(sys.version.split()[0])
+print("mcp=" + md.version("mcp"))
+print("pydantic=" + md.version("pydantic"))
+print("pytest=" + md.version("pytest"))
+'@
+    & $Python -c $probe
+}
+
+Invoke-Required "Python local source import" {
+    $oldPythonPath = $env:PYTHONPATH
+    try {
+        $env:PYTHONPATH = $PythonSrc
+        & $Python -c "from prts_mcp.server import main; print('prts_mcp.server import ok')"
+    } finally {
+        $env:PYTHONPATH = $oldPythonPath
+    }
+}
+
+if (Test-Path -LiteralPath $PythonVenv) {
+    $venvProbe = & $PythonVenv -c "import importlib.util as u; print(u.find_spec('mcp'))"
+    if ($venvProbe -eq "None") {
+        Invoke-Warning "python\.venv exists but lacks mcp; use $Python instead."
+    }
+}
+
+Invoke-Required "Node runtime" {
+    $nodeVersion = & node -v
+    Write-Host "node=$nodeVersion"
+    if ($nodeVersion -notmatch '^v(\d+)\.') {
+        throw "Could not parse Node version: $nodeVersion"
+    }
+    if ([int]$Matches[1] -lt 22) {
+        throw "Node >=22 is required by ts/package.json."
+    }
+}
+
+Invoke-Required "npm PowerShell-safe shim" {
+    $npmCmd = Get-Command npm.cmd -ErrorAction Stop
+    Write-Host "npm.cmd=$($npmCmd.Source)"
+    & npm.cmd -v
+
+    $bareNpm = Get-Command npm -ErrorAction SilentlyContinue
+    if ($bareNpm -and $bareNpm.Source -like "*.ps1") {
+        Invoke-Warning "bare npm resolves to $($bareNpm.Source); prefer npm.cmd in PowerShell."
+    }
+}
+
+Invoke-Required "TypeScript dependencies" {
+    $tsc = Join-Path $TsDir "node_modules\typescript\bin\tsc"
+    $tsx = Join-Path $TsDir "node_modules\tsx\dist\cli.mjs"
+    if (-not (Test-Path -LiteralPath $tsc)) {
+        throw "Missing TypeScript dependency tree. Run npm.cmd ci in ts\ if dependencies need reinstalling."
+    }
+    if (-not (Test-Path -LiteralPath $tsx)) {
+        throw "Missing tsx dependency tree. Run npm.cmd ci in ts\ if dependencies need reinstalling."
+    }
+    Write-Host "typescript and tsx are installed under ts\node_modules"
+}
+
+if ($Full) {
+    Invoke-Required "Python tests" {
+        Push-Location (Join-Path $RepoRoot "python")
+        try {
+            & $Python -m pytest tests -q
+        } finally {
+            Pop-Location
+        }
+    }
+
+    Invoke-Required "TypeScript tests" {
+        Push-Location $TsDir
+        try {
+            & npm.cmd test
+        } finally {
+            Pop-Location
+        }
+    }
+
+    Invoke-Required "TypeScript typecheck" {
+        Push-Location $TsDir
+        try {
+            & npm.cmd run typecheck
+        } finally {
+            Pop-Location
+        }
+    }
+}
+
+Write-Host ""
+Write-Host "Runtime check complete: $Failures failure(s), $Warnings warning(s)."
+if ($Failures -gt 0) {
+    exit 1
+}
+

--- a/scripts/check-runtime.ps1
+++ b/scripts/check-runtime.ps1
@@ -165,4 +165,3 @@ Write-Host "Runtime check complete: $Failures failure(s), $Warnings warning(s)."
 if ($Failures -gt 0) {
     exit 1
 }
-

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Operator memoir discovery.** New `get_operator_memoirs(operator_name)` tool
   resolves operator Chinese name to memoir story keys via `chardict.json`,
   enabling LLM agents to find and read operator memoir (干员密录) dialogue.
+- This new tool is treated as a one-off patch-line exception because it exposes
+  story data that already existed in the synced StoryJson archive but was not
+  discoverable through the public tool surface.
 - `list_story_events(category="memoirs")` now exposes 372 previously hidden
   operator memoir events.
 - Operator memoir dialogue is now indexed by `search_stories`.

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,7 +4,33 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [1.6.1] - 2026-06-03
+
+### Added
+
+- **Operator memoir discovery.** New `get_operator_memoirs(operator_name)` tool
+  resolves operator Chinese name to memoir story keys via `chardict.json`,
+  enabling LLM agents to find and read operator memoir (干员密录) dialogue.
+- `list_story_events(category="memoirs")` now exposes 372 previously hidden
+  operator memoir events.
+- Operator memoir dialogue is now indexed by `search_stories`.
+
+### Changed
+
+- Search tools backed by local game/story data now reuse cached search records
+  instead of rebuilding parsed text on every call, substantially improving
+  repeated full-story and full-table regex searches.
+- Enemy search records now include `enemyTags` in searchable text.
+
+### Fixed
+
+- Story search now caps `max_results` and `context_lines` consistently to
+  prevent oversized MCP responses from long-running full-dataset searches.
+- `search_stages` and `search_items` now enforce `max_results` bounds (1–100)
+  for parity with other search tools.
+- `list_story_events` and `search_stories` no longer ignore entries with
+  `entryType: "NONE"` when those entries have valid story data (was the
+  root cause of memoirs being undiscoverable).
 
 ## [1.6.0] - 2026-05-28
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP)",
   "type": "module",
   "main": "dist/server.js",

--- a/ts/src/data/enemy.ts
+++ b/ts/src/data/enemy.ts
@@ -14,6 +14,7 @@ import { DirectoryStore } from "./stores.js";
 let _handbook: EnemyHandbook | null = null;
 let _dbIndex: Record<string, EnemyDbEntry> | null = null;
 let _nameToEnemyId: Map<string, string> | null = null;
+let _enemySearchRecords: EnemySearchRecord[] | null = null;
 
 const HANDBOOK_FILE = "enemy_handbook_table.json";
 const DATABASE_FILE = "enemy_database.json";
@@ -22,6 +23,7 @@ export function clearEnemyCaches(): void {
   _handbook = null;
   _dbIndex = null;
   _nameToEnemyId = null;
+  _enemySearchRecords = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -99,6 +101,11 @@ interface EnemyDbRow {
 
 interface EnemyDatabase {
   enemies?: EnemyDbRow[];
+}
+
+interface EnemySearchRecord {
+  info: EnemyHandbookEntry;
+  searchText: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -404,24 +411,23 @@ export function getEnemyInfo(name: string): string {
 
 export function searchEnemies(pattern: string, maxResults = 30): string {
   if (!hasEnemyData()) return missingDataMessage();
+  if (maxResults < 1) return "max_results 必须 >= 1。";
+  if (maxResults > 100) return "max_results 必须 <= 100。";
 
   let regex: RegExp;
   try { regex = new RegExp(pattern, "i"); } catch (err) {
     return `正则表达式无效：${err instanceof Error ? err.message : String(err)}`;
   }
 
-  let raw: EnemyHandbook;
-  try { raw = getHandbook(); } catch (err) {
+  let records: EnemySearchRecord[];
+  try { records = getEnemySearchRecords(); } catch (err) {
     return err instanceof Error ? err.message : String(err);
   }
 
-  const ed = raw.enemyData ?? {};
   const matches: EnemyHandbookEntry[] = [];
-  for (const info of Object.values(ed)) {
-    if (info.hideInHandbook) continue;
-    const searchable = `${info.name ?? ""} ${info.description ?? ""} ${info.ability ?? ""}`;
-    if (regex.test(searchable)) {
-      matches.push(info);
+  for (const record of records) {
+    if (regex.test(record.searchText)) {
+      matches.push(record.info);
       if (matches.length >= maxResults) break;
     }
   }
@@ -431,4 +437,21 @@ export function searchEnemies(pattern: string, maxResults = 30): string {
   const lines: string[] = [`# 搜索结果：${pattern}（共 ${matches.length} 个）\n`];
   for (const info of matches) { lines.push(fmtEnemy(info)); lines.push(""); }
   return lines.join("\n").trim();
+}
+
+function getEnemySearchRecords(): EnemySearchRecord[] {
+  if (_enemySearchRecords !== null) return _enemySearchRecords;
+  const ed = getHandbook().enemyData ?? {};
+  _enemySearchRecords = Object.values(ed)
+    .filter((info) => !info.hideInHandbook)
+    .map((info) => ({
+      info,
+      searchText: [
+        info.name ?? "",
+        info.description ?? "",
+        info.ability ?? "",
+        ...(info.enemyTags ?? []),
+      ].join(" "),
+    }));
+  return _enemySearchRecords;
 }

--- a/ts/src/data/item.ts
+++ b/ts/src/data/item.ts
@@ -64,12 +64,20 @@ interface ItemTable {
   items?: Record<string, ItemEntry>;
 }
 
+interface ItemSearchRecord {
+  itemId: string;
+  info: ItemEntry;
+  searchText: string;
+}
+
 let itemTable: Record<string, ItemEntry> | null = null;
 let itemLookup: Map<string, string> | null = null;
+let itemSearchRecords: ItemSearchRecord[] | null = null;
 
 export function clearItemCaches(): void {
   itemTable = null;
   itemLookup = null;
+  itemSearchRecords = null;
 }
 
 function itemStore(): DirectoryStore {
@@ -282,31 +290,17 @@ export function searchItems(pattern: string, maxResults = 30): string {
     return `正则表达式无效：${err instanceof Error ? err.message : String(err)}`;
   }
 
-  let entries: Array<[string, ItemEntry]>;
+  let records: ItemSearchRecord[];
   try {
-    entries = visibleItems();
+    records = getItemSearchRecords();
   } catch (err) {
     return missingDataMessage() + `（${err instanceof Error ? err.message : String(err)}）`;
   }
 
-  const results: Array<[string, ItemEntry]> = [];
-  entries.sort((a, b) => {
-    const sa = a[1].sortId ?? 999999;
-    const sb = b[1].sortId ?? 999999;
-    return sa !== sb ? sa - sb : a[0].localeCompare(b[0]);
-  });
-  for (const [itemId, info] of entries) {
-    const searchText = [
-      info.name,
-      info.description,
-      info.usage,
-      info.obtainApproach,
-      info.classifyType,
-      info.itemType,
-      itemId,
-    ].filter(Boolean).join(" ");
-    if (regex.test(searchText)) {
-      results.push([itemId, info]);
+  const results: ItemSearchRecord[] = [];
+  for (const record of records) {
+    if (regex.test(record.searchText)) {
+      results.push(record);
       if (results.length >= maxResults) break;
     }
   }
@@ -314,7 +308,9 @@ export function searchItems(pattern: string, maxResults = 30): string {
   if (results.length === 0) return `未找到匹配 '${pattern}' 的物品。`;
 
   const lines = [`# 搜索结果：${pattern}（共 ${results.length} 个）`];
-  for (const [itemId, info] of results) {
+  for (const record of results) {
+    const itemId = record.itemId;
+    const info = record.info;
     const itemName = info.name || "（无名）";
     const classify = classifyLabel(info.classifyType ?? "");
     const itemType = info.itemType ?? "-";
@@ -325,4 +321,28 @@ export function searchItems(pattern: string, maxResults = 30): string {
     if (info.obtainApproach) lines.push(`- **获取方式**：${info.obtainApproach}`);
   }
   return lines.join("\n");
+}
+
+function getItemSearchRecords(): ItemSearchRecord[] {
+  if (itemSearchRecords !== null) return itemSearchRecords;
+  const entries = visibleItems();
+  entries.sort((a, b) => {
+    const sa = a[1].sortId ?? 999999;
+    const sb = b[1].sortId ?? 999999;
+    return sa !== sb ? sa - sb : a[0].localeCompare(b[0]);
+  });
+  itemSearchRecords = entries.map(([itemId, info]) => ({
+    itemId,
+    info,
+    searchText: [
+      info.name,
+      info.description,
+      info.usage,
+      info.obtainApproach,
+      info.classifyType,
+      info.itemType,
+      itemId,
+    ].filter(Boolean).join(" "),
+  }));
+  return itemSearchRecords;
 }

--- a/ts/src/data/operator.ts
+++ b/ts/src/data/operator.ts
@@ -9,6 +9,7 @@
 import { loadConfig, hasOperatorData } from "../config.js";
 import { DirectoryStore } from "./stores.js";
 import { stripWikitext } from "../utils/sanitizer.js";
+import { clearSearchCaches } from "./search.js";
 
 // ---------------------------------------------------------------------------
 // Module-level lazy caches
@@ -31,6 +32,8 @@ export function clearOperatorCaches(): void {
   _handbookTable = null;
   _charwordTable = null;
   _nameToId = null;
+  // Propagate to search cache; see Python operator.clear_operator_caches.
+  clearSearchCaches();
 }
 
 // ---------------------------------------------------------------------------

--- a/ts/src/data/search.ts
+++ b/ts/src/data/search.ts
@@ -42,7 +42,16 @@ interface SearchResult {
   text: string;
 }
 
+let operatorSearchRecords: SearchResult[] | null = null;
+
+export function clearSearchCaches(): void {
+  operatorSearchRecords = null;
+}
+
 export function searchOperatorData(pattern: string, maxResults = 30): string {
+  if (maxResults < 1) return "max_results 必须 >= 1。";
+  if (maxResults > 100) return "max_results 必须 <= 100。";
+
   const cfg = loadConfig();
   if (!hasOperatorData(cfg)) {
     return (
@@ -60,88 +69,17 @@ export function searchOperatorData(pattern: string, maxResults = 30): string {
     return `正则表达式无效：${exc instanceof Error ? exc.message : String(exc)}`;
   }
 
-  let ct: Record<string, { name?: string; description?: string }>;
-  let handbook: HandbookTable;
-  let charwords: CharwordTable;
+  const results: SearchResult[] = [];
+  let records: SearchResult[];
   try {
-    ct = getCharacterTable();
-    handbook = getHandbookTable();
-    charwords = getCharwordTable();
+    records = getOperatorSearchRecords();
   } catch (err) {
     return err instanceof Error ? err.message : String(err);
   }
-
-  // Build name → id and charId → voice entries index
-  const nameToId = new Map<string, string>();
-  for (const [cid, info] of Object.entries(ct)) {
-    if (info.name && cid.startsWith("char_")) nameToId.set(info.name, cid);
-  }
-
-  const charidToVoices = new Map<string, CharwordEntry[]>();
-  for (const entry of Object.values(charwords.charWords ?? {})) {
-    if (entry.charId && entry.voiceText) {
-      const list = charidToVoices.get(entry.charId);
-      if (list) {
-        list.push(entry);
-      } else {
-        charidToVoices.set(entry.charId, [entry]);
-      }
-    }
-  }
-
-  const results: SearchResult[] = [];
-
-  for (const [name, charId] of nameToId) {
-    if (results.length >= maxResults) break;
-    const info = ct[charId];
-    if (!info) continue;
-
-    // --- basic: operator name ---
-    if (regex.test(name)) {
-      results.push({ operator: name, category: "basic", field: "干员名称", text: name });
+  for (const record of records) {
+    if (regex.test(record.text)) {
+      results.push(record);
       if (results.length >= maxResults) break;
-    }
-
-    // --- basic: description ---
-    const desc = info.description ?? "";
-    if (desc) {
-      const cleaned = stripWikitext(desc);
-      if (regex.test(cleaned)) {
-        results.push({ operator: name, category: "basic", field: "攻击属性", text: cleaned });
-        if (results.length >= maxResults) break;
-      }
-    }
-
-    // --- archives ---
-    const hbEntry = handbook.handbookDict?.[charId];
-    if (hbEntry) {
-      for (const story of hbEntry.storyTextAudio ?? []) {
-        if (results.length >= maxResults) break;
-        const title = story.storyTitle ?? "";
-        for (const s of story.stories ?? []) {
-          if (results.length >= maxResults) break;
-          const text = s.storyText ?? "";
-          if (text && regex.test(text)) {
-            results.push({ operator: name, category: "archives", field: title, text });
-          }
-        }
-      }
-    }
-
-    // --- voicelines ---
-    const voices = charidToVoices.get(charId);
-    if (voices) {
-      for (const v of voices) {
-        if (results.length >= maxResults) break;
-        if (regex.test(v.voiceText!)) {
-          results.push({
-            operator: name,
-            category: "voicelines",
-            field: v.voiceTitle ?? "未知",
-            text: v.voiceText!,
-          });
-        }
-      }
     }
   }
 
@@ -157,4 +95,62 @@ export function searchOperatorData(pattern: string, maxResults = 30): string {
   }
 
   return blocks.join("");
+}
+
+function getOperatorSearchRecords(): SearchResult[] {
+  if (operatorSearchRecords !== null) return operatorSearchRecords;
+
+  const ct = getCharacterTable();
+  const handbook = getHandbookTable();
+  const charwords = getCharwordTable();
+
+  const nameToId = new Map<string, string>();
+  for (const [cid, info] of Object.entries(ct)) {
+    if (info.name && cid.startsWith("char_")) nameToId.set(info.name, cid);
+  }
+
+  const charidToVoices = new Map<string, CharwordEntry[]>();
+  for (const entry of Object.values(charwords.charWords ?? {})) {
+    if (entry.charId && entry.voiceText) {
+      const list = charidToVoices.get(entry.charId);
+      if (list) list.push(entry);
+      else charidToVoices.set(entry.charId, [entry]);
+    }
+  }
+
+  const records: SearchResult[] = [];
+  for (const [name, charId] of nameToId) {
+    const info = ct[charId];
+    if (!info) continue;
+
+    records.push({ operator: name, category: "basic", field: "干员名称", text: name });
+
+    const desc = info.description ?? "";
+    if (desc) {
+      records.push({ operator: name, category: "basic", field: "攻击属性", text: stripWikitext(desc) });
+    }
+
+    const hbEntry = handbook.handbookDict?.[charId];
+    if (hbEntry) {
+      for (const story of hbEntry.storyTextAudio ?? []) {
+        const title = story.storyTitle ?? "";
+        for (const s of story.stories ?? []) {
+          const text = s.storyText ?? "";
+          if (text) records.push({ operator: name, category: "archives", field: title, text });
+        }
+      }
+    }
+
+    for (const v of charidToVoices.get(charId) ?? []) {
+      records.push({
+        operator: name,
+        category: "voicelines",
+        field: v.voiceTitle ?? "未知",
+        text: v.voiceText!,
+      });
+    }
+  }
+
+  operatorSearchRecords = records;
+  return records;
 }

--- a/ts/src/data/stage.ts
+++ b/ts/src/data/stage.ts
@@ -34,6 +34,12 @@ interface ZoneEntry {
 
 type ZoneTable = Record<string, ZoneEntry>;
 
+interface StageSearchRecord {
+  stageId: string;
+  entry: StageEntry;
+  searchText: string;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -65,11 +71,13 @@ const DIFFICULTY_LABELS: Record<string, string> = {
 let _stageTable: StageTable | null = null;
 let _zoneTable: ZoneTable | null = null;
 let _zoneTableFailed = false;
+let _stageSearchRecords: StageSearchRecord[] | null = null;
 
 export function clearStageCaches(): void {
   _stageTable = null;
   _zoneTable = null;
   _zoneTableFailed = false;
+  _stageSearchRecords = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -308,6 +316,7 @@ export function getStageInfo(stageId: string): string {
 
 export function searchStages(pattern: string, maxResults: number = 30): string {
   if (maxResults < 1) return "max_results 必须 >= 1。";
+  if (maxResults > 100) return "max_results 必须 <= 100。";
 
   let regex: RegExp;
   try {
@@ -316,25 +325,17 @@ export function searchStages(pattern: string, maxResults: number = 30): string {
     return `正则表达式无效：${e instanceof Error ? e.message : String(e)}`;
   }
 
-  let stages: StageTable;
+  let records: StageSearchRecord[];
   try {
-    stages = getStageTable();
+    records = getStageSearchRecords();
   } catch (e) {
     return missingDataMessage() + `（${e instanceof Error ? e.message : String(e)}）`;
   }
 
-  const matched: StageEntry[] = [];
-  for (const [, entry] of Object.entries(stages).sort(([a], [b]) => a.localeCompare(b))) {
-    const searchText =
-      (entry.name ?? "") +
-      " " +
-      (entry.code ?? "") +
-      " " +
-      cleanDescription(entry.description ?? "") +
-      " " +
-      (entry.stageType ?? "");
-    if (regex.test(searchText)) {
-      matched.push(entry);
+  const matched: StageSearchRecord[] = [];
+  for (const record of records) {
+    if (regex.test(record.searchText)) {
+      matched.push(record);
       if (matched.length >= maxResults) break;
     }
   }
@@ -342,7 +343,8 @@ export function searchStages(pattern: string, maxResults: number = 30): string {
   if (matched.length === 0) return `未找到匹配 '${pattern}' 的关卡。`;
 
   const lines = [`# 搜索结果：${pattern}（共 ${matched.length} 个）`];
-  for (const e of matched) {
+  for (const record of matched) {
+    const e = record.entry;
     const name = e.name || "（无名）";
     const code = e.code || "?";
     const tLabel = stageTypeLabel(e.stageType ?? "");
@@ -351,7 +353,7 @@ export function searchStages(pattern: string, maxResults: number = 30): string {
     const ap = e.apCost ?? "?";
     const cdesc = cleanDescription(e.description ?? "");
 
-    const sid = e.stageId ?? "";
+    const sid = record.stageId;
     lines.push(`\n## ${name} [${tLabel}] ${code}（id: ${sid}）`);
     lines.push(`- **区域**：${zd}`);
     lines.push(`- **难度**：${dLabel}`);
@@ -360,4 +362,22 @@ export function searchStages(pattern: string, maxResults: number = 30): string {
   }
 
   return lines.join("\n");
+}
+
+function getStageSearchRecords(): StageSearchRecord[] {
+  if (_stageSearchRecords !== null) return _stageSearchRecords;
+  _stageSearchRecords = Object.entries(getStageTable())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([stageId, entry]) => ({
+      stageId,
+      entry,
+      searchText: [
+        entry.name ?? "",
+        entry.code ?? "",
+        cleanDescription(entry.description ?? ""),
+        entry.stageType ?? "",
+        stageId,
+      ].join(" "),
+    }));
+  return _stageSearchRecords;
 }

--- a/ts/src/data/stageEnemy.ts
+++ b/ts/src/data/stageEnemy.ts
@@ -66,12 +66,14 @@ let stageTable: Record<string, StageEntry> | null = null;
 let enemyHandbook: Record<string, EnemyHandbookEntry> | null = null;
 let enemyDatabase: Record<string, Record<number, EnemyData>> | null = null;
 let nameToEnemyId: Map<string, string> | null = null;
+let enemyAppearanceIndex: Map<string, Array<[string, number]>> | null = null;
 
 export function clearStageEnemyCaches(): void {
   stageTable = null;
   enemyHandbook = null;
   enemyDatabase = null;
   nameToEnemyId = null;
+  enemyAppearanceIndex = null;
 }
 
 function excelStore(): DirectoryStore {
@@ -301,7 +303,12 @@ export function getStageEnemies(stageId: string): string {
 }
 
 function findEnemyAppearances(enemyId: string): Array<[string, number]> {
-  const appearances: Array<[string, number]> = [];
+  return getEnemyAppearanceIndex().get(enemyId) ?? [];
+}
+
+function getEnemyAppearanceIndex(): Map<string, Array<[string, number]>> {
+  if (enemyAppearanceIndex !== null) return enemyAppearanceIndex;
+  const index = new Map<string, Array<[string, number]>>();
   const stages = loadStageTable();
   const store = levelsStore();
   for (const [stageId, stage] of Object.entries(stages)) {
@@ -310,10 +317,14 @@ function findEnemyAppearances(enemyId: string): Array<[string, number]> {
     if (!store.exists(path)) continue;
     const level = store.readJson<LevelJson>(path);
     if (!level || typeof level !== "object" || Array.isArray(level)) continue;
-    const count = spawnCounts(level).get(enemyId);
-    if (count) appearances.push([stageId, count]);
+    for (const [enemyId, count] of spawnCounts(level)) {
+      const appearances = index.get(enemyId);
+      if (appearances) appearances.push([stageId, count]);
+      else index.set(enemyId, [[stageId, count]]);
+    }
   }
-  return appearances;
+  enemyAppearanceIndex = index;
+  return enemyAppearanceIndex;
 }
 
 function resolveEnemyId(name: string): string | null {

--- a/ts/src/data/story.ts
+++ b/ts/src/data/story.ts
@@ -10,8 +10,9 @@
  *   zh_CN/gamedata/story/{story_key}.json         — per-chapter dialogue JSON
  */
 
-import { JsonStore, ZipStore } from "./stores.js";
+import { DirectoryStore, JsonStore, ZipStore } from "./stores.js";
 import { statSync } from "node:fs";
+import { join } from "node:path";
 
 // ---------------------------------------------------------------------------
 // Zip path constants
@@ -682,6 +683,15 @@ function storyStoreDescriptor(store: JsonStore): string | null {
     const stat = statSync(store.zipPath);
     return `zip:${store.zipPath}:${stat.size}:${stat.mtimeMs}`;
   }
+  if (store instanceof DirectoryStore) {
+    const review = join(store.root, STORY_REVIEW_TABLE);
+    try {
+      const stat = statSync(review);
+      return `directory:${store.root}:${stat.size}:${stat.mtimeMs}`;
+    } catch {
+      return null;
+    }
+  }
   return null;
 }
 
@@ -694,6 +704,8 @@ function buildStorySearchIndex(store: JsonStore): StorySearchIndex {
   for (const [evId, entry] of Object.entries(table)) {
     const datas = (entry.infoUnlockDatas ?? []).slice();
     if (datas.length === 0) continue;
+    // Only include NONE entries that are operator memoirs
+    if ((entry.entryType ?? "NONE") === "NONE" && !isMemoirEvent(evId)) continue;
     eventIds.add(evId);
     datas.sort((a, b) => (a.storySort ?? 0) - (b.storySort ?? 0));
     for (const d of datas) {

--- a/ts/src/data/story.ts
+++ b/ts/src/data/story.ts
@@ -164,7 +164,7 @@ interface CharDictEntry {
   id?: string;
 }
 
-let charDictCache: Record<string, CharDictEntry> | null = null;
+let charDictCache: { descriptor: string; data: Record<string, CharDictEntry> } | null = null;
 
 export function clearStoryCaches(): void {
   storySearchCache = null;
@@ -436,17 +436,21 @@ export function readActivityFromStore(
 // ---------------------------------------------------------------------------
 
 function loadCharDict(store: JsonStore): Record<string, CharDictEntry> {
-  if (charDictCache) return charDictCache;
+  const descriptor = charDictStoreDescriptor(store);
+  if (descriptor !== null && charDictCache?.descriptor === descriptor) {
+    return charDictCache.data;
+  }
   if (!store.exists(CHARDICT)) {
-    charDictCache = {};
-    return charDictCache;
+    return {};
   }
+  let data: Record<string, CharDictEntry>;
   try {
-    charDictCache = store.readJson<Record<string, CharDictEntry>>(CHARDICT);
+    data = store.readJson<Record<string, CharDictEntry>>(CHARDICT);
   } catch {
-    charDictCache = {};
+    data = {};
   }
-  return charDictCache ?? {};
+  if (descriptor !== null) charDictCache = { descriptor, data };
+  return data;
 }
 
 function resolveOperatorCode(
@@ -680,14 +684,35 @@ function storySearchIndex(store: JsonStore): StorySearchIndex {
 
 function storyStoreDescriptor(store: JsonStore): string | null {
   if (store instanceof ZipStore) {
-    const stat = statSync(store.zipPath);
-    return `zip:${store.zipPath}:${stat.size}:${String(stat.mtimeNs)}`;
+    const stat = statSync(store.zipPath, { bigint: true });
+    return `zip:${store.zipPath}:${stat.size}:${stat.mtimeNs}`;
   }
   if (store instanceof DirectoryStore) {
     const review = join(store.root, STORY_REVIEW_TABLE);
     try {
-      const stat = statSync(review);
-      return `directory:${store.root}:${stat.size}:${String(stat.mtimeNs)}`;
+      const stat = statSync(review, { bigint: true });
+      return `directory:${store.root}:${stat.size}:${stat.mtimeNs}`;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+function charDictStoreDescriptor(store: JsonStore): string | null {
+  if (store instanceof ZipStore) {
+    try {
+      const stat = statSync(store.zipPath, { bigint: true });
+      return `zip:${store.zipPath}:${stat.size}:${stat.mtimeNs}:chardict`;
+    } catch {
+      return null;
+    }
+  }
+  if (store instanceof DirectoryStore) {
+    const chardict = join(store.root, CHARDICT);
+    try {
+      const stat = statSync(chardict, { bigint: true });
+      return `directory:${store.root}:${stat.size}:${stat.mtimeNs}:chardict`;
     } catch {
       return null;
     }

--- a/ts/src/data/story.ts
+++ b/ts/src/data/story.ts
@@ -681,13 +681,13 @@ function storySearchIndex(store: JsonStore): StorySearchIndex {
 function storyStoreDescriptor(store: JsonStore): string | null {
   if (store instanceof ZipStore) {
     const stat = statSync(store.zipPath);
-    return `zip:${store.zipPath}:${stat.size}:${stat.mtimeMs}`;
+    return `zip:${store.zipPath}:${stat.size}:${String(stat.mtimeNs)}`;
   }
   if (store instanceof DirectoryStore) {
     const review = join(store.root, STORY_REVIEW_TABLE);
     try {
       const stat = statSync(review);
-      return `directory:${store.root}:${stat.size}:${stat.mtimeMs}`;
+      return `directory:${store.root}:${stat.size}:${String(stat.mtimeNs)}`;
     } catch {
       return null;
     }

--- a/ts/src/data/story.ts
+++ b/ts/src/data/story.ts
@@ -11,6 +11,7 @@
  */
 
 import { JsonStore, ZipStore } from "./stores.js";
+import { statSync } from "node:fs";
 
 // ---------------------------------------------------------------------------
 // Zip path constants
@@ -20,6 +21,7 @@ const STORY_REVIEW_TABLE = "zh_CN/gamedata/excel/story_review_table.json";
 const STORYINFO = "zh_CN/storyinfo.json";
 const SUMMARIES = "zh_CN/summaries.json";
 const EVENT_SUMMARIES = "zh_CN/event_summaries.json";
+const CHARDICT = "zh_CN/chardict.json";
 
 function storyZipPath(storyKey: string): string {
   return `zh_CN/gamedata/story/${storyKey}.json`;
@@ -29,6 +31,7 @@ function storyZipPath(storyKey: string): string {
 const CATEGORY_MAP: Record<string, string[]> = {
   main: ["MAINLINE"],
   activities: ["ACTIVITY", "MINI_ACTIVITY"],
+  memoirs: ["NONE"],
 };
 
 // ---------------------------------------------------------------------------
@@ -36,6 +39,7 @@ const CATEGORY_MAP: Record<string, string[]> = {
 // ---------------------------------------------------------------------------
 
 const RICH_TAG_RE = /<[^>]+>/g;
+const MEMOIR_EVENT_RE = /^story_([a-z0-9_]+)_set_\d+$/;
 
 function cleanText(text: string): string {
   return text.replace(/\{@nickname\}/g, "博士").replace(RICH_TAG_RE, "").trim();
@@ -115,6 +119,55 @@ export interface ActivityResult {
   totalChapters: number;
   hasMore: boolean;
   chapters: StoryChapter[];
+}
+
+export interface MemoirChapter {
+  eventId: string;
+  storyKey: string;
+  storyCode: string;
+  storyName: string;
+}
+
+export interface OperatorMemoirResult {
+  operatorName: string;
+  internalCode: string;
+  operatorId: string;
+  totalChapters: number;
+  chapters: MemoirChapter[];
+}
+
+interface StorySearchChapter {
+  eventId: string;
+  storyCode: string;
+  lines: StoryLine[];
+}
+
+interface StorySearchRecord {
+  chapterIndex: number;
+  lineIndex: number;
+  line: StoryLine;
+}
+
+interface StorySearchIndex {
+  eventIds: Set<string>;
+  chapters: StorySearchChapter[];
+  records: StorySearchRecord[];
+}
+
+let storySearchCache:
+  | { descriptor: string; index: StorySearchIndex }
+  | null = null;
+
+interface CharDictEntry {
+  name?: string;
+  id?: string;
+}
+
+let charDictCache: Record<string, CharDictEntry> | null = null;
+
+export function clearStoryCaches(): void {
+  storySearchCache = null;
+  charDictCache = null;
 }
 
 // ---------------------------------------------------------------------------
@@ -211,7 +264,14 @@ export function listStoryEventsFromStore(
   const events: EventInfo[] = [];
   for (const [eventId, entry] of Object.entries(table)) {
     const entryType = entry.entryType ?? "NONE";
-    if (allowedTypes !== null && !allowedTypes.includes(entryType)) continue;
+    if (allowedTypes !== null) {
+      if (allowedTypes.length === 1 && allowedTypes[0] === "NONE") {
+        // "memoirs" category: NONE entries whose eventId matches memoir pattern
+        if (!isMemoirEvent(eventId)) continue;
+      } else if (!allowedTypes.includes(entryType)) {
+        continue;
+      }
+    }
     events.push({
       eventId,
       name: entry.name ?? eventId,
@@ -371,6 +431,103 @@ export function readActivityFromStore(
 }
 
 // ---------------------------------------------------------------------------
+// Chardict + operator memoir helpers
+// ---------------------------------------------------------------------------
+
+function loadCharDict(store: JsonStore): Record<string, CharDictEntry> {
+  if (charDictCache) return charDictCache;
+  if (!store.exists(CHARDICT)) {
+    charDictCache = {};
+    return charDictCache;
+  }
+  try {
+    charDictCache = store.readJson<Record<string, CharDictEntry>>(CHARDICT);
+  } catch {
+    charDictCache = {};
+  }
+  return charDictCache ?? {};
+}
+
+function resolveOperatorCode(
+  charDict: Record<string, CharDictEntry>,
+  operatorName: string
+): string | null {
+  for (const [code, info] of Object.entries(charDict)) {
+    if (info.name === operatorName) return code;
+  }
+  return null;
+}
+
+function isMemoirEvent(eventId: string): boolean {
+  return MEMOIR_EVENT_RE.test(eventId);
+}
+
+export function getOperatorMemoirs(
+  zipPath: string,
+  operatorName: string,
+): OperatorMemoirResult {
+  return withStoryStore(zipPath, (store) => getOperatorMemoirsFromStore(store, operatorName));
+}
+
+export function getOperatorMemoirsFromStore(
+  store: JsonStore,
+  operatorName: string,
+): OperatorMemoirResult {
+  const charDict = loadCharDict(store);
+  if (Object.keys(charDict).length === 0) {
+    throw new Error("chardict.json 未在 story zip 中找到。");
+  }
+
+  const code = resolveOperatorCode(charDict, operatorName);
+  if (code === null) {
+    throw new Error(
+      `未找到干员名称 '${operatorName}' 对应的内部代码。请使用游戏内中文名称。`
+    );
+  }
+
+  const charInfo = charDict[code];
+  const operatorId = charInfo.id ?? "";
+
+  const table = store.readJson<Record<string, RawReviewEntry>>(STORY_REVIEW_TABLE);
+  const prefix = `story_${code}_set_`;
+  const memoirEvents = Object.keys(table)
+    .filter((eid) => eid.startsWith(prefix))
+    .sort((a, b) => {
+      const aNum = parseInt(a.split("_").pop() ?? "0", 10) || 0;
+      const bNum = parseInt(b.split("_").pop() ?? "0", 10) || 0;
+      return aNum - bNum;
+    });
+
+  if (memoirEvents.length === 0) {
+    throw new Error(`干员 '${operatorName}' (code=${code}) 暂无密录数据。`);
+  }
+
+  const chapters: MemoirChapter[] = [];
+  for (const eventId of memoirEvents) {
+    const entry = table[eventId];
+    const datas = (entry?.infoUnlockDatas ?? []).slice();
+    datas.sort((a, b) => (a.storySort ?? 0) - (b.storySort ?? 0));
+    for (const d of datas) {
+      if (!d.storyTxt) continue;
+      chapters.push({
+        eventId,
+        storyKey: d.storyTxt,
+        storyCode: d.storyCode ?? "",
+        storyName: d.storyName ?? "",
+      });
+    }
+  }
+
+  return {
+    operatorName,
+    internalCode: code,
+    operatorId,
+    totalChapters: chapters.length,
+    chapters,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Search helpers
 // ---------------------------------------------------------------------------
 
@@ -431,6 +588,11 @@ export function searchStoriesFromStore(
   maxResults = 30,
   eventId?: string,
 ): string {
+  if (maxResults < 1) return "max_results 必须 >= 1。";
+  if (maxResults > 100) return "max_results 必须 <= 100。";
+  if (contextLines < 0) return "context_lines 必须 >= 0。";
+  if (contextLines > 5) return "context_lines 必须 <= 5。";
+
   let regex: RegExp;
   try {
     regex = new RegExp(pattern, "i");
@@ -443,78 +605,47 @@ export function searchStoriesFromStore(
     return `无效的 line_type：${JSON.stringify(lineType)}，可选值：${valid}`;
   }
 
-  let table: Record<string, RawReviewEntry>;
+  let index: StorySearchIndex;
   try {
-    table = store.readJson<Record<string, RawReviewEntry>>(STORY_REVIEW_TABLE);
+    index = storySearchIndex(store);
   } catch (exc) {
     return `读取剧情数据索引失败：${exc instanceof Error ? exc.message : String(exc)}`;
   }
 
-  // Build active event list, excluding NONE entries
-  const activeEvents: Array<[string, RawReviewEntry]> = [];
-  for (const [evId, entry] of Object.entries(table)) {
-    if (eventId !== undefined && evId !== eventId) continue;
-    if ((entry.entryType ?? "NONE") === "NONE") continue;
-    activeEvents.push([evId, entry]);
-  }
-
-  if (eventId !== undefined && activeEvents.length === 0) {
+  if (eventId !== undefined && !index.eventIds.has(eventId)) {
     return `未找到匹配的活动：${JSON.stringify(eventId)}。`;
   }
 
   const results: SearchResult[] = [];
 
-  for (const [evId, entry] of activeEvents) {
+  for (const record of index.records) {
     if (results.length >= maxResults) break;
+    const chapter = index.chapters[record.chapterIndex];
+    const line = record.line;
 
-    const datas = (entry.infoUnlockDatas ?? []).slice();
-    datas.sort((a, b) => (a.storySort ?? 0) - (b.storySort ?? 0));
-
-    for (const d of datas) {
-      if (results.length >= maxResults) break;
-      if (!d.storyTxt) continue;
-      const storyCode = d.storyCode ?? "";
-
-      let chapter: StoryChapter;
-      try {
-        chapter = readStoryFromStore(store, d.storyTxt, true);
-      } catch (err) {
-        if (err instanceof SyntaxError) continue;
-        if (err instanceof Error && /not found/i.test(err.message)) continue;
-        throw err;
-      }
-
-      for (let i = 0; i < chapter.lines.length; i++) {
-        if (results.length >= maxResults) break;
-        const line = chapter.lines[i];
-
-        // --- filters ---
-        if (character !== undefined) {
-          if (line.type !== "dialog" || (line.role ?? "").toLowerCase() !== character.toLowerCase()) {
-            continue;
-          }
-        }
-        if (lineType !== undefined && line.type !== lineType) continue;
-
-        if (!regex.test(line.text)) continue;
-
-        // --- context collection ---
-        const start = Math.max(0, i - contextLines);
-        const end = Math.min(chapter.lines.length, i + contextLines + 1);
-        const ctxParts: string[] = [];
-        for (let j = start; j < end; j++) {
-          const prefix = j === i ? ">>> " : "    ";
-          ctxParts.push(prefix + formatStoryLine(chapter.lines[j]));
-        }
-
-        results.push({
-          eventId: evId,
-          storyCode,
-          lineNumber: i + 1,
-          context: ctxParts.join("\n"),
-        });
+    if (eventId !== undefined && chapter.eventId !== eventId) continue;
+    if (character !== undefined) {
+      if (line.type !== "dialog" || (line.role ?? "").toLowerCase() !== character.toLowerCase()) {
+        continue;
       }
     }
+    if (lineType !== undefined && line.type !== lineType) continue;
+    if (!regex.test(line.text)) continue;
+
+    const start = Math.max(0, record.lineIndex - contextLines);
+    const end = Math.min(chapter.lines.length, record.lineIndex + contextLines + 1);
+    const ctxParts: string[] = [];
+    for (let j = start; j < end; j++) {
+      const prefix = j === record.lineIndex ? ">>> " : "    ";
+      ctxParts.push(prefix + formatStoryLine(chapter.lines[j]));
+    }
+
+    results.push({
+      eventId: chapter.eventId,
+      storyCode: chapter.storyCode,
+      lineNumber: record.lineIndex + 1,
+      context: ctxParts.join("\n"),
+    });
   }
 
   if (results.length === 0) {
@@ -534,6 +665,60 @@ export function searchStoriesFromStore(
   }
 
   return parts.join("\n");
+}
+
+function storySearchIndex(store: JsonStore): StorySearchIndex {
+  const descriptor = storyStoreDescriptor(store);
+  if (descriptor !== null && storySearchCache?.descriptor === descriptor) {
+    return storySearchCache.index;
+  }
+  const index = buildStorySearchIndex(store);
+  if (descriptor !== null) storySearchCache = { descriptor, index };
+  return index;
+}
+
+function storyStoreDescriptor(store: JsonStore): string | null {
+  if (store instanceof ZipStore) {
+    const stat = statSync(store.zipPath);
+    return `zip:${store.zipPath}:${stat.size}:${stat.mtimeMs}`;
+  }
+  return null;
+}
+
+function buildStorySearchIndex(store: JsonStore): StorySearchIndex {
+  const table = store.readJson<Record<string, RawReviewEntry>>(STORY_REVIEW_TABLE);
+  const eventIds = new Set<string>();
+  const chapters: StorySearchChapter[] = [];
+  const records: StorySearchRecord[] = [];
+
+  for (const [evId, entry] of Object.entries(table)) {
+    const datas = (entry.infoUnlockDatas ?? []).slice();
+    if (datas.length === 0) continue;
+    eventIds.add(evId);
+    datas.sort((a, b) => (a.storySort ?? 0) - (b.storySort ?? 0));
+    for (const d of datas) {
+      if (!d.storyTxt) continue;
+      let chapter: StoryChapter;
+      try {
+        chapter = readStoryFromStore(store, d.storyTxt, true);
+      } catch (err) {
+        if (err instanceof SyntaxError) continue;
+        if (err instanceof Error && /not found/i.test(err.message)) continue;
+        throw err;
+      }
+      const chapterIndex = chapters.length;
+      chapters.push({
+        eventId: evId,
+        storyCode: d.storyCode ?? "",
+        lines: chapter.lines,
+      });
+      for (let i = 0; i < chapter.lines.length; i++) {
+        records.push({ chapterIndex, lineIndex: i, line: chapter.lines[i] });
+      }
+    }
+  }
+
+  return { eventIds, chapters, records };
 }
 
 // ---------------------------------------------------------------------------

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -22,7 +22,7 @@ import { clearEnemyCaches, listEnemies, getEnemyInfo, searchEnemies } from "./da
 import { clearStageCaches, listStages, getStageInfo, searchStages } from "./data/stage.js";
 import { clearItemCaches, listItems, getItemInfo, searchItems } from "./data/item.js";
 import { clearStageEnemyCaches, getStageEnemies, getEnemyAppearances, getEnemyStageInfo } from "./data/stageEnemy.js";
-import { searchOperatorData } from "./data/search.js";
+import { clearSearchCaches, searchOperatorData } from "./data/search.js";
 import { syncRelease, syncReleaseArchive } from "./data/sync.js";
 import { archiveSpecForDataset, releaseSpecForDataset, GAMEDATA_EXCEL, GAMEDATA_LEVELS, STORY_ZH_CN } from "./data/datasets.js";
 import {
@@ -31,8 +31,10 @@ import {
   readStory as _readStory,
   readActivity as _readActivity,
   searchStories as _searchStories,
+  clearStoryCaches,
   getEventSummary as _getEventSummary,
   getStorySummary as _getStorySummary,
+  getOperatorMemoirs as _getOperatorMemoirs,
   type StoryChapter,
   type StoryLine,
 } from "./data/story.js";
@@ -460,10 +462,11 @@ function createMcpServer(): McpServer {
     "list_story_events",
     [
       "列出明日方舟剧情活动列表。",
-      "返回格式：每行 `- [类型] 活动ID：名称（N 章）`，类型为 MAINLINE / ACTIVITY / MINI_ACTIVITY 之一。",
+      "返回格式：每行 `- [类型] 活动ID：名称（N 章）`，类型为 MAINLINE / ACTIVITY / MINI_ACTIVITY / NONE 之一。",
       "获取活动 ID 后，可调用 list_stories 查看该活动的章节列表。",
+      "category=\"memoirs\" 可列出所有干员密录。",
     ].join(" "),
-    { category: z.string().optional().describe("可选过滤分类。\"main\" = 主线章节，\"activities\" = 活动剧情（含联动）。不填则返回全部活动。") },
+    { category: z.string().optional().describe("可选过滤分类。\"main\" = 主线章节，\"activities\" = 活动剧情（含联动），\"memoirs\" = 干员密录。不填则返回全部活动。") },
     ({ category }) => {
       let zipPath: string;
       try {
@@ -738,7 +741,9 @@ function createMcpServer(): McpServer {
               "- enemies：敌人图鉴（名称、威胁等级、描述、属性）。\n" +
               "  使用 list_enemies / get_enemy_info / search_enemies 查询。\n" +
               "- items：物品/材料（名称、描述、用途、掉落、商店关联）。\n" +
-              "  使用 list_items / get_item_info / search_items 查询。",
+              "  使用 list_items / get_item_info / search_items 查询。\n" +
+              "- memoirs：干员密录剧情，可通过 get_operator_memoirs 按干员名查找。\n" +
+              "  获取 story_key 后使用 read_story 读取完整台词。",
           },
         ],
       };
@@ -801,6 +806,44 @@ function createMcpServer(): McpServer {
         return { content: [{ type: "text", text }] };
       } catch (e) {
         return { content: [{ type: "text", text: `剧情搜索失败：${e instanceof Error ? e.message : String(e)}` }] };
+      }
+    }
+  );
+
+  server.tool(
+    "get_operator_memoirs",
+    [
+      "根据干员名称查询干员密录剧情。",
+      "返回干员的密录章节列表，包含章节 key（story_key）和元数据。",
+      "获取 story_key 后可传入 read_story 读取密录台词。",
+      "若需先查找正确的干员名称，可使用 search_data 搜索干员数据。",
+    ].join(" "),
+    {
+      operator_name: z.string().describe("干员的游戏内中文名，如「阿米娅」、「能天使」。"),
+    },
+    ({ operator_name }) => {
+      let zipPath: string;
+      try {
+        zipPath = requireStoryZip();
+      } catch (e) {
+        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+      }
+      try {
+        const result = _getOperatorMemoirs(zipPath, operator_name);
+        const lines: string[] = [
+          `# ${result.operatorName}（code: ${result.internalCode}，id: ${result.operatorId}）`,
+          `共 ${result.totalChapters} 章密录\n`,
+        ];
+        for (const ch of result.chapters) {
+          lines.push(`- ${ch.storyCode} ${ch.storyName}（key: ${ch.storyKey}）`);
+        }
+        return { content: [{ type: "text", text: lines.join("\n") }] };
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        if (msg.includes("未找到干员名称") || msg.includes("暂无密录数据")) {
+          return { content: [{ type: "text", text: msg }] };
+        }
+        return { content: [{ type: "text", text: `查询干员密录失败：${msg}` }] };
       }
     }
   );
@@ -883,6 +926,7 @@ async function runStartupSync(): Promise<void> {
         clearStageCaches();
         clearItemCaches();
         clearStageEnemyCaches();
+        clearSearchCaches();
         log("INFO", `Data updated from GitHub Release (${r.spec.repo} @ ${sha}).`);
       } else if (r.status === "up_to_date") {
         log("INFO", `Data is up to date (${r.spec.repo} @ ${sha}).`);
@@ -948,6 +992,7 @@ async function runStartupSync(): Promise<void> {
       const r = await syncRelease(releaseSpec);
       const sha = r.commitSha ? r.commitSha.slice(0, 8) : "unknown";
       if (r.status === "updated") {
+        clearStoryCaches();
         log("INFO", `Storyjson updated from GitHub Release (${r.spec.repo} @ ${sha}).`);
       } else if (r.status === "up_to_date") {
         log("INFO", `Storyjson is up to date (${r.spec.repo} @ ${sha}).`);

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -165,7 +165,7 @@ test("E2E", async (t) => {
   });
 
   // --- tools/list ---
-  await t.test("tools/list returns all 29 tools", async () => {
+  await t.test("tools/list returns all 30 tools", async () => {
     const tl = await mcpPost(
       origin,
       { jsonrpc: "2.0", method: "tools/list", id: 2 },
@@ -175,7 +175,7 @@ test("E2E", async (t) => {
     assert.equal(tl.status, 200);
     const tools = (tl.body?.result as Record<string, unknown>)?.tools as Array<{ name: string }> | undefined;
     assert.ok(tools, "tools/list should return tools");
-    assert.equal(tools!.length, 29, `got ${tools!.length} tools`);
+    assert.equal(tools!.length, 30, `got ${tools!.length} tools`);
 
     const expected = new Set([
       "search_prts", "read_prts_page", "list_prts_sections",

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -188,6 +188,7 @@ test("E2E", async (t) => {
       "list_story_events", "list_stories", "read_story", "read_activity",
       "list_search_scopes", "search_data", "search_stories",
       "get_event_summary", "get_story_summary",
+      "get_operator_memoirs",
     ]);
     const names = new Set(tools!.map((t) => t.name));
     for (const name of expected) {

--- a/ts/tests/search.test.ts
+++ b/ts/tests/search.test.ts
@@ -210,6 +210,17 @@ test("search_operator_data max_results", async () => {
   assert.match(result, /共 2 条/);
 });
 
+test("search_operator_data max_results cap", async () => {
+  const root = tempRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  delete process.env["STORYJSON_PATH"];
+  writeMinimalGamedata(root);
+
+  const search = await loadSearchModule();
+  const result = search.searchOperatorData(".", 101);
+  assert.match(result, /max_results 必须 <= 100/);
+});
+
 // ---------------------------------------------------------------------------
 // Story search tests
 // ---------------------------------------------------------------------------
@@ -289,6 +300,20 @@ for (const kind of ["directory", "zip"] as const) {
     const store = storyStore(kind, root);
     const result = searchStoriesFromStore(store, ".", undefined, "invalid");
     assert.match(result, /无效的 line_type/);
+  });
+
+  test(`search_stories max_results cap (${kind})`, () => {
+    const root = tempRoot();
+    const store = storyStore(kind, root);
+    const result = searchStoriesFromStore(store, ".", undefined, undefined, 1, 101);
+    assert.match(result, /max_results 必须 <= 100/);
+  });
+
+  test(`search_stories context_lines cap (${kind})`, () => {
+    const root = tempRoot();
+    const store = storyStore(kind, root);
+    const result = searchStoriesFromStore(store, ".", undefined, undefined, 6);
+    assert.match(result, /context_lines 必须 <= 5/);
   });
 }
 

--- a/ts/tests/search.test.ts
+++ b/ts/tests/search.test.ts
@@ -315,6 +315,20 @@ for (const kind of ["directory", "zip"] as const) {
     const result = searchStoriesFromStore(store, ".", undefined, undefined, 6);
     assert.match(result, /context_lines 必须 <= 5/);
   });
+
+  test(`search_stories max_results lower bound (${kind})`, () => {
+    const root = tempRoot();
+    const store = storyStore(kind, root);
+    const result = searchStoriesFromStore(store, ".", undefined, undefined, 1, 0);
+    assert.match(result, /max_results 必须 >= 1/);
+  });
+
+  test(`search_stories context_lines lower bound (${kind})`, () => {
+    const root = tempRoot();
+    const store = storyStore(kind, root);
+    const result = searchStoriesFromStore(store, ".", undefined, undefined, -1);
+    assert.match(result, /context_lines 必须 >= 0/);
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/ts/tests/toolSurface.test.ts
+++ b/ts/tests/toolSurface.test.ts
@@ -33,6 +33,7 @@ const EXPECTED_TOOLS = [
   "list_search_scopes",
   "search_data",
   "search_stories",
+  "get_operator_memoirs",
 ];
 
 test("TypeScript MCP tool names are frozen", () => {


### PR DESCRIPTION
## Summary

### Operator memoir discovery (干员密录)
- New MCP tool `get_operator_memoirs(operator_name)` — resolves operator Chinese name to memoir story keys via `chardict.json` lookup
- `list_story_events(category="memoirs")` now returns 372 memoir events that were previously hidden (entryType "NONE" was hard-filtered)
- `search_stories` search index now includes memoir dialogue (changed from filtering by entryType to filtering by data presence)
- Python + TypeScript dual implementation, 30 tools total

### Search index optimization
- Local data search tools (operators, enemies, items, stages, stage enemies) now reuse cached search records instead of rebuilding parsed text on every call
- Story search caps `max_results` (<=100) and `context_lines` (<=5) consistently

### Mapping chain
```
operator_name -> internal_code (chardict.json reverse lookup)
internal_code -> memoir event_ids (story_review_table prefix match)
memoir event_id -> story_keys -> dialogue text (read_story)
```

## Test plan
- Python: 190 passed, 2 skipped
- TypeScript: 134 passed, 2 skipped, 0 failed
- Manual E2E: `get_operator_memoirs("能天使")` returns 2 chapters, `read_story` reads full text, `search_stories` indexes memoir dialogue

## 未尽事宜
- No operator name fuzzy matching — exact Chinese name required (use `search_data` to find correct name first)
- 121 operators in chardict.json have no memoir data yet (game content gap)