### PR TITLE
feat(story): 1.7.0 story character tracking (find_character_appearances + find_speakers_in)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,9 +67,11 @@ details.
 ### 1.7.0 — Story Character Tracking + Operator Depth
 
 **Story character tracking (no new data source — indexes existing story JSON)**
-- `find_character_appearances(name, scope?)` — chapters / events where the
-  character speaks or is mentioned.
-- `find_speakers_in(event_id)` — every speaker who appears in an event.
+- `find_character_appearances(name, scope?, max_events?)` — chapters / events
+  where the character speaks (dialog role exact match) or is mentioned (name
+  substring in any line text). Implemented on `dev` for 1.7.0.
+- `find_speakers_in(event_id)` — every speaker who appears in an event, with
+  dialog line counts. Implemented on `dev` for 1.7.0.
 
 **Main: building (base) skill data domain**
 - `get_operator_building_skills(name)` — base skills, efficiency, slotting.

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -64,8 +64,11 @@ Patch 版本（1.x.y）仅用于 bug 修复、文档以及不破坏兼容的体�
 ### 1.7.0 — 剧情角色追踪 + 干员深度
 
 **剧情角色追踪（无新数据源——基于现有剧情 JSON 索引化）**
-- `find_character_appearances(name, scope?)` — 该角色出现的章节 / 活动。
-- `find_speakers_in(event_id)` — 该活动中所有发言角色。
+- `find_character_appearances(name, scope?, max_events?)` — 该角色出现的章节 /
+  活动（说话：对话角色名精确匹配；被提及：名字作为子串出现在台词/旁白中）。
+  已在 dev 上为 1.7.0 实现。
+- `find_speakers_in(event_id)` — 该活动中所有发言角色及其台词数。已在 dev 上
+  为 1.7.0 实现。
 
 **主：基建技能数据域**
 - `get_operator_building_skills(name)` — 基建技能、效率、槽位。

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # PRTS-MCP 项目状态
 
-_Last updated: 2026-06-15_
+_Last updated: 2026-07-01_
 
 ## 当前版本
 
@@ -9,8 +9,8 @@ _Last updated: 2026-06-15_
 | Python | 1.6.1 | release candidate |
 | TypeScript | 1.6.1 | release candidate |
 
-- 当前发版候选：30 个 MCP 工具（1.6.1，新增干员密录发现与搜索缓存优化）
-- 当前稳定发布：29 个 MCP 工具（1.6.0）
+- 当前发版候选：32 个 MCP 工具（1.7.0 开发中，新增剧情角色追踪）
+- 当前稳定发布：30 个 MCP 工具（1.6.1）
 - 兼容性合约：1.x 期间既有工具名和必填参数不变；minor 版本允许新增工具和可选参数
 
 ## 当前分支
@@ -18,7 +18,7 @@ _Last updated: 2026-06-15_
 - `main`：1.6.1（已发布）
 - `dev`：1.7.0-dev（开发中）
 
-将 server.py/server.ts 和 story.py/story.ts 单体文件拆分为聚焦子模块，为 1.7.0 功能开发做准备。原有公开 API 通过向后兼容垫片（shim）保持不变。
+将 server.py/server.ts 和 story.py/story.ts 单体文件拆分为聚焦子模块，为 1.7.0 功能开发做准备。原有公开 API 通过向后兼容垫片（shim）保持不变。1.7.0 首个功能（剧情角色追踪：`find_character_appearances`、`find_speakers_in`）已在 dev 上落地。
 
 ## 仓库结构
 
@@ -91,7 +91,7 @@ PRTS-MCP/
 | [ArknightsStoryJson](https://github.com/3aKHP/ArknightsStoryJson) | 剧情台词 | GitHub Release `zh_CN.zip` |
 | [PRTS Wiki API](https://prts.wiki/api.php) | 世界观词条/阵营设定 | 实时 HTTP 请求 |
 
-## 工具清单 (30, current branch)
+## 工具清单 (32, current branch)
 
 | # | 工具 | 数据源 | 版本 |
 |---|------|--------|------|
@@ -125,6 +125,8 @@ PRTS-MCP/
 | 28 | `get_item_info` | GameData | 1.6.0 |
 | 29 | `search_items` | GameData | 1.6.0 |
 | 30 | `get_operator_memoirs` | StoryJson | 1.6.1 |
+| 31 | `find_character_appearances` | StoryJson | 1.7.0 |
+| 32 | `find_speakers_in` | StoryJson | 1.7.0 |
 
 ## 遗留 TODO
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Story character tracking.** Two new tools reuse the existing story search
+  index (no new data source): `find_character_appearances(name, scope?,
+  max_events?)` returns chapters where a character **speaks** (dialog role
+  exact match) or is **mentioned** (name substring in any line text);
+  `find_speakers_in(event_id)` lists every speaker in an event with dialog
+  line counts. Brings the tool surface to 32.
+
 ### Changed
 
 - **Module split: story and server god files.** `data/story.py` (916 lines) and

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -17,9 +17,12 @@ from __future__ import annotations
 from prts_mcp.data.story_reader import (
     ActivityResult,
     ChapterSummary,
+    CharacterAppearance,
+    CharacterAppearanceResult,
     EventInfo,
     MemoirChapter,
     OperatorMemoirResult,
+    SpeakerCount,
     StoryChapter,
     StoryLine,
     _clean_text,
@@ -47,6 +50,12 @@ from prts_mcp.data.story_summary import (
     get_story_summary,
     get_story_summary_from_store,
 )
+from prts_mcp.data.story_character import (
+    find_character_appearances,
+    find_character_appearances_from_store,
+    find_speakers_in,
+    find_speakers_in_from_store,
+)
 from prts_mcp.data.story_search import clear_search_cache as _clear_search_cache
 from prts_mcp.data.story_memoir import clear_chardict_cache as _clear_chardict_cache
 
@@ -66,6 +75,9 @@ __all__ = [
     "ActivityResult",
     "MemoirChapter",
     "OperatorMemoirResult",
+    "CharacterAppearance",
+    "CharacterAppearanceResult",
+    "SpeakerCount",
     # Reader
     "list_story_events",
     "list_story_events_from_store",
@@ -86,6 +98,11 @@ __all__ = [
     "get_event_summary_from_store",
     "get_story_summary",
     "get_story_summary_from_store",
+    # Character tracking
+    "find_character_appearances",
+    "find_character_appearances_from_store",
+    "find_speakers_in",
+    "find_speakers_in_from_store",
     # Cache management
     "clear_story_caches",
 ]

--- a/python/src/prts_mcp/data/story_character.py
+++ b/python/src/prts_mcp/data/story_character.py
@@ -1,0 +1,186 @@
+"""Story character tracking — who appears where, and who speaks in an event.
+
+Split from story.py. Reuses the lazily-cached search index built by
+``story_search`` (which already walks every chapter and line), so this module
+performs no file IO of its own and needs no separate cache. Two questions are
+answered:
+
+- *Where does a character show up?* — chapters/events where the character
+  **speaks** (dialog ``role`` exact match, consistent with the ``character``
+  filter of ``search_stories``) or is **mentioned** (name appears as a
+  substring in any line's text).
+- *Who speaks in an event?* — distinct speakers with their dialog line counts.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from prts_mcp.data.stores import JsonStore
+from prts_mcp.data.story_reader import (
+    CharacterAppearance,
+    CharacterAppearanceResult,
+    SpeakerCount,
+    story_store,
+)
+from prts_mcp.data.story_search import _story_search_index
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _classify_chapter(chapter, name_lower: str) -> tuple[bool, bool]:
+    """Return (speaks, mentioned) flags for one indexed chapter.
+
+    Args:
+        chapter: a ``_StorySearchChapter`` from the search index.
+        name_lower: the lowercased character name to look for.
+
+    ``speaks`` is True when any dialog line's ``role`` equals *name_lower*
+    (case-insensitive), mirroring the ``character`` filter of
+    :func:`search_stories`. ``mentioned`` is True when *name_lower* occurs as a
+    substring in any line's text.
+    """
+    speaks = False
+    mentioned = False
+    for line in chapter.lines:
+        if line.type == "dialog" and (line.role or "").lower() == name_lower:
+            speaks = True
+        if name_lower in line.text.lower():
+            mentioned = True
+    return speaks, mentioned
+
+
+# ---------------------------------------------------------------------------
+# Public API — zip-path wrappers
+# ---------------------------------------------------------------------------
+
+
+def find_character_appearances(
+    zip_path: Path,
+    name: str,
+    scope: str | None = None,
+    max_events: int = 50,
+) -> CharacterAppearanceResult:
+    """Find chapters/events where *name* speaks or is mentioned.
+
+    Convenience wrapper around :func:`find_character_appearances_from_store`
+    that auto-creates a ZipStore from *zip_path*.
+    """
+    with story_store(zip_path) as store:
+        return find_character_appearances_from_store(
+            store, name, scope=scope, max_events=max_events,
+        )
+
+
+def find_speakers_in(zip_path: Path, event_id: str) -> list[SpeakerCount]:
+    """List every speaker in an event, with dialog line counts.
+
+    Convenience wrapper around :func:`find_speakers_in_from_store`.
+    """
+    with story_store(zip_path) as store:
+        return find_speakers_in_from_store(store, event_id)
+
+
+# ---------------------------------------------------------------------------
+# Public API — store-based variants
+# ---------------------------------------------------------------------------
+
+
+def find_character_appearances_from_store(
+    store: JsonStore,
+    name: str,
+    scope: str | None = None,
+    max_events: int = 50,
+) -> CharacterAppearanceResult:
+    """Find chapters/events where *name* speaks or is mentioned.
+
+    Args:
+        store: JsonStore (ZipStore or DirectoryStore) for story data.
+        name: Character name (e.g. 「阿米娅」). ``speaks`` uses case-insensitive
+            exact match on dialog ``role``; ``mentioned`` uses substring match
+            on any line's text. Use the full name to avoid substring false
+            positives (e.g. 「阿」 matches 「阿米娅」).
+        scope: Optional event_id filter (e.g. "act31side").
+        max_events: Cap on returned chapters (default 50, max 200).
+
+    Returns:
+        Aggregated appearance report ordered by the index's chapter order.
+    """
+    if not name:
+        raise ValueError("name 不能为空。")
+    if max_events < 1:
+        raise ValueError("max_events 必须 >= 1。")
+    if max_events > 200:
+        raise ValueError("max_events 必须 <= 200。")
+
+    index = _story_search_index(store)
+
+    if scope is not None and scope not in index.event_ids:
+        raise KeyError(f"未找到匹配的活动：{scope!r}。")
+
+    name_lower = name.lower()
+    appearances: list[CharacterAppearance] = []
+
+    for chapter in index.chapters:
+        if scope is not None and chapter.event_id != scope:
+            continue
+        speaks, mentioned = _classify_chapter(chapter, name_lower)
+        if not speaks and not mentioned:
+            continue
+        appearances.append(CharacterAppearance(
+            event_id=chapter.event_id,
+            story_key=chapter.story_key,
+            story_code=chapter.story_code,
+            story_name=chapter.story_name,
+            speaks=speaks,
+            mentioned=mentioned,
+        ))
+        if len(appearances) >= max_events:
+            break
+
+    return CharacterAppearanceResult(
+        name=name,
+        total_chapters=len(appearances),
+        appearances=appearances,
+    )
+
+
+def find_speakers_in_from_store(
+    store: JsonStore,
+    event_id: str,
+) -> list[SpeakerCount]:
+    """List every speaker in an event, with dialog line counts.
+
+    Iterates the cached search index, collecting distinct dialog ``role``
+    values (dropping ``None``/empty — those are narration placeholders) and
+    counting their lines. Results are sorted by line count descending, then by
+    name for a stable order.
+
+    Args:
+        store: JsonStore (ZipStore or DirectoryStore) for story data.
+        event_id: Event to restrict the scan to (e.g. "act31side").
+
+    Returns:
+        Speakers with their dialog line counts, most prolific first.
+    """
+    index = _story_search_index(store)
+
+    if event_id not in index.event_ids:
+        raise KeyError(f"未找到匹配的活动：{event_id!r}。")
+
+    counts: dict[str, int] = {}
+    for chapter in index.chapters:
+        if chapter.event_id != event_id:
+            continue
+        for line in chapter.lines:
+            if line.type == "dialog" and line.role:
+                counts[line.role] = counts.get(line.role, 0) + 1
+
+    speakers = [
+        SpeakerCount(name=name, line_count=count)
+        for name, count in counts.items()
+    ]
+    speakers.sort(key=lambda s: (-s.line_count, s.name))
+    return speakers

--- a/python/src/prts_mcp/data/story_character.py
+++ b/python/src/prts_mcp/data/story_character.py
@@ -22,7 +22,7 @@ from prts_mcp.data.story_reader import (
     SpeakerCount,
     story_store,
 )
-from prts_mcp.data.story_search import _story_search_index
+from prts_mcp.data.story_search import story_search_index, StorySearchChapter
 
 
 # ---------------------------------------------------------------------------
@@ -30,11 +30,11 @@ from prts_mcp.data.story_search import _story_search_index
 # ---------------------------------------------------------------------------
 
 
-def _classify_chapter(chapter, name_lower: str) -> tuple[bool, bool]:
+def _classify_chapter(chapter: StorySearchChapter, name_lower: str) -> tuple[bool, bool]:
     """Return (speaks, mentioned) flags for one indexed chapter.
 
     Args:
-        chapter: a ``_StorySearchChapter`` from the search index.
+        chapter: a ``StorySearchChapter`` from the search index.
         name_lower: the lowercased character name to look for.
 
     ``speaks`` is True when any dialog line's ``role`` equals *name_lower*
@@ -49,6 +49,8 @@ def _classify_chapter(chapter, name_lower: str) -> tuple[bool, bool]:
             speaks = True
         if name_lower in line.text.lower():
             mentioned = True
+        if speaks and mentioned:
+            break
     return speaks, mentioned
 
 
@@ -115,7 +117,7 @@ def find_character_appearances_from_store(
     if max_events > 200:
         raise ValueError("max_events 必须 <= 200。")
 
-    index = _story_search_index(store)
+    index = story_search_index(store)
 
     if scope is not None and scope not in index.event_ids:
         raise KeyError(f"未找到匹配的活动：{scope!r}。")
@@ -165,7 +167,7 @@ def find_speakers_in_from_store(
     Returns:
         Speakers with their dialog line counts, most prolific first.
     """
-    index = _story_search_index(store)
+    index = story_search_index(store)
 
     if event_id not in index.event_ids:
         raise KeyError(f"未找到匹配的活动：{event_id!r}。")

--- a/python/src/prts_mcp/data/story_reader.py
+++ b/python/src/prts_mcp/data/story_reader.py
@@ -130,6 +130,32 @@ class OperatorMemoirResult:
     chapters: list[MemoirChapter]
 
 
+@dataclass(frozen=True)
+class CharacterAppearance:
+    """A single chapter where a character speaks or is mentioned."""
+    event_id: str
+    story_key: str
+    story_code: str
+    story_name: str
+    speaks: bool
+    mentioned: bool
+
+
+@dataclass(frozen=True)
+class CharacterAppearanceResult:
+    """Aggregated appearance report for find_character_appearances."""
+    name: str
+    total_chapters: int
+    appearances: list[CharacterAppearance]
+
+
+@dataclass(frozen=True)
+class SpeakerCount:
+    """A speaker and how many dialog lines they have (within one event)."""
+    name: str
+    line_count: int
+
+
 # ---------------------------------------------------------------------------
 # Store helpers
 # ---------------------------------------------------------------------------

--- a/python/src/prts_mcp/data/story_search.py
+++ b/python/src/prts_mcp/data/story_search.py
@@ -30,7 +30,9 @@ from prts_mcp.data.story_reader import (
 @dataclass(frozen=True)
 class _StorySearchChapter:
     event_id: str
+    story_key: str
     story_code: str
+    story_name: str
     lines: tuple[StoryLine, ...]
 
 
@@ -277,7 +279,9 @@ def _build_story_search_index(store: JsonStore) -> _StorySearchIndex:
             chapter_index = len(chapters)
             indexed_chapter = _StorySearchChapter(
                 event_id=ev_id,
+                story_key=d.get("storyTxt", ""),
                 story_code=d.get("storyCode", ""),
+                story_name=d.get("storyName", ""),
                 lines=tuple(chapter.lines),
             )
             chapters.append(indexed_chapter)

--- a/python/src/prts_mcp/data/story_search.py
+++ b/python/src/prts_mcp/data/story_search.py
@@ -28,7 +28,7 @@ from prts_mcp.data.story_reader import (
 
 
 @dataclass(frozen=True)
-class _StorySearchChapter:
+class StorySearchChapter:
     event_id: str
     story_key: str
     story_code: str
@@ -46,7 +46,7 @@ class _StorySearchRecord:
 @dataclass(frozen=True)
 class _StorySearchIndex:
     event_ids: frozenset[str]
-    chapters: tuple[_StorySearchChapter, ...]
+    chapters: tuple[StorySearchChapter, ...]
     records: tuple[_StorySearchRecord, ...]
 
 
@@ -145,7 +145,7 @@ def search_stories_from_store(
         return f"无效的 line_type：{line_type!r}，可选值：{', '.join(sorted(_VALID_LINE_TYPES))}"
 
     try:
-        index = _story_search_index(store)
+        index = story_search_index(store)
     except Exception as exc:
         return f"读取剧情数据索引失败：{exc}"
 
@@ -211,7 +211,12 @@ def search_stories_from_store(
 # ---------------------------------------------------------------------------
 
 
-def _story_search_index(store: JsonStore) -> _StorySearchIndex:
+def story_search_index(store: JsonStore) -> _StorySearchIndex:
+    """Return the cached story search index, building it on first access.
+
+    Public so sibling story modules (e.g. story_character) can reuse the same
+    lazily-cached index without re-walking the store.
+    """
     descriptor = _story_store_descriptor(store)
     if descriptor is None:
         return _build_story_search_index(store)
@@ -254,7 +259,7 @@ def _cached_story_search_index(
 def _build_story_search_index(store: JsonStore) -> _StorySearchIndex:
     table: dict = load_json(store, STORY_REVIEW_TABLE)  # type: ignore[assignment]
     event_ids: set[str] = set()
-    chapters: list[_StorySearchChapter] = []
+    chapters: list[StorySearchChapter] = []
     records: list[_StorySearchRecord] = []
 
     for ev_id, entry in table.items():
@@ -277,7 +282,7 @@ def _build_story_search_index(store: JsonStore) -> _StorySearchIndex:
             except (KeyError, FileNotFoundError, json.JSONDecodeError):
                 continue
             chapter_index = len(chapters)
-            indexed_chapter = _StorySearchChapter(
+            indexed_chapter = StorySearchChapter(
                 event_id=ev_id,
                 story_key=d.get("storyTxt", ""),
                 story_code=d.get("storyCode", ""),

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -1,6 +1,6 @@
-"""Story tool registrations — events, chapters, dialogue, summaries, search, memoirs.
+"""Story tool registrations — events, chapters, dialogue, summaries, search, memoirs, characters.
 
-Split from server.py. Covers 8 tools that read story data from the
+Split from server.py. Covers 10 tools that read story data from the
 synced zh_CN.zip via the story submodules.
 """
 from __future__ import annotations
@@ -19,12 +19,14 @@ from prts_mcp.data.story import (
     get_event_summary as _get_event_summary,
     get_story_summary as _get_story_summary,
     get_operator_memoirs as _get_operator_memoirs,
+    find_character_appearances as _find_character_appearances,
+    find_speakers_in as _find_speakers_in,
 )
 from prts_mcp.startup_sync import _require_story_zip
 
 
 def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
-    """Register the 8 story-backed tools on the given FastMCP instance."""
+    """Register the 10 story-backed tools on the given FastMCP instance."""
 
     @mcp.tool()
     def list_story_events(
@@ -316,3 +318,84 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         for ch in result.chapters:
             lines.append(f"- {ch.story_code} {ch.story_name}（key: {ch.story_key}）")
         return "\n".join(lines)
+
+    @mcp.tool()
+    def find_character_appearances(
+        name: Annotated[str, Field(description="角色名（干员中文名或「博士」）。speaks 按对话角色名精确匹配，mentioned 按名字在台词/旁白文本中的子串匹配——请使用完整名字以免误报（如「阿」会命中「阿米娅」）。")],
+        scope: Annotated[str | None, Field(default=None, description="限定活动 ID，如「act31side」。不填则检索全部活动。")] = None,
+        max_events: Annotated[int, Field(default=50, ge=1, le=200, description="最多返回章节数，默认 50。")] = 50,
+    ) -> str:
+        """查找某个角色在剧情中的出场（说话或被提及）。
+
+        返回该角色「说话」（speaks，作为对话发言者）或「被提及」（mentioned，
+        名字出现在任意台词/旁白文本中）的所有章节，每章标注 speaks / mentioned /
+        两者皆有。适合快速定位一个角色的剧情登场分布。如需精确台词，可用返回的
+        story_key 调用 read_story。
+        """
+        from prts_mcp.config import Config
+        cfg = Config.load()
+        try:
+            zip_path = _require_story_zip(cfg)
+        except RuntimeError as e:
+            return str(e)
+
+        try:
+            result = _find_character_appearances(
+                zip_path, name, scope=scope, max_events=max_events,
+            )
+        except ValueError as e:
+            return str(e)
+        except KeyError as e:
+            return str(e)
+        except Exception as e:
+            return f"查询角色出场失败：{e}"
+
+        if not result.appearances:
+            scope_note = f"（限定活动：{scope!r}）" if scope else ""
+            return f"未找到「{name}」的出场记录。{scope_note}"
+
+        parts = [f"# 「{result.name}」的出场（共 {result.total_chapters} 章）"]
+        for ap in result.appearances:
+            tags = []
+            if ap.speaks:
+                tags.append("speaks")
+            if ap.mentioned:
+                tags.append("mentioned")
+            tag = "+".join(tags)
+            name_disp = f"{ap.story_code} {ap.story_name}".strip()
+            parts.append(
+                f"- [{tag}] {ap.event_id} / {name_disp}（key: {ap.story_key}）"
+            )
+        return "\n".join(parts)
+
+    @mcp.tool()
+    def find_speakers_in(
+        event_id: Annotated[str, Field(description="活动 ID，如 \"act31side\"（可从 list_story_events 获取）。")],
+    ) -> str:
+        """列出某活动中的所有发言角色及其台词数。
+
+        返回该活动所有章节中去重后的对话发言者，按台词句数降序排列。适合了解
+        一个活动的角色戏份分布。如需读取某角色说的具体内容，可结合
+        search_stories(character=...) 过滤。
+        """
+        from prts_mcp.config import Config
+        cfg = Config.load()
+        try:
+            zip_path = _require_story_zip(cfg)
+        except RuntimeError as e:
+            return str(e)
+
+        try:
+            speakers = _find_speakers_in(zip_path, event_id)
+        except KeyError as e:
+            return str(e)
+        except Exception as e:
+            return f"查询发言角色失败：{e}"
+
+        if not speakers:
+            return f"活动 {event_id!r} 暂无对话发言者数据。"
+
+        parts = [f"# {event_id} 的发言角色（共 {len(speakers)} 位）"]
+        for sp in speakers:
+            parts.append(f"- {sp.name}（{sp.line_count} 句）")
+        return "\n".join(parts)

--- a/python/tests/test_e2e.py
+++ b/python/tests/test_e2e.py
@@ -150,6 +150,7 @@ EXPECTED_TOOLS = {
     "list_search_scopes", "search_data", "search_stories",
     "get_event_summary", "get_story_summary",
     "get_operator_memoirs",
+    "find_character_appearances", "find_speakers_in",
 }
 
 
@@ -180,7 +181,7 @@ def test_tools_list(server: subprocess.Popen) -> None:
     tools = resp["result"]["tools"]
     names = {t["name"] for t in tools}
 
-    assert len(names) == 30, f"Expected 30 tools, got {len(names)}: {sorted(names)}"
+    assert len(names) == 32, f"Expected 32 tools, got {len(names)}: {sorted(names)}"
     for name in EXPECTED_TOOLS:
         assert name in names, f"Missing tool: {name}"
 

--- a/python/tests/test_story_character.py
+++ b/python/tests/test_story_character.py
@@ -225,3 +225,74 @@ class TestFindSpeakersIn:
         store = _story_store("directory", tmp_path)
         with pytest.raises(KeyError):
             find_speakers_in_from_store(store, "no_such_event")
+
+
+# ---------------------------------------------------------------------------
+# Edge case: event exists but has no dialog (narration only)
+# ---------------------------------------------------------------------------
+
+
+NARRATION_ONLY_KEY = "activities/act_narration/level_narration_01"
+
+
+def _narration_only_files() -> dict[str, object]:
+    return {
+        STORY_REVIEW_PATH: {
+            "act_narration": {
+                "name": "纯旁白活动",
+                "entryType": "ACTIVITY",
+                "infoUnlockDatas": [
+                    {
+                        "storyTxt": NARRATION_ONLY_KEY,
+                        "storyCode": "NAR-1",
+                        "storyName": "旁白章",
+                        "avgTag": None,
+                        "storySort": 1,
+                    },
+                ],
+            },
+        },
+        _story_path(NARRATION_ONLY_KEY): {
+            "storyCode": "NAR-1",
+            "storyName": "旁白章",
+            "avgTag": None,
+            "eventName": "纯旁白活动",
+            "storyInfo": "",
+            "storyList": [
+                {"prop": "sticker", "attributes": {"content": "只有旁白文本。"}},
+            ],
+        },
+    }
+
+
+def _narration_only_store(kind: str, tmp_path: Path) -> DirectoryStore | ZipStore:
+    files = _narration_only_files()
+    if kind == "directory":
+        for path, data in files.items():
+            target = tmp_path / path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+        return DirectoryStore(tmp_path)
+    else:
+        zip_path = tmp_path / "zh_CN.zip"
+        zip_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(zip_path, "w") as zf:
+            for inner_path, data in files.items():
+                zf.writestr(inner_path, json.dumps(data, ensure_ascii=False))
+        return ZipStore(zip_path)
+
+
+class TestNarrationOnlyEvent:
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_speakers_empty(self, tmp_path: Path, store_kind: str) -> None:
+        # Event exists in the index but has zero dialog lines → empty speakers.
+        store = _narration_only_store(store_kind, tmp_path)
+        speakers = find_speakers_in_from_store(store, "act_narration")
+        assert speakers == []
+
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_character_no_match(self, tmp_path: Path, store_kind: str) -> None:
+        # The narration text mentions no real speaker name; any lookup is empty.
+        store = _narration_only_store(store_kind, tmp_path)
+        result = find_character_appearances_from_store(store, "博士")
+        assert result.total_chapters == 0

--- a/python/tests/test_story_character.py
+++ b/python/tests/test_story_character.py
@@ -1,0 +1,227 @@
+"""Tests for story character tracking — find_character_appearances and find_speakers_in.
+
+Mirrors the synthetic-fixture pattern of test_search.py: a tiny ``act_test``
+event with two chapters is written to a directory or zip store, and the
+store-based variants are exercised directly. No real zh_CN.zip is required.
+
+Fixture dialogue (the source of truth for the assertions below):
+  ch1 (TEST-1 开端):
+    - 阿米娅：你好，博士。        ← 阿米娅 speaks; "博士" in text
+    - *罗德岛走廊*               ← narration, no names
+    - 博士：我们出发吧。          ← 博士 speaks; no names in text
+  ch2 (TEST-2 终章):
+    - 博士：任务完成。阿米娅干得不错。  ← 博士 speaks; "阿米娅" in text
+"""
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from prts_mcp.data.stores import DirectoryStore, ZipStore
+from prts_mcp.data.story_character import (
+    find_character_appearances_from_store,
+    find_speakers_in_from_store,
+)
+
+
+# ---------------------------------------------------------------------------
+# Story test data (same shape as test_search.py)
+# ---------------------------------------------------------------------------
+
+STORY_REVIEW_PATH = "zh_CN/gamedata/excel/story_review_table.json"
+FIRST_STORY_KEY = "activities/act_test/level_act_test_01_beg"
+SECOND_STORY_KEY = "activities/act_test/level_act_test_02_end"
+
+
+def _story_path(story_key: str) -> str:
+    return f"zh_CN/gamedata/story/{story_key}.json"
+
+
+def _story_files() -> dict[str, object]:
+    return {
+        STORY_REVIEW_PATH: {
+            "act_test": {
+                "name": "测试活动",
+                "entryType": "ACTIVITY",
+                "infoUnlockDatas": [
+                    {
+                        "storyTxt": FIRST_STORY_KEY,
+                        "storyCode": "TEST-1",
+                        "storyName": "开端",
+                        "avgTag": "BEG",
+                        "storySort": 1,
+                    },
+                    {
+                        "storyTxt": SECOND_STORY_KEY,
+                        "storyCode": "TEST-2",
+                        "storyName": "终章",
+                        "avgTag": "END",
+                        "storySort": 2,
+                    },
+                ],
+            },
+        },
+        _story_path(FIRST_STORY_KEY): {
+            "storyCode": "TEST-1",
+            "storyName": "开端",
+            "avgTag": "BEG",
+            "eventName": "测试活动",
+            "storyInfo": "测试简介",
+            "storyList": [
+                {"prop": "name", "attributes": {"name": "阿米娅", "content": "你好，博士。"}},
+                {"prop": "sticker", "attributes": {"content": "罗德岛走廊"}},
+                {"prop": "name", "attributes": {"name": "博士", "content": "我们出发吧。"}},
+            ],
+        },
+        _story_path(SECOND_STORY_KEY): {
+            "storyCode": "TEST-2",
+            "storyName": "终章",
+            "avgTag": "END",
+            "eventName": "测试活动",
+            "storyInfo": "",
+            "storyList": [
+                {"prop": "name", "attributes": {"name": "博士", "content": "任务完成。阿米娅干得不错。"}},
+            ],
+        },
+    }
+
+
+def _write_story_dir(root: Path) -> None:
+    for path, data in _story_files().items():
+        target = root / path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+
+def _write_story_zip(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path, "w") as zf:
+        for inner_path, data in _story_files().items():
+            zf.writestr(inner_path, json.dumps(data, ensure_ascii=False))
+
+
+def _story_store(kind: str, tmp_path: Path) -> DirectoryStore | ZipStore:
+    if kind == "directory":
+        _write_story_dir(tmp_path)
+        return DirectoryStore(tmp_path)
+    else:
+        zip_path = tmp_path / "zh_CN.zip"
+        _write_story_zip(zip_path)
+        return ZipStore(zip_path)
+
+
+# ---------------------------------------------------------------------------
+# find_character_appearances
+# ---------------------------------------------------------------------------
+
+
+class TestFindCharacterAppearances:
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_doctor_speaks_both_mentioned_in_one(self, tmp_path: Path, store_kind: str) -> None:
+        # 博士: speaks in both chapters; mentioned only in ch1 (阿米娅's line contains 博士).
+        store = _story_store(store_kind, tmp_path)
+        result = find_character_appearances_from_store(store, "博士")
+
+        assert result.name == "博士"
+        assert result.total_chapters == 2
+        ch1, ch2 = result.appearances
+        assert ch1.story_key == FIRST_STORY_KEY
+        assert ch1.speaks is True
+        assert ch1.mentioned is True   # "博士" appears in 阿米娅's ch1 text
+        assert ch2.story_key == SECOND_STORY_KEY
+        assert ch2.speaks is True
+        assert ch2.mentioned is False  # 博士 not in ch2 text ("任务完成。阿米娅干得不错。")
+
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_amiya_speaks_one_mentioned_other(self, tmp_path: Path, store_kind: str) -> None:
+        # 阿米娅: speaks in ch1; mentioned only in ch2 (博士's line contains 阿米娅).
+        store = _story_store(store_kind, tmp_path)
+        result = find_character_appearances_from_store(store, "阿米娅")
+
+        assert result.total_chapters == 2
+        ch1, ch2 = result.appearances
+        assert ch1.speaks is True
+        assert ch1.mentioned is False  # 阿米娅 not in ch1 text
+        assert ch2.speaks is False
+        assert ch2.mentioned is True   # "阿米娅" in ch2 text
+
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_scope_filter(self, tmp_path: Path, store_kind: str) -> None:
+        store = _story_store(store_kind, tmp_path)
+        result = find_character_appearances_from_store(store, "博士", scope="act_test")
+        assert result.total_chapters == 2
+
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_scope_unknown_event_raises(self, tmp_path: Path, store_kind: str) -> None:
+        store = _story_store(store_kind, tmp_path)
+        with pytest.raises(KeyError):
+            find_character_appearances_from_store(store, "博士", scope="no_such_event")
+
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_no_match_returns_empty(self, tmp_path: Path, store_kind: str) -> None:
+        store = _story_store(store_kind, tmp_path)
+        result = find_character_appearances_from_store(store, "不存在的角色")
+        assert result.total_chapters == 0
+        assert result.appearances == []
+
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_substring_false_positive(self, tmp_path: Path, store_kind: str) -> None:
+        # Documented behavior: mentioned uses substring match on line text only
+        # (role matching is exact). "阿" is not in any ch1 text, but is a
+        # substring of "阿米娅" in ch2's text → only ch2 is mentioned.
+        store = _story_store(store_kind, tmp_path)
+        result = find_character_appearances_from_store(store, "阿")
+        assert result.total_chapters == 1
+        assert result.appearances[0].story_key == SECOND_STORY_KEY
+        assert result.appearances[0].speaks is False
+        assert result.appearances[0].mentioned is True
+
+    def test_empty_name_raises(self, tmp_path: Path) -> None:
+        store = _story_store("directory", tmp_path)
+        with pytest.raises(ValueError):
+            find_character_appearances_from_store(store, "")
+
+    def test_max_events_bounds(self, tmp_path: Path) -> None:
+        store = _story_store("directory", tmp_path)
+        with pytest.raises(ValueError):
+            find_character_appearances_from_store(store, "博士", max_events=0)
+        with pytest.raises(ValueError):
+            find_character_appearances_from_store(store, "博士", max_events=201)
+
+    def test_max_events_cap(self, tmp_path: Path) -> None:
+        store = _story_store("directory", tmp_path)
+        result = find_character_appearances_from_store(store, "博士", max_events=1)
+        assert result.total_chapters == 1
+
+
+# ---------------------------------------------------------------------------
+# find_speakers_in
+# ---------------------------------------------------------------------------
+
+
+class TestFindSpeakersIn:
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_speakers_with_counts(self, tmp_path: Path, store_kind: str) -> None:
+        # 阿米娅 speaks once (ch1), 博士 speaks twice (ch1 + ch2).
+        store = _story_store(store_kind, tmp_path)
+        speakers = find_speakers_in_from_store(store, "act_test")
+
+        by_name = {s.name: s.line_count for s in speakers}
+        assert by_name == {"博士": 2, "阿米娅": 1}
+
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_sorted_by_count_desc(self, tmp_path: Path, store_kind: str) -> None:
+        store = _story_store(store_kind, tmp_path)
+        speakers = find_speakers_in_from_store(store, "act_test")
+        counts = [s.line_count for s in speakers]
+        assert counts == sorted(counts, reverse=True)
+        # 博士 (2) ranks above 阿米娅 (1).
+        assert speakers[0].name == "博士"
+
+    def test_unknown_event_raises(self, tmp_path: Path) -> None:
+        store = _story_store("directory", tmp_path)
+        with pytest.raises(KeyError):
+            find_speakers_in_from_store(store, "no_such_event")

--- a/python/tests/test_tool_surface.py
+++ b/python/tests/test_tool_surface.py
@@ -35,6 +35,8 @@ EXPECTED_TOOL_SURFACE = {
     "search_data": ("pattern", "scope", "max_results"),
     "search_stories": ("pattern", "character", "line_type", "context_lines", "max_results", "event_id"),
     "get_operator_memoirs": ("operator_name",),
+    "find_character_appearances": ("name", "scope", "max_events"),
+    "find_speakers_in": ("event_id",),
 }
 
 

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Story character tracking.** Two new tools reuse the existing story search
+  index (no new data source): `find_character_appearances(name, scope?,
+  max_events?)` returns chapters where a character **speaks** (dialog role
+  exact match) or is **mentioned** (name substring in any line text);
+  `find_speakers_in(event_id)` lists every speaker in an event with dialog
+  line counts. Brings the tool surface to 32.
+
 ### Changed
 
 - **Module split: story and server god files.** `data/story.ts` (907 lines) and

--- a/ts/src/data/story.ts
+++ b/ts/src/data/story.ts
@@ -24,6 +24,9 @@ export type {
   ActivityResult,
   MemoirChapter,
   OperatorMemoirResult,
+  CharacterAppearance,
+  CharacterAppearanceResult,
+  SpeakerCount,
 } from "./storyReader.js";
 
 // Public reader functions from storyReader
@@ -57,6 +60,14 @@ export {
   getStorySummary,
   getStorySummaryFromStore,
 } from "./storySummary.js";
+
+// Character tracking
+export {
+  findCharacterAppearances,
+  findCharacterAppearancesFromStore,
+  findSpeakersIn,
+  findSpeakersInFromStore,
+} from "./storyCharacter.js";
 
 // Cache management
 import { clearSearchCache } from "./storySearch.js";

--- a/ts/src/data/storyCharacter.ts
+++ b/ts/src/data/storyCharacter.ts
@@ -1,0 +1,151 @@
+/**
+ * Story character tracking — who appears where, and who speaks in an event.
+ *
+ * Split from story.ts. Reuses the lazily-cached search index built by
+ * storySearch (which already walks every chapter and line), so this module
+ * performs no file IO of its own and needs no separate cache. Two questions
+ * are answered:
+ *
+ * - *Where does a character show up?* — chapters/events where the character
+ *   **speaks** (dialog `role` exact match, consistent with the `character`
+ *   filter of searchStories) or is **mentioned** (name appears as a substring
+ *   in any line's text).
+ * - *Who speaks in an event?* — distinct speakers with their dialog line
+ *   counts.
+ *
+ * Mirrors python/src/prts_mcp/data/story_character.py.
+ */
+
+import { type JsonStore } from "./stores.js";
+import {
+  type CharacterAppearance,
+  type CharacterAppearanceResult,
+  type SpeakerCount,
+  withStoryStore,
+} from "./storyReader.js";
+import { storySearchIndex, type StorySearchChapter } from "./storySearch.js";
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return [speaks, mentioned] flags for one indexed chapter.
+ *
+ * `speaks` is true when any dialog line's `role` equals nameLower
+ * (case-insensitive), mirroring the `character` filter of searchStories.
+ * `mentioned` is true when nameLower occurs as a substring in any line's text.
+ */
+function classifyChapter(
+  chapter: StorySearchChapter,
+  nameLower: string,
+): [boolean, boolean] {
+  let speaks = false;
+  let mentioned = false;
+  for (const line of chapter.lines) {
+    if (line.type === "dialog" && (line.role ?? "").toLowerCase() === nameLower) {
+      speaks = true;
+    }
+    if (line.text.toLowerCase().includes(nameLower)) {
+      mentioned = true;
+    }
+  }
+  return [speaks, mentioned];
+}
+
+// ---------------------------------------------------------------------------
+// Public API — zip-path wrappers
+// ---------------------------------------------------------------------------
+
+export function findCharacterAppearances(
+  zipPath: string,
+  name: string,
+  scope?: string,
+  maxEvents = 50,
+): CharacterAppearanceResult {
+  return withStoryStore(zipPath, (store) =>
+    findCharacterAppearancesFromStore(store, name, scope, maxEvents),
+  );
+}
+
+export function findSpeakersIn(
+  zipPath: string,
+  eventId: string,
+): SpeakerCount[] {
+  return withStoryStore(zipPath, (store) =>
+    findSpeakersInFromStore(store, eventId),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Public API — store-based variants
+// ---------------------------------------------------------------------------
+
+export function findCharacterAppearancesFromStore(
+  store: JsonStore,
+  name: string,
+  scope?: string,
+  maxEvents = 50,
+): CharacterAppearanceResult {
+  if (!name) throw new Error("name 不能为空。");
+  if (maxEvents < 1) throw new Error("max_events 必须 >= 1。");
+  if (maxEvents > 200) throw new Error("max_events 必须 <= 200。");
+
+  const index = storySearchIndex(store);
+
+  if (scope !== undefined && !index.eventIds.has(scope)) {
+    throw new Error(`未找到匹配的活动：${JSON.stringify(scope)}。`);
+  }
+
+  const nameLower = name.toLowerCase();
+  const appearances: CharacterAppearance[] = [];
+
+  for (const chapter of index.chapters) {
+    if (scope !== undefined && chapter.eventId !== scope) continue;
+    const [speaks, mentioned] = classifyChapter(chapter, nameLower);
+    if (!speaks && !mentioned) continue;
+    appearances.push({
+      eventId: chapter.eventId,
+      storyKey: chapter.storyKey,
+      storyCode: chapter.storyCode,
+      storyName: chapter.storyName,
+      speaks,
+      mentioned,
+    });
+    if (appearances.length >= maxEvents) break;
+  }
+
+  return {
+    name,
+    totalChapters: appearances.length,
+    appearances,
+  };
+}
+
+export function findSpeakersInFromStore(
+  store: JsonStore,
+  eventId: string,
+): SpeakerCount[] {
+  const index = storySearchIndex(store);
+
+  if (!index.eventIds.has(eventId)) {
+    throw new Error(`未找到匹配的活动：${JSON.stringify(eventId)}。`);
+  }
+
+  const counts = new Map<string, number>();
+  for (const chapter of index.chapters) {
+    if (chapter.eventId !== eventId) continue;
+    for (const line of chapter.lines) {
+      if (line.type === "dialog" && line.role) {
+        counts.set(line.role, (counts.get(line.role) ?? 0) + 1);
+      }
+    }
+  }
+
+  const speakers: SpeakerCount[] = [];
+  for (const [speakerName, lineCount] of counts) {
+    speakers.push({ name: speakerName, lineCount });
+  }
+  speakers.sort((a, b) => b.lineCount - a.lineCount || a.name.localeCompare(b.name));
+  return speakers;
+}

--- a/ts/src/data/storyCharacter.ts
+++ b/ts/src/data/storyCharacter.ts
@@ -146,6 +146,8 @@ export function findSpeakersInFromStore(
   for (const [speakerName, lineCount] of counts) {
     speakers.push({ name: speakerName, lineCount });
   }
-  speakers.sort((a, b) => b.lineCount - a.lineCount || a.name.localeCompare(b.name));
+  // Sort by line count desc, then by name using codepoint ordering to match
+  // the Python implementation's `(-line_count, name)` tuple sort.
+  speakers.sort((a, b) => b.lineCount - a.lineCount || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
   return speakers;
 }

--- a/ts/src/data/storyReader.ts
+++ b/ts/src/data/storyReader.ts
@@ -138,6 +138,29 @@ export interface OperatorMemoirResult {
   chapters: MemoirChapter[];
 }
 
+export interface CharacterAppearance {
+  /** A single chapter where a character speaks or is mentioned. */
+  eventId: string;
+  storyKey: string;
+  storyCode: string;
+  storyName: string;
+  speaks: boolean;
+  mentioned: boolean;
+}
+
+export interface CharacterAppearanceResult {
+  /** Aggregated appearance report for findCharacterAppearances. */
+  name: string;
+  totalChapters: number;
+  appearances: CharacterAppearance[];
+}
+
+export interface SpeakerCount {
+  /** A speaker and how many dialog lines they have (within one event). */
+  name: string;
+  lineCount: number;
+}
+
 // ---------------------------------------------------------------------------
 // Store helpers
 // ---------------------------------------------------------------------------

--- a/ts/src/data/storySearch.ts
+++ b/ts/src/data/storySearch.ts
@@ -24,9 +24,11 @@ import {
 // Internal types
 // ---------------------------------------------------------------------------
 
-interface StorySearchChapter {
+export interface StorySearchChapter {
   eventId: string;
+  storyKey: string;
   storyCode: string;
+  storyName: string;
   lines: StoryLine[];
 }
 
@@ -36,7 +38,7 @@ interface StorySearchRecord {
   line: StoryLine;
 }
 
-interface StorySearchIndex {
+export interface StorySearchIndex {
   eventIds: Set<string>;
   chapters: StorySearchChapter[];
   records: StorySearchRecord[];
@@ -197,7 +199,7 @@ export function searchStoriesFromStore(
 // Index building + caching
 // ---------------------------------------------------------------------------
 
-function storySearchIndex(store: JsonStore): StorySearchIndex {
+export function storySearchIndex(store: JsonStore): StorySearchIndex {
   const descriptor = storyStoreDescriptor(store);
   if (descriptor !== null && storySearchCache?.descriptor === descriptor) {
     return storySearchCache.index;
@@ -250,7 +252,9 @@ function buildStorySearchIndex(store: JsonStore): StorySearchIndex {
       const chapterIndex = chapters.length;
       chapters.push({
         eventId: evId,
+        storyKey: d.storyTxt ?? "",
         storyCode: d.storyCode ?? "",
+        storyName: d.storyName ?? "",
         lines: chapter.lines,
       });
       for (let i = 0; i < chapter.lines.length; i++) {

--- a/ts/src/tools/storyTools.ts
+++ b/ts/src/tools/storyTools.ts
@@ -410,7 +410,7 @@ export function registerStoryTools(server: McpServer): void {
       "每章标注 speaks / mentioned / 两者皆有。如需精确台词，可用返回的 story_key 调用 read_story。",
     ].join(" "),
     {
-      name: z.string().describe("角色名（干员中文名或「博士」）。speaks 按对话角色名精确匹配，mentioned 按名字在台词/旁白文本中的子串匹配——请使用完整名字以免误报。"),
+      name: z.string().describe("角色名（干员中文名或「博士」）。speaks 按对话角色名精确匹配，mentioned 按名字在台词/旁白文本中的子串匹配——请使用完整名字以免误报（如「阿」会命中「阿米娅」）。"),
       scope: z.string().optional().describe("限定活动 ID，如「act31side」。不填则检索全部活动。"),
       max_events: z.number().int().min(1).max(200).default(50).describe("最多返回章节数，默认 50。"),
     },
@@ -439,7 +439,10 @@ export function registerStoryTools(server: McpServer): void {
         return { content: [{ type: "text", text: parts.join("\n") }] };
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
-        return { content: [{ type: "text", text: msg.includes("未找到") ? msg : `查询角色出场失败：${msg}` }] };
+        // Validation errors (不能为空 / 必须) and not-found (未找到) are
+        // user-facing messages returned bare; only unexpected errors get a prefix.
+        const isUserFacing = msg.includes("未找到") || msg.includes("不能为空") || msg.includes("必须");
+        return { content: [{ type: "text", text: isUserFacing ? msg : `查询角色出场失败：${msg}` }] };
       }
     }
   );

--- a/ts/src/tools/storyTools.ts
+++ b/ts/src/tools/storyTools.ts
@@ -1,7 +1,7 @@
 /**
- * Story tool registrations — events, chapters, dialogue, summaries, search, memoirs.
+ * Story tool registrations — events, chapters, dialogue, summaries, search, memoirs, characters.
  *
- * Split from server.ts. Exports registerStoryTools which attaches the 8
+ * Split from server.ts. Exports registerStoryTools which attaches the 10
  * story-backed tools to a McpServer instance. Also exports the shared
  * requireStoryZip helper and line/chapter formatters.
  */
@@ -19,6 +19,8 @@ import {
   getEventSummary as _getEventSummary,
   getStorySummary as _getStorySummary,
   getOperatorMemoirs as _getOperatorMemoirs,
+  findCharacterAppearances as _findCharacterAppearances,
+  findSpeakersIn as _findSpeakersIn,
   type StoryChapter,
   type StoryLine,
 } from "../data/story.js";
@@ -396,6 +398,82 @@ export function registerStoryTools(server: McpServer): void {
           return { content: [{ type: "text", text: msg }] };
         }
         return { content: [{ type: "text", text: `查询干员密录失败：${msg}` }] };
+      }
+    }
+  );
+
+  server.tool(
+    "find_character_appearances",
+    [
+      "查找某个角色在剧情中的出场（说话或被提及）。",
+      "返回该角色「说话」（speaks，作为对话发言者）或「被提及」（mentioned，名字出现在任意台词/旁白文本中）的所有章节，",
+      "每章标注 speaks / mentioned / 两者皆有。如需精确台词，可用返回的 story_key 调用 read_story。",
+    ].join(" "),
+    {
+      name: z.string().describe("角色名（干员中文名或「博士」）。speaks 按对话角色名精确匹配，mentioned 按名字在台词/旁白文本中的子串匹配——请使用完整名字以免误报。"),
+      scope: z.string().optional().describe("限定活动 ID，如「act31side」。不填则检索全部活动。"),
+      max_events: z.number().int().min(1).max(200).default(50).describe("最多返回章节数，默认 50。"),
+    },
+    ({ name, scope, max_events }) => {
+      let zipPath: string;
+      try {
+        zipPath = requireStoryZip();
+      } catch (e) {
+        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+      }
+      try {
+        const result = _findCharacterAppearances(zipPath, name, scope, max_events);
+        if (result.appearances.length === 0) {
+          const scopeNote = scope ? `（限定活动：${JSON.stringify(scope)}）` : "";
+          return { content: [{ type: "text", text: `未找到「${name}」的出场记录。${scopeNote}` }] };
+        }
+        const parts: string[] = [`# 「${result.name}」的出场（共 ${result.totalChapters} 章）`];
+        for (const ap of result.appearances) {
+          const tags: string[] = [];
+          if (ap.speaks) tags.push("speaks");
+          if (ap.mentioned) tags.push("mentioned");
+          const tag = tags.join("+");
+          const nameDisp = `${ap.storyCode} ${ap.storyName}`.trim();
+          parts.push(`- [${tag}] ${ap.eventId} / ${nameDisp}（key: ${ap.storyKey}）`);
+        }
+        return { content: [{ type: "text", text: parts.join("\n") }] };
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { content: [{ type: "text", text: msg.includes("未找到") ? msg : `查询角色出场失败：${msg}` }] };
+      }
+    }
+  );
+
+  server.tool(
+    "find_speakers_in",
+    [
+      "列出某活动中的所有发言角色及其台词数。",
+      "返回该活动所有章节中去重后的对话发言者，按台词句数降序排列。",
+      "如需读取某角色说的具体内容，可结合 search_stories(character=...) 过滤。",
+    ].join(" "),
+    {
+      event_id: z.string().describe("活动 ID，如 \"act31side\"（可从 list_story_events 获取）。"),
+    },
+    ({ event_id }) => {
+      let zipPath: string;
+      try {
+        zipPath = requireStoryZip();
+      } catch (e) {
+        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+      }
+      try {
+        const speakers = _findSpeakersIn(zipPath, event_id);
+        if (speakers.length === 0) {
+          return { content: [{ type: "text", text: `活动 "${event_id}" 暂无对话发言者数据。` }] };
+        }
+        const parts: string[] = [`# ${event_id} 的发言角色（共 ${speakers.length} 位）`];
+        for (const sp of speakers) {
+          parts.push(`- ${sp.name}（${sp.lineCount} 句）`);
+        }
+        return { content: [{ type: "text", text: parts.join("\n") }] };
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { content: [{ type: "text", text: msg.includes("未找到") ? msg : `查询发言角色失败：${msg}` }] };
       }
     }
   );

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -165,7 +165,7 @@ test("E2E", async (t) => {
   });
 
   // --- tools/list ---
-  await t.test("tools/list returns all 30 tools", async () => {
+  await t.test("tools/list returns all 32 tools", async () => {
     const tl = await mcpPost(
       origin,
       { jsonrpc: "2.0", method: "tools/list", id: 2 },
@@ -175,7 +175,7 @@ test("E2E", async (t) => {
     assert.equal(tl.status, 200);
     const tools = (tl.body?.result as Record<string, unknown>)?.tools as Array<{ name: string }> | undefined;
     assert.ok(tools, "tools/list should return tools");
-    assert.equal(tools!.length, 30, `got ${tools!.length} tools`);
+    assert.equal(tools!.length, 32, `got ${tools!.length} tools`);
 
     const expected = new Set([
       "search_prts", "read_prts_page", "list_prts_sections",
@@ -189,6 +189,7 @@ test("E2E", async (t) => {
       "list_search_scopes", "search_data", "search_stories",
       "get_event_summary", "get_story_summary",
       "get_operator_memoirs",
+      "find_character_appearances", "find_speakers_in",
     ]);
     const names = new Set(tools!.map((t) => t.name));
     for (const name of expected) {

--- a/ts/tests/storyCharacter.test.ts
+++ b/ts/tests/storyCharacter.test.ts
@@ -224,3 +224,74 @@ test("find_speakers_in: unknown event throws", () => {
   const store = storyStore("directory", tempRoot());
   assert.throws(() => findSpeakersInFromStore(store, "no_such_event"));
 });
+
+// ---------------------------------------------------------------------------
+// Edge case: event exists but has no dialog (narration only)
+// ---------------------------------------------------------------------------
+
+const NARRATION_ONLY_KEY = "activities/act_narration/level_narration_01";
+
+function narrationOnlyFiles(): Record<string, unknown> {
+  return {
+    [STORY_REVIEW_PATH]: {
+      act_narration: {
+        name: "纯旁白活动",
+        entryType: "ACTIVITY",
+        infoUnlockDatas: [
+          {
+            storyTxt: NARRATION_ONLY_KEY,
+            storyCode: "NAR-1",
+            storyName: "旁白章",
+            avgTag: null,
+            storySort: 1,
+          },
+        ],
+      },
+    },
+    [storyPath(NARRATION_ONLY_KEY)]: {
+      storyCode: "NAR-1",
+      storyName: "旁白章",
+      avgTag: null,
+      eventName: "纯旁白活动",
+      storyInfo: "",
+      storyList: [
+        { prop: "sticker", attributes: { content: "只有旁白文本。" } },
+      ],
+    },
+  };
+}
+
+function narrationOnlyStore(kind: "directory" | "zip", root: string): JsonStore {
+  const files = narrationOnlyFiles();
+  if (kind === "directory") {
+    for (const [path, data] of Object.entries(files)) {
+      const target = join(root, path);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, JSON.stringify(data), "utf-8");
+    }
+    return new DirectoryStore(root);
+  } else {
+    const zipPath = join(root, "zh_CN.zip");
+    mkdirSync(dirname(zipPath), { recursive: true });
+    const zip = new AdmZip();
+    for (const [innerPath, data] of Object.entries(files)) {
+      zip.addFile(innerPath, Buffer.from(JSON.stringify(data), "utf-8"));
+    }
+    zip.writeZip(zipPath);
+    return new ZipStore(zipPath);
+  }
+}
+
+for (const kind of ["directory", "zip"] as const) {
+  test(`find_speakers_in: narration-only event returns empty (${kind})`, () => {
+    const store = narrationOnlyStore(kind, tempRoot());
+    const speakers = findSpeakersInFromStore(store, "act_narration");
+    assert.deepEqual(speakers, []);
+  });
+
+  test(`find_character_appearances: narration-only event has no speaker match (${kind})`, () => {
+    const store = narrationOnlyStore(kind, tempRoot());
+    const result = findCharacterAppearancesFromStore(store, "博士");
+    assert.equal(result.totalChapters, 0);
+  });
+}

--- a/ts/tests/storyCharacter.test.ts
+++ b/ts/tests/storyCharacter.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Tests for story character tracking — findCharacterAppearances and findSpeakersIn.
+ * Mirrors python/tests/test_story_character.py.
+ *
+ * Fixture dialogue (the source of truth for the assertions below):
+ *   ch1 (TEST-1 开端):
+ *     - 阿米娅：你好，博士。        ← 阿米娅 speaks; "博士" in text
+ *     - *罗德岛走廊*               ← narration, no names
+ *     - 博士：我们出发吧。          ← 博士 speaks; no names in text
+ *   ch2 (TEST-2 终章):
+ *     - 博士：任务完成。阿米娅干得不错。  ← 博士 speaks; "阿米娅" in text
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import AdmZip from "adm-zip";
+
+import { DirectoryStore, ZipStore, type JsonStore } from "../src/data/stores.ts";
+import {
+  findCharacterAppearancesFromStore,
+  findSpeakersInFromStore,
+} from "../src/data/storyCharacter.ts";
+
+// ---------------------------------------------------------------------------
+// Story test data (same shape as search.test.ts)
+// ---------------------------------------------------------------------------
+
+const STORY_REVIEW_PATH = "zh_CN/gamedata/excel/story_review_table.json";
+const FIRST_STORY_KEY = "activities/act_test/level_act_test_01_beg";
+const SECOND_STORY_KEY = "activities/act_test/level_act_test_02_end";
+
+function storyPath(storyKey: string): string {
+  return `zh_CN/gamedata/story/${storyKey}.json`;
+}
+
+function storyFiles(): Record<string, unknown> {
+  return {
+    [STORY_REVIEW_PATH]: {
+      act_test: {
+        name: "测试活动",
+        entryType: "ACTIVITY",
+        infoUnlockDatas: [
+          {
+            storyTxt: FIRST_STORY_KEY,
+            storyCode: "TEST-1",
+            storyName: "开端",
+            avgTag: "BEG",
+            storySort: 1,
+          },
+          {
+            storyTxt: SECOND_STORY_KEY,
+            storyCode: "TEST-2",
+            storyName: "终章",
+            avgTag: "END",
+            storySort: 2,
+          },
+        ],
+      },
+    },
+    [storyPath(FIRST_STORY_KEY)]: {
+      storyCode: "TEST-1",
+      storyName: "开端",
+      avgTag: "BEG",
+      eventName: "测试活动",
+      storyInfo: "测试简介",
+      storyList: [
+        { prop: "name", attributes: { name: "阿米娅", content: "你好，博士。" } },
+        { prop: "sticker", attributes: { content: "罗德岛走廊" } },
+        { prop: "name", attributes: { name: "博士", content: "我们出发吧。" } },
+      ],
+    },
+    [storyPath(SECOND_STORY_KEY)]: {
+      storyCode: "TEST-2",
+      storyName: "终章",
+      avgTag: "END",
+      eventName: "测试活动",
+      storyInfo: "",
+      storyList: [
+        { prop: "name", attributes: { name: "博士", content: "任务完成。阿米娅干得不错。" } },
+      ],
+    },
+  };
+}
+
+function writeStoryDir(root: string): void {
+  for (const [path, data] of Object.entries(storyFiles())) {
+    const target = join(root, path);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, JSON.stringify(data), "utf-8");
+  }
+}
+
+function writeStoryZip(path: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const zip = new AdmZip();
+  for (const [innerPath, data] of Object.entries(storyFiles())) {
+    zip.addFile(innerPath, Buffer.from(JSON.stringify(data), "utf-8"));
+  }
+  zip.writeZip(path);
+}
+
+function storyStore(kind: "directory" | "zip", root: string): JsonStore {
+  if (kind === "directory") {
+    writeStoryDir(root);
+    return new DirectoryStore(root);
+  } else {
+    const zipPath = join(root, "zh_CN.zip");
+    writeStoryZip(zipPath);
+    return new ZipStore(zipPath);
+  }
+}
+
+function tempRoot(): string {
+  return mkdtempSync(join(tmpdir(), "prts-character-test-"));
+}
+
+// ---------------------------------------------------------------------------
+// findCharacterAppearances
+// ---------------------------------------------------------------------------
+
+for (const kind of ["directory", "zip"] as const) {
+  test(`find_character_appearances: 博士 speaks both, mentioned in ch1 (${kind})`, () => {
+    const store = storyStore(kind, tempRoot());
+    const result = findCharacterAppearancesFromStore(store, "博士");
+
+    assert.equal(result.name, "博士");
+    assert.equal(result.totalChapters, 2);
+    const [ch1, ch2] = result.appearances;
+    assert.equal(ch1.storyKey, FIRST_STORY_KEY);
+    assert.equal(ch1.speaks, true);
+    assert.equal(ch1.mentioned, true);   // "博士" in 阿米娅's ch1 text
+    assert.equal(ch2.storyKey, SECOND_STORY_KEY);
+    assert.equal(ch2.speaks, true);
+    assert.equal(ch2.mentioned, false);  // 博士 not in ch2 text
+  });
+
+  test(`find_character_appearances: 阿米娅 speaks ch1, mentioned ch2 (${kind})`, () => {
+    const store = storyStore(kind, tempRoot());
+    const result = findCharacterAppearancesFromStore(store, "阿米娅");
+
+    assert.equal(result.totalChapters, 2);
+    const [ch1, ch2] = result.appearances;
+    assert.equal(ch1.speaks, true);
+    assert.equal(ch1.mentioned, false);  // 阿米娅 not in ch1 text
+    assert.equal(ch2.speaks, false);
+    assert.equal(ch2.mentioned, true);   // "阿米娅" in ch2 text
+  });
+
+  test(`find_character_appearances: scope filter (${kind})`, () => {
+    const store = storyStore(kind, tempRoot());
+    const result = findCharacterAppearancesFromStore(store, "博士", "act_test");
+    assert.equal(result.totalChapters, 2);
+  });
+
+  test(`find_character_appearances: unknown scope throws (${kind})`, () => {
+    const store = storyStore(kind, tempRoot());
+    assert.throws(() => findCharacterAppearancesFromStore(store, "博士", "no_such_event"));
+  });
+
+  test(`find_character_appearances: no match returns empty (${kind})`, () => {
+    const store = storyStore(kind, tempRoot());
+    const result = findCharacterAppearancesFromStore(store, "不存在的角色");
+    assert.equal(result.totalChapters, 0);
+    assert.deepEqual(result.appearances, []);
+  });
+
+  test(`find_character_appearances: substring false positive on text only (${kind})`, () => {
+    // mentioned is substring on line text (role is exact). "阿" is not in any
+    // ch1 text, but is a substring of "阿米娅" in ch2 text → only ch2.
+    const store = storyStore(kind, tempRoot());
+    const result = findCharacterAppearancesFromStore(store, "阿");
+    assert.equal(result.totalChapters, 1);
+    assert.equal(result.appearances[0].storyKey, SECOND_STORY_KEY);
+    assert.equal(result.appearances[0].speaks, false);
+    assert.equal(result.appearances[0].mentioned, true);
+  });
+}
+
+test("find_character_appearances: empty name throws", () => {
+  const store = storyStore("directory", tempRoot());
+  assert.throws(() => findCharacterAppearancesFromStore(store, ""));
+});
+
+test("find_character_appearances: max_events bounds", () => {
+  const store = storyStore("directory", tempRoot());
+  assert.throws(() => findCharacterAppearancesFromStore(store, "博士", undefined, 0));
+  assert.throws(() => findCharacterAppearancesFromStore(store, "博士", undefined, 201));
+});
+
+test("find_character_appearances: max_events cap", () => {
+  const store = storyStore("directory", tempRoot());
+  const result = findCharacterAppearancesFromStore(store, "博士", undefined, 1);
+  assert.equal(result.totalChapters, 1);
+});
+
+// ---------------------------------------------------------------------------
+// findSpeakersIn
+// ---------------------------------------------------------------------------
+
+for (const kind of ["directory", "zip"] as const) {
+  test(`find_speakers_in: speakers with counts (${kind})`, () => {
+    // 阿米娅 speaks once (ch1), 博士 speaks twice (ch1 + ch2).
+    const store = storyStore(kind, tempRoot());
+    const speakers = findSpeakersInFromStore(store, "act_test");
+
+    const byName: Record<string, number> = {};
+    for (const s of speakers) byName[s.name] = s.lineCount;
+    assert.deepEqual(byName, { "博士": 2, "阿米娅": 1 });
+  });
+
+  test(`find_speakers_in: sorted by count desc (${kind})`, () => {
+    const store = storyStore(kind, tempRoot());
+    const speakers = findSpeakersInFromStore(store, "act_test");
+    const counts = speakers.map((s) => s.lineCount);
+    assert.deepEqual(counts, [...counts].sort((a, b) => b - a));
+    // 博士 (2) ranks above 阿米娅 (1).
+    assert.equal(speakers[0].name, "博士");
+  });
+}
+
+test("find_speakers_in: unknown event throws", () => {
+  const store = storyStore("directory", tempRoot());
+  assert.throws(() => findSpeakersInFromStore(store, "no_such_event"));
+});

--- a/ts/tests/toolSurface.test.ts
+++ b/ts/tests/toolSurface.test.ts
@@ -34,6 +34,8 @@ const EXPECTED_TOOLS = [
   "search_data",
   "search_stories",
   "get_operator_memoirs",
+  "find_character_appearances",
+  "find_speakers_in",
 ];
 
 test("TypeScript MCP tool names are frozen", () => {


### PR DESCRIPTION
## Summary

Lands the **story character tracking** portion of the 1.7.0 roadmap
(`ROADMAP.md` §1.7.0). Two new MCP tools, both reusing the existing
lazily-cached story search index — **no new data source, no new sync path,
no new cache layer**.

- `find_character_appearances(name, scope?, max_events?)` — chapters/events
  where a character **speaks** (dialog `role` case-insensitive exact match,
  consistent with the `search_stories` `character` filter) or is **mentioned**
  (name as substring in any line's text). Each hit is tagged
  `speaks` / `mentioned` / `both` and carries a `story_key` for follow-up
  `read_story`.
- `find_speakers_in(event_id)` — distinct speakers in an event with their
  dialog line counts, sorted by count desc then name.

Brings the frozen tool surface **30 → 32**. Python + TypeScript implemented
in lockstep; outputs are markdown in the existing story-tool style.

### Commits (bisect-friendly)

1. `feat(story): add character tracking data module` — new
   `story_character.py` / `storyCharacter.ts`, new dataclasses/interfaces
   (`CharacterAppearance`, `CharacterAppearanceResult`, `SpeakerCount`), and
   the search-index chapter struct gains `story_key`/`story_name` fields so
   the appearance report can locate chapters. Existing search is unaffected.
2. `feat(story): register character tracking tools` — wires the two tools
   into `tools_story.py` / `storyTools.ts`.
3. `test(story): cover character tracking + freeze tool surface` — synthetic
   `act_test` fixtures (directory/zip parametrized) exercising speaks /
   mentioned / both / scope / substring false-positive / bounds; updates the
   four CI-enforced surface registries.
4. `docs: record character tracking in changelog, status, roadmap`.

### Design decisions

- **speaks = role exact match** (not substring). Operator names are short and
  frequently substrings of each other (阿 / 阿米娅 / 阿消); exact match avoids
  false positives and stays consistent with the only existing speaker filter.
- **mentioned = substring on line text**. The ROADMAP's "speaks or is
  mentioned" wording is the only contract; substring-on-text is the defensible
  reading given the available line fields. Documented trade-off: a bare 阿
  matches 阿米娅 — the tool description advises using full names.
- **Reuse `_story_search_index`** rather than building a parallel index. It
  already walks every chapter/line; a second index would duplicate the full
  story-JSON IO. Cache invalidation rides on the existing
  `clear_story_caches()` → `clear_search_cache()`.
- The TS `storySearchIndex` function (and `StorySearchIndex` /
  `StorySearchChapter` types) were promoted from module-private to exported so
  `storyCharacter.ts` can reuse the cached index — additive, no existing API
  broken.

## Test plan

- [x] Python: `pytest tests -q` → **214 passed, 2 skipped** (20 new tests)
- [x] TypeScript: `npm test` → **158 passed, 0 fail, 2 skipped** (16 new tests)
- [x] TypeScript: `npm run typecheck` → clean
- [x] `test_tool_surface` / `toolSurface.test.ts` pass with 32 tools
- [x] Both store kinds (directory + zip) exercised in every behavior test
- [x] Synthetic fixture is self-contained — no real zh_CN.zip needed

## Unfinished

- 1.7.0 still has the **building (base) skill domain** and **skins** items
  outstanding per ROADMAP; this PR does not address them — they need the full
  new-data-domain flow (dataset spec → reader → sync).