### PR TITLE
refactor: unify PRTS page tools into prts_page(action)

### DIFF
--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -76,7 +76,7 @@ jobs:
             const line = list.body.split('\n').find(l => l.startsWith('data: '));
             const result = JSON.parse(line.slice(6));
             const names = result.result.tools.map(t => t.name);
-            const required = ['search_prts', 'read_prts_page', 'get_operator_archives', 'get_operator_voicelines', 'get_operator_basic_info', 'list_story_events', 'list_stories', 'read_story', 'read_activity'];
+            const required = ['search_prts', 'prts_page', 'get_operator_archives', 'get_operator_voicelines', 'get_operator_basic_info', 'list_story_events', 'list_stories', 'read_story', 'read_activity'];
             for (const t of required) {
               if (!names.includes(t)) throw new Error('Missing tool: ' + t);
             }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Both implementations expose the same tool set:
 | Tool | Description |
 |------|-------------|
 | `search_prts(query, limit)` | Search PRTS Wiki by keyword, returns matching article titles |
-| `read_prts_page(page_title)` | Fetch the plain-text content of a PRTS Wiki article |
+| `prts_page(page_title, action, ...)` | Read a wiki page or its metadata; `action` ∈ read / sections / categories / links / template |
 | `get_operator_archives(name)` | Retrieve operator archive records (Chinese name) |
 | `get_operator_voicelines(name)` | Retrieve operator voice lines (Chinese name) |
 | `get_operator_basic_info(name)` | Retrieve basic operator profile: class, rarity, faction, recruit tags, talents (Chinese name) |
@@ -57,10 +57,6 @@ Both implementations expose the same tool set:
 | `read_activity(event_id, include_narration, page, page_size)` | Read a complete activity's transcript, with pagination |
 | `search(scope, pattern, max_results)` | Full-text regex search within a data domain: `scope` ∈ operators / enemies / stages / items |
 | `search_stories(pattern, character?, line_type?, context_lines?, max_results?, event_id?)` | Full-text regex search across story dialogue, narration, and choice lines with filtering |
-| `list_prts_sections(page_title)` | Section table of contents for a wiki page |
-| `get_prts_categories(page_title)` | Category tags for a wiki page |
-| `get_prts_links(page_title, direction, limit)` | Outbound links or inbound backlinks with pagination |
-| `get_prts_template(page_title)` | Extract structured template data (key-value pairs) from a wiki page |
 | `list_enemies()` | List all enemies in the handbook with threat level and description |
 | `get_enemy_info(name, stage_id?)` | Retrieve full enemy handbook entry by name, or stage-specific stats when `stage_id` is provided |
 | `get_stage_enemies(stage_id)` | List enemies actually spawned in a stage, with stage-specific levels and combat stats |
@@ -124,7 +120,7 @@ Published Docker images and the npm package include bundled fallback game/level/
 | 工具 | 说明 |
 |------|------|
 | `search_prts(query, limit)` | 关键词搜索 PRTS 维基词条，返回匹配标题列表 |
-| `read_prts_page(page_title)` | 读取指定词条的纯文本内容 |
+| `prts_page(page_title, action, ...)` | 读取词条正文或元数据；`action` ∈ read / sections / categories / links / template |
 | `get_operator_archives(name)` | 获取干员档案资料（中文名） |
 | `get_operator_voicelines(name)` | 获取干员语音记录（中文名） |
 | `get_operator_basic_info(name)` | 获取干员基本信息：职业、稀有度、所属、招募标签、天赋（中文名） |
@@ -136,10 +132,6 @@ Published Docker images and the npm package include bundled fallback game/level/
 | `read_activity(event_id, include_narration, page, page_size)` | 读取整个活动的完整剧情，支持分页 |
 | `search(scope, pattern, max_results)` | 在指定数据域执行全文正则搜索：`scope` ∈ operators / enemies / stages / items |
 | `search_stories(pattern, character?, line_type?, context_lines?, max_results?, event_id?)` | 在剧情台词中执行全文正则搜索，支持按角色和台词类型过滤 |
-| `list_prts_sections(page_title)` | 获取词条的章节目录 |
-| `get_prts_categories(page_title)` | 获取词条的分类标签 |
-| `get_prts_links(page_title, direction, limit)` | 获取词条的出链或入链，支持分页 |
-| `get_prts_template(page_title)` | 提取词条中的结构化模板键值对数据 |
 | `list_enemies()` | 列出敌方图鉴中所有敌人及其威胁等级和描述 |
 | `get_enemy_info(name, stage_id?)` | 获取指定敌人的详细图鉴资料；传入 `stage_id` 时返回关卡级数值 |
 | `get_stage_enemies(stage_id)` | 获取指定关卡实际出场敌人及关卡级等级/战斗属性 |

--- a/STATUS.md
+++ b/STATUS.md
@@ -29,7 +29,7 @@ PRTS-MCP/
 ├── python/                 # Python 实现 (stdio, FastMCP)
 │   ├── src/prts_mcp/       # 源码
 │   │   ├── server.py       # 入口点 → tools_* 模块
-│   │   ├── tools_prts.py   # PRTS Wiki 工具注册（6 工具）
+│   │   ├── tools_prts.py   # PRTS Wiki 工具注册（2 工具）
 │   │   ├── tools_gamedata.py # GameData 工具注册（12 工具）
 │   │   ├── tools_story.py  # 剧情工具注册（10 工具）
 │   │   ├── config.py       # 路径解析、环境变量
@@ -93,12 +93,12 @@ PRTS-MCP/
 | [ArknightsStoryJson](https://github.com/3aKHP/ArknightsStoryJson) | 剧情台词 | GitHub Release `zh_CN.zip` |
 | [PRTS Wiki API](https://prts.wiki/api.php) | 世界观词条/阵营设定 | 实时 HTTP 请求 |
 
-## 工具清单 (28, current branch)
+## 工具清单 (24, current branch)
 
 | # | 工具 | 数据源 | 版本 |
 |---|------|--------|------|
 | 1 | `search_prts` | PRTS Wiki | 0.1.0 |
-| 2 | `read_prts_page` | PRTS Wiki | 0.1.0 |
+| 2 | `prts_page` | PRTS Wiki | 2.0.0 |
 | 3 | `get_operator_archives` | GameData | 0.1.0 |
 | 4 | `get_operator_voicelines` | GameData | 0.1.0 |
 | 5 | `get_operator_basic_info` | GameData | 0.1.0 |
@@ -110,26 +110,27 @@ PRTS-MCP/
 | 11 | `search_stories` | StoryJson | 1.1.0 |
 | 12 | `get_event_summary` | StoryJson | 1.2.0 |
 | 13 | `get_story_summary` | StoryJson | 1.2.0 |
-| 14 | `list_prts_sections` | PRTS Wiki | 1.3.0 |
-| 15 | `get_prts_categories` | PRTS Wiki | 1.3.0 |
-| 16 | `get_prts_links` | PRTS Wiki | 1.3.0 |
-| 17 | `get_prts_template` | PRTS Wiki | 1.4.0 |
-| 18 | `list_enemies` | GameData | 1.4.0 |
-| 19 | `get_enemy_info` | GameData | 1.4.0 |
-| 20 | `get_stage_enemies` | GameData levels | 1.6.0 |
-| 21 | `get_enemy_appearances` | GameData levels | 1.6.0 |
-| 22 | `list_stages` | GameData | 1.5.0 |
-| 23 | `get_stage_info` | GameData | 1.5.0 |
-| 24 | `list_items` | GameData | 1.6.0 |
-| 25 | `get_item_info` | GameData | 1.6.0 |
-| 26 | `get_operator_memoirs` | StoryJson | 1.6.1 |
-| 27 | `find_character_appearances` | StoryJson | 1.7.0 |
-| 28 | `find_speakers_in` | StoryJson | 1.7.0 |
+| 14 | `list_enemies` | GameData | 1.4.0 |
+| 15 | `get_enemy_info` | GameData | 1.4.0 |
+| 16 | `get_stage_enemies` | GameData levels | 1.6.0 |
+| 17 | `get_enemy_appearances` | GameData levels | 1.6.0 |
+| 18 | `list_stages` | GameData | 1.5.0 |
+| 19 | `get_stage_info` | GameData | 1.5.0 |
+| 20 | `list_items` | GameData | 1.6.0 |
+| 21 | `get_item_info` | GameData | 1.6.0 |
+| 22 | `get_operator_memoirs` | StoryJson | 1.6.1 |
+| 23 | `find_character_appearances` | StoryJson | 1.7.0 |
+| 24 | `find_speakers_in` | StoryJson | 1.7.0 |
 
 > `search(scope, pattern, max_results)` 统一了 1.x 的 `search_data` /
 > `search_enemies` / `search_stages` / `search_items` 与 `list_search_scopes`
 > （scope ∈ operators/enemies/stages/items）。剧情台词搜索仍为独立的
 > `search_stories`（参数不同）。
+>
+> `prts_page(page_title, action, …)` 统一了 1.x 的 `read_prts_page` /
+> `list_prts_sections` / `get_prts_categories` / `get_prts_links` /
+> `get_prts_template`（action ∈ read/sections/categories/links/template）。
+> 维基关键词搜索仍为独立的 `search_prts`。
 
 ## 遗留 TODO
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -17,6 +17,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   `search(scope, pattern, max_results)` tool with a required `scope` enum
   (`operators` / `enemies` / `stages` / `items`). Story dialogue search remains a
   separate `search_stories` (its filters differ). Tool surface drops 32 → 28.
+- **Unified PRTS page tool (2.0, breaking).** `read_prts_page`,
+  `list_prts_sections`, `get_prts_categories`, `get_prts_links`, and
+  `get_prts_template` are consolidated into a single `prts_page(page_title,
+  action, ...)` tool with a required `action` enum (`read` / `sections` /
+  `categories` / `links` / `template`). Wiki keyword search remains a separate
+  `search_prts`. Tool surface drops 28 → 24.
 
 ### Removed
 
@@ -24,6 +30,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   `list_search_scopes` (2.0, breaking).** Replaced by unified `search(scope, ...)`;
   the scope catalogue previously returned by `list_search_scopes` is folded into
   the `search` tool description.
+- **`read_prts_page`, `list_prts_sections`, `get_prts_categories`,
+  `get_prts_links`, `get_prts_template` (2.0, breaking).** Replaced by unified
+  `prts_page(page_title, action, ...)`.
 
 ## [1.7.0] - 2026-07-02
 

--- a/python/docs/deployment.md
+++ b/python/docs/deployment.md
@@ -128,11 +128,7 @@ docker run -i --rm `
     "args": ["run", "-i", "--rm", "-v", "prts-mcp-data:/data/gamedata", "-v", "prts-mcp-levels:/data/gamedata-levels", "-v", "prts-mcp-storyjson:/data/storyjson", "prts-mcp"],
     "alwaysAllow": [
         "search_prts",
-        "read_prts_page",
-        "list_prts_sections",
-        "get_prts_categories",
-        "get_prts_links",
-        "get_prts_template",
+        "prts_page",
         "get_operator_archives",
         "get_operator_voicelines",
         "get_operator_basic_info",
@@ -190,11 +186,8 @@ npx @modelcontextprotocol/inspector docker run -i --rm -v prts-mcp-data:/data/ga
 | Tool | 测试参数 | 依赖 |
 |------|---------|------|
 | `search_prts` | `query`: `莱茵生命` | 网络 |
-| `read_prts_page` | `page_title`: `阿米娅` | 网络 |
-| `list_prts_sections` | `page_title`: `阿米娅` | 网络 |
-| `get_prts_categories` | `page_title`: `阿米娅` | 网络 |
-| `get_prts_links` | `page_title`: `阿米娅`, `direction`: `outbound` | 网络 |
-| `get_prts_template` | `page_title`: `阿米娅` | 网络 |
+| `prts_page` | `page_title`: `阿米娅`, `action`: `sections` | 网络 |
+| `prts_page` | `page_title`: `阿米娅`, `action`: `read`, `section_index`: `1` | 网络 |
 | `get_operator_archives` | `name`: `阿米娅` | 干员数据 |
 | `get_operator_voicelines` | `name`: `阿米娅` | 干员数据 |
 | `get_operator_basic_info` | `name`: `阿米娅` | 干员数据 |

--- a/python/src/prts_mcp/tools_prts.py
+++ b/python/src/prts_mcp/tools_prts.py
@@ -55,7 +55,7 @@ def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         page_title: Annotated[str, Field(description="词条标题，需与维基页面标题完全一致，如「阿米娅」。建议先用 search_prts 获取准确标题。")],
         action: Annotated[Literal["read", "sections", "categories", "links", "template"], Field(description="操作（必填）：read=读取正文 / sections=章节目录 / categories=分类标签 / links=相关链接 / template=结构化模板数据。")],
         section_index: Annotated[int | None, Field(default=None, description="仅 action=read 生效：章节编号（从 action=sections 获取）。不填返回整页。")] = None,
-        direction: Annotated[str, Field(default="outbound", description="仅 action=links 生效：outbound（出链，默认）或 inbound（入链）。")] = "outbound",
+        direction: Annotated[Literal["outbound", "inbound"], Field(default="outbound", description="仅 action=links 生效：outbound（出链，默认）或 inbound（入链）。")] = "outbound",
         limit: Annotated[int, Field(default=30, description="仅 action=links 生效：返回链接数量上限，默认 30。")] = 30,
     ) -> str:
         """读取 PRTS 维基页面的内容或元数据（按 action 分派）。

--- a/python/src/prts_mcp/tools_prts.py
+++ b/python/src/prts_mcp/tools_prts.py
@@ -56,53 +56,44 @@ def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         action: Annotated[Literal["read", "sections", "categories", "links", "template"], Field(description="操作（必填）：read=读取正文 / sections=章节目录 / categories=分类标签 / links=相关链接 / template=结构化模板数据。")],
         section_index: Annotated[int | None, Field(default=None, description="仅 action=read 生效：章节编号（从 action=sections 获取）。不填返回整页。")] = None,
         direction: Annotated[Literal["outbound", "inbound"], Field(default="outbound", description="仅 action=links 生效：outbound（出链，默认）或 inbound（入链）。")] = "outbound",
-        limit: Annotated[int, Field(default=30, description="仅 action=links 生效：返回链接数量上限，默认 30。")] = 30,
+        limit: Annotated[int, Field(default=30, ge=1, le=100, description="仅 action=links 生效：返回链接数量上限，默认 30。")] = 30,
     ) -> str:
         """读取 PRTS 维基页面的内容或元数据（按 action 分派）。
 
-        推荐流程：先用 action="sections" 看目录，再用 action="read" + section_index
-        读特定章节，避免整页过载。其余 action：categories=分类标签，links=相关链接，
-        template=结构化模板数据。先用 search_prts 获取准确标题。
+        推荐流程：先用 action="sections" 看目录（返回 [编号] L层级 标题，T- 前缀表示
+        模板嵌入的节），再用 action="read" + section_index 读特定章节，避免整页过载。
+        其余 action：categories=分类标签；links=相关链接（outbound 出链 / inbound 反向
+        链接，探索维基知识图谱）；template=结构化模板数据（如干员 CharinfoV2、敌人
+        敌人信息/common2、物品 道具信息）。先用 search_prts 获取准确标题。
         """
-        if action == "read":
-            return await _read_page(page_title, section_index=section_index)
-        if action == "sections":
-            try:
-                sections = await _list_sections(page_title)
-            except RuntimeError as e:
-                return str(e)
-            if not sections:
-                return f"页面 '{page_title}' 没有章节目录。"
-            return "\n".join(f"[{s['index']}] L{s['level']} {s['line']}" for s in sections)
-        if action == "categories":
-            try:
-                cats = await _get_categories(page_title)
-            except RuntimeError as e:
-                return str(e)
-            if not cats:
-                return f"页面 '{page_title}' 没有分类标签。"
-            return "\n".join(f"- {c}" for c in cats)
-        if action == "links":
-            if direction not in ("outbound", "inbound"):
-                return "无效的 direction 参数，可选值：outbound、inbound。"
-            try:
-                result = await _get_links(page_title, direction=direction, limit=limit)
-            except RuntimeError as e:
-                return str(e)
-            links = result["links"]
-            if not links:
-                return f"页面 '{page_title}' 没有{'出站' if direction == 'outbound' else '入站'}链接。"
-            total = result["total"]
-            has_more = result["has_more"]
-            suffix = f"\n（共 {total} 条，还有更多）" if has_more else f"\n（共 {total} 条）"
-            return "\n".join(f"- {ln}" for ln in links) + suffix
-        # action == "template"
         try:
+            if action == "read":
+                return await _read_page(page_title, section_index=section_index)
+            if action == "sections":
+                sections = await _list_sections(page_title)
+                if not sections:
+                    return f"页面 '{page_title}' 没有章节目录。"
+                return "\n".join(f"[{s['index']}] L{s['level']} {s['line']}" for s in sections)
+            if action == "categories":
+                cats = await _get_categories(page_title)
+                if not cats:
+                    return f"页面 '{page_title}' 没有分类标签。"
+                return "\n".join(f"- {c}" for c in cats)
+            if action == "links":
+                result = await _get_links(page_title, direction=direction, limit=limit)
+                links = result["links"]
+                if not links:
+                    return f"页面 '{page_title}' 没有{'出站' if direction == 'outbound' else '入站'}链接。"
+                total = result["total"]
+                has_more = result["has_more"]
+                suffix = f"\n（共 {total} 条，还有更多）" if has_more else f"\n（共 {total} 条）"
+                return "\n".join(f"- {ln}" for ln in links) + suffix
+            # action == "template"
             templates = await _get_template_data(page_title)
+            if not templates:
+                return f"页面 '{page_title}' 未找到可提取的模板数据。"
+            return json.dumps(templates, ensure_ascii=False, indent=2)
         except RuntimeError as e:
             return str(e)
         except Exception as e:
-            return f"获取页面 '{page_title}' 的模板数据失败：{e}"
-        if not templates:
-            return f"页面 '{page_title}' 未找到可提取的模板数据。"
-        return json.dumps(templates, ensure_ascii=False, indent=2)
+            return f"访问 PRTS 页面失败：{e}"

--- a/python/src/prts_mcp/tools_prts.py
+++ b/python/src/prts_mcp/tools_prts.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from pydantic import Field
 
@@ -22,7 +22,7 @@ from prts_mcp.api.prts_wiki import (
 
 
 def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
-    """Register the 6 PRTS Wiki tools on the given FastMCP instance."""
+    """Register the 2 PRTS Wiki tools on the given FastMCP instance."""
 
     @mcp.tool()
     async def search_prts(
@@ -35,7 +35,7 @@ def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
 
         返回匹配词条的标题和简短摘要列表，含匹配总数。这是探索维基的第一步：当需要查找
         不确定的专有名词、干员、关卡或世界观设定时，先用此工具搜索获取准确
-        标题，再将标题传入 read_prts_page 获取完整内容。
+        标题，再将标题传入 prts_page 获取完整内容。
         """
         if search_mode not in ("text", "title"):
             return "无效的 search_mode 参数，可选值：text、title。"
@@ -51,93 +51,52 @@ def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         return header + "\n\n---\n\n".join(parts)
 
     @mcp.tool()
-    async def read_prts_page(
-        page_title: Annotated[str, Field(description="词条标题，需与维基页面标题完全一致，如「阿米娅」、「整合运动」。建议通过 search_prts 获取准确标题后再传入。")],
-        section_index: Annotated[int | None, Field(default=None, description="可选章节编号（从 list_prts_sections 获取）。不填则返回整页内容；填入编号如 1 则仅返回该节。")] = None,
+    async def prts_page(
+        page_title: Annotated[str, Field(description="词条标题，需与维基页面标题完全一致，如「阿米娅」。建议先用 search_prts 获取准确标题。")],
+        action: Annotated[Literal["read", "sections", "categories", "links", "template"], Field(description="操作（必填）：read=读取正文 / sections=章节目录 / categories=分类标签 / links=相关链接 / template=结构化模板数据。")],
+        section_index: Annotated[int | None, Field(default=None, description="仅 action=read 生效：章节编号（从 action=sections 获取）。不填返回整页。")] = None,
+        direction: Annotated[str, Field(default="outbound", description="仅 action=links 生效：outbound（出链，默认）或 inbound（入链）。")] = "outbound",
+        limit: Annotated[int, Field(default=30, description="仅 action=links 生效：返回链接数量上限，默认 30。")] = 30,
     ) -> str:
-        """读取 PRTS 维基指定词条的纯文本内容。
+        """读取 PRTS 维基页面的内容或元数据（按 action 分派）。
 
-        返回该词条经过清洗的纯文本，已去除 CSS、HTML 标签和实体，
-        内容可能较长。强烈建议先调用 list_prts_sections 查看目录结构，
-        再用 section_index 按需读取特定章节，避免整页内容过载。
-        不填 section_index 时返回整页。
+        推荐流程：先用 action="sections" 看目录，再用 action="read" + section_index
+        读特定章节，避免整页过载。其余 action：categories=分类标签，links=相关链接，
+        template=结构化模板数据。先用 search_prts 获取准确标题。
         """
-        return await _read_page(page_title, section_index=section_index)
-
-    @mcp.tool()
-    async def list_prts_sections(
-        page_title: Annotated[str, Field(description="词条标题，需与维基页面标题完全一致，如「阿米娅」。")],
-    ) -> str:
-        """列出 PRTS 维基页面的目录（章节列表）。
-
-        返回章节编号、层级和标题，其中以 T- 开头的编号表示该节来自模板嵌入
-        （如角色信息框）。获取编号后可传入 read_prts_page 的 section_index
-        参数按需读取特定章节，避免一次加载整页内容。
-        """
-        try:
-            sections = await _list_sections(page_title)
-        except RuntimeError as e:
-            return str(e)
-        if not sections:
-            return f"页面 '{page_title}' 没有章节目录。"
-        lines = []
-        for s in sections:
-            lines.append(f"[{s['index']}] L{s['level']} {s['line']}")
-        return "\n".join(lines)
-
-    @mcp.tool()
-    async def get_prts_categories(
-        page_title: Annotated[str, Field(description="词条标题，如「阿米娅」、「塔露拉」。")],
-    ) -> str:
-        """获取 PRTS 维基页面的分类标签。
-
-        返回该页面所属的所有分类，如「干员」「术师干员」「属于罗德岛的干员」。
-        可用于理解页面类型和所属体系，辅助导航和发现相关页面。
-        """
-        try:
-            cats = await _get_categories(page_title)
-        except RuntimeError as e:
-            return str(e)
-        if not cats:
-            return f"页面 '{page_title}' 没有分类标签。"
-        return "\n".join(f"- {c}" for c in cats)
-
-    @mcp.tool()
-    async def get_prts_links(
-        page_title: Annotated[str, Field(description="词条标题，如「阿米娅」。")],
-        direction: Annotated[str, Field(default="outbound", description="链接方向：outbound（页面引用的链接，默认）或 inbound（引用该页面的链接）。")] = "outbound",
-        limit: Annotated[int, Field(default=30, description="返回链接数量上限，默认 30。")] = 30,
-    ) -> str:
-        """获取 PRTS 维基页面的相关链接。
-
-        outbound 返回该页面引用的所有其他词条链接；inbound 返回所有引用了该页面的
-        词条链接（反向链接）。可用于探索维基的知识图谱关系。
-        """
-        if direction not in ("outbound", "inbound"):
-            return "无效的 direction 参数，可选值：outbound、inbound。"
-        try:
-            result = await _get_links(page_title, direction=direction, limit=limit)
-        except RuntimeError as e:
-            return str(e)
-        links = result["links"]
-        if not links:
-            return f"页面 '{page_title}' 没有{'出站' if direction == 'outbound' else '入站'}链接。"
-        total = result["total"]
-        has_more = result["has_more"]
-        suffix = f"\n（共 {total} 条，还有更多）" if has_more else f"\n（共 {total} 条）"
-        return "\n".join(f"- {ln}" for ln in links) + suffix
-
-    @mcp.tool()
-    async def get_prts_template(
-        page_title: Annotated[str, Field(description="词条标题，如「阿米娅」。")],
-    ) -> str:
-        """获取 PRTS 维基页面的结构化模板数据。
-
-        提取页面中所有模板调用的键值对，返回按模板名分组的 dict。
-        典型模板：干员页面的 CharinfoV2（干员名、稀有度、职业、所属等），
-        敌人页面的 敌人信息/common2（名称、地位级别、描述、伤害类型等），
-        物品页面的 道具信息（名称、用途、获得方式等）。
-        """
+        if action == "read":
+            return await _read_page(page_title, section_index=section_index)
+        if action == "sections":
+            try:
+                sections = await _list_sections(page_title)
+            except RuntimeError as e:
+                return str(e)
+            if not sections:
+                return f"页面 '{page_title}' 没有章节目录。"
+            return "\n".join(f"[{s['index']}] L{s['level']} {s['line']}" for s in sections)
+        if action == "categories":
+            try:
+                cats = await _get_categories(page_title)
+            except RuntimeError as e:
+                return str(e)
+            if not cats:
+                return f"页面 '{page_title}' 没有分类标签。"
+            return "\n".join(f"- {c}" for c in cats)
+        if action == "links":
+            if direction not in ("outbound", "inbound"):
+                return "无效的 direction 参数，可选值：outbound、inbound。"
+            try:
+                result = await _get_links(page_title, direction=direction, limit=limit)
+            except RuntimeError as e:
+                return str(e)
+            links = result["links"]
+            if not links:
+                return f"页面 '{page_title}' 没有{'出站' if direction == 'outbound' else '入站'}链接。"
+            total = result["total"]
+            has_more = result["has_more"]
+            suffix = f"\n（共 {total} 条，还有更多）" if has_more else f"\n（共 {total} 条）"
+            return "\n".join(f"- {ln}" for ln in links) + suffix
+        # action == "template"
         try:
             templates = await _get_template_data(page_title)
         except RuntimeError as e:
@@ -146,5 +105,4 @@ def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
             return f"获取页面 '{page_title}' 的模板数据失败：{e}"
         if not templates:
             return f"页面 '{page_title}' 未找到可提取的模板数据。"
-
         return json.dumps(templates, ensure_ascii=False, indent=2)

--- a/python/tests/test_e2e.py
+++ b/python/tests/test_e2e.py
@@ -139,8 +139,7 @@ def server():
 # ---------------------------------------------------------------------------
 
 EXPECTED_TOOLS = {
-    "search_prts", "read_prts_page", "list_prts_sections",
-    "get_prts_categories", "get_prts_links", "get_prts_template",
+    "search_prts", "prts_page",
     "get_operator_archives", "get_operator_voicelines", "get_operator_basic_info",
     "list_enemies", "get_enemy_info",
     "get_stage_enemies", "get_enemy_appearances",
@@ -181,7 +180,7 @@ def test_tools_list(server: subprocess.Popen) -> None:
     tools = resp["result"]["tools"]
     names = {t["name"] for t in tools}
 
-    assert len(names) == 28, f"Expected 28 tools, got {len(names)}: {sorted(names)}"
+    assert len(names) == 24, f"Expected 24 tools, got {len(names)}: {sorted(names)}"
     for name in EXPECTED_TOOLS:
         assert name in names, f"Missing tool: {name}"
 
@@ -234,6 +233,6 @@ def test_search_prts(server: subprocess.Popen) -> None:
 
 
 @pytest.mark.skipif(not _run_prts_api, reason="E2E_PRTS_API not set")
-def test_list_prts_sections(server: subprocess.Popen) -> None:
-    text = _call_result_text(server, "list_prts_sections", {"page_title": "阿米娅"}, 21)
+def test_prts_page_sections(server: subprocess.Popen) -> None:
+    text = _call_result_text(server, "prts_page", {"page_title": "阿米娅", "action": "sections"}, 21)
     assert "[" in text and "] L" in text

--- a/python/tests/test_tool_surface.py
+++ b/python/tests/test_tool_surface.py
@@ -6,11 +6,7 @@ from pathlib import Path
 
 EXPECTED_TOOL_SURFACE = {
     "search_prts": ("query", "limit", "search_mode", "filter_technical"),
-    "read_prts_page": ("page_title", "section_index"),
-    "list_prts_sections": ("page_title",),
-    "get_prts_categories": ("page_title",),
-    "get_prts_links": ("page_title", "direction", "limit"),
-    "get_prts_template": ("page_title",),
+    "prts_page": ("page_title", "action", "section_index", "direction", "limit"),
     "get_operator_archives": ("name",),
     "get_operator_voicelines": ("name",),
     "get_operator_basic_info": ("name",),

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -17,6 +17,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   `search(scope, pattern, max_results)` tool with a required `scope` enum
   (`operators` / `enemies` / `stages` / `items`). Story dialogue search remains a
   separate `search_stories` (its filters differ). Tool surface drops 32 → 28.
+- **Unified PRTS page tool (2.0, breaking).** `read_prts_page`,
+  `list_prts_sections`, `get_prts_categories`, `get_prts_links`, and
+  `get_prts_template` are consolidated into a single `prts_page(page_title,
+  action, ...)` tool with a required `action` enum (`read` / `sections` /
+  `categories` / `links` / `template`). Wiki keyword search remains a separate
+  `search_prts`. Tool surface drops 28 → 24.
 
 ### Removed
 
@@ -24,6 +30,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   `list_search_scopes` (2.0, breaking).** Replaced by unified `search(scope, ...)`;
   the scope catalogue previously returned by `list_search_scopes` is folded into
   the `search` tool description.
+- **`read_prts_page`, `list_prts_sections`, `get_prts_categories`,
+  `get_prts_links`, `get_prts_template` (2.0, breaking).** Replaced by unified
+  `prts_page(page_title, action, ...)`.
 
 ## [1.7.0] - 2026-07-02
 

--- a/ts/src/tools/prtsTools.ts
+++ b/ts/src/tools/prtsTools.ts
@@ -46,8 +46,8 @@ export function registerPrtsTools(server: McpServer): void {
     "prts_page",
     [
       "读取 PRTS 维基页面的内容或元数据（按 action 分派）。",
-      "推荐流程：先用 action=\"sections\" 看目录，再用 action=\"read\" + section_index 读特定章节，避免整页过载。",
-      "其余 action：categories=分类标签，links=相关链接，template=结构化模板数据。先用 search_prts 获取准确标题。",
+      "推荐流程：先用 action=\"sections\" 看目录（返回 [编号] L层级 标题，T- 前缀表示模板嵌入的节），再用 action=\"read\" + section_index 读特定章节，避免整页过载。",
+      "其余 action：categories=分类标签；links=相关链接（outbound 出链 / inbound 反向链接，探索维基知识图谱）；template=结构化模板数据（如干员 CharinfoV2、敌人 敌人信息/common2、物品 道具信息）。先用 search_prts 获取准确标题。",
     ].join(" "),
     {
       page_title: z.string().describe("词条标题，需与维基页面标题完全一致，如「阿米娅」。建议先用 search_prts 获取准确标题。"),

--- a/ts/src/tools/prtsTools.ts
+++ b/ts/src/tools/prtsTools.ts
@@ -1,7 +1,7 @@
 /**
  * PRTS Wiki tool registrations — search, read, sections, categories, links, template.
  *
- * Split from server.ts. Exports registerPrtsTools which attaches the 6 PRTS
+ * Split from server.ts. Exports registerPrtsTools which attaches the 2 PRTS
  * Wiki tools to a McpServer instance.
  */
 
@@ -21,7 +21,7 @@ export function registerPrtsTools(server: McpServer): void {
     "search_prts",
     [
       "搜索 PRTS 明日方舟中文维基词条。",
-      "返回匹配词条的标题和简短摘要列表，含匹配总数。这是探索维基的第一步：当需要查找不确定的专有名词、干员、关卡或世界观设定时，先用此工具搜索获取准确标题，再将标题传入 read_prts_page 获取完整内容。",
+      "返回匹配词条的标题和简短摘要列表，含匹配总数。这是探索维基的第一步：当需要查找不确定的专有名词、干员、关卡或世界观设定时，先用此工具搜索获取准确标题，再将标题传入 prts_page 获取完整内容。",
     ].join(" "),
     {
       query: z.string().describe("搜索关键词，支持中文，如「罗德岛」、「整合运动」。"),
@@ -43,111 +43,51 @@ export function registerPrtsTools(server: McpServer): void {
   );
 
   server.tool(
-    "read_prts_page",
+    "prts_page",
     [
-      "读取 PRTS 维基指定词条的纯文本内容。",
-      "返回该词条经过清洗的纯文本，已去除 CSS、HTML 标签和实体，内容可能较长。",
-      "强烈建议先调用 list_prts_sections 查看目录结构，再用 section_index 按需读取特定章节，避免整页内容过载。",
-      "不填 section_index 时返回整页。",
+      "读取 PRTS 维基页面的内容或元数据（按 action 分派）。",
+      "推荐流程：先用 action=\"sections\" 看目录，再用 action=\"read\" + section_index 读特定章节，避免整页过载。",
+      "其余 action：categories=分类标签，links=相关链接，template=结构化模板数据。先用 search_prts 获取准确标题。",
     ].join(" "),
     {
-      page_title: z.string().describe("词条标题，需与维基页面标题完全一致，如「阿米娅」、「整合运动」。建议通过 search_prts 获取准确标题后再传入。"),
-      section_index: z.number().int().optional().describe("可选章节编号（从 list_prts_sections 获取）。不填则返回整页内容；填入编号如 1 则仅返回该节。"),
+      page_title: z.string().describe("词条标题，需与维基页面标题完全一致，如「阿米娅」。建议先用 search_prts 获取准确标题。"),
+      action: z.enum(["read", "sections", "categories", "links", "template"]).describe("操作（必填）：read=读取正文 / sections=章节目录 / categories=分类标签 / links=相关链接 / template=结构化模板数据。"),
+      section_index: z.number().int().optional().describe("仅 action=read 生效：章节编号（从 action=sections 获取）。不填返回整页。"),
+      direction: z.enum(["outbound", "inbound"]).default("outbound").describe("仅 action=links 生效：outbound（出链，默认）或 inbound（入链）。"),
+      limit: z.number().int().min(1).max(100).default(30).describe("仅 action=links 生效：返回链接数量上限，默认 30。"),
     },
-    async ({ page_title, section_index }) => {
-      const text = await readPage(page_title, section_index);
-      return { content: [{ type: "text", text }] };
-    }
-  );
-
-  server.tool(
-    "list_prts_sections",
-    [
-      "列出 PRTS 维基页面的目录（章节列表）。",
-      "返回章节编号、层级和标题，其中以 T- 开头的编号表示该节来自模板嵌入（如角色信息框）。",
-      "获取编号后可传入 read_prts_page 的 section_index 参数按需读取特定章节，避免一次加载整页内容。",
-    ].join(" "),
-    { page_title: z.string().describe("词条标题，需与维基页面标题完全一致，如「阿米娅」。") },
-    async ({ page_title }) => {
+    async ({ page_title, action, section_index, direction, limit }) => {
       try {
-        const sections = await listSections(page_title);
-        if (sections.length === 0) {
-          return { content: [{ type: "text", text: `页面 '${page_title}' 没有章节目录。` }] };
+        if (action === "read") {
+          const text = await readPage(page_title, section_index);
+          return { content: [{ type: "text", text }] };
         }
-        const lines = sections.map(
-          (s) => `[${s.index}] L${s.level} ${s.line}`
-        );
-        return { content: [{ type: "text", text: lines.join("\n") }] };
-      } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
-      }
-    }
-  );
-
-  server.tool(
-    "get_prts_categories",
-    [
-      "获取 PRTS 维基页面的分类标签。",
-      "返回该页面所属的所有分类，如「干员」「术师干员」「属于罗德岛的干员」。",
-      "可用于理解页面类型和所属体系，辅助导航和发现相关页面。",
-    ].join(" "),
-    { page_title: z.string().describe("词条标题，如「阿米娅」、「塔露拉」。") },
-    async ({ page_title }) => {
-      try {
-        const cats = await getCategories(page_title);
-        if (cats.length === 0) {
-          return { content: [{ type: "text", text: `页面 '${page_title}' 没有分类标签。` }] };
+        if (action === "sections") {
+          const sections = await listSections(page_title);
+          if (sections.length === 0) {
+            return { content: [{ type: "text", text: `页面 '${page_title}' 没有章节目录。` }] };
+          }
+          return { content: [{ type: "text", text: sections.map((s) => `[${s.index}] L${s.level} ${s.line}`).join("\n") }] };
         }
-        return { content: [{ type: "text", text: cats.map((c) => `- ${c}`).join("\n") }] };
-      } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
-      }
-    }
-  );
-
-  server.tool(
-    "get_prts_links",
-    [
-      "获取 PRTS 维基页面的相关链接。",
-      "outbound 返回该页面引用的所有其他词条链接；inbound 返回所有引用了该页面的词条链接（反向链接）。",
-      "可用于探索维基的知识图谱关系。",
-    ].join(" "),
-    {
-      page_title: z.string().describe("词条标题，如「阿米娅」。"),
-      direction: z.enum(["outbound", "inbound"]).default("outbound").describe("链接方向：outbound（页面引用的链接，默认）或 inbound（引用该页面的链接）。"),
-      limit: z.number().int().min(1).max(100).default(30).describe("返回链接数量上限，默认 30。"),
-    },
-    async ({ page_title, direction, limit }) => {
-      try {
-        const result = await getLinks(page_title, direction, limit);
-        if (result.links.length === 0) {
-          const dirLabel = direction === "outbound" ? "出站" : "入站";
-          return { content: [{ type: "text", text: `页面 '${page_title}' 没有${dirLabel}链接。` }] };
+        if (action === "categories") {
+          const cats = await getCategories(page_title);
+          if (cats.length === 0) {
+            return { content: [{ type: "text", text: `页面 '${page_title}' 没有分类标签。` }] };
+          }
+          return { content: [{ type: "text", text: cats.map((c) => `- ${c}`).join("\n") }] };
         }
-        const suffix = result.hasMore
-          ? `\n（共 ${result.total} 条，还有更多）`
-          : `\n（共 ${result.total} 条）`;
-        return { content: [{ type: "text", text: result.links.map((ln) => `- ${ln}`).join("\n") + suffix }] };
-      } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
-      }
-    }
-  );
-
-  server.tool(
-    "get_prts_template",
-    [
-      "获取 PRTS 维基页面的结构化模板数据。",
-      "提取页面中所有模板调用的键值对，返回按模板名分组的 dict。",
-      "典型模板：干员页面的 CharinfoV2（干员名、稀有度、职业、所属等），",
-      "敌人页面的 敌人信息/common2（名称、地位级别、描述、伤害类型等），",
-      "物品页面的 道具信息（名称、用途、获得方式等）。",
-    ].join(" "),
-    {
-      page_title: z.string().describe("词条标题，如「阿米娅」。"),
-    },
-    async ({ page_title }) => {
-      try {
+        if (action === "links") {
+          const result = await getLinks(page_title, direction, limit);
+          if (result.links.length === 0) {
+            const dirLabel = direction === "outbound" ? "出站" : "入站";
+            return { content: [{ type: "text", text: `页面 '${page_title}' 没有${dirLabel}链接。` }] };
+          }
+          const suffix = result.hasMore
+            ? `\n（共 ${result.total} 条，还有更多）`
+            : `\n（共 ${result.total} 条）`;
+          return { content: [{ type: "text", text: result.links.map((ln) => `- ${ln}`).join("\n") + suffix }] };
+        }
+        // action === "template"
         const templates = await getTemplateData(page_title);
         if (Object.keys(templates).length === 0) {
           return { content: [{ type: "text", text: `页面 '${page_title}' 未找到可提取的模板数据。` }] };

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -165,7 +165,7 @@ test("E2E", async (t) => {
   });
 
   // --- tools/list ---
-  await t.test("tools/list returns all 28 tools", async () => {
+  await t.test("tools/list returns all 24 tools", async () => {
     const tl = await mcpPost(
       origin,
       { jsonrpc: "2.0", method: "tools/list", id: 2 },
@@ -175,11 +175,10 @@ test("E2E", async (t) => {
     assert.equal(tl.status, 200);
     const tools = (tl.body?.result as Record<string, unknown>)?.tools as Array<{ name: string }> | undefined;
     assert.ok(tools, "tools/list should return tools");
-    assert.equal(tools!.length, 28, `got ${tools!.length} tools`);
+    assert.equal(tools!.length, 24, `got ${tools!.length} tools`);
 
     const expected = new Set([
-      "search_prts", "read_prts_page", "list_prts_sections",
-      "get_prts_categories", "get_prts_links", "get_prts_template",
+      "search_prts", "prts_page",
       "get_operator_archives", "get_operator_voicelines", "get_operator_basic_info",
       "list_enemies", "get_enemy_info",
       "get_stage_enemies", "get_enemy_appearances",
@@ -268,8 +267,8 @@ test("E2E", async (t) => {
     assert.ok(text.includes("阿米娅") && text.includes("匹配"), text.slice(0, 80));
   });
 
-  await t.test("list_prts_sections", { skip: !RUN_PRTS_API }, async () => {
-    const r = await mcpPost(origin, tc("list_prts_sections", { page_title: "阿米娅" }, 21), sessionId);
+  await t.test("prts_page sections", { skip: !RUN_PRTS_API }, async () => {
+    const r = await mcpPost(origin, tc("prts_page", { page_title: "阿米娅", action: "sections" }, 21), sessionId);
     assert.equal(r.status, 200);
     const text = toolResultText(r);
     assert.ok(text.includes("[") && text.includes("] L"), text.slice(0, 80));

--- a/ts/tests/toolSurface.test.ts
+++ b/ts/tests/toolSurface.test.ts
@@ -5,11 +5,7 @@ import { join } from "node:path";
 
 const EXPECTED_TOOLS = [
   "search_prts",
-  "read_prts_page",
-  "list_prts_sections",
-  "get_prts_categories",
-  "get_prts_links",
-  "get_prts_template",
+  "prts_page",
   "get_operator_archives",
   "get_operator_voicelines",
   "get_operator_basic_info",


### PR DESCRIPTION
## Summary

Third PR of the 2.0 tool-surface consolidation. Merges the five PRTS page tools — `read_prts_page`, `list_prts_sections`, `get_prts_categories`, `get_prts_links`, `get_prts_template` — into a single `prts_page(page_title, action, ...)` with a **required** `action` enum (`read` / `sections` / `categories` / `links` / `template`). `search_prts` (live MediaWiki keyword search) stays separate.

**Tool surface: 28 → 24.** Breaking change (2.0). This is the action-dispatch (god-tool) shape — accepted deliberately per our design decision; the read/sections workflow is compensated in the tool description (recommend `action="sections"` then `action="read"` + `section_index`). Per-action formatting and error handling are preserved verbatim. `action` and `direction` are schema-level enums (`Literal` / `z.enum`) in both implementations.

## Test plan

- Python: `pytest` — 217 passed, 2 skipped. Tool-surface snapshot → `prts_page: (page_title, action, section_index, direction, limit)`; e2e set = 24; opt-in sections test now calls `prts_page` with `action="sections"`.
- TypeScript: `npm test` — 162 pass, 0 fail; `npm run typecheck` clean.
- Docs: STATUS tool table (24), README (EN+zh), deployment; both CHANGELOGs (`Changed` + `Removed`).
- Also fixed the `cd-ts.yml` post-publish smoke-test required-tools list (`read_prts_page` → `prts_page`) — it would otherwise fail after 2.0 publishes. (Python `cd.yml` only checks `search_prts`, unaffected.)

## 未尽事宜 (follow-ups)

- API layer (`read_page` / `list_sections` / `get_categories` / `get_links` / `get_template_data`) unchanged — the action tool routes to them.
- Next PR: `list_stories` summary absorption (drops `get_event_summary`, 24 → 23), then the description-standardization sweep.
- ROADMAP consolidation section still has stale "24 → ~16" numbers and lists `search_stories` in the search merge — a broader ROADMAP rewrite tracked separately.