### PR TITLE
refactor: absorb event summary into list_stories, drop get_event_summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ Both implementations expose the same tool set:
 | `get_operator_voicelines(name)` | Retrieve operator voice lines (Chinese name) |
 | `get_operator_basic_info(name)` | Retrieve basic operator profile: class, rarity, faction, recruit tags, talents (Chinese name) |
 | `list_story_events(category?)` | List story events; optional filter: `main` (main story) or `activities` |
-| `list_stories(event_id, include_summaries?)` | List chapters of an event in official order, with optional summaries |
-| `get_event_summary(event_id)` | Narrative overview of all chapters in an event with summaries |
+| `list_stories(event_id, include_summaries?)` | List chapters of an event in official order; `include_summaries` adds the event-level overview + per-chapter summaries |
 | `get_story_summary(story_key)` | Single-chapter summary (LLM long summary or official one-liner) |
 | `read_story(story_key, include_narration)` | Read full dialogue for a single chapter |
 | `read_activity(event_id, include_narration, page, page_size)` | Read a complete activity's transcript, with pagination |
@@ -125,8 +124,7 @@ Published Docker images and the npm package include bundled fallback game/level/
 | `get_operator_voicelines(name)` | 获取干员语音记录（中文名） |
 | `get_operator_basic_info(name)` | 获取干员基本信息：职业、稀有度、所属、招募标签、天赋（中文名） |
 | `list_story_events(category?)` | 列出剧情活动，可选过滤：`main`（主线）或 `activities`（活动） |
-| `list_stories(event_id, include_summaries?)` | 列出指定活动的章节（按官方顺序），可选附带梗概 |
-| `get_event_summary(event_id)` | 获取活动的章节梗概概览，含 LLM 长摘要 |
+| `list_stories(event_id, include_summaries?)` | 列出指定活动的章节（按官方顺序）；`include_summaries` 附活动级概览 + 每章梗概 |
 | `get_story_summary(story_key)` | 获取单章梗概（LLM 长摘要或官方一句话简介） |
 | `read_story(story_key, include_narration)` | 读取单章完整台词 |
 | `read_activity(event_id, include_narration, page, page_size)` | 读取整个活动的完整剧情，支持分页 |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,7 +143,7 @@ The 1.x tool surface reached 32 tools by the 1.7.0 LTS release. For long-context
   LLM selection accuracy more than it saves context.
 - Enemy triplet (`list_enemies` / `get_enemy_info` / `search_enemies`):
   same reason.
-- Story tools (`read_story` / `read_activity` / `get_event_summary`):
+- Story tools (`read_story` / `read_activity` / `get_story_summary`):
   genuinely distinct actions on related-but-different data.
 
 The bar for consolidation: same parameter shape, similar output length and structure, an LLM choosing between them today is choosing between near-synonyms.

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -136,7 +136,7 @@ PRTS-MCP 已进入 1.x 稳定期。1.7.0 是最后一个 1.x 功能版本和 1.7
   输出形态和长度差异大，合并反而降低 LLM 选择准确率，得不偿失。
 - 敌人三件套（`list_enemies` / `get_enemy_info` / `search_enemies`）：
   同上。
-- 剧情工具（`read_story` / `read_activity` / `get_event_summary`）：
+- 剧情工具（`read_story` / `read_activity` / `get_story_summary`）：
   在相关但不同的数据上做真正不同的动作。
 
 合并的门槛：参数形态相同、输出长度和结构相似、LLM 在它们之间 做选择本质上是在选近义词。

--- a/STATUS.md
+++ b/STATUS.md
@@ -31,7 +31,7 @@ PRTS-MCP/
 │   │   ├── server.py       # 入口点 → tools_* 模块
 │   │   ├── tools_prts.py   # PRTS Wiki 工具注册（2 工具）
 │   │   ├── tools_gamedata.py # GameData 工具注册（12 工具）
-│   │   ├── tools_story.py  # 剧情工具注册（10 工具）
+│   │   ├── tools_story.py  # 剧情工具注册（9 工具）
 │   │   ├── config.py       # 路径解析、环境变量
 │   │   ├── startup_sync.py # 后台数据同步编排
 │   │   ├── api/            # PRTS Wiki MediaWiki API 客户端
@@ -93,7 +93,7 @@ PRTS-MCP/
 | [ArknightsStoryJson](https://github.com/3aKHP/ArknightsStoryJson) | 剧情台词 | GitHub Release `zh_CN.zip` |
 | [PRTS Wiki API](https://prts.wiki/api.php) | 世界观词条/阵营设定 | 实时 HTTP 请求 |
 
-## 工具清单 (24, current branch)
+## 工具清单 (23, current branch)
 
 | # | 工具 | 数据源 | 版本 |
 |---|------|--------|------|
@@ -108,19 +108,18 @@ PRTS-MCP/
 | 9 | `read_activity` | StoryJson | 0.3.0 |
 | 10 | `search` | GameData | 2.0.0 |
 | 11 | `search_stories` | StoryJson | 1.1.0 |
-| 12 | `get_event_summary` | StoryJson | 1.2.0 |
-| 13 | `get_story_summary` | StoryJson | 1.2.0 |
-| 14 | `list_enemies` | GameData | 1.4.0 |
-| 15 | `get_enemy_info` | GameData | 1.4.0 |
-| 16 | `get_stage_enemies` | GameData levels | 1.6.0 |
-| 17 | `get_enemy_appearances` | GameData levels | 1.6.0 |
-| 18 | `list_stages` | GameData | 1.5.0 |
-| 19 | `get_stage_info` | GameData | 1.5.0 |
-| 20 | `list_items` | GameData | 1.6.0 |
-| 21 | `get_item_info` | GameData | 1.6.0 |
-| 22 | `get_operator_memoirs` | StoryJson | 1.6.1 |
-| 23 | `find_character_appearances` | StoryJson | 1.7.0 |
-| 24 | `find_speakers_in` | StoryJson | 1.7.0 |
+| 12 | `get_story_summary` | StoryJson | 1.2.0 |
+| 13 | `list_enemies` | GameData | 1.4.0 |
+| 14 | `get_enemy_info` | GameData | 1.4.0 |
+| 15 | `get_stage_enemies` | GameData levels | 1.6.0 |
+| 16 | `get_enemy_appearances` | GameData levels | 1.6.0 |
+| 17 | `list_stages` | GameData | 1.5.0 |
+| 18 | `get_stage_info` | GameData | 1.5.0 |
+| 19 | `list_items` | GameData | 1.6.0 |
+| 20 | `get_item_info` | GameData | 1.6.0 |
+| 21 | `get_operator_memoirs` | StoryJson | 1.6.1 |
+| 22 | `find_character_appearances` | StoryJson | 1.7.0 |
+| 23 | `find_speakers_in` | StoryJson | 1.7.0 |
 
 > `search(scope, pattern, max_results)` 统一了 1.x 的 `search_data` /
 > `search_enemies` / `search_stages` / `search_items` 与 `list_search_scopes`
@@ -131,6 +130,9 @@ PRTS-MCP/
 > `list_prts_sections` / `get_prts_categories` / `get_prts_links` /
 > `get_prts_template`（action ∈ read/sections/categories/links/template）。
 > 维基关键词搜索仍为独立的 `search_prts`。
+>
+> `list_stories(event_id, include_summaries=True)` 现附带活动级长摘要（吸收了
+> 1.x 的 `get_event_summary`）；单章深摘要仍为独立的 `get_story_summary`。
 
 ## 遗留 TODO
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -23,6 +23,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   action, ...)` tool with a required `action` enum (`read` / `sections` /
   `categories` / `links` / `template`). Wiki keyword search remains a separate
   `search_prts`. Tool surface drops 28 → 24.
+- **`list_stories` absorbs the event-level summary (2.0, breaking).**
+  `list_stories(event_id, include_summaries=True)` now prepends the event's LLM
+  overview (from `event_summaries.json`) when present, on top of the per-chapter
+  one-liners it already returned — making it a superset of the former
+  `get_event_summary`. Tool surface drops 24 → 23.
 
 ### Removed
 
@@ -33,6 +38,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **`read_prts_page`, `list_prts_sections`, `get_prts_categories`,
   `get_prts_links`, `get_prts_template` (2.0, breaking).** Replaced by unified
   `prts_page(page_title, action, ...)`.
+- **`get_event_summary` (2.0, breaking).** Folded into
+  `list_stories(include_summaries=True)`; `get_story_summary` (single-chapter
+  deep summary) is unchanged.
 
 ## [1.7.0] - 2026-07-02
 

--- a/python/docs/deployment.md
+++ b/python/docs/deployment.md
@@ -142,7 +142,6 @@ docker run -i --rm `
         "get_item_info",
         "list_story_events",
         "list_stories",
-        "get_event_summary",
         "get_story_summary",
         "read_story",
         "read_activity",
@@ -204,8 +203,7 @@ npx @modelcontextprotocol/inspector docker run -i --rm -v prts-mcp-data:/data/ga
 | `find_character_appearances` | `name`: `阿米娅`, `max_events`: `5` | 剧情数据 |
 | `find_speakers_in` | `event_id`: `act31side` | 剧情数据 |
 | `list_story_events` | `category`: `activities` | 剧情数据 |
-| `list_stories` | `event_id`: `act31side` | 剧情数据 |
-| `get_event_summary` | `event_id`: `act31side` | 剧情数据 |
+| `list_stories` | `event_id`: `act31side`, `include_summaries`: `true` | 剧情数据 |
 | `get_story_summary` | `story_key`: `activities/act31side/level_act31side_01_beg` | 剧情数据 |
 | `read_story` | `story_key`: `activities/act31side/level_act31side_01_beg` | 剧情数据 |
 | `read_activity` | `event_id`: `act31side`, `page`: `1` | 剧情数据 |

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -45,8 +45,6 @@ from prts_mcp.data.story_memoir import (
     get_operator_memoirs_from_store,
 )
 from prts_mcp.data.story_summary import (
-    get_event_summary,
-    get_event_summary_from_store,
     get_story_summary,
     get_story_summary_from_store,
 )
@@ -94,8 +92,6 @@ __all__ = [
     "get_operator_memoirs",
     "get_operator_memoirs_from_store",
     # Summary
-    "get_event_summary",
-    "get_event_summary_from_store",
     "get_story_summary",
     "get_story_summary_from_store",
     # Character tracking

--- a/python/src/prts_mcp/data/story_reader.py
+++ b/python/src/prts_mcp/data/story_reader.py
@@ -21,7 +21,6 @@ from prts_mcp.data.stores import JsonStore, ZipStore
 STORY_REVIEW_TABLE = "zh_CN/gamedata/excel/story_review_table.json"
 STORYINFO = "zh_CN/storyinfo.json"
 SUMMARIES = "zh_CN/summaries.json"
-EVENT_SUMMARIES = "zh_CN/event_summaries.json"
 CHARDICT = "zh_CN/chardict.json"
 
 # entryType values → user-facing category strings

--- a/python/src/prts_mcp/data/story_summary.py
+++ b/python/src/prts_mcp/data/story_summary.py
@@ -1,8 +1,7 @@
-"""Story chapter and event summary readers.
+"""Story chapter summary reader.
 
-Split from story.py. Provides event-level overview (get_event_summary)
-and per-chapter summary with a three-tier fallback chain:
-LLM long summary → official one-liner → chapter storyInfo field.
+Split from story.py. Provides per-chapter summary with a three-tier fallback
+chain: LLM long summary → official one-liner → chapter storyInfo field.
 """
 from __future__ import annotations
 
@@ -10,96 +9,12 @@ from pathlib import Path
 
 from prts_mcp.data.stores import JsonStore
 from prts_mcp.data.story_reader import (
-    EVENT_SUMMARIES,
-    STORY_REVIEW_TABLE,
     STORYINFO,
     SUMMARIES,
     load_json,
     story_store,
     story_zip_path,
 )
-
-
-# ---------------------------------------------------------------------------
-# Event summary (all chapters of an event)
-# ---------------------------------------------------------------------------
-
-
-def get_event_summary(zip_path: Path, event_id: str) -> str:
-    """Return a chapter-by-chapter summary overview of an event.
-
-    Convenience wrapper around get_event_summary_from_store.
-    """
-    with story_store(zip_path) as store:
-        return get_event_summary_from_store(store, event_id)
-
-
-def get_event_summary_from_store(store: JsonStore, event_id: str) -> str:
-    """Return a chapter-by-chapter summary overview of an event.
-
-    Reads story_review_table for chapter ordering and storyinfo.json
-    for per-chapter summaries, producing a narrative table of contents
-    suitable for getting the big picture of an event at a glance.
-    """
-    # --- event metadata ---
-    try:
-        table: dict = load_json(store, STORY_REVIEW_TABLE)
-    except Exception as exc:
-        return f"读取剧情数据索引失败：{exc}"
-
-    entry = table.get(event_id)
-    if entry is None:
-        return f"未找到活动：{event_id!r}。请先调用 list_story_events 确认活动 ID。"
-
-    event_name = entry.get("name") or event_id
-    datas = sorted(
-        entry.get("infoUnlockDatas") or [],
-        key=lambda x: x.get("storySort", 0),
-    )
-
-    if not datas:
-        return f"活动 {event_id!r}（{event_name}）暂无剧情章节。"
-
-    # --- load summary index ---
-    summaries: dict[str, str] = {}
-    if store.exists(STORYINFO):
-        try:
-            raw = load_json(store, STORYINFO)
-            if isinstance(raw, dict):
-                summaries = {str(k): str(v) for k, v in raw.items() if v}
-        except Exception:
-            pass  # storyinfo.json is optional for this tool
-
-    # --- tier 1: LLM event summary ---
-    event_summary_text = ""
-    if store.exists(EVENT_SUMMARIES):
-        try:
-            raw = load_json(store, EVENT_SUMMARIES)
-            if isinstance(raw, dict):
-                event_summary_text = str(raw.get(event_id) or "").strip()
-        except Exception:
-            pass
-
-    # --- build output ---
-    total = len(datas)
-    lines = [f"# {event_name} — 共 {total} 章"]
-    if event_summary_text:
-        lines.append(f"\n{event_summary_text}")
-    for d in datas:
-        story_key = d.get("storyTxt")
-        if not story_key:
-            continue
-        code = d.get("storyCode", "")
-        name = d.get("storyName", "")
-        tag = f"[{d['avgTag']}] " if d.get("avgTag") else ""
-
-        summary = summaries.get(story_key, "")
-        if summary:
-            lines.append(f"\n{code} {tag}{name}\n  {summary}")
-        else:
-            lines.append(f"\n{code} {tag}{name}")
-
-    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -16,7 +16,6 @@ from prts_mcp.data.story import (
     read_story as _read_story,
     read_activity as _read_activity,
     search_stories as _search_stories,
-    get_event_summary as _get_event_summary,
     get_story_summary as _get_story_summary,
     get_operator_memoirs as _get_operator_memoirs,
     find_character_appearances as _find_character_appearances,
@@ -61,13 +60,13 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     @mcp.tool()
     def list_stories(
         event_id: Annotated[str, Field(description="活动 ID，如 \"act31side\"（可从 list_story_events 获取）。")],
-        include_summaries: Annotated[bool, Field(default=False, description="是否附带每章梗概，默认 False。")] = False,
+        include_summaries: Annotated[bool, Field(default=False, description="是否附带梗概，默认 False。设为 True 时顶部附活动级长摘要（若有）、每章下方附一句话梗概。")] = False,
     ) -> str:
         """列出指定活动的所有剧情章节（按官方顺序排列）。
 
         返回格式：每行 `- 章节编号 [标签] 章节名（key: story_key）`，其中 story_key
-        可直接传入 read_story 读取该章台词。设置 include_summaries=True 时每章下方会
-        附带梗概。如需一次性了解活动整体剧情脉络，可使用 get_event_summary。
+        可直接传入 read_story 读取该章台词。设 include_summaries=True 时，顶部附活动级
+        长摘要（若有），每章下方附一句话梗概——可一次性了解活动整体剧情脉络。
         """
         from prts_mcp.config import Config
         cfg = Config.load()
@@ -87,6 +86,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
             return f"活动 {event_id!r} 暂无剧情章节。"
 
         summaries: dict[str, str] = {}
+        event_summary_text = ""
         if include_summaries:
             try:
                 with ZipStore(zip_path) as store:
@@ -94,10 +94,17 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
                         raw = store.read_json("zh_CN/storyinfo.json")
                         if isinstance(raw, dict):
                             summaries = {str(k): str(v) for k, v in raw.items() if v}
+                    if store.exists("zh_CN/event_summaries.json"):
+                        raw_ev = store.read_json("zh_CN/event_summaries.json")
+                        if isinstance(raw_ev, dict):
+                            event_summary_text = str(raw_ev.get(event_id) or "").strip()
             except Exception:
                 pass
 
         lines = []
+        if event_summary_text:
+            lines.append(event_summary_text)
+            lines.append("")
         for ch in chapters:
             tag = f"[{ch.avg_tag}] " if ch.avg_tag else ""
             lines.append(f"- {ch.story_code} {tag}{ch.story_name}（key: {ch.story_key}）")
@@ -106,28 +113,6 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
                 if summary:
                     lines.append(f"  {summary}")
         return "\n".join(lines)
-
-    @mcp.tool()
-    def get_event_summary(
-        event_id: Annotated[str, Field(description="活动 ID，如 \"act31side\"（可从 list_story_events 获取）。")],
-    ) -> str:
-        """获取指定活动的章节梗概概览。
-
-        返回活动的所有章节编号、标题和每章故事简介，按官方顺序排列，
-        适合快速了解一个活动的整体剧情脉络。如需读取完整台词，请使用
-        read_story 或 read_activity。
-        """
-        from prts_mcp.config import Config
-        cfg = Config.load()
-        try:
-            zip_path = _require_story_zip(cfg)
-        except RuntimeError as e:
-            return str(e)
-
-        try:
-            return _get_event_summary(zip_path, event_id)
-        except Exception as e:
-            return f"读取活动梗概失败：{e}"
 
     @mcp.tool()
     def get_story_summary(
@@ -139,7 +124,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         未就绪时回退到官方一句话梗概（zh_CN/storyinfo.json），最后回退到章节
         JSON 中的 storyInfo 字段。
 
-        如需获取整个活动的章节概览，请使用 get_event_summary。
+        如需获取整个活动的章节概览，请使用 list_stories(include_summaries=True)。
         """
         from prts_mcp.config import Config
         cfg = Config.load()

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -1,6 +1,6 @@
 """Story tool registrations — events, chapters, dialogue, summaries, search, memoirs, characters.
 
-Split from server.py. Covers 10 tools that read story data from the
+Split from server.py. Covers 9 tools that read story data from the
 synced zh_CN.zip via the story submodules.
 """
 from __future__ import annotations
@@ -25,7 +25,7 @@ from prts_mcp.startup_sync import _require_story_zip
 
 
 def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
-    """Register the 10 story-backed tools on the given FastMCP instance."""
+    """Register the 9 story-backed tools on the given FastMCP instance."""
 
     @mcp.tool()
     def list_story_events(

--- a/python/tests/test_e2e.py
+++ b/python/tests/test_e2e.py
@@ -147,7 +147,7 @@ EXPECTED_TOOLS = {
     "list_items", "get_item_info",
     "list_story_events", "list_stories", "read_story", "read_activity",
     "search", "search_stories",
-    "get_event_summary", "get_story_summary",
+    "get_story_summary",
     "get_operator_memoirs",
     "find_character_appearances", "find_speakers_in",
 }
@@ -180,7 +180,7 @@ def test_tools_list(server: subprocess.Popen) -> None:
     tools = resp["result"]["tools"]
     names = {t["name"] for t in tools}
 
-    assert len(names) == 24, f"Expected 24 tools, got {len(names)}: {sorted(names)}"
+    assert len(names) == 23, f"Expected 23 tools, got {len(names)}: {sorted(names)}"
     for name in EXPECTED_TOOLS:
         assert name in names, f"Missing tool: {name}"
 

--- a/python/tests/test_tool_surface.py
+++ b/python/tests/test_tool_surface.py
@@ -16,7 +16,6 @@ EXPECTED_TOOL_SURFACE = {
     "get_enemy_appearances": ("name", "limit", "offset"),
     "list_story_events": ("category",),
     "list_stories": ("event_id", "include_summaries"),
-    "get_event_summary": ("event_id",),
     "get_story_summary": ("story_key",),
     "read_story": ("story_key", "include_narration"),
     "read_activity": ("event_id", "include_narration", "page", "page_size"),

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -23,6 +23,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   action, ...)` tool with a required `action` enum (`read` / `sections` /
   `categories` / `links` / `template`). Wiki keyword search remains a separate
   `search_prts`. Tool surface drops 28 → 24.
+- **`list_stories` absorbs the event-level summary (2.0, breaking).**
+  `list_stories(event_id, include_summaries=true)` now prepends the event's LLM
+  overview (from `event_summaries.json`) when present, on top of the per-chapter
+  one-liners it already returned — making it a superset of the former
+  `get_event_summary`. Tool surface drops 24 → 23.
 
 ### Removed
 
@@ -33,6 +38,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **`read_prts_page`, `list_prts_sections`, `get_prts_categories`,
   `get_prts_links`, `get_prts_template` (2.0, breaking).** Replaced by unified
   `prts_page(page_title, action, ...)`.
+- **`get_event_summary` (2.0, breaking).** Folded into
+  `list_stories(include_summaries=true)`; `get_story_summary` (single-chapter
+  deep summary) is unchanged.
 
 ## [1.7.0] - 2026-07-02
 

--- a/ts/src/data/story.ts
+++ b/ts/src/data/story.ts
@@ -55,8 +55,6 @@ export {
 
 // Summary
 export {
-  getEventSummary,
-  getEventSummaryFromStore,
   getStorySummary,
   getStorySummaryFromStore,
 } from "./storySummary.js";

--- a/ts/src/data/storyReader.ts
+++ b/ts/src/data/storyReader.ts
@@ -16,7 +16,6 @@ import { JsonStore, ZipStore } from "./stores.js";
 export const STORY_REVIEW_TABLE = "zh_CN/gamedata/excel/story_review_table.json";
 export const STORYINFO = "zh_CN/storyinfo.json";
 export const SUMMARIES = "zh_CN/summaries.json";
-export const EVENT_SUMMARIES = "zh_CN/event_summaries.json";
 export const CHARDICT = "zh_CN/chardict.json";
 
 export function storyZipPath(storyKey: string): string {

--- a/ts/src/data/storySummary.ts
+++ b/ts/src/data/storySummary.ts
@@ -1,99 +1,18 @@
 /**
- * Story chapter and event summary readers.
+ * Story chapter summary reader.
  *
- * Split from story.ts. Provides event-level overview (getEventSummary)
- * and per-chapter summary with a three-tier fallback chain:
- * LLM long summary → official one-liner → chapter storyInfo field.
+ * Split from story.ts. Provides per-chapter summary with a three-tier fallback
+ * chain: LLM long summary → official one-liner → chapter storyInfo field.
  * Mirrors python/src/prts_mcp/data/story_summary.py.
  */
 
 import type { JsonStore } from "./stores.js";
 import {
-  EVENT_SUMMARIES,
-  type RawReviewTable,
-  STORY_REVIEW_TABLE,
   STORYINFO,
   SUMMARIES,
   storyZipPath,
   withStoryStore,
 } from "./storyReader.js";
-
-// ---------------------------------------------------------------------------
-// Event summary (all chapters of an event)
-// ---------------------------------------------------------------------------
-
-export function getEventSummary(zipPath: string, eventId: string): string {
-  return withStoryStore(zipPath, (store) => getEventSummaryFromStore(store, eventId));
-}
-
-export function getEventSummaryFromStore(store: JsonStore, eventId: string): string {
-  // --- event metadata ---
-  let table: RawReviewTable;
-  try {
-    table = store.readJson<RawReviewTable>(STORY_REVIEW_TABLE);
-  } catch (exc) {
-    return `读取剧情数据索引失败：${exc instanceof Error ? exc.message : String(exc)}`;
-  }
-
-  const entry = table[eventId];
-  if (!entry) {
-    return `未找到活动：${JSON.stringify(eventId)}。请先调用 list_story_events 确认活动 ID。`;
-  }
-
-  const eventName = entry.name ?? eventId;
-  const datas = (entry.infoUnlockDatas ?? []).slice();
-  datas.sort((a, b) => (a.storySort ?? 0) - (b.storySort ?? 0));
-
-  if (datas.length === 0) {
-    return `活动 ${JSON.stringify(eventId)}（${eventName}）暂无剧情章节。`;
-  }
-
-  // --- load summary index ---
-  let summaries: Record<string, string> = {};
-  if (store.exists(STORYINFO)) {
-    try {
-      const raw = store.readJson<Record<string, unknown>>(STORYINFO);
-      for (const [k, v] of Object.entries(raw)) {
-        if (v) summaries[k] = String(v);
-      }
-    } catch {
-      // storyinfo.json is optional for this tool
-    }
-  }
-
-  // --- tier 1: LLM event summary ---
-  let eventSummaryText = "";
-  if (store.exists(EVENT_SUMMARIES)) {
-    try {
-      const raw = store.readJson<Record<string, unknown>>(EVENT_SUMMARIES);
-      const text = raw[eventId];
-      if (typeof text === "string") eventSummaryText = text.trim();
-    } catch {
-      // continue without LLM event summary
-    }
-  }
-
-  // --- build output ---
-  const total = datas.length;
-  const lines: string[] = [`# ${eventName} — 共 ${total} 章`];
-  if (eventSummaryText) lines.push(`\n${eventSummaryText}`);
-  for (const d of datas) {
-    const storyKey = d.storyTxt;
-    if (!storyKey) continue;
-    const code = d.storyCode ?? "";
-    const name = d.storyName ?? "";
-    const tag = d.avgTag ? `[${d.avgTag}] ` : "";
-
-    const summary = summaries[storyKey] ?? "";
-    if (summary) {
-      lines.push(`\n${code} ${tag}${name}\n  ${summary}`);
-    } else {
-      lines.push(`\n${code} ${tag}${name}`);
-    }
-  }
-
-  return lines.join("\n");
-}
 
 // ---------------------------------------------------------------------------
 // Per-chapter summary

--- a/ts/src/tools/storyTools.ts
+++ b/ts/src/tools/storyTools.ts
@@ -1,7 +1,7 @@
 /**
  * Story tool registrations — events, chapters, dialogue, summaries, search, memoirs, characters.
  *
- * Split from server.ts. Exports registerStoryTools which attaches the 10
+ * Split from server.ts. Exports registerStoryTools which attaches the 9
  * story-backed tools to a McpServer instance. Also exports the shared
  * requireStoryZip helper and line/chapter formatters.
  */

--- a/ts/src/tools/storyTools.ts
+++ b/ts/src/tools/storyTools.ts
@@ -16,7 +16,6 @@ import {
   readStory as _readStory,
   readActivity as _readActivity,
   searchStories as _searchStories,
-  getEventSummary as _getEventSummary,
   getStorySummary as _getStorySummary,
   getOperatorMemoirs as _getOperatorMemoirs,
   findCharacterAppearances as _findCharacterAppearances,
@@ -102,11 +101,11 @@ export function registerStoryTools(server: McpServer): void {
     [
       "列出指定活动的所有剧情章节（按官方顺序排列）。",
       "返回格式：每行 `- 章节编号 [标签] 章节名（key: story_key）`，其中 story_key 可直接传入 read_story 读取该章台词。",
-      "设置 include_summaries=true 时每章下方会附带梗概。如需一次性了解活动整体剧情脉络，可使用 get_event_summary。",
+      "设 include_summaries=true 时顶部附活动级长摘要（若有）、每章下方附一句话梗概，可一次性了解活动整体剧情脉络。",
     ].join(" "),
     {
       event_id: z.string().describe("活动 ID，如 \"act31side\"（可从 list_story_events 获取）。"),
-      include_summaries: z.boolean().default(false).describe("是否附带每章梗概，默认 false。"),
+      include_summaries: z.boolean().default(false).describe("是否附带梗概，默认 false。设为 true 时顶部附活动级长摘要（若有）、每章下方附一句话梗概。"),
     },
     ({ event_id, include_summaries }) => {
       let zipPath: string;
@@ -123,6 +122,7 @@ export function registerStoryTools(server: McpServer): void {
 
         // Load summaries if requested
         let summaries: Record<string, string> = {};
+        let eventSummaryText = "";
         if (include_summaries) {
           const store = new ZipStore(zipPath);
           try {
@@ -132,14 +132,22 @@ export function registerStoryTools(server: McpServer): void {
                 if (v) summaries[k] = String(v);
               }
             }
+            if (store.exists("zh_CN/event_summaries.json")) {
+              const rawEv = store.readJson<Record<string, unknown>>("zh_CN/event_summaries.json");
+              const text = rawEv[event_id];
+              if (typeof text === "string") eventSummaryText = text.trim();
+            }
           } catch {
-            // storyinfo.json missing is non-fatal
+            // summary indexes are optional
           } finally {
             store.close();
           }
         }
 
         const lines: string[] = [];
+        if (eventSummaryText) {
+          lines.push(eventSummaryText, "");
+        }
         for (const ch of chapters) {
           const tag = ch.avgTag ? `[${ch.avgTag}] ` : "";
           lines.push(`- ${ch.storyCode} ${tag}${ch.storyName}（key: ${ch.storyKey}）`);
@@ -162,30 +170,6 @@ export function registerStoryTools(server: McpServer): void {
           };
         }
         return { content: [{ type: "text", text: `读取章节列表失败：${msg}` }] };
-      }
-    }
-  );
-
-  server.tool(
-    "get_event_summary",
-    [
-      "获取指定活动的章节梗概概览。",
-      "返回活动的所有章节编号、标题和每章故事简介，按官方顺序排列，",
-      "适合快速了解一个活动的整体剧情脉络。",
-    ].join(" "),
-    { event_id: z.string().describe("活动 ID，如 \"act31side\"（可从 list_story_events 获取）。") },
-    ({ event_id }) => {
-      let zipPath: string;
-      try {
-        zipPath = requireStoryZip();
-      } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
-      }
-      try {
-        const text = _getEventSummary(zipPath, event_id);
-        return { content: [{ type: "text", text }] };
-      } catch (e) {
-        return { content: [{ type: "text", text: `读取活动梗概失败：${e instanceof Error ? e.message : String(e)}` }] };
       }
     }
   );

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -165,7 +165,7 @@ test("E2E", async (t) => {
   });
 
   // --- tools/list ---
-  await t.test("tools/list returns all 24 tools", async () => {
+  await t.test("tools/list returns all 23 tools", async () => {
     const tl = await mcpPost(
       origin,
       { jsonrpc: "2.0", method: "tools/list", id: 2 },
@@ -175,7 +175,7 @@ test("E2E", async (t) => {
     assert.equal(tl.status, 200);
     const tools = (tl.body?.result as Record<string, unknown>)?.tools as Array<{ name: string }> | undefined;
     assert.ok(tools, "tools/list should return tools");
-    assert.equal(tools!.length, 24, `got ${tools!.length} tools`);
+    assert.equal(tools!.length, 23, `got ${tools!.length} tools`);
 
     const expected = new Set([
       "search_prts", "prts_page",
@@ -186,7 +186,7 @@ test("E2E", async (t) => {
       "list_items", "get_item_info",
       "list_story_events", "list_stories", "read_story", "read_activity",
       "search", "search_stories",
-      "get_event_summary", "get_story_summary",
+      "get_story_summary",
       "get_operator_memoirs",
       "find_character_appearances", "find_speakers_in",
     ]);

--- a/ts/tests/toolSurface.test.ts
+++ b/ts/tests/toolSurface.test.ts
@@ -19,7 +19,6 @@ const EXPECTED_TOOLS = [
   "get_item_info",
   "list_story_events",
   "list_stories",
-  "get_event_summary",
   "get_story_summary",
   "read_story",
   "read_activity",


### PR DESCRIPTION
## Summary

Fourth PR of the 2.0 tool-surface consolidation. Absorbs the event-level summary into `list_stories` and removes `get_event_summary`.

`list_stories(event_id, include_summaries=True)` now prepends the event's LLM overview (from `event_summaries.json`) when present, on top of the per-chapter one-liners it already returned. That makes it a strict superset of the old `get_event_summary` (which lacked the `story_key` navigation `list_stories` provides), so `get_event_summary` is removed. `get_story_summary` (single-chapter deep summary, its own 3-tier fallback) is unchanged.

**Tool surface: 24 → 23.** Breaking change (2.0).

The orphaned data-layer `get_event_summary` / `get_event_summary_from_store` are also removed from both implementations (`story_summary.py` / `storySummary.ts`) and their shim re-exports, along with now-unused imports (`EVENT_SUMMARIES`, `STORY_REVIEW_TABLE`, `RawReviewTable`).

## Test plan

- Python: `pytest` — 217 passed, 2 skipped. Tool-surface snapshot + e2e set = 23.
- TypeScript: `npm test` — 162 pass, 0 fail; `npm run typecheck` clean.
- Docs: STATUS (23 + migration note), README (EN+zh — `list_stories` row updated, `get_event_summary` removed), deployment; both CHANGELOGs (`Changed` + `Removed`).

## 未尽事宜 (follow-ups)

- `event_summaries.json` is an optional upstream artifact (no local generation pipeline); when absent, `list_stories(include_summaries=True)` returns the per-chapter one-liners exactly as before — no regression.
- Final tools PR next: the description-standardization sweep (all ~23 tools to the STYLE spec; no tool-count change).