### PR TITLE
feat(python): gamedata list/fusion structuredContent (2.0 output-channel P2b PR2a)

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -49,10 +49,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   gamedata list/fusion tools (`list_enemies`, `list_items`,
   `get_stage_enemies`, `get_enemy_appearances`) migrated to the build/render
   split with real structuredContent. Listing payloads carry pagination
-  metadata + filters + entries with chainable IDs and raw/label field
-  pairs; the fusion tool (`get_stage_enemies`) carries per-enemy spawn
-  counts, level, overwrite flag, and stats text. The story-list/wiki-search
-  tools and the heterogeneous `search` follow in P2b PR2b/PR3.
+  metadata + filters (raw user input + normalized filter) + entries with
+  chainable IDs and raw/label field pairs; the fusion tool
+  (`get_stage_enemies`) carries per-enemy spawn counts, level, overwrite
+  flag, and stats text. **Empty-result contract**: legitimate-but-empty
+  results (filter no-match, offset past end) now return a structured
+  payload `{total:0, entries:[]}` that the structured channel carries,
+  while the content channel still emits the original human message
+  verbatim — so structured consumers can uniformly rely on
+  "empty ⇒ {total:0}". True errors (invalid params, missing data) stay
+  content-only. The story-list/wiki-search tools and the heterogeneous
+  `search` follow in P2b PR2b/PR3.
 
 ### Changed
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -45,6 +45,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   localized text.
   The list/fusion tools (`list_enemies`, `search`, …) and the `search`
   consolidation follow in P2b PR2/PR3.
+- **Gamedata list/fusion structuredContent (2.0, P2b PR2a).** The four
+  gamedata list/fusion tools (`list_enemies`, `list_items`,
+  `get_stage_enemies`, `get_enemy_appearances`) migrated to the build/render
+  split with real structuredContent. Listing payloads carry pagination
+  metadata + filters + entries with chainable IDs and raw/label field
+  pairs; the fusion tool (`get_stage_enemies`) carries per-enemy spawn
+  counts, level, overwrite flag, and stats text. The story-list/wiki-search
+  tools and the heterogeneous `search` follow in P2b PR2b/PR3.
 
 ### Changed
 

--- a/python/src/prts_mcp/data/enemy.py
+++ b/python/src/prts_mcp/data/enemy.py
@@ -202,19 +202,16 @@ def _fmt_enemy(info: dict, include_id: bool = False) -> str:
 # ---------------------------------------------------------------------------
 
 
-def list_enemies(
+def build_enemies_listing(
     threat_level: str | None = None,
     limit: int = 50,
     offset: int = 0,
     full: bool = False,
-) -> str:
-    """List enemies with optional filtering and pagination.
+) -> dict | str:
+    """Build the structured payload for an enemies listing.
 
-    Args:
-        threat_level: Filter by BOSS / ELITE / NORMAL.
-        limit: Max entries to return (ignored when full=True).
-        offset: Pagination offset.
-        full: Return ALL entries. Discouraged for normal use.
+    Returns the dict payload on success, or a markdown error string on a
+    validation / missing-data / empty-result path.
     """
     if not _has_enemy_data():
         return _missing_data_message()
@@ -239,6 +236,7 @@ def list_enemies(
         if not info.get("hideInHandbook") and info.get("name")
     ]
 
+    level_filter: str | None = None
     if threat_level:
         level_filter = threat_level.upper()
         if level_filter not in _ENEMY_LEVEL_ZH:
@@ -252,27 +250,73 @@ def list_enemies(
     if not full and offset >= total and total > 0:
         return f"# 敌人图鉴（共 {total} 个）\n\noffset={offset} 超出范围（总计 {total} 条）。"
 
-    if full:
-        displayed = entries
-    else:
-        displayed = entries[offset:offset + limit]
+    displayed = entries if full else entries[offset:offset + limit]
+
+    item_entries = []
+    for eid, info in displayed:
+        level_raw = info.get("enemyLevel", "")
+        desc = (info.get("description") or "").replace("\n", " ")[:60]
+        item_entries.append({
+            "enemy_id": eid,
+            "name": info.get("name", ""),
+            "enemy_index": info.get("enemyIndex", ""),
+            "level_raw": level_raw,
+            "level_label": _ENEMY_LEVEL_ZH.get(level_raw, level_raw),
+            "description_excerpt": desc,
+        })
+
+    return {
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "full": full,
+        "filters": {"threat_level": level_filter},
+        "enemies": item_entries,
+    }
+
+
+def render_enemies_listing(data: dict) -> str:
+    """Render an enemies-listing payload dict to markdown.
+
+    Pure renderer; the inverse of ``build_enemies_listing``'s success path.
+    """
+    total = data["total"]
+    offset = data["offset"]
+    limit = data["limit"]
+    full = data["full"]
+    enemies = data["enemies"]
 
     header = f"# 敌人图鉴（共 {total} 个）\n"
-    for _eid, info in displayed:
-        level = info.get("enemyLevel", "")
-        level_zh = _ENEMY_LEVEL_ZH.get(level, level)
-        index = info.get("enemyIndex", "")
-        name = info.get("name", "")
-        desc = (info.get("description") or "").replace("\n", " ")[:60]
-        line = f"- **{name}** [{level_zh}] ({index})"
-        if desc:
-            line += f" — {desc}"
+    for e in enemies:
+        line = f"- **{e['name']}** [{e['level_label']}] ({e['enemy_index']})"
+        if e["description_excerpt"]:
+            line += f" — {e['description_excerpt']}"
         header += line + "\n"
 
     if not full and total > offset + limit:
         header += f"\n（显示第 {offset+1}–{min(offset+limit, total)} 条，共 {total} 条。使用 offset={offset+limit} 查看下一页）"
 
     return header.strip()
+
+
+def list_enemies(
+    threat_level: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+    full: bool = False,
+) -> str:
+    """List enemies with optional filtering and pagination.
+
+    Args:
+        threat_level: Filter by BOSS / ELITE / NORMAL.
+        limit: Max entries to return (ignored when full=True).
+        offset: Pagination offset.
+        full: Return ALL entries. Discouraged for normal use.
+    """
+    data = build_enemies_listing(threat_level=threat_level, limit=limit, offset=offset, full=full)
+    if isinstance(data, str):
+        return data
+    return render_enemies_listing(data)
 
 
 def build_enemy_info(name: str) -> dict | str:

--- a/python/src/prts_mcp/data/enemy.py
+++ b/python/src/prts_mcp/data/enemy.py
@@ -247,8 +247,20 @@ def build_enemies_listing(
     entries.sort(key=lambda x: (x[1].get("sortId", 9999), x[0]))
     total = len(entries)
 
+    # Legitimate-but-empty: offset past end (total>0) is a normal structured
+    # payload, not an error (P2b plan §3.4). Filter-no-match (total==0) falls
+    # through to the standard empty-dict path below.
+    filters_payload = {"threat_level": threat_level, "threat_level_filter": level_filter}
     if not full and offset >= total and total > 0:
-        return f"# 敌人图鉴（共 {total} 个）\n\noffset={offset} 超出范围（总计 {total} 条）。"
+        return {
+            "total": total,
+            "offset": offset,
+            "limit": limit,
+            "full": full,
+            "filters": filters_payload,
+            "enemies": [],
+            "empty_reason": "offset_out_of_range",
+        }
 
     displayed = entries if full else entries[offset:offset + limit]
 
@@ -270,7 +282,7 @@ def build_enemies_listing(
         "offset": offset,
         "limit": limit,
         "full": full,
-        "filters": {"threat_level": level_filter},
+        "filters": filters_payload,
         "enemies": item_entries,
     }
 
@@ -280,6 +292,11 @@ def render_enemies_listing(data: dict) -> str:
 
     Pure renderer; the inverse of ``build_enemies_listing``'s success path.
     """
+    if data.get("empty_reason") == "offset_out_of_range":
+        total = data["total"]
+        offset = data["offset"]
+        return f"# 敌人图鉴（共 {total} 个）\n\noffset={offset} 超出范围（总计 {total} 条）。"
+
     total = data["total"]
     offset = data["offset"]
     limit = data["limit"]

--- a/python/src/prts_mcp/data/item.py
+++ b/python/src/prts_mcp/data/item.py
@@ -207,10 +207,20 @@ def build_items_listing(
     total = len(entries)
     page = entries[offset : offset + limit]
 
+    # Legitimate-but-empty results (no match / offset past end) are a normal
+    # structured payload, NOT an error — structured consumers can rely on
+    # "empty ⇒ {total:0, items:[]}" (P2b plan §3.4). The renderer still emits
+    # the original human-readable message, so content is byte-for-byte stable.
     if not page:
-        if total == 0:
-            return f"没有匹配的物品（category={category or 'none'}）。"
-        return f"offset {offset} 超出范围（共 {total} 条）。"
+        empty_reason = "no_match" if total == 0 else "offset_out_of_range"
+        return {
+            "total": total,
+            "offset": offset,
+            "limit": limit,
+            "filters": {"category": category, "category_filter": category_filter},
+            "items": [],
+            "empty_reason": empty_reason,
+        }
 
     item_entries = []
     for item_id, info in page:
@@ -242,6 +252,15 @@ def render_items_listing(data: dict) -> str:
 
     Pure renderer; the inverse of ``build_items_listing``'s success path.
     """
+    # Legitimate-but-empty results render as the original human message
+    # (byte-for-byte stable content) while the structured payload carries
+    # {total:0, items:[]} for capable clients.
+    empty_reason = data.get("empty_reason")
+    if empty_reason == "no_match":
+        return f"没有匹配的物品（category={data['filters']['category'] or 'none'}）。"
+    if empty_reason == "offset_out_of_range":
+        return f"offset {data['offset']} 超出范围（共 {data['total']} 条）。"
+
     total = data["total"]
     offset = data["offset"]
     limit = data["limit"]

--- a/python/src/prts_mcp/data/item.py
+++ b/python/src/prts_mcp/data/item.py
@@ -173,12 +173,16 @@ def _format_related(label: str, entries: Any) -> list[str]:
     return lines
 
 
-def list_items(
+def build_items_listing(
     category: str | None = None,
     limit: int = 50,
     offset: int = 0,
-) -> str:
-    """List visible items with optional classifyType/itemType filtering."""
+) -> dict | str:
+    """Build the structured payload for an items listing.
+
+    Returns the dict payload on success, or a markdown error string on a
+    validation / missing-data / empty-result path.
+    """
     if limit < 1:
         return "limit 必须 >= 1。"
     if limit > 200:
@@ -208,19 +212,51 @@ def list_items(
             return f"没有匹配的物品（category={category or 'none'}）。"
         return f"offset {offset} 超出范围（共 {total} 条）。"
 
-    title = f"# 物品列表（共 {total} 个）"
-    if category:
-        title = f"# 物品列表：{category}（共 {total} 个）"
-    lines = [title]
+    item_entries = []
     for item_id, info in page:
-        name = info.get("name") or "（无名）"
-        rarity = _rarity_label(str(info.get("rarity") or ""))
-        classify = _classify_label(str(info.get("classifyType") or ""))
-        item_type = info.get("itemType") or "-"
-        usage = _short_text(str(info.get("usage") or info.get("description") or ""))
-        line = f"- **{name}** [{classify}/{item_type}] {rarity}（id: {item_id}）"
-        if usage:
-            line += f" — {usage}"
+        item_entries.append({
+            "item_id": item_id,
+            "name": info.get("name") or "（无名）",
+            "rarity_raw": str(info.get("rarity") or ""),
+            "rarity_label": _rarity_label(str(info.get("rarity") or "")),
+            "classify_raw": str(info.get("classifyType") or ""),
+            "classify_label": _classify_label(str(info.get("classifyType") or "")),
+            "item_type": info.get("itemType") or "-",
+            "usage_excerpt": _short_text(str(info.get("usage") or info.get("description") or "")),
+        })
+
+    return {
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        # `category` is the raw user input (echoed in the title verbatim,
+        # matching the pre-refactor behaviour); `category_filter` is the
+        # normalized value actually used for filtering.
+        "filters": {"category": category, "category_filter": category_filter},
+        "items": item_entries,
+    }
+
+
+def render_items_listing(data: dict) -> str:
+    """Render an items-listing payload dict to markdown.
+
+    Pure renderer; the inverse of ``build_items_listing``'s success path.
+    """
+    total = data["total"]
+    offset = data["offset"]
+    limit = data["limit"]
+    category = data["filters"]["category"]
+    items = data["items"]
+
+    title = f"# 物品列表：{category}（共 {total} 个）" if category else f"# 物品列表（共 {total} 个）"
+    lines = [title]
+    for it in items:
+        line = (
+            f"- **{it['name']}** [{it['classify_label']}/{it['item_type']}] "
+            f"{it['rarity_label']}（id: {it['item_id']}）"
+        )
+        if it["usage_excerpt"]:
+            line += f" — {it['usage_excerpt']}"
         lines.append(line)
 
     start = offset + 1
@@ -230,6 +266,18 @@ def list_items(
         f"使用 offset={offset + limit} 查看下一页）"
     )
     return "\n".join(lines)
+
+
+def list_items(
+    category: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> str:
+    """List visible items with optional classifyType/itemType filtering."""
+    data = build_items_listing(category=category, limit=limit, offset=offset)
+    if isinstance(data, str):
+        return data
+    return render_items_listing(data)
 
 
 def build_item_info(name: str) -> dict | str:

--- a/python/src/prts_mcp/data/stage_enemy.py
+++ b/python/src/prts_mcp/data/stage_enemy.py
@@ -214,8 +214,12 @@ def _format_stats(enemy_data: dict[str, Any] | None) -> str:
     return "；".join(parts)
 
 
-def get_stage_enemies(stage_id: str) -> str:
-    """Return enemies actually spawned by a stage, using stage-specific levels."""
+def build_stage_enemies(stage_id: str) -> dict | str:
+    """Build the structured payload for enemies actually spawned by a stage.
+
+    Returns the dict payload on success, or a markdown error string on a
+    missing-data / not-found / empty path.
+    """
     if not _get_config().has_levels_data:
         return _missing_levels_message()
     try:
@@ -234,7 +238,7 @@ def get_stage_enemies(stage_id: str) -> str:
     if not counts:
         return f"关卡 {stage_id!r} 未解析到实际出怪。"
 
-    lines = [f"# {_stage_label(stage, stage_id)} — 敌人列表"]
+    enemy_entries = []
     for enemy_id, count in counts.most_common():
         ref = refs.get(enemy_id, {})
         try:
@@ -244,13 +248,47 @@ def get_stage_enemies(stage_id: str) -> str:
         overwritten = ref.get("overwrittenData")
         data = _stage_specific_enemy_data(enemy_id, level_no, overwritten)
         name = _overwritten_enemy_name(overwritten) or _handbook_name(enemy_id)
-        lines.append(f"\n## {name}（{enemy_id}）")
-        lines.append(f"- **出场数量**：{count}")
-        lines.append(f"- **敌人等级**：{level_no}")
-        if overwritten:
+        enemy_entries.append({
+            "enemy_id": enemy_id,
+            "name": name,
+            "count": count,
+            "level": level_no,
+            "overwritten": bool(overwritten),
+            # Stats kept as the compact rendered text (the same string the
+            # markdown emits); structured per-stat extraction is deferred.
+            "stats_text": _format_stats(data),
+        })
+
+    return {
+        "stage_id": stage_id,
+        "stage_label": _stage_label(stage, stage_id),
+        "total": len(enemy_entries),
+        "enemies": enemy_entries,
+    }
+
+
+def render_stage_enemies(data: dict) -> str:
+    """Render a stage-enemies payload dict to markdown.
+
+    Pure renderer; the inverse of ``build_stage_enemies``'s success path.
+    """
+    lines = [f"# {data['stage_label']} — 敌人列表"]
+    for e in data["enemies"]:
+        lines.append(f"\n## {e['name']}（{e['enemy_id']}）")
+        lines.append(f"- **出场数量**：{e['count']}")
+        lines.append(f"- **敌人等级**：{e['level']}")
+        if e["overwritten"]:
             lines.append("- **关卡覆盖**：是")
-        lines.append(f"- **战斗属性**：{_format_stats(data)}")
+        lines.append(f"- **战斗属性**：{e['stats_text']}")
     return "\n".join(lines)
+
+
+def get_stage_enemies(stage_id: str) -> str:
+    """Return enemies actually spawned by a stage, using stage-specific levels."""
+    data = build_stage_enemies(stage_id)
+    if isinstance(data, str):
+        return data
+    return render_stage_enemies(data)
 
 
 def _find_enemy_appearances(enemy_id: str) -> list[tuple[str, int]]:

--- a/python/src/prts_mcp/data/stage_enemy.py
+++ b/python/src/prts_mcp/data/stage_enemy.py
@@ -236,7 +236,14 @@ def build_stage_enemies(stage_id: str) -> dict | str:
         return f"读取关卡敌人失败：{exc}"
 
     if not counts:
-        return f"关卡 {stage_id!r} 未解析到实际出怪。"
+        # Legitimate-but-empty: the stage exists but spawns nothing.
+        return {
+            "stage_id": stage_id,
+            "stage_label": _stage_label(stage, stage_id),
+            "total": 0,
+            "enemies": [],
+            "empty_reason": "no_match",
+        }
 
     enemy_entries = []
     for enemy_id, count in counts.most_common():
@@ -272,6 +279,9 @@ def render_stage_enemies(data: dict) -> str:
 
     Pure renderer; the inverse of ``build_stage_enemies``'s success path.
     """
+    if data.get("empty_reason") == "no_match":
+        return f"关卡 {data['stage_id']!r} 未解析到实际出怪。"
+
     lines = [f"# {data['stage_label']} — 敌人列表"]
     for e in data["enemies"]:
         lines.append(f"\n## {e['name']}（{e['enemy_id']}）")
@@ -341,10 +351,19 @@ def build_enemy_appearances(name: str, limit: int = 50, offset: int = 0) -> dict
     total = len(appearances)
     page = appearances[offset : offset + limit]
     enemy_name = _handbook_name(enemy_id)
+    # Legitimate-but-empty (no appearances / offset past end) is a normal
+    # structured payload, not an error (P2b plan §3.4).
     if not page:
-        if total == 0:
-            return f"未找到 {enemy_name}（{enemy_id}）的实际出场关卡。"
-        return f"offset {offset} 超出范围（共 {total} 条）。"
+        empty_reason = "no_match" if total == 0 else "offset_out_of_range"
+        return {
+            "enemy_id": enemy_id,
+            "enemy_name": enemy_name,
+            "total": total,
+            "offset": offset,
+            "limit": limit,
+            "stages": [],
+            "empty_reason": empty_reason,
+        }
 
     stage_entries = []
     for stage_id, count in page:
@@ -371,6 +390,12 @@ def render_enemy_appearances(data: dict) -> str:
 
     Pure renderer; the inverse of ``build_enemy_appearances``'s success path.
     """
+    empty_reason = data.get("empty_reason")
+    if empty_reason == "no_match":
+        return f"未找到 {data['enemy_name']}（{data['enemy_id']}）的实际出场关卡。"
+    if empty_reason == "offset_out_of_range":
+        return f"offset {data['offset']} 超出范围（共 {data['total']} 条）。"
+
     enemy_name = data["enemy_name"]
     enemy_id = data["enemy_id"]
     total = data["total"]

--- a/python/src/prts_mcp/data/stage_enemy.py
+++ b/python/src/prts_mcp/data/stage_enemy.py
@@ -276,8 +276,12 @@ def _enemy_appearance_index() -> dict[str, list[tuple[str, int]]]:
     return appearances
 
 
-def get_enemy_appearances(name: str, limit: int = 50, offset: int = 0) -> str:
-    """Return stages where an enemy actually spawns."""
+def build_enemy_appearances(name: str, limit: int = 50, offset: int = 0) -> dict | str:
+    """Build the structured payload for where an enemy actually spawns.
+
+    Returns the dict payload on success, or a markdown error string on a
+    validation / missing-data / not-found / empty path.
+    """
     if limit < 1:
         return "limit 必须 >= 1。"
     if limit > 200:
@@ -304,16 +308,53 @@ def get_enemy_appearances(name: str, limit: int = 50, offset: int = 0) -> str:
             return f"未找到 {enemy_name}（{enemy_id}）的实际出场关卡。"
         return f"offset {offset} 超出范围（共 {total} 条）。"
 
-    lines = [f"# {enemy_name}（{enemy_id}）— 出场关卡（共 {total} 个）"]
+    stage_entries = []
     for stage_id, count in page:
         stage = stages.get(stage_id, {})
-        code = stage.get("code") or stage_id
-        stage_name = stage.get("name") or "（无名）"
-        lines.append(f"- **{stage_name}** {code}（{stage_id}）：{count} 个")
+        stage_entries.append({
+            "stage_id": stage_id,
+            "stage_name": stage.get("name") or "（无名）",
+            "code": stage.get("code") or stage_id,
+            "count": count,
+        })
+
+    return {
+        "enemy_id": enemy_id,
+        "enemy_name": enemy_name,
+        "total": total,
+        "offset": offset,
+        "limit": limit,
+        "stages": stage_entries,
+    }
+
+
+def render_enemy_appearances(data: dict) -> str:
+    """Render an enemy-appearances payload dict to markdown.
+
+    Pure renderer; the inverse of ``build_enemy_appearances``'s success path.
+    """
+    enemy_name = data["enemy_name"]
+    enemy_id = data["enemy_id"]
+    total = data["total"]
+    offset = data["offset"]
+    limit = data["limit"]
+    stages = data["stages"]
+
+    lines = [f"# {enemy_name}（{enemy_id}）— 出场关卡（共 {total} 个）"]
+    for s in stages:
+        lines.append(f"- **{s['stage_name']}** {s['code']}（{s['stage_id']}）：{s['count']} 个")
     start = offset + 1
     end = min(offset + limit, total)
     lines.append(f"\n（显示第 {start}–{end} 条，共 {total} 条。使用 offset={offset + limit} 查看下一页）")
     return "\n".join(lines)
+
+
+def get_enemy_appearances(name: str, limit: int = 50, offset: int = 0) -> str:
+    """Return stages where an enemy actually spawns."""
+    data = build_enemy_appearances(name, limit=limit, offset=offset)
+    if isinstance(data, str):
+        return data
+    return render_enemy_appearances(data)
 
 
 def get_enemy_stage_info(name: str, stage_id: str) -> str:

--- a/python/src/prts_mcp/tools_gamedata.py
+++ b/python/src/prts_mcp/tools_gamedata.py
@@ -30,7 +30,8 @@ from prts_mcp.data.stage import (
     search_stages as _search_stages,
 )
 from prts_mcp.data.item import (
-    list_items as _list_items,
+    build_items_listing as _build_items_listing,
+    render_items_listing as _render_items_listing,
     build_item_info as _build_item_info,
     render_item_info as _render_item_info,
     search_items as _search_items,
@@ -194,12 +195,15 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         category: Annotated[str | None, Field(default=None, description="按物品分类过滤，如 MATERIAL（材料）、NORMAL（普通）、CONSUME（消耗品）。不填则返回全部可见物品。")] = None,
         limit: Annotated[int, Field(default=50, description="返回数量上限，默认 50。")] = 50,
         offset: Annotated[int, Field(default=0, description="分页偏移量，默认 0。")] = 0,
-    ) -> str:
+    ) -> object:
         """列出物品/材料列表，支持按分类过滤和分页。
 
         返回每个物品的名称、分类、类型、稀有度、ID 和简短用途，适合查找材料、货币、凭证等。
         """
-        return _list_items(category=category, limit=limit, offset=offset)
+        data = _build_items_listing(category=category, limit=limit, offset=offset)
+        if isinstance(data, str):
+            return text_result(data)
+        return render_result(data, _render_items_listing(data))
 
     @mcp.tool()
     def get_item_info(

--- a/python/src/prts_mcp/tools_gamedata.py
+++ b/python/src/prts_mcp/tools_gamedata.py
@@ -16,7 +16,8 @@ from prts_mcp.data.operator import (
     render_operator_basic_info as _render_basic_info,
 )
 from prts_mcp.data.enemy import (
-    list_enemies as _list_enemies,
+    build_enemies_listing as _build_enemies_listing,
+    render_enemies_listing as _render_enemies_listing,
     build_enemy_info as _build_enemy_info,
     render_enemy_info as _render_enemy_info,
     search_enemies as _search_enemies,
@@ -92,13 +93,16 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         limit: Annotated[int, Field(default=50, description="返回数量上限，默认 50。")] = 50,
         offset: Annotated[int, Field(default=0, description="分页偏移量，默认 0。")] = 0,
         full: Annotated[bool, Field(default=False, description="返回全部敌人（忽略 limit/offset）。不推荐常规使用，密集输出极易污染上下文。仅在需要完整扫描时使用。")] = False,
-    ) -> str:
+    ) -> object:
         """列出敌方图鉴，支持按威胁等级过滤和分页。
 
         默认返回前 50 条；翻页增大 offset，只看领袖/BOSS 设 threat_level="boss"。
         图鉴共 1500+ 条目，不推荐 full=true。
         """
-        return _list_enemies(threat_level=threat_level, limit=limit, offset=offset, full=full)
+        data = _build_enemies_listing(threat_level=threat_level, limit=limit, offset=offset, full=full)
+        if isinstance(data, str):
+            return text_result(data)
+        return render_result(data, _render_enemies_listing(data))
 
     @mcp.tool()
     def get_enemy_info(

--- a/python/src/prts_mcp/tools_gamedata.py
+++ b/python/src/prts_mcp/tools_gamedata.py
@@ -37,7 +37,8 @@ from prts_mcp.data.item import (
     search_items as _search_items,
 )
 from prts_mcp.data.stage_enemy import (
-    get_stage_enemies as _get_stage_enemies,
+    build_stage_enemies as _build_stage_enemies,
+    render_stage_enemies as _render_stage_enemies,
     build_enemy_appearances as _build_enemy_appearances,
     render_enemy_appearances as _render_enemy_appearances,
     get_enemy_stage_info as _get_enemy_stage_info,
@@ -132,13 +133,16 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     @mcp.tool()
     def get_stage_enemies(
         stage_id: Annotated[str, Field(description="关卡 ID，如 'main_00-01'（可从 list_stages 获取）。")],
-    ) -> str:
+    ) -> object:
         """获取指定关卡实际出场的敌人列表。
 
         只统计关卡内真正刷出的敌人，并附上其在该关卡等级下的战斗属性。
         反向查询某敌人出现在哪些关卡见 get_enemy_appearances。
         """
-        return _get_stage_enemies(stage_id)
+        data = _build_stage_enemies(stage_id)
+        if isinstance(data, str):
+            return text_result(data)
+        return render_result(data, _render_stage_enemies(data))
 
     @mcp.tool()
     def get_enemy_appearances(

--- a/python/src/prts_mcp/tools_gamedata.py
+++ b/python/src/prts_mcp/tools_gamedata.py
@@ -38,7 +38,8 @@ from prts_mcp.data.item import (
 )
 from prts_mcp.data.stage_enemy import (
     get_stage_enemies as _get_stage_enemies,
-    get_enemy_appearances as _get_enemy_appearances,
+    build_enemy_appearances as _build_enemy_appearances,
+    render_enemy_appearances as _render_enemy_appearances,
     get_enemy_stage_info as _get_enemy_stage_info,
 )
 from prts_mcp.data.search import search_operator_data as _search_operator_data
@@ -144,12 +145,15 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         name: Annotated[str, Field(description="敌人的游戏内中文名或 enemyId，如「源石虫」或 enemy_1007_slime。")],
         limit: Annotated[int, Field(default=50, description="返回数量上限，默认 50。")] = 50,
         offset: Annotated[int, Field(default=0, description="分页偏移量，默认 0。")] = 0,
-    ) -> str:
+    ) -> object:
         """反向查询指定敌人实际出现在哪些关卡。
 
         只统计该敌人真正刷出的关卡，不计入引用但未实际出场的关卡。
         """
-        return _get_enemy_appearances(name, limit=limit, offset=offset)
+        data = _build_enemy_appearances(name, limit=limit, offset=offset)
+        if isinstance(data, str):
+            return text_result(data)
+        return render_result(data, _render_enemy_appearances(data))
 
     @mcp.tool()
     def list_stages(

--- a/python/src/prts_mcp/tools_gamedata.py
+++ b/python/src/prts_mcp/tools_gamedata.py
@@ -142,7 +142,14 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         data = _build_stage_enemies(stage_id)
         if isinstance(data, str):
             return text_result(data)
-        return render_result(data, _render_stage_enemies(data))
+        # total here is distinct enemy *types* in one stage, not a pagination
+        # total — pass an explicit summary so the structured channel doesn't
+        # misread it as "N result pages".
+        return render_result(
+            data,
+            _render_stage_enemies(data),
+            summary=f"{data['stage_label']} 的敌人列表（共 {data['total']} 种）",
+        )
 
     @mcp.tool()
     def get_enemy_appearances(

--- a/python/tests/test_enemy.py
+++ b/python/tests/test_enemy.py
@@ -144,6 +144,23 @@ class TestListEnemies:
         assert "源石虫" in out
         assert "隐藏敌人" not in out
 
+    def test_golden_default_listing(self, gamedata):
+        # Golden: exact full markdown for the default listing against the
+        # fixture. Stronger than substring asserts — catches build-layer
+        # field omissions, ordering, and label regressions. Not a tautology
+        # (the expected string is hardcoded, not derived from build/render).
+        assert list_enemies() == (
+            "# 敌人图鉴（共 2 个）\n"
+            "- **源石虫** [普通] (B1) — 野生的被感染生物。\n"
+            "- **霜星** [领袖] (FN) — 整合运动法术部队干部。"
+        )
+
+    def test_golden_boss_filter(self, gamedata):
+        assert list_enemies(threat_level="boss") == (
+            "# 敌人图鉴（共 1 个）\n"
+            "- **霜星** [领袖] (FN) — 整合运动法术部队干部。"
+        )
+
     def test_threat_level_filter(self, gamedata):
         out = list_enemies(threat_level="boss", limit=10)
         assert "霜星" in out

--- a/python/tests/test_enemy.py
+++ b/python/tests/test_enemy.py
@@ -10,12 +10,14 @@ import pytest
 
 from prts_mcp.data.enemy import (
     build_enemy_info,
+    build_enemies_listing,
     clear_enemy_caches,
     list_enemies,
     get_enemy_info,
     render_enemy_info,
     search_enemies,
 )
+from prts_mcp.output import render_result
 
 
 def _write_handbook(excel: Path) -> None:
@@ -160,6 +162,15 @@ class TestListEnemies:
             "# 敌人图鉴（共 1 个）\n"
             "- **霜星** [领袖] (FN) — 整合运动法术部队干部。"
         )
+
+    def test_both_channel_attaches_structured_content(self, gamedata):
+        # Verify the tool wiring actually populates structuredContent in the
+        # both channel (the build dict rides the structured axis).
+        data = build_enemies_listing()
+        assert isinstance(data, dict)
+        r = render_result(data, list_enemies(), channel="both")
+        assert r.structuredContent == data
+        assert r.content[0].text == list_enemies()
 
     def test_threat_level_filter(self, gamedata):
         out = list_enemies(threat_level="boss", limit=10)

--- a/python/tests/test_enemy.py
+++ b/python/tests/test_enemy.py
@@ -163,6 +163,21 @@ class TestListEnemies:
             "- **霜星** [领袖] (FN) — 整合运动法术部队干部。"
         )
 
+    def test_offset_out_of_range_is_structured_not_error(self, gamedata):
+        # Empty-result contract (P2b plan §3.4): offset past the end is a
+        # legitimate-but-empty structured payload, not a content-only error.
+        # Content stays byte-for-byte (the original header + out-of-range msg).
+        data = build_enemies_listing(offset=999)
+        assert isinstance(data, dict)
+        assert data["enemies"] == []
+        assert data["empty_reason"] == "offset_out_of_range"
+        assert list_enemies(offset=999) == (
+            f"# 敌人图鉴（共 {data['total']} 个）\n\n"
+            f"offset=999 超出范围（总计 {data['total']} 条）。"
+        )
+        r = render_result(data, list_enemies(offset=999), channel="structured")
+        assert r.structuredContent == data
+
     def test_both_channel_attaches_structured_content(self, gamedata):
         # Verify the tool wiring actually populates structuredContent in the
         # both channel (the build dict rides the structured axis).

--- a/python/tests/test_item.py
+++ b/python/tests/test_item.py
@@ -151,6 +151,23 @@ def test_list_items_both_channel(gamedata: str) -> None:
     assert r.content[0].text == list_items()
 
 
+def test_list_items_empty_match_is_structured_not_error(gamedata: str) -> None:
+    # Empty-result contract (P2b plan §3.4): a legitimate-but-empty result
+    # (filter no-match) is a normal structured payload {total:0, items:[]},
+    # NOT a content-only error — structured consumers can rely on it. The
+    # content channel still emits the original "没有匹配" message verbatim.
+    data = build_items_listing(category="NONEXISTENT")
+    assert isinstance(data, dict)
+    assert data["total"] == 0
+    assert data["items"] == []
+    assert data["empty_reason"] == "no_match"
+    # content stays byte-for-byte (the original message)
+    assert list_items(category="NONEXISTENT") == "没有匹配的物品（category=NONEXISTENT）。"
+    # structured channel carries the empty payload
+    r = render_result(data, list_items(category="NONEXISTENT"), channel="structured")
+    assert r.structuredContent == data
+
+
 def test_list_items_category_filter(gamedata: str) -> None:
     out = list_items(category="MATERIAL")
     assert "源岩" in out

--- a/python/tests/test_item.py
+++ b/python/tests/test_item.py
@@ -8,12 +8,14 @@ from pathlib import Path
 import pytest
 
 from prts_mcp.data.item import (
+    build_items_listing,
     clear_item_caches,
     get_item_info,
     get_item_name_by_id,
     list_items,
     search_items,
 )
+from prts_mcp.output import render_result
 
 
 def _write_sentinels(excel: Path) -> None:
@@ -139,6 +141,14 @@ def test_list_items_golden_category_filter(gamedata: str) -> None:
         "\n"
         "（显示第 1–1 条，共 1 条。使用 offset=50 查看下一页）"
     )
+
+
+def test_list_items_both_channel(gamedata: str) -> None:
+    data = build_items_listing()
+    assert isinstance(data, dict)
+    r = render_result(data, list_items(), channel="both")
+    assert r.structuredContent == data
+    assert r.content[0].text == list_items()
 
 
 def test_list_items_category_filter(gamedata: str) -> None:

--- a/python/tests/test_item.py
+++ b/python/tests/test_item.py
@@ -120,6 +120,27 @@ def test_list_items_default(gamedata: str) -> None:
     assert "共 2 个" in out
 
 
+def test_list_items_golden_default(gamedata: str) -> None:
+    # Golden: exact full markdown. Hardcoded expectation (not a tautology),
+    # catches build-layer field omissions, ordering, and label regressions.
+    assert list_items() == (
+        "# 物品列表（共 2 个）\n"
+        "- **招聘许可** [普通/TKT_RECRUIT] T4（id: 7001） — 可从公开渠道招聘一位干员。\n"
+        "- **源岩** [材料/MATERIAL] T1（id: 30011） — 可用于多种强化场合。\n"
+        "\n"
+        "（显示第 1–2 条，共 2 条。使用 offset=50 查看下一页）"
+    )
+
+
+def test_list_items_golden_category_filter(gamedata: str) -> None:
+    assert list_items(category="MATERIAL") == (
+        "# 物品列表：MATERIAL（共 1 个）\n"
+        "- **源岩** [材料/MATERIAL] T1（id: 30011） — 可用于多种强化场合。\n"
+        "\n"
+        "（显示第 1–1 条，共 1 条。使用 offset=50 查看下一页）"
+    )
+
+
 def test_list_items_category_filter(gamedata: str) -> None:
     out = list_items(category="MATERIAL")
     assert "源岩" in out

--- a/python/tests/test_stage_enemy.py
+++ b/python/tests/test_stage_enemy.py
@@ -194,6 +194,17 @@ def test_get_enemy_appearances(gamedata: Path) -> None:
     assert "6 个" in out
 
 
+def test_get_enemy_appearances_golden(gamedata: Path) -> None:
+    # Golden: exact full markdown. Hardcoded (not tautology) — catches
+    # build-layer field omissions and header/pagination regressions.
+    assert get_enemy_appearances("源石虫") == (
+        "# 源石虫（enemy_1007_slime）— 出场关卡（共 1 个）\n"
+        "- **坍塌** 0-1（main_00-01）：6 个\n"
+        "\n"
+        "（显示第 1–1 条，共 1 条。使用 offset=50 查看下一页）"
+    )
+
+
 def test_get_enemy_stage_info(gamedata: Path) -> None:
     out = get_enemy_stage_info("士兵", "main_00-01")
     assert "士兵" in out

--- a/python/tests/test_stage_enemy.py
+++ b/python/tests/test_stage_enemy.py
@@ -186,6 +186,32 @@ def test_get_stage_enemies_uses_spawn_actions_and_overrides(gamedata: Path) -> N
     assert "未出场敌人" not in out
 
 
+def test_get_stage_enemies_golden(gamedata: Path) -> None:
+    # Golden: exact full markdown for main_00-01 against the fixture.
+    # Hardcoded (not tautology) — catches build-layer field omissions,
+    # enemy ordering (most_common), and the overwritten-flag/section logic.
+    assert get_stage_enemies("main_00-01") == (
+        "# 坍塌 0-1（main_00-01） — 敌人列表\n"
+        "\n"
+        "## 源石虫（enemy_1007_slime）\n"
+        "- **出场数量**：6\n"
+        "- **敌人等级**：0\n"
+        "- **战斗属性**：HP 550；ATK 130；DEF 0；RES 0；移速 1.0；攻击间隔 1.7s\n"
+        "\n"
+        "## 士兵（enemy_1002_nsabr）\n"
+        "- **出场数量**：1\n"
+        "- **敌人等级**：0\n"
+        "- **关卡覆盖**：是\n"
+        "- **战斗属性**：HP 1,650；ATK 200；DEF 30；RES 0\n"
+        "\n"
+        "## 关卡特化敌人（enemy_custom）\n"
+        "- **出场数量**：1\n"
+        "- **敌人等级**：0\n"
+        "- **关卡覆盖**：是\n"
+        "- **战斗属性**：HP 1,234；ATK 321；DEF 45；RES 10"
+    )
+
+
 def test_get_enemy_appearances(gamedata: Path) -> None:
     out = get_enemy_appearances("源石虫")
     assert "源石虫" in out

--- a/python/tests/test_stage_enemy.py
+++ b/python/tests/test_stage_enemy.py
@@ -8,11 +8,14 @@ from unittest.mock import patch
 import pytest
 
 from prts_mcp.data.stage_enemy import (
+    build_enemy_appearances,
+    build_stage_enemies,
     clear_stage_enemy_caches,
     get_enemy_appearances,
     get_enemy_stage_info,
     get_stage_enemies,
 )
+from prts_mcp.output import render_result
 
 
 def _write_fixture(root: Path) -> None:
@@ -212,6 +215,14 @@ def test_get_stage_enemies_golden(gamedata: Path) -> None:
     )
 
 
+def test_get_stage_enemies_both_channel(gamedata: Path) -> None:
+    data = build_stage_enemies("main_00-01")
+    assert isinstance(data, dict)
+    r = render_result(data, get_stage_enemies("main_00-01"), channel="both")
+    assert r.structuredContent == data
+    assert r.content[0].text == get_stage_enemies("main_00-01")
+
+
 def test_get_enemy_appearances(gamedata: Path) -> None:
     out = get_enemy_appearances("源石虫")
     assert "源石虫" in out
@@ -229,6 +240,14 @@ def test_get_enemy_appearances_golden(gamedata: Path) -> None:
         "\n"
         "（显示第 1–1 条，共 1 条。使用 offset=50 查看下一页）"
     )
+
+
+def test_get_enemy_appearances_both_channel(gamedata: Path) -> None:
+    data = build_enemy_appearances("源石虫")
+    assert isinstance(data, dict)
+    r = render_result(data, get_enemy_appearances("源石虫"), channel="both")
+    assert r.structuredContent == data
+    assert r.content[0].text == get_enemy_appearances("源石虫")
 
 
 def test_get_enemy_stage_info(gamedata: Path) -> None:


### PR DESCRIPTION
## Summary

**P2b PR2a** of the 2.0 output-channel plan (`dev/docs/2.0-output-channel-p2b-plan.md` §4). Extends the build/render + structuredContent pattern to the **four gamedata list/fusion tools**.

**What shipped (one commit per tool + changelog + CR fixes):**
- `list_enemies` — list with hideInHandbook + threat_level filter + full/pagination
- `list_items` — list with category filter + pagination (title echoes raw category; filter uses normalized)
- `get_enemy_appearances` — reverse lookup (enemy → stages), pagination
- `get_stage_enemies` — fusion (stage → enemies with spawn counts + stage-specific stats); the most complex. Stats kept as compact rendered `stats_text` (per-stat extraction deferred); explicit `summary` since `total` is enemy-type count, not pagination.

Each: data layer `build_X() -> dict|str` + `render_X(dict) -> str`; tool `-> object`; `render_result`/`text_result`. Payloads carry pagination metadata + filters + entries with chainable IDs and raw/label field pairs.

## Test plan

- [x] Python full suite: **260 passed, 2 skipped** (+9 new: 4 golden + 4 both-channel + 1 stage-enemies summary)
- [x] `check-runtime.ps1 -Full`: **0 failure** (TS untouched, typecheck clean)
- [x] Byte-for-byte equivalence: 4 hardcoded golden tests (genuine, not tautology — per plan §3.4). CR independently verified parity across all branches with a throwaway probe.
- [x] Scope check: the 4 migrated tools show `outputSchema=None`; 8 unmigrated tools still carry the str-wrapper
- [x] Independent sub-agent CR: Approve, no Blocking. 1 Should-fix (stage-enemies summary semantics — **fixed**) + channel-test gap nit (**fixed**: both-channel assertions added for all 4)

## 未尽事宜 (out of scope, per plan §4)

- **P2b PR2b** — 7 story-list + wiki-search tools (`list_story_events`, `list_stories`, `search_stories`, `get_operator_memoirs`, `find_character_appearances`, `find_speakers_in`, `search_prts`)
- **P2b PR3** — heterogeneous `search` (4-scope unified envelope) + full-inventory outputSchema scan invariant
- TS port — P3