### PR TITLE
refactor: standardize all tool descriptions to STYLE spec

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -28,6 +28,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   overview (from `event_summaries.json`) when present, on top of the per-chapter
   one-liners it already returned — making it a superset of the former
   `get_event_summary`. Tool surface drops 24 → 23.
+- **Tool descriptions standardized (2.0).** All tool descriptions were rewritten
+  to a consistent house style (verb-first purpose, output-shape note, at most one
+  cross-reference, parameter semantics kept in the parameter schema) and trimmed
+  ~20% to reduce context budget on smaller-context models. No change to tool
+  names, parameters, or output format.
 
 ### Removed
 

--- a/python/src/prts_mcp/tools_gamedata.py
+++ b/python/src/prts_mcp/tools_gamedata.py
@@ -47,8 +47,7 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         """获取指定干员的档案资料。
 
         返回干员的客观履历、个人档案（基础档案及解锁档案）等背景故事文本。
-        若需查询干员的职业、稀有度等数值信息，请使用 get_operator_basic_info；
-        若需查询语音台词，请使用 get_operator_voicelines。
+        数值信息见 get_operator_basic_info，语音台词见 get_operator_voicelines。
         """
         return _get_archives(name)
 
@@ -58,9 +57,8 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """获取指定干员的所有语音台词记录。
 
-        返回包含触发条件（如「交谈1」、「晋升后交谈」、「信赖提升后交谈」）及对应
-        台词文本的完整列表。此工具仅返回语音文本；若需查询干员背景故事或客观
-        履历，请使用 get_operator_archives。
+        返回触发条件（如「交谈1」、「晋升后交谈」、「信赖提升后交谈」）及对应台词文本的
+        完整列表。背景故事与客观履历见 get_operator_archives。
         """
         return _get_voicelines(name)
 
@@ -70,9 +68,8 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """获取指定干员的基本数值信息。
 
-        返回干员的职业、子职业、稀有度（星级）、所属阵营、招募标签、天赋名称
-        及描述等结构化信息。适合快速了解干员定位；若需完整背景故事请使用
-        get_operator_archives，若需语音台词请使用 get_operator_voicelines。
+        返回干员的职业、子职业、稀有度（星级）、所属阵营、招募标签、天赋名称及描述等
+        结构化信息，适合快速了解干员定位。完整背景故事见 get_operator_archives。
         """
         return _get_basic_info(name)
 
@@ -85,9 +82,8 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """列出敌方图鉴，支持按威胁等级过滤和分页。
 
-        默认返回前 50 条。若需翻页，增大 offset 即可。
-        若只想看领袖/BOSS 级敌人，设置 threat_level="boss"。
-        不推荐使用 full=true，图鉴共有 1500+ 条目。
+        默认返回前 50 条；翻页增大 offset，只看领袖/BOSS 设 threat_level="boss"。
+        图鉴共 1500+ 条目，不推荐 full=true。
         """
         return _list_enemies(threat_level=threat_level, limit=limit, offset=offset, full=full)
 
@@ -98,8 +94,8 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """获取指定敌人的详细图鉴资料。
 
-        默认返回该敌人的威胁等级、描述、攻击方式、伤害类型和特殊能力等图鉴信息。
-        若提供 stage_id，则返回该敌人在指定关卡内的等级与关卡覆盖后的战斗属性。
+        默认返回威胁等级、描述、攻击方式、伤害类型和特殊能力等图鉴信息。
+        提供 stage_id 时改为返回该敌人在指定关卡内的等级与关卡覆盖后的战斗属性。
         """
         if stage_id:
             return _get_enemy_stage_info(name, stage_id)
@@ -111,8 +107,8 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """获取指定关卡实际出场的敌人列表。
 
-        基于关卡 level JSON 的 SPAWN 动作统计实际出怪，并合并 enemy_database 中
-        对应该关卡敌人等级的战斗属性。
+        只统计关卡内真正刷出的敌人，并附上其在该关卡等级下的战斗属性。
+        反向查询某敌人出现在哪些关卡见 get_enemy_appearances。
         """
         return _get_stage_enemies(stage_id)
 
@@ -124,8 +120,7 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """反向查询指定敌人实际出现在哪些关卡。
 
-        只统计关卡 level JSON 中 SPAWN 动作真正刷出的敌人，不把 enemyDbRefs 中
-        未实际出场的引用计入结果。
+        只统计该敌人真正刷出的关卡，不计入引用但未实际出场的关卡。
         """
         return _get_enemy_appearances(name, limit=limit, offset=offset)
 
@@ -150,6 +145,7 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         """获取指定关卡的详细信息。
 
         返回关卡的编号、类型、难度、所属区域、理智消耗、掉落奖励、解锁条件等。
+        关卡实际出场的敌人见 get_stage_enemies。
         """
         return _get_stage_info(stage_id)
 
@@ -161,8 +157,7 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """列出物品/材料列表，支持按分类过滤和分页。
 
-        返回物品名称、分类、类型、稀有度、ID 和简短用途。适合查找材料、
-        货币、凭证等 item_table 物品。
+        返回每个物品的名称、分类、类型、稀有度、ID 和简短用途，适合查找材料、货币、凭证等。
         """
         return _list_items(category=category, limit=limit, offset=offset)
 
@@ -186,7 +181,7 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
 
         scope 选择搜索域：operators（名称/属性/档案/语音）、enemies（图鉴）、
         stages（关卡）、items（物品/材料）。返回带域标签的匹配结果。
-        剧情台词搜索请用 search_stories（参数不同）。
+        剧情台词搜索见 search_stories。
         """
         searchers = {
             "operators": _search_operator_data,

--- a/python/src/prts_mcp/tools_prts.py
+++ b/python/src/prts_mcp/tools_prts.py
@@ -33,9 +33,8 @@ def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """搜索 PRTS 明日方舟中文维基词条。
 
-        返回匹配词条的标题和简短摘要列表，含匹配总数。这是探索维基的第一步：当需要查找
-        不确定的专有名词、干员、关卡或世界观设定时，先用此工具搜索获取准确
-        标题，再将标题传入 prts_page 获取完整内容。
+        返回匹配词条的标题、简短摘要列表及匹配总数。查询专有名词、干员、关卡或世界观设定
+        时先用此工具拿到准确标题，再传入 prts_page 获取完整内容。
         """
         if search_mode not in ("text", "title"):
             return "无效的 search_mode 参数，可选值：text、title。"
@@ -58,13 +57,12 @@ def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         direction: Annotated[Literal["outbound", "inbound"], Field(default="outbound", description="仅 action=links 生效：outbound（出链，默认）或 inbound（入链）。")] = "outbound",
         limit: Annotated[int, Field(default=30, ge=1, le=100, description="仅 action=links 生效：返回链接数量上限，默认 30。")] = 30,
     ) -> str:
-        """读取 PRTS 维基页面的内容或元数据（按 action 分派）。
+        """读取 PRTS 维基页面的正文或元数据，按 action 分派。
 
-        推荐流程：先用 action="sections" 看目录（返回 [编号] L层级 标题，T- 前缀表示
-        模板嵌入的节），再用 action="read" + section_index 读特定章节，避免整页过载。
-        其余 action：categories=分类标签；links=相关链接（outbound 出链 / inbound 反向
-        链接，探索维基知识图谱）；template=结构化模板数据（如干员 CharinfoV2、敌人
-        敌人信息/common2、物品 道具信息）。先用 search_prts 获取准确标题。
+        推荐流程：先用 action="sections" 看目录（每行 `[编号] L层级 标题`，T- 前缀表示模板
+        嵌入的节），再用 action="read" + section_index 读特定章节，避免整页过载。其余 action：
+        categories 返回分类标签；links 返回相关链接（outbound 出链 / inbound 反向链接）；
+        template 返回结构化模板数据（如干员 CharinfoV2、敌人 敌人信息/common2、物品 道具信息）。
         """
         try:
             if action == "read":

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -34,8 +34,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         """列出明日方舟剧情活动列表。
 
         返回格式：每行 `- [类型] 活动ID：名称（N 章）`，类型为 MAINLINE / ACTIVITY /
-        MINI_ACTIVITY / NONE 之一。获取活动 ID 后，可调用 list_stories 查看该活动的章节列表。
-        category="memoirs" 可列出所有干员密录。
+        MINI_ACTIVITY / NONE 之一。获取活动 ID 后可调用 list_stories 查看该活动的章节列表。
         """
         from prts_mcp.config import Config
         cfg = Config.load()
@@ -64,9 +63,8 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """列出指定活动的所有剧情章节（按官方顺序排列）。
 
-        返回格式：每行 `- 章节编号 [标签] 章节名（key: story_key）`，其中 story_key
-        可直接传入 read_story 读取该章台词。设 include_summaries=True 时，顶部附活动级
-        长摘要（若有），每章下方附一句话梗概——可一次性了解活动整体剧情脉络。
+        返回格式：每行 `- 章节编号 [标签] 章节名（key: story_key）`，其中 story_key 可直接
+        传入 read_story 读取该章台词。设 include_summaries=True 可一次性了解活动整体剧情脉络。
         """
         from prts_mcp.config import Config
         cfg = Config.load()
@@ -120,11 +118,8 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """获取单章剧情的梗概。
 
-        返回指定章节的故事摘要。优先使用 LLM 生成的长摘要（zh_CN/summaries.json），
-        未就绪时回退到官方一句话梗概（zh_CN/storyinfo.json），最后回退到章节
-        JSON 中的 storyInfo 字段。
-
-        如需获取整个活动的章节概览，请使用 list_stories(include_summaries=True)。
+        返回指定章节的故事摘要，优先长摘要，未就绪时回退到官方一句话梗概。
+        整个活动的章节概览见 list_stories(include_summaries=True)。
         """
         from prts_mcp.config import Config
         cfg = Config.load()
@@ -148,8 +143,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         """读取单章剧情的完整台词。
 
         返回格式：首行为【活动名】章节名，随后按顺序输出对话（`角色：台词`）、
-        旁白（`*旁白文本*`）和选项（`【选项】文本`）。story_key 可从 list_stories
-        的返回结果中获取。
+        旁白（`*旁白文本*`）和选项（`【选项】文本`）。
         """
         from prts_mcp.config import Config
         cfg = Config.load()
@@ -187,10 +181,8 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """读取整个活动的完整剧情台词（按官方章节顺序合并）。
 
-        适合需要了解完整活动故事的场景。返回各章节台词的合并文本，格式与
-        read_story 一致，章节间以分隔标题区分。单次活动文本量可能较大，建议
-        使用 page 参数分批获取；返回结果末尾会附上 total_chapters 和 has_more
-        字段，便于判断是否还有后续内容。
+        返回各章节台词的合并文本，格式与 read_story 一致，章节间以分隔标题区分。
+        单次文本量可能较大，建议用 page 分批获取，返回末尾会提示是否还有后续内容。
         """
         from prts_mcp.config import Config
         cfg = Config.load()
@@ -248,9 +240,8 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """在剧情台词中执行全文正则搜索，支持角色和台词类型过滤。
 
-        返回格式：以 `[stories/活动ID/章节编号 L行号]` 标注位置，
-        命中行前缀 `>>> ` 标记，上下文行以 4 空格缩进显示。
-        可结合 list_story_events 和 list_stories 确认活动 ID 后过滤到特定活动。
+        返回格式：以 `[stories/活动ID/章节编号 L行号]` 标注位置，命中行前缀 `>>> ` 标记，
+        上下文行以 4 空格缩进显示。
         """
         from prts_mcp.config import Config
         cfg = Config.load()
@@ -278,9 +269,8 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """根据干员名称查询干员密录剧情。
 
-        返回干员的密录章节列表，包含章节 key（story_key）和元数据。
+        返回干员的密录章节列表，含章节 key（story_key）和元数据。
         获取 story_key 后可传入 read_story 读取密录台词。
-        若需先查找正确的干员名称，可用 search（scope=operators）搜索干员数据。
         """
         from prts_mcp.config import Config
         cfg = Config.load()
@@ -312,10 +302,9 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """查找某个角色在剧情中的出场（说话或被提及）。
 
-        返回该角色「说话」（speaks，作为对话发言者）或「被提及」（mentioned，
-        名字出现在任意台词/旁白文本中）的所有章节，每章标注 speaks / mentioned /
-        两者皆有。适合快速定位一个角色的剧情登场分布。如需精确台词，可用返回的
-        story_key 调用 read_story。
+        返回该角色作为对话发言者（speaks）或名字出现在台词/旁白文本中（mentioned）的所有章节，
+        每章标注 speaks / mentioned / 两者皆有，适合快速定位角色的登场分布。
+        如需精确台词，可用返回的 story_key 调用 read_story。
         """
         from prts_mcp.config import Config
         cfg = Config.load()
@@ -359,9 +348,8 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     ) -> str:
         """列出某活动中的所有发言角色及其台词数。
 
-        返回该活动所有章节中去重后的对话发言者，按台词句数降序排列。适合了解
-        一个活动的角色戏份分布。如需读取某角色说的具体内容，可结合
-        search_stories(character=...) 过滤。
+        返回该活动去重后的对话发言者，按台词句数降序排列，适合了解角色戏份分布。
+        读取某角色说的具体内容可用 search_stories(character=...) 过滤。
         """
         from prts_mcp.config import Config
         cfg = Config.load()

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -28,6 +28,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   overview (from `event_summaries.json`) when present, on top of the per-chapter
   one-liners it already returned — making it a superset of the former
   `get_event_summary`. Tool surface drops 24 → 23.
+- **Tool descriptions standardized (2.0).** All tool descriptions were rewritten
+  to a consistent house style (verb-first purpose, output-shape note, at most one
+  cross-reference, parameter semantics kept in the parameter schema) and trimmed
+  ~20% to reduce context budget on smaller-context models. No change to tool
+  names, parameters, or output format.
 
 ### Removed
 

--- a/ts/src/tools/gamedataTools.ts
+++ b/ts/src/tools/gamedataTools.ts
@@ -20,7 +20,7 @@ export function registerGamedataTools(server: McpServer): void {
     [
       "获取指定干员的档案资料。",
       "返回干员的客观履历、个人档案（基础档案及解锁档案）等背景故事文本。",
-      "若需查询干员的职业、稀有度等数值信息，请使用 get_operator_basic_info；若需查询语音台词，请使用 get_operator_voicelines。",
+      "数值信息见 get_operator_basic_info，语音台词见 get_operator_voicelines。",
     ].join(" "),
     { name: z.string().describe("干员的游戏内中文名，如「阿米娅」、「能天使」。") },
     ({ name }) => {
@@ -33,8 +33,8 @@ export function registerGamedataTools(server: McpServer): void {
     "get_operator_voicelines",
     [
       "获取指定干员的所有语音台词记录。",
-      "返回包含触发条件（如「交谈1」、「晋升后交谈」、「信赖提升后交谈」）及对应台词文本的完整列表。",
-      "此工具仅返回语音文本；若需查询干员背景故事或客观履历，请使用 get_operator_archives。",
+      "返回触发条件（如「交谈1」、「晋升后交谈」、「信赖提升后交谈」）及对应台词文本的完整列表。",
+      "背景故事与客观履历见 get_operator_archives。",
     ].join(" "),
     { name: z.string().describe("干员的游戏内中文名，如「阿米娅」、「能天使」。") },
     ({ name }) => {
@@ -47,8 +47,8 @@ export function registerGamedataTools(server: McpServer): void {
     "get_operator_basic_info",
     [
       "获取指定干员的基本数值信息。",
-      "返回干员的职业、子职业、稀有度（星级）、所属阵营、招募标签、天赋名称及描述等结构化信息。",
-      "适合快速了解干员定位；若需完整背景故事请使用 get_operator_archives，若需语音台词请使用 get_operator_voicelines。",
+      "返回干员的职业、子职业、稀有度（星级）、所属阵营、招募标签、天赋名称及描述等结构化信息，适合快速了解干员定位。",
+      "完整背景故事见 get_operator_archives。",
     ].join(" "),
     { name: z.string().describe("干员的游戏内中文名，如「阿米娅」、「能天使」。") },
     ({ name }) => {
@@ -63,9 +63,8 @@ export function registerGamedataTools(server: McpServer): void {
     "list_enemies",
     [
       "列出敌方图鉴，支持按威胁等级过滤和分页。",
-      "默认返回前 50 条。若需翻页，增大 offset 即可。",
-      "若只想看领袖/BOSS 级敌人，设置 threat_level=\"boss\"。",
-      "不推荐使用 full=true，图鉴共有 1500+ 条目，密集输出极易污染上下文。",
+      "默认返回前 50 条；翻页增大 offset，只看领袖/BOSS 设 threat_level=\"boss\"。",
+      "图鉴共 1500+ 条目，不推荐 full=true。",
     ].join(" "),
     {
       threat_level: z.string().optional().describe("按威胁等级过滤：boss（领袖）、elite（精英）、normal（普通）。不填则返回全部。"),
@@ -82,7 +81,7 @@ export function registerGamedataTools(server: McpServer): void {
     "get_enemy_info",
     [
       "获取指定敌人的详细图鉴资料。",
-      "默认返回图鉴信息；若提供 stage_id，则返回该敌人在指定关卡内的等级与关卡覆盖后的战斗属性。",
+      "默认返回威胁等级、描述、攻击方式、伤害类型和特殊能力等图鉴信息；提供 stage_id 时改为返回该敌人在指定关卡内的等级与关卡覆盖后的战斗属性。",
     ].join(" "),
     {
       name: z.string().describe("敌人的游戏内中文名，如「源石虫」、「霜星」。"),
@@ -97,7 +96,8 @@ export function registerGamedataTools(server: McpServer): void {
     "get_stage_enemies",
     [
       "获取指定关卡实际出场的敌人列表。",
-      "基于关卡 level JSON 的 SPAWN 动作统计实际出怪，并合并 enemy_database 中对应该关卡敌人等级的战斗属性。",
+      "只统计关卡内真正刷出的敌人，并附上其在该关卡等级下的战斗属性。",
+      "反向查询某敌人出现在哪些关卡见 get_enemy_appearances。",
     ].join(" "),
     {
       stage_id: z.string().describe("关卡 ID，如 'main_00-01'（可从 list_stages 获取）。"),
@@ -109,7 +109,7 @@ export function registerGamedataTools(server: McpServer): void {
     "get_enemy_appearances",
     [
       "反向查询指定敌人实际出现在哪些关卡。",
-      "只统计关卡 level JSON 中 SPAWN 动作真正刷出的敌人，不把 enemyDbRefs 中未实际出场的引用计入结果。",
+      "只统计该敌人真正刷出的关卡，不计入引用但未实际出场的关卡。",
     ].join(" "),
     {
       name: z.string().describe("敌人的游戏内中文名或 enemyId，如「源石虫」或 enemy_1007_slime。"),
@@ -143,7 +143,7 @@ export function registerGamedataTools(server: McpServer): void {
 
   server.tool(
     "get_stage_info",
-    "获取指定关卡的详细信息。返回关卡的编号、类型、难度、所属区域、理智消耗、掉落奖励、解锁条件等。",
+    "获取指定关卡的详细信息。返回关卡的编号、类型、难度、所属区域、理智消耗、掉落奖励、解锁条件等。关卡实际出场的敌人见 get_stage_enemies。",
     { stage_id: z.string().describe("关卡 ID，如 'main_00-01'（可从 list_stages 获取）。") },
     ({ stage_id }) => ({ content: [{ type: "text", text: getStageInfo(stage_id) }] })
   );
@@ -154,8 +154,7 @@ export function registerGamedataTools(server: McpServer): void {
     "list_items",
     [
       "列出物品/材料列表，支持按分类过滤和分页。",
-      "返回物品名称、分类、类型、稀有度、ID 和简短用途。",
-      "适合查找材料、货币、凭证等 item_table 物品。",
+      "返回每个物品的名称、分类、类型、稀有度、ID 和简短用途，适合查找材料、货币、凭证等。",
     ].join(" "),
     {
       category: z.string().optional().describe("按物品分类过滤，如 MATERIAL（材料）、NORMAL（普通）、CONSUME（消耗品）。不填则返回全部可见物品。"),
@@ -185,8 +184,8 @@ export function registerGamedataTools(server: McpServer): void {
     "search",
     [
       "在指定数据域中执行全文正则搜索。",
-      "scope 选择搜索域：operators（干员：名称/属性/档案/语音）、enemies（敌人图鉴）、stages（关卡）、items（物品/材料）。",
-      "返回带域标签的匹配结果。剧情台词搜索请用 search_stories（参数不同）。",
+      "scope 选择搜索域：operators（名称/属性/档案/语音）、enemies（图鉴）、stages（关卡）、items（物品/材料）。",
+      "返回带域标签的匹配结果。剧情台词搜索见 search_stories。",
     ].join(" "),
     {
       scope: z.enum(["operators", "enemies", "stages", "items"]).describe("搜索域（必填）：operators / enemies / stages / items。"),

--- a/ts/src/tools/gamedataTools.ts
+++ b/ts/src/tools/gamedataTools.ts
@@ -81,7 +81,8 @@ export function registerGamedataTools(server: McpServer): void {
     "get_enemy_info",
     [
       "获取指定敌人的详细图鉴资料。",
-      "默认返回威胁等级、描述、攻击方式、伤害类型和特殊能力等图鉴信息；提供 stage_id 时改为返回该敌人在指定关卡内的等级与关卡覆盖后的战斗属性。",
+      "默认返回威胁等级、描述、攻击方式、伤害类型和特殊能力等图鉴信息。",
+      "提供 stage_id 时改为返回该敌人在指定关卡内的等级与关卡覆盖后的战斗属性。",
     ].join(" "),
     {
       name: z.string().describe("敌人的游戏内中文名，如「源石虫」、「霜星」。"),

--- a/ts/src/tools/prtsTools.ts
+++ b/ts/src/tools/prtsTools.ts
@@ -21,7 +21,7 @@ export function registerPrtsTools(server: McpServer): void {
     "search_prts",
     [
       "搜索 PRTS 明日方舟中文维基词条。",
-      "返回匹配词条的标题和简短摘要列表，含匹配总数。这是探索维基的第一步：当需要查找不确定的专有名词、干员、关卡或世界观设定时，先用此工具搜索获取准确标题，再将标题传入 prts_page 获取完整内容。",
+      "返回匹配词条的标题、简短摘要列表及匹配总数。查询专有名词、干员、关卡或世界观设定时先用此工具拿到准确标题，再传入 prts_page 获取完整内容。",
     ].join(" "),
     {
       query: z.string().describe("搜索关键词，支持中文，如「罗德岛」、「整合运动」。"),
@@ -45,9 +45,9 @@ export function registerPrtsTools(server: McpServer): void {
   server.tool(
     "prts_page",
     [
-      "读取 PRTS 维基页面的内容或元数据（按 action 分派）。",
-      "推荐流程：先用 action=\"sections\" 看目录（返回 [编号] L层级 标题，T- 前缀表示模板嵌入的节），再用 action=\"read\" + section_index 读特定章节，避免整页过载。",
-      "其余 action：categories=分类标签；links=相关链接（outbound 出链 / inbound 反向链接，探索维基知识图谱）；template=结构化模板数据（如干员 CharinfoV2、敌人 敌人信息/common2、物品 道具信息）。先用 search_prts 获取准确标题。",
+      "读取 PRTS 维基页面的正文或元数据，按 action 分派。",
+      "推荐流程：先用 action=\"sections\" 看目录（每行 `[编号] L层级 标题`，T- 前缀表示模板嵌入的节），再用 action=\"read\" + section_index 读特定章节，避免整页过载。",
+      "其余 action：categories 返回分类标签；links 返回相关链接（outbound 出链 / inbound 反向链接）；template 返回结构化模板数据（如干员 CharinfoV2、敌人 敌人信息/common2、物品 道具信息）。",
     ].join(" "),
     {
       page_title: z.string().describe("词条标题，需与维基页面标题完全一致，如「阿米娅」。建议先用 search_prts 获取准确标题。"),

--- a/ts/src/tools/storyTools.ts
+++ b/ts/src/tools/storyTools.ts
@@ -70,8 +70,7 @@ export function registerStoryTools(server: McpServer): void {
     [
       "列出明日方舟剧情活动列表。",
       "返回格式：每行 `- [类型] 活动ID：名称（N 章）`，类型为 MAINLINE / ACTIVITY / MINI_ACTIVITY / NONE 之一。",
-      "获取活动 ID 后，可调用 list_stories 查看该活动的章节列表。",
-      "category=\"memoirs\" 可列出所有干员密录。",
+      "获取活动 ID 后可调用 list_stories 查看该活动的章节列表。",
     ].join(" "),
     { category: z.string().optional().describe("可选过滤分类。\"main\" = 主线章节，\"activities\" = 活动剧情（含联动），\"memoirs\" = 干员密录。不填则返回全部活动。") },
     ({ category }) => {
@@ -101,7 +100,7 @@ export function registerStoryTools(server: McpServer): void {
     [
       "列出指定活动的所有剧情章节（按官方顺序排列）。",
       "返回格式：每行 `- 章节编号 [标签] 章节名（key: story_key）`，其中 story_key 可直接传入 read_story 读取该章台词。",
-      "设 include_summaries=true 时顶部附活动级长摘要（若有）、每章下方附一句话梗概，可一次性了解活动整体剧情脉络。",
+      "设 include_summaries=true 可一次性了解活动整体剧情脉络。",
     ].join(" "),
     {
       event_id: z.string().describe("活动 ID，如 \"act31side\"（可从 list_story_events 获取）。"),
@@ -178,8 +177,8 @@ export function registerStoryTools(server: McpServer): void {
     "get_story_summary",
     [
       "获取单章剧情的梗概。",
-      "返回指定章节的故事摘要。优先使用 LLM 生成的长摘要，",
-      "未就绪时回退到官方一句话梗概，最后回退到章节自带的 storyInfo。",
+      "返回指定章节的故事摘要，优先长摘要，未就绪时回退到官方一句话梗概。",
+      "整个活动的章节概览见 list_stories(include_summaries=true)。",
     ].join(" "),
     { story_key: z.string().describe("章节 key，如 \"activities/act31side/level_act31side_01_beg\"（可从 list_stories 获取）。") },
     ({ story_key }) => {
@@ -207,7 +206,6 @@ export function registerStoryTools(server: McpServer): void {
     [
       "读取单章剧情的完整台词。",
       "返回格式：首行为【活动名】章节名，随后按顺序输出对话（`角色：台词`）、旁白（`*旁白文本*`）和选项（`【选项】文本`）。",
-      "story_key 可从 list_stories 的返回结果中获取。",
     ].join(" "),
     {
       story_key: z.string().describe("章节 key，如 \"activities/act31side/level_act31side_01_beg\"（可从 list_stories 获取）。"),
@@ -244,8 +242,8 @@ export function registerStoryTools(server: McpServer): void {
     "read_activity",
     [
       "读取整个活动的完整剧情台词（按官方章节顺序合并）。",
-      "适合需要了解完整活动故事的场景。返回各章节台词的合并文本，格式与 read_story 一致，章节间以分隔标题区分。",
-      "单次活动文本量可能较大，建议使用 page 参数分批获取；返回结果会提示是否还有更多页。",
+      "返回各章节台词的合并文本，格式与 read_story 一致，章节间以分隔标题区分。",
+      "单次文本量可能较大，建议用 page 分批获取，返回末尾会提示是否还有后续内容。",
     ].join(" "),
     {
       event_id: z.string().describe("活动 ID，如 \"act31side\"（可从 list_story_events 获取）。"),
@@ -313,8 +311,7 @@ export function registerStoryTools(server: McpServer): void {
     "search_stories",
     [
       "在剧情台词中执行全文正则搜索，支持角色和台词类型过滤。",
-      "返回格式：以 [stories/活动ID/章节编号 L行号] 标注位置，",
-      "命中行前缀 >>> 标记，上下文行以 4 空格缩进显示。",
+      "返回格式：以 `[stories/活动ID/章节编号 L行号]` 标注位置，命中行前缀 `>>> ` 标记，上下文行以 4 空格缩进显示。",
     ].join(" "),
     {
       pattern: z.string().describe("正则表达式搜索模式，大小写不敏感。"),
@@ -352,9 +349,8 @@ export function registerStoryTools(server: McpServer): void {
     "get_operator_memoirs",
     [
       "根据干员名称查询干员密录剧情。",
-      "返回干员的密录章节列表，包含章节 key（story_key）和元数据。",
+      "返回干员的密录章节列表，含章节 key（story_key）和元数据。",
       "获取 story_key 后可传入 read_story 读取密录台词。",
-      "若需先查找正确的干员名称，可用 search（scope=operators）搜索干员数据。",
     ].join(" "),
     {
       name: z.string().describe("干员的游戏内中文名，如「阿米娅」、「能天使」。"),
@@ -390,8 +386,8 @@ export function registerStoryTools(server: McpServer): void {
     "find_character_appearances",
     [
       "查找某个角色在剧情中的出场（说话或被提及）。",
-      "返回该角色「说话」（speaks，作为对话发言者）或「被提及」（mentioned，名字出现在任意台词/旁白文本中）的所有章节，",
-      "每章标注 speaks / mentioned / 两者皆有。如需精确台词，可用返回的 story_key 调用 read_story。",
+      "返回该角色作为对话发言者（speaks）或名字出现在台词/旁白文本中（mentioned）的所有章节，每章标注 speaks / mentioned / 两者皆有，适合快速定位角色的登场分布。",
+      "如需精确台词，可用返回的 story_key 调用 read_story。",
     ].join(" "),
     {
       name: z.string().describe("角色名（干员中文名或「博士」）。speaks 按对话角色名精确匹配，mentioned 按名字在台词/旁白文本中的子串匹配——请使用完整名字以免误报（如「阿」会命中「阿米娅」）。"),
@@ -435,8 +431,8 @@ export function registerStoryTools(server: McpServer): void {
     "find_speakers_in",
     [
       "列出某活动中的所有发言角色及其台词数。",
-      "返回该活动所有章节中去重后的对话发言者，按台词句数降序排列。",
-      "如需读取某角色说的具体内容，可结合 search_stories(character=...) 过滤。",
+      "返回该活动去重后的对话发言者，按台词句数降序排列，适合了解角色戏份分布。",
+      "读取某角色说的具体内容可用 search_stories(character=...) 过滤。",
     ].join(" "),
     {
       event_id: z.string().describe("活动 ID，如 \"act31side\"（可从 list_story_events 获取）。"),


### PR DESCRIPTION
## Summary

Final PR of the 2.0 tool-surface work: the description-standardization sweep. All 23 tool descriptions are rewritten in both implementations to the STYLE.md house style — verb-first purpose, output-shape note, at most one cross-reference, parameter semantics kept in the parameter schema.

This is **prose-only: no change to tool names, parameters, types/defaults, logic, or output format.** It removes implementation-leak wording (e.g. `SPAWN` actions, `enemy_database`, `enemyDbRefs`, `item_table`, internal JSON paths), condenses cross-reference chains (the operator triplet drops from two "若需…请用…" clauses each to one concise pointer), and moves param details into the field/`.describe()` text. Description prose trimmed ~20% (~1,960 chars) to reduce context budget on smaller-context models.

Tool surface unchanged at 23.

## Test plan

- Python: `pytest` — 217 passed, 2 skipped (tool-surface + e2e unaffected — names/params unchanged).
- TypeScript: `npm test` — 162 pass, 0 fail; `npm run typecheck` clean (confirms no broken TS string escaping).
- `git diff --stat`: only the 6 tool files + 2 CHANGELOGs changed.
- The bulk rewrite was drafted by a sub-agent to a tight spec, then the full diff was hand-reviewed for parity, accuracy, and no logic drift.

## 未尽事宜 (follow-ups)

- Completes the 2.0 tool-surface theme (32 → 23 tools + standardized descriptions).
- Separate, still open: the broader ROADMAP consolidation-section rewrite (stale "24 → ~16" target numbers; the Phase-1 prose predates the final design).