### PR TITLE
feat(python): 2.0 output-channel pilot — structuredContent for list_stages

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Output channel (2.0).** Optional structured-content delivery via MCP's
+  native `structuredContent` channel, controlled by a connection-level
+  `OUTPUT_CHANNEL` env var (`content` (default) / `structured` / `both`).
+  Capable clients (Claude Code, Codex) receive a structured payload; the
+  default `content` channel reproduces today's markdown-only behaviour
+  byte-for-byte, so this is non-breaking. `list_stages` is the pilot tool;
+  its `structuredContent` carries both raw enums (e.g. `type=ACTIVITY`) and
+  rendered labels (`type_label=活动`). The remaining structural tools and the
+  TypeScript implementation follow in subsequent commits.
+
 ### Changed
 
 - **Parameter naming normalization (2.0, breaking).** Operator tools

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -11,16 +11,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 - **Output channel (2.0).** Optional structured-content delivery via MCP's
   native `structuredContent` channel, controlled by a connection-level
   `PRTS_OUTPUT_CHANNEL` env var (`content` (default) / `structured` / `both`).
-  Capable clients (Claude Code, Codex) receive a structured payload; the
-  default `content` channel reproduces today's markdown-only behaviour
-  byte-for-byte, so this is non-breaking. `list_stages` is the pilot tool;
-  its `structuredContent` carries both raw enums (e.g. `type=ACTIVITY`) and
-  rendered labels (`type_label=活动`). The remaining structural tools and the
-  TypeScript implementation follow in subsequent commits. Note: `structured`
-  mode is intended for deployments known to use a structuredContent-capable
-  client — an incapable client (e.g. Chatbox) receives only a one-line
-  summary, so leave the default `content` unless the client is confirmed
-  capable.
+  The default `content` channel preserves the human-readable markdown content
+  for clients that only consume MCP `content`. Migrated tools intentionally
+  change the MCP manifest/wire shape by replacing FastMCP's automatic
+  `outputSchema={result:string}` plus `structuredContent={"result": markdown}`
+  wrapper with explicit `CallToolResult` delivery, so capable clients no
+  longer receive duplicate markdown unless `both` is selected. `list_stages`
+  is the pilot tool; its `structuredContent` carries both raw enums (e.g.
+  `type=ACTIVITY`) and rendered labels (`type_label=活动`). The remaining
+  structural tools and the TypeScript implementation follow in subsequent
+  commits. Note: `structured` mode is intended for deployments known to use a
+  structuredContent-capable client — an incapable client (e.g. Chatbox)
+  receives only a one-line summary, so leave the default `content` unless the
+  client is confirmed capable.
 
 ### Changed
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -16,7 +16,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   byte-for-byte, so this is non-breaking. `list_stages` is the pilot tool;
   its `structuredContent` carries both raw enums (e.g. `type=ACTIVITY`) and
   rendered labels (`type_label=活动`). The remaining structural tools and the
-  TypeScript implementation follow in subsequent commits.
+  TypeScript implementation follow in subsequent commits. Note: `structured`
+  mode is intended for deployments known to use a structuredContent-capable
+  client — an incapable client (e.g. Chatbox) receives only a one-line
+  summary, so leave the default `content` unless the client is confirmed
+  capable.
 
 ### Changed
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **Output channel (2.0).** Optional structured-content delivery via MCP's
   native `structuredContent` channel, controlled by a connection-level
-  `OUTPUT_CHANNEL` env var (`content` (default) / `structured` / `both`).
+  `PRTS_OUTPUT_CHANNEL` env var (`content` (default) / `structured` / `both`).
   Capable clients (Claude Code, Codex) receive a structured payload; the
   default `content` channel reproduces today's markdown-only behaviour
   byte-for-byte, so this is non-breaking. `list_stages` is the pilot tool;

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -24,6 +24,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   structuredContent-capable client — an incapable client (e.g. Chatbox)
   receives only a one-line summary, so leave the default `content` unless the
   client is confirmed capable.
+- **Narrative-tool wire slimming (2.0).** The six narrative/prose tools
+  (`get_operator_archives`, `get_operator_voicelines`, `read_story`,
+  `read_activity`, `get_story_summary`, `prts_page`) migrated from `-> str`
+  to explicit `CallToolResult` delivery via the new `text_result(markdown)`
+  helper. Their content text is unchanged, but they no longer derive
+  FastMCP's automatic `outputSchema` nor emit a duplicate
+  `structuredContent={"result": markdown}` — narrative output has no useful
+  structured form. The remaining structural tools keep their structured
+  payloads behind `output_channel`.
 
 ### Changed
 

--- a/python/src/prts_mcp/data/stage.py
+++ b/python/src/prts_mcp/data/stage.py
@@ -180,13 +180,18 @@ def clear_stage_caches() -> None:
 # ---------------------------------------------------------------------------
 
 
-def list_stages(
+def build_stages_listing(
     chapter: str | None = None,
     type: str | None = None,
     limit: int = 50,
     offset: int = 0,
-) -> str:
-    """List stages, optionally filtered by zone ID and/or stage type."""
+) -> dict | str:
+    """Build the structured payload for a stages listing.
+
+    Returns the dict payload on success, or a markdown error string on a
+    user-input / missing-data / empty-result path. The dict is the single
+    source of truth that ``render_stages_listing`` consumes.
+    """
     if limit < 1:
         return "limit 必须 >= 1。"
     if limit > 200:
@@ -223,16 +228,49 @@ def list_stages(
             return f"没有匹配的关卡（filter: {', '.join(filters) or 'none'}）。"
         return f"offset {offset} 超出范围（共 {total} 条）。"
 
-    lines = [f"# 关卡列表（共 {total} 个）"]
+    entries = []
     for e in page:
-        t_label = _stage_type_label(e.get("stageType", ""))
-        d_label = _difficulty_label(e.get("difficulty", ""))
-        zd = _zone_display(e.get("zoneId", ""))
-        name = e.get("name") or "（无名）"
-        code = e.get("code") or "?"
-        sid = e.get("stageId", "")
+        entries.append(
+            {
+                "stage_id": e.get("stageId", ""),
+                "name": e.get("name") or "（无名）",
+                "code": e.get("code") or "?",
+                "type": e.get("stageType", ""),
+                "type_label": _stage_type_label(e.get("stageType", "")),
+                "difficulty_label": _difficulty_label(e.get("difficulty", "")),
+                "zone_id": e.get("zoneId", ""),
+                "zone_display": _zone_display(e.get("zoneId", "")),
+            }
+        )
+
+    return {
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "filters": {
+            "chapter": chapter,
+            "type": type.upper() if type else None,
+        },
+        "stages": entries,
+    }
+
+
+def render_stages_listing(data: dict) -> str:
+    """Render a stages-listing payload dict to markdown.
+
+    Pure renderer; the inverse of ``build_stages_listing``'s success path.
+    """
+    total = data["total"]
+    offset = data["offset"]
+    limit = data["limit"]
+    stages = data["stages"]
+
+    lines = [f"# 关卡列表（共 {total} 个）"]
+    for s in stages:
         lines.append(
-            f"- **{name}** [{t_label}] {code} — {d_label} — {zd}（id: {sid}）"
+            f"- **{s['name']}** [{s['type_label']}] {s['code']} — "
+            f"{s['difficulty_label']} — {s['zone_display']}"
+            f"（id: {s['stage_id']}）"
         )
 
     start = offset + 1
@@ -242,6 +280,19 @@ def list_stages(
         f"使用 offset={offset + limit} 查看下一页）"
     )
     return "\n".join(lines)
+
+
+def list_stages(
+    chapter: str | None = None,
+    type: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """List stages, optionally filtered by zone ID and/or stage type."""
+    data = build_stages_listing(chapter=chapter, type=type, limit=limit, offset=offset)
+    if isinstance(data, str):
+        return data
+    return render_stages_listing(data)
 
 
 def get_stage_info(stage_id: str) -> str:

--- a/python/src/prts_mcp/data/stage.py
+++ b/python/src/prts_mcp/data/stage.py
@@ -247,6 +247,8 @@ def build_stages_listing(
         "total": total,
         "offset": offset,
         "limit": limit,
+        # chapter is echoed verbatim (it is an exact zoneId match, no
+        # normalization); type is upper-cased to match stageType values.
         "filters": {
             "chapter": chapter,
             "type": type.upper() if type else None,

--- a/python/src/prts_mcp/output.py
+++ b/python/src/prts_mcp/output.py
@@ -27,8 +27,10 @@ from mcp.types import CallToolResult, TextContent
 
 _logger = logging.getLogger("prts_mcp.output")
 
-#: Accepted channel values. ``content`` is the default and reproduces the
-#: pre-2.0 behaviour byte-for-byte (markdown text only, no structuredContent).
+#: Accepted channel values. ``content`` is the default and preserves the
+#: human-readable markdown text while avoiding FastMCP's automatic
+#: ``outputSchema`` / ``structuredContent={"result": markdown}`` wrapper for
+#: tools that opt in to explicit ``CallToolResult`` delivery.
 OutputChannel = Literal["content", "structured", "both"]
 
 _VALID_CHANNELS: frozenset[str] = frozenset({"content", "structured", "both"})
@@ -59,7 +61,8 @@ def _parse_channel(raw: str | None) -> OutputChannel:
 #: The module-level identifier ``OUTPUT_CHANNEL`` is the parsed value's name;
 #: the *environment variable* that populates it is ``PRTS_OUTPUT_CHANNEL``
 #: (``PRTS_`` prefix to avoid collisions in shared Docker/CI environments).
-#: The HTTP query/header name stays the unprefixed ``output_channel``.
+#: Other transports can map their own connection-level control names to the
+#: same parsed value.
 OUTPUT_CHANNEL: OutputChannel = _parse_channel(os.environ.get("PRTS_OUTPUT_CHANNEL"))
 
 
@@ -77,7 +80,9 @@ def render_result(
     Channel behaviour:
 
     - ``content``   → content = ``markdown``; no structuredContent.
-                      (Today's behaviour, byte-for-byte. The default.)
+                      Preserves the text seen by content-only clients while
+                      suppressing FastMCP's automatic duplicate structured
+                      wrapper for migrated tools. The default.
     - ``structured`` → content = a one-line summary derived from ``data``;
                       structuredContent = ``data``. ``markdown`` is unused
                       in this mode (the summary is the only text an incapable

--- a/python/src/prts_mcp/output.py
+++ b/python/src/prts_mcp/output.py
@@ -73,8 +73,10 @@ def render_result(
     - ``content``   → content = ``markdown``; no structuredContent.
                       (Today's behaviour, byte-for-byte. The default.)
     - ``structured`` → content = a one-line summary derived from ``data``;
-                      structuredContent = ``data``. Avoids emitting both the
-                      full markdown and the JSON for capable clients.
+                      structuredContent = ``data``. ``markdown`` is unused
+                      in this mode (the summary is the only text an incapable
+                      client sees). Avoids emitting both the full markdown and
+                      the JSON for capable clients.
     - ``both``      → content = ``markdown``; structuredContent = ``data``.
                       Debug / dual-channel compatibility, accepts the token cost.
 
@@ -117,9 +119,11 @@ def _summarize(data: dict[str, Any]) -> str:
     """Derive a one-line content summary for ``structured`` mode.
 
     The floor per the design doc (§4/§10) is "don't degrade to
-    'incapable clients see nothing'". A short header naming the payload and
-    its size is the generic template; tools with richer summary needs may
-    build their own string and pass it as ``markdown`` instead.
+    'incapable clients see nothing'": a short header naming the payload
+    size. This summary is the only content a non-capable client sees when
+    the channel is misconfigured to ``structured``, so the ``markdown``
+    argument to ``render_result`` is intentionally ignored in this mode
+    (it carries the full rendering for ``content``/``both`` only).
     """
     total = data.get("total")
     if isinstance(total, int):

--- a/python/src/prts_mcp/output.py
+++ b/python/src/prts_mcp/output.py
@@ -140,3 +140,24 @@ def _summarize(data: dict[str, Any]) -> str:
     if isinstance(total, int):
         return f"（结构化结果共 {total} 条，详见 structuredContent）"
     return "（结构化结果详见 structuredContent）"
+
+
+def text_result(markdown: str) -> CallToolResult:
+    """Build a content-only ``CallToolResult`` carrying markdown text.
+
+    For narrative tools (§5) — whose output is prose with no useful
+    structured form — and for error/missing-data paths across all tools.
+    The structured payload axis simply does not apply: ``structuredContent``
+    is always ``None`` regardless of ``OUTPUT_CHANNEL``, and the markdown is
+    the whole result.
+
+    Use this instead of ``render_result(None, …)`` for narrative tools:
+    "narrative tool has no structure" is the *normal* success case here, not
+    a "data missing" condition, so the dedicated helper keeps the semantics
+    honest (design doc §11).
+    """
+    return CallToolResult(
+        content=[TextContent(type="text", text=markdown)],
+        structuredContent=None,
+        isError=False,
+    )

--- a/python/src/prts_mcp/output.py
+++ b/python/src/prts_mcp/output.py
@@ -10,7 +10,7 @@ know.
 
 This module hosts:
 
-- ``OutputChannel`` — the enum and env-var parser (``OUTPUT_CHANNEL``).
+- ``OutputChannel`` — the enum and env-var parser (``PRTS_OUTPUT_CHANNEL``).
 - ``render_result`` — the cross-cutting helper that turns a
   ``(data, markdown)`` pair into a ``CallToolResult`` shaped by the channel.
 
@@ -46,7 +46,8 @@ def _parse_channel(raw: str | None) -> OutputChannel:
     value = raw.strip().lower()
     if value not in _VALID_CHANNELS:
         _logger.warning(
-            "OUTPUT_CHANNEL=%r 不合法（可选 content/structured/both），回退到 content。", raw
+            "PRTS_OUTPUT_CHANNEL=%r 不合法（可选 content/structured/both），回退到 content。",
+            raw,
         )
         return "content"
     return value  # type: ignore[return-value]
@@ -54,7 +55,12 @@ def _parse_channel(raw: str | None) -> OutputChannel:
 
 #: Connection-level channel, read once at import time. On stdio a connection
 #: maps to one process, so a module-level constant is the right scope.
-OUTPUT_CHANNEL: OutputChannel = _parse_channel(os.environ.get("OUTPUT_CHANNEL"))
+#:
+#: The module-level identifier ``OUTPUT_CHANNEL`` is the parsed value's name;
+#: the *environment variable* that populates it is ``PRTS_OUTPUT_CHANNEL``
+#: (``PRTS_`` prefix to avoid collisions in shared Docker/CI environments).
+#: The HTTP query/header name stays the unprefixed ``output_channel``.
+OUTPUT_CHANNEL: OutputChannel = _parse_channel(os.environ.get("PRTS_OUTPUT_CHANNEL"))
 
 
 def render_result(

--- a/python/src/prts_mcp/output.py
+++ b/python/src/prts_mcp/output.py
@@ -1,0 +1,127 @@
+"""Output-channel rendering for 2.0 structuredContent support.
+
+The 2.0 output-channel plan (``dev/docs/2.0-output-channel-plan.md``) splits
+the orthogonal axes of *text rendering* (markdown) and *structured data*
+(dict) and carries them on MCP's native ``content`` / ``structuredContent``
+channels. The control plane is a single connection-level knob
+``output_channel`` — not a per-call tool parameter — because its correct
+value depends on which client owns the connection, which the LLM cannot
+know.
+
+This module hosts:
+
+- ``OutputChannel`` — the enum and env-var parser (``OUTPUT_CHANNEL``).
+- ``render_result`` — the cross-cutting helper that turns a
+  ``(data, markdown)`` pair into a ``CallToolResult`` shaped by the channel.
+
+Layering: depends only on ``mcp.types``. No data/api imports. Called from
+the ``tools_*`` registration modules.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Literal
+
+from mcp.types import CallToolResult, TextContent
+
+_logger = logging.getLogger("prts_mcp.output")
+
+#: Accepted channel values. ``content`` is the default and reproduces the
+#: pre-2.0 behaviour byte-for-byte (markdown text only, no structuredContent).
+OutputChannel = Literal["content", "structured", "both"]
+
+_VALID_CHANNELS: frozenset[str] = frozenset({"content", "structured", "both"})
+
+
+def _parse_channel(raw: str | None) -> OutputChannel:
+    """Resolve the env var to a valid channel, falling back to ``content``.
+
+    An unset or empty value yields the default ``content``. An unrecognized
+    value logs a warning and also falls back to ``content`` rather than
+    raising — a misconfigured channel must never break tool calls.
+    """
+    if not raw:
+        return "content"
+    value = raw.strip().lower()
+    if value not in _VALID_CHANNELS:
+        _logger.warning(
+            "OUTPUT_CHANNEL=%r 不合法（可选 content/structured/both），回退到 content。", raw
+        )
+        return "content"
+    return value  # type: ignore[return-value]
+
+
+#: Connection-level channel, read once at import time. On stdio a connection
+#: maps to one process, so a module-level constant is the right scope.
+OUTPUT_CHANNEL: OutputChannel = _parse_channel(os.environ.get("OUTPUT_CHANNEL"))
+
+
+def render_result(
+    data: dict[str, Any] | None,
+    markdown: str,
+    channel: OutputChannel = OUTPUT_CHANNEL,
+) -> CallToolResult:
+    """Build a ``CallToolResult`` carrying markdown text and/or structured data.
+
+    The two inputs are kept orthogonal: ``markdown`` is always the
+    human-readable rendering, ``data`` is always the structured payload
+    (or ``None`` when the call hit an error/missing-data path).
+
+    Channel behaviour:
+
+    - ``content``   → content = ``markdown``; no structuredContent.
+                      (Today's behaviour, byte-for-byte. The default.)
+    - ``structured`` → content = a one-line summary derived from ``data``;
+                      structuredContent = ``data``. Avoids emitting both the
+                      full markdown and the JSON for capable clients.
+    - ``both``      → content = ``markdown``; structuredContent = ``data``.
+                      Debug / dual-channel compatibility, accepts the token cost.
+
+    When ``data is None`` (error / missing data), every channel falls back to
+    a content-only result carrying ``markdown`` — per the design doc, errors
+    never travel in structuredContent.
+    """
+    if data is None:
+        # Error / missing-data path: text only, regardless of channel.
+        return CallToolResult(
+            content=[TextContent(type="text", text=markdown)],
+            structuredContent=None,
+            isError=False,
+        )
+
+    if channel == "content":
+        return CallToolResult(
+            content=[TextContent(type="text", text=markdown)],
+            structuredContent=None,
+            isError=False,
+        )
+
+    if channel == "both":
+        return CallToolResult(
+            content=[TextContent(type="text", text=markdown)],
+            structuredContent=data,
+            isError=False,
+        )
+
+    # channel == "structured": minimal content summary + structured payload.
+    summary = _summarize(data)
+    return CallToolResult(
+        content=[TextContent(type="text", text=summary)],
+        structuredContent=data,
+        isError=False,
+    )
+
+
+def _summarize(data: dict[str, Any]) -> str:
+    """Derive a one-line content summary for ``structured`` mode.
+
+    The floor per the design doc (§4/§10) is "don't degrade to
+    'incapable clients see nothing'". A short header naming the payload and
+    its size is the generic template; tools with richer summary needs may
+    build their own string and pass it as ``markdown`` instead.
+    """
+    total = data.get("total")
+    if isinstance(total, int):
+        return f"（结构化结果共 {total} 条，详见 structuredContent）"
+    return "（结构化结果详见 structuredContent）"

--- a/python/src/prts_mcp/tools_gamedata.py
+++ b/python/src/prts_mcp/tools_gamedata.py
@@ -20,7 +20,8 @@ from prts_mcp.data.enemy import (
     search_enemies as _search_enemies,
 )
 from prts_mcp.data.stage import (
-    list_stages as _list_stages,
+    build_stages_listing as _build_stages_listing,
+    render_stages_listing as _render_stages_listing,
     get_stage_info as _get_stage_info,
     search_stages as _search_stages,
 )
@@ -35,6 +36,7 @@ from prts_mcp.data.stage_enemy import (
     get_enemy_stage_info as _get_enemy_stage_info,
 )
 from prts_mcp.data.search import search_operator_data as _search_operator_data
+from prts_mcp.output import OUTPUT_CHANNEL, render_result
 
 
 def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
@@ -130,13 +132,19 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         type: Annotated[str | None, Field(default=None, description="按关卡类型过滤：MAIN（主线）/ ACTIVITY（活动）/ SUB（支线）/ DAILY（每日）/ CAMPAIGN（剿灭）/ CLIMB_TOWER（爬塔）/ SPECIAL_STORY（特殊故事）/ GUIDE（教程）。不填则返回全部。")] = None,
         limit: Annotated[int, Field(default=50, description="返回数量上限，默认 50。")] = 50,
         offset: Annotated[int, Field(default=0, description="分页偏移量，默认 0。")] = 0,
-    ) -> str:
+    ) -> object:
         """列出关卡列表，支持按章节和类型过滤。
 
         返回格式：每行 `- **关卡名** [类型] 编号 — 难度 — 区域`。
         获取 stage_id 后可传入 get_stage_info 查看详情。
         """
-        return _list_stages(chapter=chapter, type=type, limit=limit, offset=offset)
+        data = _build_stages_listing(chapter=chapter, type=type, limit=limit, offset=offset)
+        if isinstance(data, str):
+            # Error / missing-data path: text only, no structuredContent.
+            return render_result(None, data, channel=OUTPUT_CHANNEL)
+        return render_result(
+            data, _render_stages_listing(data), channel=OUTPUT_CHANNEL
+        )
 
     @mcp.tool()
     def get_stage_info(

--- a/python/src/prts_mcp/tools_gamedata.py
+++ b/python/src/prts_mcp/tools_gamedata.py
@@ -36,7 +36,7 @@ from prts_mcp.data.stage_enemy import (
     get_enemy_stage_info as _get_enemy_stage_info,
 )
 from prts_mcp.data.search import search_operator_data as _search_operator_data
-from prts_mcp.output import OUTPUT_CHANNEL, render_result
+from prts_mcp.output import OUTPUT_CHANNEL, render_result, text_result
 
 
 def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
@@ -45,24 +45,24 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     @mcp.tool()
     async def get_operator_archives(
         name: Annotated[str, Field(description="干员的游戏内中文名，如「阿米娅」、「能天使」。")],
-    ) -> str:
+    ) -> object:
         """获取指定干员的档案资料。
 
         返回干员的客观履历、个人档案（基础档案及解锁档案）等背景故事文本。
         数值信息见 get_operator_basic_info，语音台词见 get_operator_voicelines。
         """
-        return _get_archives(name)
+        return text_result(_get_archives(name))
 
     @mcp.tool()
     async def get_operator_voicelines(
         name: Annotated[str, Field(description="干员的游戏内中文名，如「阿米娅」、「能天使」。")],
-    ) -> str:
+    ) -> object:
         """获取指定干员的所有语音台词记录。
 
         返回触发条件（如「交谈1」、「晋升后交谈」、「信赖提升后交谈」）及对应台词文本的
         完整列表。背景故事与客观履历见 get_operator_archives。
         """
-        return _get_voicelines(name)
+        return text_result(_get_voicelines(name))
 
     @mcp.tool()
     async def get_operator_basic_info(

--- a/python/src/prts_mcp/tools_gamedata.py
+++ b/python/src/prts_mcp/tools_gamedata.py
@@ -133,6 +133,9 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         limit: Annotated[int, Field(default=50, description="返回数量上限，默认 50。")] = 50,
         offset: Annotated[int, Field(default=0, description="分页偏移量，默认 0。")] = 0,
     ) -> object:
+        # Keep the return annotation as object: FastMCP auto-wraps -> str tools
+        # into outputSchema={result:string} plus duplicate structuredContent.
+        # Explicit CallToolResult delivery requires bypassing that wrapper.
         """列出关卡列表，支持按章节和类型过滤。
 
         返回格式：每行 `- **关卡名** [类型] 编号 — 难度 — 区域`。

--- a/python/src/prts_mcp/tools_gamedata.py
+++ b/python/src/prts_mcp/tools_gamedata.py
@@ -36,7 +36,7 @@ from prts_mcp.data.stage_enemy import (
     get_enemy_stage_info as _get_enemy_stage_info,
 )
 from prts_mcp.data.search import search_operator_data as _search_operator_data
-from prts_mcp.output import OUTPUT_CHANNEL, render_result, text_result
+from prts_mcp.output import render_result, text_result
 
 
 def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
@@ -144,10 +144,8 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         data = _build_stages_listing(chapter=chapter, type=type, limit=limit, offset=offset)
         if isinstance(data, str):
             # Error / missing-data path: text only, no structuredContent.
-            return render_result(None, data, channel=OUTPUT_CHANNEL)
-        return render_result(
-            data, _render_stages_listing(data), channel=OUTPUT_CHANNEL
-        )
+            return render_result(None, data)
+        return render_result(data, _render_stages_listing(data))
 
     @mcp.tool()
     def get_stage_info(

--- a/python/src/prts_mcp/tools_prts.py
+++ b/python/src/prts_mcp/tools_prts.py
@@ -19,6 +19,7 @@ from prts_mcp.api.prts_wiki import (
     get_links as _get_links,
     get_template_data as _get_template_data,
 )
+from prts_mcp.output import text_result
 
 
 def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
@@ -54,9 +55,9 @@ def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         page_title: Annotated[str, Field(description="词条标题，需与维基页面标题完全一致，如「阿米娅」。建议先用 search_prts 获取准确标题。")],
         action: Annotated[Literal["read", "sections", "categories", "links", "template"], Field(description="操作（必填）：read=读取正文 / sections=章节目录 / categories=分类标签 / links=相关链接 / template=结构化模板数据。")],
         section_index: Annotated[int | None, Field(default=None, description="仅 action=read 生效：章节编号（从 action=sections 获取）。不填返回整页。")] = None,
-        direction: Annotated[Literal["outbound", "inbound"], Field(default="outbound", description="仅 action=links 生效：outbound（出链，默认）或 inbound（入链）。")] = "outbound",
+        direction: Annotated[Literal["outbound", "inbound"], Field(default="outbound", description="仅 action=links 生效：outbound（出链，默认）或 inbound（入站）。")] = "outbound",
         limit: Annotated[int, Field(default=30, ge=1, le=100, description="仅 action=links 生效：返回链接数量上限，默认 30。")] = 30,
-    ) -> str:
+    ) -> object:
         """读取 PRTS 维基页面的正文或元数据，按 action 分派。
 
         推荐流程：先用 action="sections" 看目录（每行 `[编号] L层级 标题`，T- 前缀表示模板
@@ -66,32 +67,36 @@ def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         """
         try:
             if action == "read":
-                return await _read_page(page_title, section_index=section_index)
+                return text_result(await _read_page(page_title, section_index=section_index))
             if action == "sections":
                 sections = await _list_sections(page_title)
                 if not sections:
-                    return f"页面 '{page_title}' 没有章节目录。"
-                return "\n".join(f"[{s['index']}] L{s['level']} {s['line']}" for s in sections)
+                    return text_result(f"页面 '{page_title}' 没有章节目录。")
+                return text_result(
+                    "\n".join(f"[{s['index']}] L{s['level']} {s['line']}" for s in sections)
+                )
             if action == "categories":
                 cats = await _get_categories(page_title)
                 if not cats:
-                    return f"页面 '{page_title}' 没有分类标签。"
-                return "\n".join(f"- {c}" for c in cats)
+                    return text_result(f"页面 '{page_title}' 没有分类标签。")
+                return text_result("\n".join(f"- {c}" for c in cats))
             if action == "links":
                 result = await _get_links(page_title, direction=direction, limit=limit)
                 links = result["links"]
                 if not links:
-                    return f"页面 '{page_title}' 没有{'出站' if direction == 'outbound' else '入站'}链接。"
+                    return text_result(
+                        f"页面 '{page_title}' 没有{'出站' if direction == 'outbound' else '入站'}链接。"
+                    )
                 total = result["total"]
                 has_more = result["has_more"]
                 suffix = f"\n（共 {total} 条，还有更多）" if has_more else f"\n（共 {total} 条）"
-                return "\n".join(f"- {ln}" for ln in links) + suffix
+                return text_result("\n".join(f"- {ln}" for ln in links) + suffix)
             # action == "template"
             templates = await _get_template_data(page_title)
             if not templates:
-                return f"页面 '{page_title}' 未找到可提取的模板数据。"
-            return json.dumps(templates, ensure_ascii=False, indent=2)
+                return text_result(f"页面 '{page_title}' 未找到可提取的模板数据。")
+            return text_result(json.dumps(templates, ensure_ascii=False, indent=2))
         except RuntimeError as e:
-            return str(e)
+            return text_result(str(e))
         except Exception as e:
-            return f"访问 PRTS 页面失败：{e}"
+            return text_result(f"访问 PRTS 页面失败：{e}")

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -22,6 +22,7 @@ from prts_mcp.data.story import (
     find_speakers_in as _find_speakers_in,
 )
 from prts_mcp.startup_sync import _require_story_zip
+from prts_mcp.output import text_result
 
 
 def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
@@ -115,7 +116,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     @mcp.tool()
     def get_story_summary(
         story_key: Annotated[str, Field(description="章节 key，如 \"activities/act31side/level_act31side_01_beg\"（可从 list_stories 获取）。")],
-    ) -> str:
+    ) -> object:
         """获取单章剧情的梗概。
 
         返回指定章节的故事摘要，优先长摘要，未就绪时回退到官方一句话梗概。
@@ -126,20 +127,20 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         try:
             zip_path = _require_story_zip(cfg)
         except RuntimeError as e:
-            return str(e)
+            return text_result(str(e))
 
         try:
-            return _get_story_summary(zip_path, story_key)
+            return text_result(_get_story_summary(zip_path, story_key))
         except KeyError:
-            return f"未找到剧情章节：{story_key!r}。请通过 list_stories 确认章节 key。"
+            return text_result(f"未找到剧情章节：{story_key!r}。请通过 list_stories 确认章节 key。")
         except Exception as e:
-            return f"读取梗概失败：{e}"
+            return text_result(f"读取梗概失败：{e}")
 
     @mcp.tool()
     def read_story(
         story_key: Annotated[str, Field(description="章节 key，如 \"activities/act31side/level_act31side_01_beg\"（可从 list_stories 获取）。")],
         include_narration: Annotated[bool, Field(default=True, description="是否包含旁白和场景描述，默认 True。设为 False 可只保留对话台词。")] = True,
-    ) -> str:
+    ) -> object:
         """读取单章剧情的完整台词。
 
         返回格式：首行为【活动名】章节名，随后按顺序输出对话（`角色：台词`）、
@@ -150,14 +151,14 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         try:
             zip_path = _require_story_zip(cfg)
         except RuntimeError as e:
-            return str(e)
+            return text_result(str(e))
 
         try:
             chapter = _read_story(zip_path, story_key, include_narration=include_narration)
         except KeyError:
-            return f"未找到剧情：{story_key!r}。"
+            return text_result(f"未找到剧情：{story_key!r}。")
         except Exception as e:
-            return f"读取剧情失败：{e}"
+            return text_result(f"读取剧情失败：{e}")
 
         parts = [f"【{chapter.event_name}】{chapter.story_name}"]
         if chapter.story_info:
@@ -170,7 +171,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
                 parts.append(f"*{ln.text}*")
             elif ln.type == "choice":
                 parts.append(f"【选项】{ln.text}")
-        return "\n".join(parts)
+        return text_result("\n".join(parts))
 
     @mcp.tool()
     def read_activity(
@@ -178,7 +179,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         include_narration: Annotated[bool, Field(default=True, description="是否包含旁白，默认 True。")] = True,
         page: Annotated[int | None, Field(default=None, description="分页页码（从 1 开始）。不填则返回全部章节。")] = None,
         page_size: Annotated[int, Field(default=5, description="每页章节数，默认 5。")] = 5,
-    ) -> str:
+    ) -> object:
         """读取整个活动的完整剧情台词（按官方章节顺序合并）。
 
         返回各章节台词的合并文本，格式与 read_story 一致，章节间以分隔标题区分。
@@ -189,7 +190,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         try:
             zip_path = _require_story_zip(cfg)
         except RuntimeError as e:
-            return str(e)
+            return text_result(str(e))
 
         try:
             result = _read_activity(
@@ -199,9 +200,9 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
                 page_size=page_size,
             )
         except KeyError:
-            return f"未找到活动：{event_id!r}。请先调用 list_story_events 确认活动 ID。"
+            return text_result(f"未找到活动：{event_id!r}。请先调用 list_story_events 确认活动 ID。")
         except Exception as e:
-            return f"读取活动剧情失败：{e}"
+            return text_result(f"读取活动剧情失败：{e}")
 
         chapters = result.chapters
         total = result.total_chapters
@@ -227,7 +228,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
                     parts.append(f"【选项】{ln.text}")
             parts.append("")
 
-        return "\n".join(parts)
+        return text_result("\n".join(parts))
 
     @mcp.tool()
     def search_stories(

--- a/python/tests/test_output.py
+++ b/python/tests/test_output.py
@@ -26,13 +26,13 @@ def test_parse_channel_accepts_known_values_case_insensitively() -> None:
     assert _parse_channel(" Both ") == "both"
 
 
-def test_parse_channel_rejects_unknown_and_falls_back(monkeypatch) -> None:
+def test_parse_channel_rejects_unknown_and_falls_back() -> None:
     # Should not raise; unknown values fall back to content.
     assert _parse_channel("yaml") == "content"
     assert _parse_channel("json") == "content"  # deliberately not a channel
 
 
-def test_module_constant_reads_env_at_import(monkeypatch) -> None:
+def test_module_constant_reads_env_at_import() -> None:
     # OUTPUT_CHANNEL (the parsed-value constant) is resolved at import time
     # from the PRTS_OUTPUT_CHANNEL env var. We can't re-import here cheaply,
     # so just assert it is one of the valid values regardless of the ambient

--- a/python/tests/test_output.py
+++ b/python/tests/test_output.py
@@ -33,9 +33,10 @@ def test_parse_channel_rejects_unknown_and_falls_back(monkeypatch) -> None:
 
 
 def test_module_constant_reads_env_at_import(monkeypatch) -> None:
-    # OUTPUT_CHANNEL is resolved at import time from the env var. We can't
-    # re-import here cheaply, so just assert it is one of the valid values
-    # regardless of the ambient environment.
+    # OUTPUT_CHANNEL (the parsed-value constant) is resolved at import time
+    # from the PRTS_OUTPUT_CHANNEL env var. We can't re-import here cheaply,
+    # so just assert it is one of the valid values regardless of the ambient
+    # environment.
     assert OUTPUT_CHANNEL in {"content", "structured", "both"}
 
 

--- a/python/tests/test_output.py
+++ b/python/tests/test_output.py
@@ -7,6 +7,7 @@ from prts_mcp.output import (
     OUTPUT_CHANNEL,
     _parse_channel,
     render_result,
+    text_result,
 )
 
 
@@ -94,3 +95,24 @@ def test_structured_channel_without_total_falls_back_to_generic_summary() -> Non
     r = render_result(data, _MD, channel="structured")
     assert r.structuredContent == data
     assert "structuredContent" in r.content[0].text
+
+
+# ---------------------------------------------------------------------------
+# text_result — narrative / error-path content-only helper
+# ---------------------------------------------------------------------------
+
+
+def test_text_result_is_content_only() -> None:
+    r = text_result(_MD)
+    assert isinstance(r, CallToolResult)
+    assert [c.text for c in r.content] == [_MD]
+    assert r.structuredContent is None
+    assert r.isError is False
+
+
+def test_text_result_carries_error_messages_verbatim() -> None:
+    err = "未找到剧情章节：'nope'。请通过 list_stories 确认章节 key。"
+    r = text_result(err)
+    assert [c.text for c in r.content] == [err]
+    assert r.structuredContent is None
+    assert r.isError is False

--- a/python/tests/test_output.py
+++ b/python/tests/test_output.py
@@ -1,0 +1,95 @@
+"""Tests for the output-channel renderer (2.0 structuredContent support)."""
+from __future__ import annotations
+
+from mcp.types import CallToolResult
+
+from prts_mcp.output import (
+    OUTPUT_CHANNEL,
+    _parse_channel,
+    render_result,
+)
+
+
+# ---------------------------------------------------------------------------
+# Channel parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_channel_unset_defaults_to_content() -> None:
+    assert _parse_channel(None) == "content"
+    assert _parse_channel("") == "content"
+
+
+def test_parse_channel_accepts_known_values_case_insensitively() -> None:
+    assert _parse_channel("content") == "content"
+    assert _parse_channel("STRUCTURED") == "structured"
+    assert _parse_channel(" Both ") == "both"
+
+
+def test_parse_channel_rejects_unknown_and_falls_back(monkeypatch) -> None:
+    # Should not raise; unknown values fall back to content.
+    assert _parse_channel("yaml") == "content"
+    assert _parse_channel("json") == "content"  # deliberately not a channel
+
+
+def test_module_constant_reads_env_at_import(monkeypatch) -> None:
+    # OUTPUT_CHANNEL is resolved at import time from the env var. We can't
+    # re-import here cheaply, so just assert it is one of the valid values
+    # regardless of the ambient environment.
+    assert OUTPUT_CHANNEL in {"content", "structured", "both"}
+
+
+# ---------------------------------------------------------------------------
+# render_result — channel behaviour
+# ---------------------------------------------------------------------------
+
+_DATA = {"total": 2, "offset": 0, "stages": [{"stage_id": "main_00-01"}]}
+_MD = "# 关卡列表\n\n- main_00-01：第一关"
+
+
+def test_content_channel_emits_markdown_only() -> None:
+    r = render_result(_DATA, _MD, channel="content")
+    assert isinstance(r, CallToolResult)
+    assert [c.text for c in r.content] == [_MD]
+    assert r.structuredContent is None
+    assert r.isError is False
+
+
+def test_both_channel_emits_markdown_and_structured() -> None:
+    r = render_result(_DATA, _MD, channel="both")
+    assert [c.text for c in r.content] == [_MD]
+    assert r.structuredContent == _DATA
+
+
+def test_structured_channel_emits_summary_and_structured() -> None:
+    r = render_result(_DATA, _MD, channel="structured")
+    # content is the minimal summary, NOT the full markdown.
+    assert r.content[0].text != _MD
+    assert "structuredContent" in r.content[0].text or "条" in r.content[0].text
+    assert r.structuredContent == _DATA
+
+
+def test_structured_summary_mentions_total_count() -> None:
+    r = render_result(_DATA, _MD, channel="structured")
+    assert "2" in r.content[0].text
+
+
+# ---------------------------------------------------------------------------
+# render_result — error / missing-data path
+# ---------------------------------------------------------------------------
+
+
+def test_none_data_emits_markdown_only_regardless_of_channel() -> None:
+    # The error/missing-data contract: never put errors in structuredContent.
+    err = "limit 必须 >= 1。"
+    for ch in ("content", "structured", "both"):
+        r = render_result(None, err, channel=ch)  # type: ignore[arg-type]
+        assert [c.text for c in r.content] == [err], f"channel={ch}"
+        assert r.structuredContent is None, f"channel={ch}"
+
+
+def test_structured_channel_without_total_falls_back_to_generic_summary() -> None:
+    data = {"items": [1, 2, 3]}  # no "total" key
+    r = render_result(data, _MD, channel="structured")
+    assert r.structuredContent == data
+    assert "structuredContent" in r.content[0].text

--- a/python/tests/test_stage.py
+++ b/python/tests/test_stage.py
@@ -8,11 +8,14 @@ from pathlib import Path
 import pytest
 
 from prts_mcp.data.stage import (
+    build_stages_listing,
     clear_stage_caches,
     list_stages,
     get_stage_info,
+    render_stages_listing,
     search_stages,
 )
+from prts_mcp.output import render_result
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -232,6 +235,104 @@ class TestListStages:
     def test_invalid_offset(self, gamedata: str) -> None:
         out = list_stages(offset=-1)
         assert "offset 必须 >= 0" in out
+
+
+# ---------------------------------------------------------------------------
+# list_stages: build / render / structuredContent channels
+# ---------------------------------------------------------------------------
+
+
+class TestStagesBuildRender:
+    """Golden + round-trip tests for the build/render split.
+
+    The structured dict is the single source of truth; render must be its
+    exact inverse and list_stages must stay byte-for-byte equivalent to
+    render(build(...)).
+    """
+
+    def test_build_payload_shape(self, gamedata: str) -> None:
+        data = build_stages_listing()
+        assert isinstance(data, dict)
+        # Pagination + filter metadata.
+        assert set(data.keys()) == {"total", "offset", "limit", "filters", "stages"}
+        assert data["total"] == 4
+        assert data["offset"] == 0
+        assert data["limit"] == 50
+        assert data["filters"] == {"chapter": None, "type": None}
+        # Each entry carries both raw enum and rendered label, so the
+        # payload serves automation and Chinese consumers alike.
+        # Entries are sorted by stage_id (act31side_01 < daily_01 < main_*).
+        first = data["stages"][0]
+        assert first["stage_id"] == "act31side_01"
+        assert first["type"] == "ACTIVITY"
+        assert first["type_label"] == "活动"
+        assert first["difficulty_label"] == "普通"
+
+    def test_build_error_paths_return_str(self, gamedata: str) -> None:
+        assert isinstance(build_stages_listing(limit=0), str)
+        assert isinstance(build_stages_listing(offset=-1), str)
+        assert isinstance(build_stages_listing(type="NOPE"), str)
+        assert isinstance(build_stages_listing(chapter="missing"), str)
+        assert isinstance(build_stages_listing(offset=999), str)
+
+    def test_render_is_inverse_of_build(self, gamedata: str) -> None:
+        # list_stages() must equal render(build(...)) exactly — the
+        # byte-for-byte equivalence contract of the refactor.
+        data = build_stages_listing(chapter="main_0")
+        assert isinstance(data, dict)
+        assert render_stages_listing(data) == list_stages(chapter="main_0")
+
+    def test_build_respects_filters_and_pagination(self, gamedata: str) -> None:
+        data = build_stages_listing(type="DAILY")
+        assert isinstance(data, dict)
+        assert data["total"] == 1
+        assert data["stages"][0]["stage_id"] == "daily_01"
+        assert data["filters"]["type"] == "DAILY"
+
+        page = build_stages_listing(limit=2, offset=0)
+        assert isinstance(page, dict)
+        assert page["total"] == 4
+        assert len(page["stages"]) == 2
+
+
+class TestStagesOutputChannels:
+    """The three output_channel modes via the render_result helper."""
+
+    def _build(self, gamedata: str) -> dict:
+        data = build_stages_listing()
+        assert isinstance(data, dict)
+        return data
+
+    def test_content_channel_text_only(self, gamedata: str) -> None:
+        data = self._build(gamedata)
+        md = render_stages_listing(data)
+        r = render_result(data, md, channel="content")
+        assert r.structuredContent is None
+        assert [c.text for c in r.content] == [md]
+
+    def test_both_channel_emits_both(self, gamedata: str) -> None:
+        data = self._build(gamedata)
+        md = render_stages_listing(data)
+        r = render_result(data, md, channel="both")
+        assert [c.text for c in r.content] == [md]
+        assert r.structuredContent == data
+
+    def test_structured_channel_summary_and_payload(self, gamedata: str) -> None:
+        data = self._build(gamedata)
+        md = render_stages_listing(data)
+        r = render_result(data, md, channel="structured")
+        # content is the one-line summary, not the full markdown.
+        assert r.content[0].text != md
+        assert "4" in r.content[0].text  # total count appears in summary
+        assert r.structuredContent == data
+
+    def test_error_path_is_content_only_in_every_channel(self, gamedata: str) -> None:
+        err = build_stages_listing(limit=0)
+        assert isinstance(err, str)
+        for ch in ("content", "structured", "both"):
+            r = render_result(None, err, channel=ch)  # type: ignore[arg-type]
+            assert [c.text for c in r.content] == [err], f"channel={ch}"
+            assert r.structuredContent is None, f"channel={ch}"
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_structured_passthrough.py
+++ b/python/tests/test_structured_passthrough.py
@@ -1,0 +1,94 @@
+"""Regression guard for the SDK structuredContent pass-through contract.
+
+The whole output-channel design rests on one assumption validated by the
+P1 spike: a tool that returns a hand-built ``CallToolResult`` reaches the
+client with ``content`` and ``structuredContent`` exactly as built — FastMCP
+does not rewrite content to JSON, drop structuredContent, or auto-derive
+an ``outputSchema``. That assumption lives in the SDK's ``convert_result``
+``isinstance(result, CallToolResult)`` branch; if a future SDK version
+changes it, the failure is **silent** (structuredContent vanishes, or an
+extra serialized JSON block appears) and every other test stays green.
+
+These tests exercise the *real* FastMCP tool-call path
+(``ToolManager.call_tool(..., convert_result=True)`` — the same call the
+lowlevel server handler makes), not the ``render_result`` helper directly.
+A dedicated probe tool returns a fixed ``CallToolResult`` so the assertion
+isolates "did the SDK pass it through?" from env parsing and data-layer
+behaviour.
+
+The suite is synchronous (``asyncio.run``) to match the project's testing
+style — no pytest-asyncio dependency.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from mcp.types import CallToolResult
+
+from prts_mcp.output import render_result
+
+_PROBE_DATA = {"total": 2, "stages": [{"stage_id": "main_00-01"}, {"stage_id": "main_00-02"}]}
+_PROBE_MD = "# probe\n\n- main_00-01\n- main_00-02"
+
+
+def _build_probe_app(channel: str) -> FastMCP:
+    """FastMCP app with one probe tool returning render_result(...) for a channel.
+
+    The probe fixes its inputs so only the channel (and thus the SDK
+    pass-through) varies — env parsing and the data layer are out of scope.
+    """
+
+    app = FastMCP("probe")
+
+    @app.tool()
+    async def probe() -> object:  # returns a CallToolResult, not a str
+        return render_result(_PROBE_DATA, _PROBE_MD, channel=channel)  # type: ignore[arg-type]
+
+    return app
+
+
+def _call_probe(channel: str) -> CallToolResult:
+    """Drive the probe tool through the real FastMCP tool-call path."""
+    app = _build_probe_app(channel)
+    result = asyncio.run(
+        app._tool_manager.call_tool("probe", {}, convert_result=True)
+    )
+    return result  # type: ignore[return-value]
+
+
+@pytest.mark.parametrize("channel", ["content", "structured", "both"])
+def test_sdk_passes_through_call_tool_result_verbatim(channel: str) -> None:
+    result = _call_probe(channel)
+
+    # The SDK must hand back exactly the CallToolResult the tool built —
+    # not unwrap it, not re-serialize it, not append a JSON block.
+    assert isinstance(result, CallToolResult), (
+        f"SDK did not pass the CallToolResult through for channel={channel!r}; "
+        f"got {type(result).__name__}"
+    )
+
+    if channel == "content":
+        assert result.structuredContent is None
+        assert len(result.content) == 1
+        assert result.content[0].text == _PROBE_MD
+    elif channel == "both":
+        assert result.structuredContent == _PROBE_DATA
+        # Exactly one text block — no extra serialized-JSON block appended.
+        assert len(result.content) == 1, "both channel appended an extra content block"
+        assert result.content[0].text == _PROBE_MD
+    else:  # structured
+        assert result.structuredContent == _PROBE_DATA
+        assert result.content[0].text != _PROBE_MD  # summary, not full markdown
+        assert len(result.content) == 1
+
+
+def test_no_output_schema_pollutes_the_manifest() -> None:
+    app = _build_probe_app("both")
+    tools = asyncio.run(app.list_tools())
+    probe = next(t for t in tools if t.name == "probe")
+    assert probe.outputSchema is None, (
+        "Returning a CallToolResult derived an outputSchema; this would eat the "
+        "context budget the consolidation work is trying to save."
+    )

--- a/python/tests/test_structured_passthrough.py
+++ b/python/tests/test_structured_passthrough.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import asyncio
 
 import pytest
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.server.fastmcp import FastMCP
 from mcp.types import CallToolResult
 
@@ -92,3 +93,27 @@ def test_no_output_schema_pollutes_the_manifest() -> None:
         "Returning a CallToolResult derived an outputSchema; this would eat the "
         "context budget the consolidation work is trying to save."
     )
+
+
+def test_str_annotation_rejects_explicit_call_tool_result() -> None:
+    """Guard against forgetting -> object when migrating tools in P2.
+
+    FastMCP derives outputSchema from the return annotation. If a tool keeps
+    ``-> str`` but starts returning our explicit ``CallToolResult``, FastMCP
+    validates that object against ``{result: string}`` and the tool call fails.
+    """
+
+    app = FastMCP("bad-probe")
+
+    @app.tool()
+    async def bad_probe() -> str:
+        return render_result(  # type: ignore[return-value]
+            _PROBE_DATA, _PROBE_MD, channel="content"
+        )
+
+    with pytest.raises(ToolError) as excinfo:
+        asyncio.run(app._tool_manager.call_tool("bad_probe", {}, convert_result=True))
+
+    message = str(excinfo.value)
+    assert "validation error" in message
+    assert "bad_probeOutput" in message


### PR DESCRIPTION
## Summary

P1 of the 2.0 output-channel plan (`dev/docs/2.0-output-channel-plan.md`). A **Python-only** pilot validating structuredContent delivery on a single tool (`list_stages`) before rolling out to ~15 more structural tools (P2) and the TypeScript port (P3).

**Design contract** (locked by the design doc):
- Control plane = connection-level `PRTS_OUTPUT_CHANNEL` env var (NOT a per-call tool parameter). Values: `content` (default, byte-for-byte today) / `structured` / `both`.
- Structured data rides MCP's native `structuredContent` channel; `content` is always markdown.
- The tool returns a hand-built `CallToolResult`; FastMCP passes it through verbatim (spike-confirmed; regression-guarded).
- Errors/missing-data: content-only, `isError=False` (non-breaking vs 1.x), never in structuredContent.
- **Non-breaking**: default `content` channel reproduces today's markdown-only behaviour byte-for-byte.

**What shipped:**
- `output.py` — channel config parser + `render_result(data, markdown, channel)` cross-cutting helper.
- `data/stage.py` — `list_stages` split into `build_stages_listing` (→ dict|str, single source of truth) + `render_stages_listing` (dict → str), with `list_stages()` as a thin `render(build())` passthrough. Byte-for-byte equivalent.
- `tools_gamedata.py` — `list_stages` wired through `render_result`; return annotation widened `str → object` (manifest-neutral, params unchanged).
- structuredContent payload carries both raw enums (`type=ACTIVITY`) and rendered labels (`type_label=活动`) to serve automation and Chinese consumers alike.

## Test plan

- [x] Python full suite: **239 passed, 2 skipped** (+13 new tests)
- [x] `check-runtime.ps1 -Full`: **0 failure** (TS 162 passed, typecheck clean — TS untouched)
- [x] Spike (gate): FastMCP passes a hand-built `CallToolResult` through verbatim — content not rewritten to JSON, no `outputSchema` pollutes the manifest
- [x] Byte-for-byte equivalence: `render_stages_listing(build_stages_listing()) == list_stages()` (round-trip test)
- [x] SDK pass-through regression guard: 4 tests through the real `ToolManager.call_tool(convert_result=True)` path; adversarial check confirms it fails if a tool returns a bare dict
- [x] Three-channel behaviour + error-path content-only across channels
- [x] Two independent sub-agent CRs (code-only): no Blocking; all should-fixes addressed

## 未尽事宜 (out of scope, tracked for follow-up PRs)

- **P2**: roll the build/render + helper pattern out to the remaining ~15 structural tools
- **P3**: TypeScript port (incl. connection-level HTTP config parsing, per-request/session)
- **P4**: README output-channel docs + deployment guide + ROADMAP §Output-format rewrite + 2.0 migration notes
- Open item (design §6 footnote): whether "true data-unavailable" failures should set `isError=True` (behaviour change, deferred)