### PR TITLE
feat(python): story/wiki output-channel structuredContent

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -60,6 +60,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   "empty ⇒ {total:0}". True errors (invalid params, missing data) stay
   content-only. The story-list/wiki-search tools and the heterogeneous
   `search` follow in P2b PR2b/PR3.
+- **Story navigation and wiki-search structuredContent (2.0, P2b PR2b).**
+  The six story/wiki navigation tools (`list_story_events`, `list_stories`,
+  `get_operator_memoirs`, `find_character_appearances`, `find_speakers_in`,
+  `search_prts`) migrated to explicit `CallToolResult` delivery with
+  build/render payloads. Story payloads carry chainable event/story IDs,
+  raw story entry tags, and boolean speaks/mentioned flags; `search_prts`
+  now exposes `total` as MediaWiki `totalhits`, which can exceed the returned
+  page of results. Legitimate empty results carry `{total:0}` on the
+  structured channel while preserving the existing markdown text; invalid
+  parameters, missing story data, and PRTS network failures remain content-only.
 
 ### Changed
 

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -97,11 +97,8 @@ async def search_prts(
     }
     if srwhat:
         params["srwhat"] = srwhat
-    try:
-        resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
-        resp.raise_for_status()
-    except httpx.HTTPError:
-        return {"totalhits": 0, "results": []}
+    resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
+    resp.raise_for_status()
     data = resp.json()
     totalhits = data.get("query", {}).get("searchinfo", {}).get("totalhits", 0)
     results: list[dict] = []

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -83,6 +83,10 @@ async def search_prts(
     Returns:
         {"totalhits": int, "results": list[dict]} where each result has
         "title" and "snippet" keys.
+
+    Raises:
+        httpx.HTTPError: If the MediaWiki request fails. Tool wrappers turn
+        this into a content-only error rather than misreporting it as no hits.
     """
     await _rate_limit()
     srwhat = "title" if search_mode == "title" else None

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -27,6 +27,10 @@ from prts_mcp.data.story_reader import (
     StoryLine,
     _clean_text,
     _parse_story_list,
+    build_stories_listing,
+    build_stories_listing_from_store,
+    build_story_events_listing,
+    build_story_events_listing_from_store,
     list_story_events,
     list_story_events_from_store,
     list_stories,
@@ -35,24 +39,35 @@ from prts_mcp.data.story_reader import (
     read_activity_from_store,
     read_story,
     read_story_from_store,
+    render_stories_listing,
+    render_story_events_listing,
 )
 from prts_mcp.data.story_search import (
     search_stories,
     search_stories_from_store,
 )
 from prts_mcp.data.story_memoir import (
+    build_operator_memoirs,
+    build_operator_memoirs_from_store,
     get_operator_memoirs,
     get_operator_memoirs_from_store,
+    render_operator_memoirs,
 )
 from prts_mcp.data.story_summary import (
     get_story_summary,
     get_story_summary_from_store,
 )
 from prts_mcp.data.story_character import (
+    build_character_appearances,
+    build_character_appearances_from_store,
+    build_speakers_in_event,
+    build_speakers_in_event_from_store,
     find_character_appearances,
     find_character_appearances_from_store,
     find_speakers_in,
     find_speakers_in_from_store,
+    render_character_appearances,
+    render_speakers_in_event,
 )
 from prts_mcp.data.story_search import clear_search_cache as _clear_search_cache
 from prts_mcp.data.story_memoir import clear_chardict_cache as _clear_chardict_cache
@@ -79,8 +94,14 @@ __all__ = [
     # Reader
     "list_story_events",
     "list_story_events_from_store",
+    "build_story_events_listing",
+    "build_story_events_listing_from_store",
+    "render_story_events_listing",
     "list_stories",
     "list_stories_from_store",
+    "build_stories_listing",
+    "build_stories_listing_from_store",
+    "render_stories_listing",
     "read_story",
     "read_story_from_store",
     "read_activity",
@@ -91,14 +112,23 @@ __all__ = [
     # Memoir
     "get_operator_memoirs",
     "get_operator_memoirs_from_store",
+    "build_operator_memoirs",
+    "build_operator_memoirs_from_store",
+    "render_operator_memoirs",
     # Summary
     "get_story_summary",
     "get_story_summary_from_store",
     # Character tracking
     "find_character_appearances",
     "find_character_appearances_from_store",
+    "build_character_appearances",
+    "build_character_appearances_from_store",
+    "render_character_appearances",
     "find_speakers_in",
     "find_speakers_in_from_store",
+    "build_speakers_in_event",
+    "build_speakers_in_event_from_store",
+    "render_speakers_in_event",
     # Cache management
     "clear_story_caches",
 ]

--- a/python/src/prts_mcp/data/story_character.py
+++ b/python/src/prts_mcp/data/story_character.py
@@ -76,6 +76,42 @@ def find_character_appearances(
         )
 
 
+def build_character_appearances(
+    zip_path: Path,
+    name: str,
+    scope: str | None = None,
+    max_events: int = 50,
+) -> dict:
+    """Build the structured payload for character appearance lookup."""
+    with story_store(zip_path) as store:
+        return build_character_appearances_from_store(
+            store, name, scope=scope, max_events=max_events,
+        )
+
+
+def render_character_appearances(data: dict) -> str:
+    """Render a character appearance payload to markdown."""
+    appearances = data["appearances"]
+    if not appearances:
+        scope = data.get("filters", {}).get("scope")
+        scope_note = f"（限定活动：{scope!r}）" if scope else ""
+        return f"未找到「{data['name']}」的出场记录。{scope_note}"
+
+    parts = [f"# 「{data['name']}」的出场（共 {data['total']} 章）"]
+    for ap in appearances:
+        tags = []
+        if ap["speaks"]:
+            tags.append("speaks")
+        if ap["mentioned"]:
+            tags.append("mentioned")
+        tag = "+".join(tags)
+        name_disp = f"{ap['story_code']} {ap['story_name']}".strip()
+        parts.append(
+            f"- [{tag}] {ap['event_id']} / {name_disp}（key: {ap['story_key']}）"
+        )
+    return "\n".join(parts)
+
+
 def find_speakers_in(zip_path: Path, event_id: str) -> list[SpeakerCount]:
     """List every speaker in an event, with dialog line counts.
 
@@ -83,6 +119,24 @@ def find_speakers_in(zip_path: Path, event_id: str) -> list[SpeakerCount]:
     """
     with story_store(zip_path) as store:
         return find_speakers_in_from_store(store, event_id)
+
+
+def build_speakers_in_event(zip_path: Path, event_id: str) -> dict:
+    """Build the structured payload for speakers in one event."""
+    with story_store(zip_path) as store:
+        return build_speakers_in_event_from_store(store, event_id)
+
+
+def render_speakers_in_event(data: dict) -> str:
+    """Render an event speaker-count payload to markdown."""
+    speakers = data["speakers"]
+    if not speakers:
+        return f"活动 {data['event_id']!r} 暂无对话发言者数据。"
+
+    parts = [f"# {data['event_id']} 的发言角色（共 {data['total']} 位）"]
+    for sp in speakers:
+        parts.append(f"- {sp['name']}（{sp['line_count']} 句）")
+    return "\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -149,6 +203,34 @@ def find_character_appearances_from_store(
     )
 
 
+def build_character_appearances_from_store(
+    store: JsonStore,
+    name: str,
+    scope: str | None = None,
+    max_events: int = 50,
+) -> dict:
+    """Build a character appearance payload using a JSON store."""
+    result = find_character_appearances_from_store(
+        store, name, scope=scope, max_events=max_events,
+    )
+    return {
+        "name": result.name,
+        "total": result.total_chapters,
+        "filters": {"scope": scope},
+        "appearances": [
+            {
+                "event_id": ap.event_id,
+                "story_code": ap.story_code,
+                "story_name": ap.story_name,
+                "story_key": ap.story_key,
+                "speaks": ap.speaks,
+                "mentioned": ap.mentioned,
+            }
+            for ap in result.appearances
+        ],
+    }
+
+
 def find_speakers_in_from_store(
     store: JsonStore,
     event_id: str,
@@ -186,3 +268,19 @@ def find_speakers_in_from_store(
     ]
     speakers.sort(key=lambda s: (-s.line_count, s.name))
     return speakers
+
+
+def build_speakers_in_event_from_store(store: JsonStore, event_id: str) -> dict:
+    """Build an event speaker-count payload using a JSON store."""
+    speakers = find_speakers_in_from_store(store, event_id)
+    return {
+        "event_id": event_id,
+        "total": len(speakers),
+        "speakers": [
+            {
+                "name": sp.name,
+                "line_count": sp.line_count,
+            }
+            for sp in speakers
+        ],
+    }

--- a/python/src/prts_mcp/data/story_memoir.py
+++ b/python/src/prts_mcp/data/story_memoir.py
@@ -114,6 +114,26 @@ def get_operator_memoirs(
         return get_operator_memoirs_from_store(store, operator_name)
 
 
+def build_operator_memoirs(
+    zip_path: Path,
+    operator_name: str,
+) -> dict:
+    """Build the structured payload for an operator memoir listing."""
+    with story_store(zip_path) as store:
+        return build_operator_memoirs_from_store(store, operator_name)
+
+
+def render_operator_memoirs(data: dict) -> str:
+    """Render an operator memoir payload to markdown."""
+    lines = [
+        f"# {data['operator_name']}（code: {data['internal_code']}，id: {data['operator_id']}）",
+        f"共 {data['total']} 章密录\n",
+    ]
+    for ch in data["chapters"]:
+        lines.append(f"- {ch['story_code']} {ch['story_name']}（key: {ch['story_key']}）")
+    return "\n".join(lines)
+
+
 # ---------------------------------------------------------------------------
 # Public API — store-based
 # ---------------------------------------------------------------------------
@@ -172,3 +192,25 @@ def get_operator_memoirs_from_store(
         total_chapters=len(chapters),
         chapters=chapters,
     )
+
+
+def build_operator_memoirs_from_store(
+    store: JsonStore,
+    operator_name: str,
+) -> dict:
+    """Build an operator memoir payload using a JSON store."""
+    result = get_operator_memoirs_from_store(store, operator_name)
+    return {
+        "operator_name": result.operator_name,
+        "internal_code": result.internal_code,
+        "operator_id": result.operator_id,
+        "total": result.total_chapters,
+        "chapters": [
+            {
+                "story_code": ch.story_code,
+                "story_name": ch.story_name,
+                "story_key": ch.story_key,
+            }
+            for ch in result.chapters
+        ],
+    }

--- a/python/src/prts_mcp/data/story_reader.py
+++ b/python/src/prts_mcp/data/story_reader.py
@@ -20,6 +20,7 @@ from prts_mcp.data.stores import JsonStore, ZipStore
 
 STORY_REVIEW_TABLE = "zh_CN/gamedata/excel/story_review_table.json"
 STORYINFO = "zh_CN/storyinfo.json"
+EVENT_SUMMARIES = "zh_CN/event_summaries.json"
 SUMMARIES = "zh_CN/summaries.json"
 CHARDICT = "zh_CN/chardict.json"
 
@@ -221,10 +222,69 @@ def list_story_events(
         return list_story_events_from_store(store, category=category)
 
 
+def build_story_events_listing(
+    zip_path: Path,
+    category: str | None = None,
+) -> dict:
+    """Build the structured payload for story event navigation."""
+    with story_store(zip_path) as store:
+        return build_story_events_listing_from_store(store, category=category)
+
+
+def render_story_events_listing(data: dict) -> str:
+    """Render a story-event listing payload to markdown."""
+    events = data["events"]
+    if not events:
+        category = data.get("filters", {}).get("category")
+        return f"未找到符合条件的活动（category={category!r}）。"
+
+    lines = []
+    for ev in events:
+        lines.append(
+            f"- [{ev['entry_type']}] {ev['event_id']}：{ev['name']}（{ev['story_count']} 章）"
+        )
+    return "\n".join(lines)
+
+
 def list_stories(zip_path: Path, event_id: str) -> list[ChapterSummary]:
     """Return ordered chapter list for an event."""
     with story_store(zip_path) as store:
         return list_stories_from_store(store, event_id)
+
+
+def build_stories_listing(
+    zip_path: Path,
+    event_id: str,
+    include_summaries: bool = False,
+) -> dict:
+    """Build the structured payload for an event's chapter listing."""
+    with story_store(zip_path) as store:
+        return build_stories_listing_from_store(
+            store, event_id, include_summaries=include_summaries,
+        )
+
+
+def render_stories_listing(data: dict) -> str:
+    """Render an event chapter-listing payload to markdown."""
+    event_id = data["event_id"]
+    chapters = data["chapters"]
+    if not chapters:
+        return f"活动 {event_id!r} 暂无剧情章节。"
+
+    lines = []
+    event_summary = data.get("event_summary")
+    if event_summary:
+        lines.append(event_summary)
+        lines.append("")
+    include_summaries = data["include_summaries"]
+    for ch in chapters:
+        tag = f"[{ch['avg_tag']}] " if ch["avg_tag"] else ""
+        lines.append(
+            f"- {ch['story_code']} {tag}{ch['story_name']}（key: {ch['story_key']}）"
+        )
+        if include_summaries and ch.get("summary"):
+            lines.append(f"  {ch['summary']}")
+    return "\n".join(lines)
 
 
 def read_story(
@@ -289,6 +349,31 @@ def list_story_events_from_store(
     return events
 
 
+def build_story_events_listing_from_store(
+    store: JsonStore,
+    category: str | None = None,
+) -> dict:
+    """Build a story-event listing payload using a JSON store."""
+    events = list_story_events_from_store(store, category=category)
+    category_normalized = category if category in CATEGORY_MAP else None
+    return {
+        "total": len(events),
+        "filters": {
+            "category": category,
+            "category_normalized": category_normalized,
+        },
+        "events": [
+            {
+                "event_id": ev.event_id,
+                "name": ev.name,
+                "entry_type": ev.entry_type,
+                "story_count": ev.story_count,
+            }
+            for ev in events
+        ],
+    }
+
+
 def list_stories_from_store(store: JsonStore, event_id: str) -> list[ChapterSummary]:
     """Return ordered chapter list for an event using a JSON store."""
     table: dict = load_json(store, STORY_REVIEW_TABLE)  # type: ignore[assignment]
@@ -311,6 +396,53 @@ def list_stories_from_store(store: JsonStore, event_id: str) -> list[ChapterSumm
         ))
 
     return chapters
+
+
+def build_stories_listing_from_store(
+    store: JsonStore,
+    event_id: str,
+    include_summaries: bool = False,
+) -> dict:
+    """Build an event chapter-listing payload using a JSON store."""
+    chapters = list_stories_from_store(store, event_id)
+    chapter_summaries: dict[str, str] = {}
+    event_summary_text = ""
+    if include_summaries:
+        try:
+            if store.exists(STORYINFO):
+                raw = store.read_json(STORYINFO)
+                if isinstance(raw, dict):
+                    chapter_summaries = {str(k): str(v) for k, v in raw.items() if v}
+            if store.exists(EVENT_SUMMARIES):
+                raw_events = store.read_json(EVENT_SUMMARIES)
+                if isinstance(raw_events, dict):
+                    event_summary_text = str(raw_events.get(event_id) or "").strip()
+        except Exception:
+            chapter_summaries = {}
+            event_summary_text = ""
+
+    data = {
+        "event_id": event_id,
+        "total": len(chapters),
+        "include_summaries": include_summaries,
+        "chapters": [
+            {
+                "story_code": ch.story_code,
+                "story_name": ch.story_name,
+                "story_key": ch.story_key,
+                "avg_tag": ch.avg_tag,
+                **(
+                    {"summary": chapter_summaries.get(ch.story_key, "")}
+                    if include_summaries
+                    else {}
+                ),
+            }
+            for ch in chapters
+        ],
+    }
+    if event_summary_text:
+        data["event_summary"] = event_summary_text
+    return data
 
 
 def read_story_from_store(

--- a/python/src/prts_mcp/data/story_reader.py
+++ b/python/src/prts_mcp/data/story_reader.py
@@ -7,6 +7,7 @@ search, summary, and memoir logic live in their own modules.
 from __future__ import annotations
 
 import json
+import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,6 +31,8 @@ CATEGORY_MAP: dict[str, list[str]] = {
     "activities": ["ACTIVITY", "MINI_ACTIVITY"],
     "memoirs": ["NONE"],
 }
+
+_logger = logging.getLogger("prts_mcp.story")
 
 
 def story_zip_path(story_key: str) -> str:
@@ -417,7 +420,8 @@ def build_stories_listing_from_store(
                 raw_events = store.read_json(EVENT_SUMMARIES)
                 if isinstance(raw_events, dict):
                     event_summary_text = str(raw_events.get(event_id) or "").strip()
-        except Exception:
+        except Exception as exc:
+            _logger.debug("读取剧情摘要失败，跳过摘要：%s", exc)
             chapter_summaries = {}
             event_summary_text = ""
 

--- a/python/src/prts_mcp/tools_prts.py
+++ b/python/src/prts_mcp/tools_prts.py
@@ -37,6 +37,10 @@ async def _build_prts_search(
     return {
         "query": query,
         "search_mode": search_mode,
+        "filters": {
+            "limit": limit,
+            "filter_technical": filter_technical,
+        },
         "total": result["totalhits"],
         "results": [
             {

--- a/python/src/prts_mcp/tools_prts.py
+++ b/python/src/prts_mcp/tools_prts.py
@@ -19,7 +19,46 @@ from prts_mcp.api.prts_wiki import (
     get_links as _get_links,
     get_template_data as _get_template_data,
 )
-from prts_mcp.output import text_result
+from prts_mcp.output import render_result, text_result
+
+
+async def _build_prts_search(
+    query: str,
+    limit: int = 5,
+    search_mode: str = "text",
+    filter_technical: bool = True,
+) -> dict | str:
+    """Build the structured payload for PRTS keyword search."""
+    if search_mode not in ("text", "title"):
+        return "无效的 search_mode 参数，可选值：text、title。"
+    result = await _search_prts(
+        query, limit, search_mode=search_mode, filter_technical=filter_technical,
+    )
+    return {
+        "query": query,
+        "search_mode": search_mode,
+        "total": result["totalhits"],
+        "results": [
+            {
+                "title": r["title"],
+                "snippet": r["snippet"],
+            }
+            for r in result["results"]
+        ],
+    }
+
+
+def _render_prts_search(data: dict) -> str:
+    """Render a PRTS search payload to markdown."""
+    query = data["query"]
+    results = data["results"]
+    if not results:
+        return f"未找到与 '{query}' 相关的词条。"
+    header = f"# 搜索 \"{query}\"（共 {data['total']} 条匹配）\n"
+    parts = []
+    for r in results:
+        parts.append(f"**{r['title']}**\n{r['snippet']}")
+    return header + "\n\n---\n\n".join(parts)
 
 
 def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
@@ -31,24 +70,24 @@ def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         limit: Annotated[int, Field(default=5, description="返回结果数量上限，默认 5，最大建议不超过 10。")] = 5,
         search_mode: Annotated[str, Field(default="text", description="搜索模式：text（全文搜索，默认）或 title（仅搜索标题）。")] = "text",
         filter_technical: Annotated[bool, Field(default=True, description="是否过滤 /spine、/data 等技术页面，默认 True。")] = True,
-    ) -> str:
+    ) -> object:
         """搜索 PRTS 明日方舟中文维基词条。
 
         返回匹配词条的标题、简短摘要列表及匹配总数。查询专有名词、干员、关卡或世界观设定
         时先用此工具拿到准确标题，再传入 prts_page 获取完整内容。
         """
-        if search_mode not in ("text", "title"):
-            return "无效的 search_mode 参数，可选值：text、title。"
-        result = await _search_prts(query, limit, search_mode=search_mode, filter_technical=filter_technical)
-        results = result["results"]
-        totalhits = result["totalhits"]
-        if not results:
-            return f"未找到与 '{query}' 相关的词条。"
-        header = f"# 搜索 \"{query}\"（共 {totalhits} 条匹配）\n"
-        parts = []
-        for r in results:
-            parts.append(f"**{r['title']}**\n{r['snippet']}")
-        return header + "\n\n---\n\n".join(parts)
+        try:
+            data = await _build_prts_search(
+                query,
+                limit,
+                search_mode=search_mode,
+                filter_technical=filter_technical,
+            )
+        except Exception as e:
+            return text_result(f"搜索 PRTS 失败：{e}")
+        if isinstance(data, str):
+            return text_result(data)
+        return render_result(data, _render_prts_search(data))
 
     @mcp.tool()
     async def prts_page(

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -46,7 +46,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         try:
             zip_path = _require_story_zip(cfg)
         except RuntimeError as e:
-            return text_result(str(e))
+            return str(e)
 
         try:
             data = _build_story_events_listing(zip_path, category=category)
@@ -217,7 +217,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         try:
             zip_path = _require_story_zip(cfg)
         except RuntimeError as e:
-            return text_result(str(e))
+            return str(e)
 
         try:
             return _search_stories(

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -9,20 +9,24 @@ from typing import Annotated
 
 from pydantic import Field
 
-from prts_mcp.data.stores import ZipStore
 from prts_mcp.data.story import (
-    list_story_events as _list_story_events,
-    list_stories as _list_stories,
+    build_story_events_listing as _build_story_events_listing,
+    render_story_events_listing as _render_story_events_listing,
+    build_stories_listing as _build_stories_listing,
+    render_stories_listing as _render_stories_listing,
     read_story as _read_story,
     read_activity as _read_activity,
     search_stories as _search_stories,
     get_story_summary as _get_story_summary,
-    get_operator_memoirs as _get_operator_memoirs,
-    find_character_appearances as _find_character_appearances,
-    find_speakers_in as _find_speakers_in,
+    build_operator_memoirs as _build_operator_memoirs,
+    render_operator_memoirs as _render_operator_memoirs,
+    build_character_appearances as _build_character_appearances,
+    render_character_appearances as _render_character_appearances,
+    build_speakers_in_event as _build_speakers_in_event,
+    render_speakers_in_event as _render_speakers_in_event,
 )
 from prts_mcp.startup_sync import _require_story_zip
-from prts_mcp.output import text_result
+from prts_mcp.output import render_result, text_result
 
 
 def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
@@ -31,7 +35,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     @mcp.tool()
     def list_story_events(
         category: Annotated[str | None, Field(default=None, description="可选过滤分类。\"main\" = 主线章节，\"activities\" = 活动剧情（含联动），\"memoirs\" = 干员密录。不填则返回全部活动。")] = None,
-    ) -> str:
+    ) -> object:
         """列出明日方舟剧情活动列表。
 
         返回格式：每行 `- [类型] 活动ID：名称（N 章）`，类型为 MAINLINE / ACTIVITY /
@@ -42,26 +46,19 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         try:
             zip_path = _require_story_zip(cfg)
         except RuntimeError as e:
-            return str(e)
+            return text_result(str(e))
 
         try:
-            events = _list_story_events(zip_path, category=category)
+            data = _build_story_events_listing(zip_path, category=category)
         except Exception as e:
-            return f"读取活动列表失败：{e}"
-
-        if not events:
-            return f"未找到符合条件的活动（category={category!r}）。"
-
-        lines = []
-        for ev in events:
-            lines.append(f"- [{ev.entry_type}] {ev.event_id}：{ev.name}（{ev.story_count} 章）")
-        return "\n".join(lines)
+            return text_result(f"读取活动列表失败：{e}")
+        return render_result(data, _render_story_events_listing(data))
 
     @mcp.tool()
     def list_stories(
         event_id: Annotated[str, Field(description="活动 ID，如 \"act31side\"（可从 list_story_events 获取）。")],
         include_summaries: Annotated[bool, Field(default=False, description="是否附带梗概，默认 False。设为 True 时顶部附活动级长摘要（若有）、每章下方附一句话梗概。")] = False,
-    ) -> str:
+    ) -> object:
         """列出指定活动的所有剧情章节（按官方顺序排列）。
 
         返回格式：每行 `- 章节编号 [标签] 章节名（key: story_key）`，其中 story_key 可直接
@@ -72,46 +69,17 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         try:
             zip_path = _require_story_zip(cfg)
         except RuntimeError as e:
-            return str(e)
+            return text_result(str(e))
 
         try:
-            chapters = _list_stories(zip_path, event_id)
+            data = _build_stories_listing(
+                zip_path, event_id, include_summaries=include_summaries,
+            )
         except KeyError:
-            return f"未找到活动：{event_id!r}。请先调用 list_story_events 确认活动 ID。"
+            return text_result(f"未找到活动：{event_id!r}。请先调用 list_story_events 确认活动 ID。")
         except Exception as e:
-            return f"读取章节列表失败：{e}"
-
-        if not chapters:
-            return f"活动 {event_id!r} 暂无剧情章节。"
-
-        summaries: dict[str, str] = {}
-        event_summary_text = ""
-        if include_summaries:
-            try:
-                with ZipStore(zip_path) as store:
-                    if store.exists("zh_CN/storyinfo.json"):
-                        raw = store.read_json("zh_CN/storyinfo.json")
-                        if isinstance(raw, dict):
-                            summaries = {str(k): str(v) for k, v in raw.items() if v}
-                    if store.exists("zh_CN/event_summaries.json"):
-                        raw_ev = store.read_json("zh_CN/event_summaries.json")
-                        if isinstance(raw_ev, dict):
-                            event_summary_text = str(raw_ev.get(event_id) or "").strip()
-            except Exception:
-                pass
-
-        lines = []
-        if event_summary_text:
-            lines.append(event_summary_text)
-            lines.append("")
-        for ch in chapters:
-            tag = f"[{ch.avg_tag}] " if ch.avg_tag else ""
-            lines.append(f"- {ch.story_code} {tag}{ch.story_name}（key: {ch.story_key}）")
-            if include_summaries:
-                summary = summaries.get(ch.story_key, "")
-                if summary:
-                    lines.append(f"  {summary}")
-        return "\n".join(lines)
+            return text_result(f"读取章节列表失败：{e}")
+        return render_result(data, _render_stories_listing(data))
 
     @mcp.tool()
     def get_story_summary(
@@ -249,7 +217,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         try:
             zip_path = _require_story_zip(cfg)
         except RuntimeError as e:
-            return str(e)
+            return text_result(str(e))
 
         try:
             return _search_stories(
@@ -267,7 +235,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     @mcp.tool()
     def get_operator_memoirs(
         name: Annotated[str, Field(description="干员的游戏内中文名，如「阿米娅」、「能天使」。")],
-    ) -> str:
+    ) -> object:
         """根据干员名称查询干员密录剧情。
 
         返回干员的密录章节列表，含章节 key（story_key）和元数据。
@@ -278,29 +246,26 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         try:
             zip_path = _require_story_zip(cfg)
         except RuntimeError as e:
-            return str(e)
+            return text_result(str(e))
 
         try:
-            result = _get_operator_memoirs(zip_path, name)
+            data = _build_operator_memoirs(zip_path, name)
         except KeyError as e:
-            return str(e)
+            return text_result(str(e))
         except Exception as e:
-            return f"查询干员密录失败：{e}"
-
-        lines = [
-            f"# {result.operator_name}（code: {result.internal_code}，id: {result.operator_id}）",
-            f"共 {result.total_chapters} 章密录\n",
-        ]
-        for ch in result.chapters:
-            lines.append(f"- {ch.story_code} {ch.story_name}（key: {ch.story_key}）")
-        return "\n".join(lines)
+            return text_result(f"查询干员密录失败：{e}")
+        return render_result(
+            data,
+            _render_operator_memoirs(data),
+            summary=f"{data['operator_name']} 的密录列表（共 {data['total']} 章）",
+        )
 
     @mcp.tool()
     def find_character_appearances(
         name: Annotated[str, Field(description="角色名（干员中文名或「博士」）。speaks 按对话角色名精确匹配，mentioned 按名字在台词/旁白文本中的子串匹配——请使用完整名字以免误报（如「阿」会命中「阿米娅」）。")],
         scope: Annotated[str | None, Field(default=None, description="限定活动 ID，如「act31side」。不填则检索全部活动。")] = None,
         max_events: Annotated[int, Field(default=50, ge=1, le=200, description="最多返回章节数，默认 50。")] = 50,
-    ) -> str:
+    ) -> object:
         """查找某个角色在剧情中的出场（说话或被提及）。
 
         返回该角色作为对话发言者（speaks）或名字出现在台词/旁白文本中（mentioned）的所有章节，
@@ -312,41 +277,24 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         try:
             zip_path = _require_story_zip(cfg)
         except RuntimeError as e:
-            return str(e)
+            return text_result(str(e))
 
         try:
-            result = _find_character_appearances(
+            data = _build_character_appearances(
                 zip_path, name, scope=scope, max_events=max_events,
             )
         except ValueError as e:
-            return str(e)
+            return text_result(str(e))
         except KeyError as e:
-            return str(e)
+            return text_result(str(e))
         except Exception as e:
-            return f"查询角色出场失败：{e}"
-
-        if not result.appearances:
-            scope_note = f"（限定活动：{scope!r}）" if scope else ""
-            return f"未找到「{name}」的出场记录。{scope_note}"
-
-        parts = [f"# 「{result.name}」的出场（共 {result.total_chapters} 章）"]
-        for ap in result.appearances:
-            tags = []
-            if ap.speaks:
-                tags.append("speaks")
-            if ap.mentioned:
-                tags.append("mentioned")
-            tag = "+".join(tags)
-            name_disp = f"{ap.story_code} {ap.story_name}".strip()
-            parts.append(
-                f"- [{tag}] {ap.event_id} / {name_disp}（key: {ap.story_key}）"
-            )
-        return "\n".join(parts)
+            return text_result(f"查询角色出场失败：{e}")
+        return render_result(data, _render_character_appearances(data))
 
     @mcp.tool()
     def find_speakers_in(
         event_id: Annotated[str, Field(description="活动 ID，如 \"act31side\"（可从 list_story_events 获取）。")],
-    ) -> str:
+    ) -> object:
         """列出某活动中的所有发言角色及其台词数。
 
         返回该活动去重后的对话发言者，按台词句数降序排列，适合了解角色戏份分布。
@@ -357,19 +305,12 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         try:
             zip_path = _require_story_zip(cfg)
         except RuntimeError as e:
-            return str(e)
+            return text_result(str(e))
 
         try:
-            speakers = _find_speakers_in(zip_path, event_id)
+            data = _build_speakers_in_event(zip_path, event_id)
         except KeyError as e:
-            return str(e)
+            return text_result(str(e))
         except Exception as e:
-            return f"查询发言角色失败：{e}"
-
-        if not speakers:
-            return f"活动 {event_id!r} 暂无对话发言者数据。"
-
-        parts = [f"# {event_id} 的发言角色（共 {len(speakers)} 位）"]
-        for sp in speakers:
-            parts.append(f"- {sp.name}（{sp.line_count} 句）")
-        return "\n".join(parts)
+            return text_result(f"查询发言角色失败：{e}")
+        return render_result(data, _render_speakers_in_event(data))

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -1,0 +1,452 @@
+"""Golden tests for P2b story/wiki output-channel migration."""
+from __future__ import annotations
+
+import asyncio
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from prts_mcp.data.story import (
+    build_character_appearances,
+    build_operator_memoirs,
+    build_speakers_in_event,
+    build_stories_listing,
+    build_story_events_listing,
+    render_character_appearances,
+    render_operator_memoirs,
+    render_speakers_in_event,
+    render_stories_listing,
+    render_story_events_listing,
+)
+from prts_mcp.output import render_result
+from prts_mcp.tools_prts import (
+    _build_prts_search,
+    _render_prts_search,
+    register_prts_tools,
+)
+from prts_mcp.tools_story import register_story_tools
+
+STORY_REVIEW_PATH = "zh_CN/gamedata/excel/story_review_table.json"
+CHARDICT_PATH = "zh_CN/chardict.json"
+STORYINFO_PATH = "zh_CN/storyinfo.json"
+EVENT_SUMMARIES_PATH = "zh_CN/event_summaries.json"
+
+FIRST_STORY_KEY = "activities/act_test/level_act_test_01_beg"
+SECOND_STORY_KEY = "activities/act_test/level_act_test_02_end"
+NO_SUMMARY_STORY_KEY = "activities/act_no_summary/level_act_no_summary_01"
+NARRATION_STORY_KEY = "activities/act_narration/level_act_narration_01"
+MEMOIR_STORY_KEY = "memory/amiya/level_amiya_01"
+
+
+def _story_path(story_key: str) -> str:
+    return f"zh_CN/gamedata/story/{story_key}.json"
+
+
+def _story_files() -> dict[str, object]:
+    return {
+        STORY_REVIEW_PATH: {
+            "act_test": {
+                "name": "测试活动",
+                "entryType": "ACTIVITY",
+                "infoUnlockDatas": [
+                    {
+                        "storyTxt": FIRST_STORY_KEY,
+                        "storyCode": "TEST-1",
+                        "storyName": "开端",
+                        "avgTag": "BEG",
+                        "storySort": 1,
+                    },
+                    {
+                        "storyTxt": SECOND_STORY_KEY,
+                        "storyCode": "TEST-2",
+                        "storyName": "终章",
+                        "avgTag": "END",
+                        "storySort": 2,
+                    },
+                ],
+            },
+            "act_no_summary": {
+                "name": "无长摘要活动",
+                "entryType": "ACTIVITY",
+                "infoUnlockDatas": [
+                    {
+                        "storyTxt": NO_SUMMARY_STORY_KEY,
+                        "storyCode": "NS-1",
+                        "storyName": "短章",
+                        "avgTag": None,
+                        "storySort": 1,
+                    }
+                ],
+            },
+            "act_narration": {
+                "name": "纯旁白活动",
+                "entryType": "ACTIVITY",
+                "infoUnlockDatas": [
+                    {
+                        "storyTxt": NARRATION_STORY_KEY,
+                        "storyCode": "NAR-1",
+                        "storyName": "旁白章",
+                        "avgTag": None,
+                        "storySort": 1,
+                    }
+                ],
+            },
+            "act_empty": {
+                "name": "空活动",
+                "entryType": "ACTIVITY",
+                "infoUnlockDatas": [],
+            },
+            "story_amiya_set_1": {
+                "name": "阿米娅密录",
+                "entryType": "NONE",
+                "infoUnlockDatas": [
+                    {
+                        "storyTxt": MEMOIR_STORY_KEY,
+                        "storyCode": "AM-1",
+                        "storyName": "出发",
+                        "avgTag": None,
+                        "storySort": 1,
+                    }
+                ],
+            },
+        },
+        STORYINFO_PATH: {
+            FIRST_STORY_KEY: "第一章梗概",
+            SECOND_STORY_KEY: "第二章梗概",
+            NO_SUMMARY_STORY_KEY: "无长摘要的一句话梗概",
+        },
+        EVENT_SUMMARIES_PATH: {
+            "act_test": "活动总览",
+        },
+        CHARDICT_PATH: {
+            "amiya": {"name": "阿米娅", "id": "char_002_amiya"},
+        },
+        _story_path(FIRST_STORY_KEY): {
+            "storyCode": "TEST-1",
+            "storyName": "开端",
+            "avgTag": "BEG",
+            "eventName": "测试活动",
+            "storyInfo": "第一章梗概",
+            "storyList": [
+                {"prop": "name", "attributes": {"name": "阿米娅", "content": "你好，博士。"}},
+                {"prop": "sticker", "attributes": {"content": "罗德岛走廊"}},
+                {"prop": "name", "attributes": {"name": "博士", "content": "我们出发吧。"}},
+            ],
+        },
+        _story_path(SECOND_STORY_KEY): {
+            "storyCode": "TEST-2",
+            "storyName": "终章",
+            "avgTag": "END",
+            "eventName": "测试活动",
+            "storyInfo": "第二章梗概",
+            "storyList": [
+                {"prop": "name", "attributes": {"name": "博士", "content": "任务完成。阿米娅干得不错。"}},
+            ],
+        },
+        _story_path(NO_SUMMARY_STORY_KEY): {
+            "storyCode": "NS-1",
+            "storyName": "短章",
+            "avgTag": None,
+            "eventName": "无长摘要活动",
+            "storyInfo": "无长摘要的一句话梗概",
+            "storyList": [
+                {"prop": "name", "attributes": {"name": "阿米娅", "content": "短章台词。"}},
+            ],
+        },
+        _story_path(NARRATION_STORY_KEY): {
+            "storyCode": "NAR-1",
+            "storyName": "旁白章",
+            "avgTag": None,
+            "eventName": "纯旁白活动",
+            "storyInfo": "",
+            "storyList": [
+                {"prop": "sticker", "attributes": {"content": "只有旁白文本。"}},
+            ],
+        },
+    }
+
+
+@pytest.fixture()
+def story_zip(tmp_path: Path) -> Path:
+    zip_path = tmp_path / "zh_CN.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        for inner_path, data in _story_files().items():
+            zf.writestr(inner_path, json.dumps(data, ensure_ascii=False))
+    return zip_path
+
+
+def test_list_story_events_golden_and_empty(story_zip: Path) -> None:
+    data = build_story_events_listing(story_zip, category="activities")
+
+    assert data["total"] == 4
+    assert data["filters"] == {
+        "category": "activities",
+        "category_normalized": "activities",
+    }
+    assert render_story_events_listing(data) == (
+        "- [ACTIVITY] act_test：测试活动（2 章）\n"
+        "- [ACTIVITY] act_no_summary：无长摘要活动（1 章）\n"
+        "- [ACTIVITY] act_narration：纯旁白活动（1 章）\n"
+        "- [ACTIVITY] act_empty：空活动（0 章）"
+    )
+
+    empty = build_story_events_listing(story_zip, category="main")
+    assert empty["total"] == 0
+    assert empty["events"] == []
+    assert render_story_events_listing(empty) == "未找到符合条件的活动（category='main'）。"
+
+
+def test_list_stories_without_summaries_golden(story_zip: Path) -> None:
+    data = build_stories_listing(story_zip, "act_test", include_summaries=False)
+
+    assert data == {
+        "event_id": "act_test",
+        "total": 2,
+        "include_summaries": False,
+        "chapters": [
+            {
+                "story_code": "TEST-1",
+                "story_name": "开端",
+                "story_key": FIRST_STORY_KEY,
+                "avg_tag": "BEG",
+            },
+            {
+                "story_code": "TEST-2",
+                "story_name": "终章",
+                "story_key": SECOND_STORY_KEY,
+                "avg_tag": "END",
+            },
+        ],
+    }
+    assert render_stories_listing(data) == (
+        f"- TEST-1 [BEG] 开端（key: {FIRST_STORY_KEY}）\n"
+        f"- TEST-2 [END] 终章（key: {SECOND_STORY_KEY}）"
+    )
+
+
+def test_list_stories_with_summaries_golden(story_zip: Path) -> None:
+    data = build_stories_listing(story_zip, "act_test", include_summaries=True)
+
+    assert data["event_summary"] == "活动总览"
+    assert data["chapters"][0]["summary"] == "第一章梗概"
+    assert render_stories_listing(data) == (
+        "活动总览\n\n"
+        f"- TEST-1 [BEG] 开端（key: {FIRST_STORY_KEY}）\n"
+        "  第一章梗概\n"
+        f"- TEST-2 [END] 终章（key: {SECOND_STORY_KEY}）\n"
+        "  第二章梗概"
+    )
+
+
+def test_list_stories_with_summaries_but_no_event_summary(story_zip: Path) -> None:
+    data = build_stories_listing(story_zip, "act_no_summary", include_summaries=True)
+
+    assert "event_summary" not in data
+    assert render_stories_listing(data) == (
+        f"- NS-1 短章（key: {NO_SUMMARY_STORY_KEY}）\n"
+        "  无长摘要的一句话梗概"
+    )
+
+
+def test_list_stories_empty_event_is_structured_empty(story_zip: Path) -> None:
+    data = build_stories_listing(story_zip, "act_empty")
+
+    assert data["total"] == 0
+    assert data["chapters"] == []
+    assert render_stories_listing(data) == "活动 'act_empty' 暂无剧情章节。"
+
+
+def test_get_operator_memoirs_golden(story_zip: Path) -> None:
+    data = build_operator_memoirs(story_zip, "阿米娅")
+
+    assert data == {
+        "operator_name": "阿米娅",
+        "internal_code": "amiya",
+        "operator_id": "char_002_amiya",
+        "total": 1,
+        "chapters": [
+            {
+                "story_code": "AM-1",
+                "story_name": "出发",
+                "story_key": MEMOIR_STORY_KEY,
+            }
+        ],
+    }
+    assert render_operator_memoirs(data) == (
+        "# 阿米娅（code: amiya，id: char_002_amiya）\n"
+        "共 1 章密录\n\n"
+        f"- AM-1 出发（key: {MEMOIR_STORY_KEY}）"
+    )
+
+
+def test_find_character_appearances_golden_and_empty(story_zip: Path) -> None:
+    data = build_character_appearances(story_zip, "博士")
+
+    assert data["total"] == 2
+    assert data["appearances"][0]["speaks"] is True
+    assert data["appearances"][0]["mentioned"] is True
+    assert render_character_appearances(data) == (
+        "# 「博士」的出场（共 2 章）\n"
+        f"- [speaks+mentioned] act_test / TEST-1 开端（key: {FIRST_STORY_KEY}）\n"
+        f"- [speaks] act_test / TEST-2 终章（key: {SECOND_STORY_KEY}）"
+    )
+
+    empty = build_character_appearances(story_zip, "不存在", scope="act_test")
+    assert empty["total"] == 0
+    assert empty["appearances"] == []
+    assert render_character_appearances(empty) == (
+        "未找到「不存在」的出场记录。（限定活动：'act_test'）"
+    )
+
+
+def test_find_speakers_in_golden_and_empty(story_zip: Path) -> None:
+    data = build_speakers_in_event(story_zip, "act_test")
+
+    assert data == {
+        "event_id": "act_test",
+        "total": 2,
+        "speakers": [
+            {"name": "博士", "line_count": 2},
+            {"name": "阿米娅", "line_count": 1},
+        ],
+    }
+    assert render_speakers_in_event(data) == (
+        "# act_test 的发言角色（共 2 位）\n"
+        "- 博士（2 句）\n"
+        "- 阿米娅（1 句）"
+    )
+
+    empty = build_speakers_in_event(story_zip, "act_narration")
+    assert empty["total"] == 0
+    assert empty["speakers"] == []
+    assert render_speakers_in_event(empty) == "活动 'act_narration' 暂无对话发言者数据。"
+
+
+@pytest.mark.parametrize(
+    ("builder", "renderer", "args"),
+    [
+        (build_story_events_listing, render_story_events_listing, ("activities",)),
+        (build_stories_listing, render_stories_listing, ("act_test",)),
+        (build_operator_memoirs, render_operator_memoirs, ("阿米娅",)),
+        (build_character_appearances, render_character_appearances, ("博士",)),
+        (build_speakers_in_event, render_speakers_in_event, ("act_test",)),
+    ],
+)
+def test_story_payloads_emit_structured_content_in_both_channel(
+    story_zip: Path,
+    builder,
+    renderer,
+    args,
+) -> None:
+    data = builder(story_zip, *args)
+    markdown = renderer(data)
+
+    result = render_result(data, markdown, channel="both")
+
+    assert result.structuredContent == data
+    assert len(result.content) == 1
+    assert result.content[0].text == markdown
+
+
+async def _fake_search_prts(
+    query: str,
+    limit: int = 5,
+    search_mode: str = "text",
+    filter_technical: bool = True,
+) -> dict:
+    return {
+        "totalhits": 9,
+        "results": [{"title": "阿米娅", "snippet": "罗德岛公开领袖。"}],
+    }
+
+
+def test_search_prts_build_render_and_totalhits(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("prts_mcp.tools_prts._search_prts", _fake_search_prts)
+
+    data = asyncio.run(_build_prts_search("阿米娅", limit=1))
+
+    assert data == {
+        "query": "阿米娅",
+        "search_mode": "text",
+        "total": 9,
+        "results": [{"title": "阿米娅", "snippet": "罗德岛公开领袖。"}],
+    }
+    assert _render_prts_search(data) == (
+        "# 搜索 \"阿米娅\"（共 9 条匹配）\n"
+        "**阿米娅**\n"
+        "罗德岛公开领袖。"
+    )
+    result = render_result(data, _render_prts_search(data), channel="both")
+    assert result.structuredContent == data
+
+
+async def _fake_empty_search_prts(
+    query: str,
+    limit: int = 5,
+    search_mode: str = "text",
+    filter_technical: bool = True,
+) -> dict:
+    return {"totalhits": 0, "results": []}
+
+
+def test_search_prts_empty_is_structured_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("prts_mcp.tools_prts._search_prts", _fake_empty_search_prts)
+
+    data = asyncio.run(_build_prts_search("不存在"))
+
+    assert data == {
+        "query": "不存在",
+        "search_mode": "text",
+        "total": 0,
+        "results": [],
+    }
+    assert _render_prts_search(data) == "未找到与 '不存在' 相关的词条。"
+
+
+def test_search_prts_invalid_mode_is_content_only_error() -> None:
+    assert asyncio.run(_build_prts_search("阿米娅", search_mode="bad")) == (
+        "无效的 search_mode 参数，可选值：text、title。"
+    )
+
+
+async def _raising_search_prts(*_args, **_kwargs) -> dict:
+    raise RuntimeError("network down")
+
+
+def test_search_prts_network_failure_is_content_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("prts_mcp.tools_prts._search_prts", _raising_search_prts)
+    app = FastMCP("prts-test")
+    register_prts_tools(app)
+
+    result = asyncio.run(
+        app._tool_manager.call_tool(
+            "search_prts", {"query": "阿米娅"}, convert_result=True,
+        )
+    )
+
+    assert result.structuredContent is None
+    assert result.content[0].text == "搜索 PRTS 失败：network down"
+
+
+def test_p2b_manifest_output_schema_shape() -> None:
+    app = FastMCP("manifest-test")
+    register_story_tools(app)
+    register_prts_tools(app)
+
+    tools = {tool.name: tool for tool in asyncio.run(app.list_tools())}
+    for name in {
+        "list_story_events",
+        "list_stories",
+        "get_operator_memoirs",
+        "find_character_appearances",
+        "find_speakers_in",
+        "search_prts",
+    }:
+        assert tools[name].outputSchema is None, f"{name} still has outputSchema"
+
+    assert tools["search_stories"].outputSchema is not None

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -371,6 +371,10 @@ def test_search_prts_build_render_and_totalhits(monkeypatch: pytest.MonkeyPatch)
     assert data == {
         "query": "阿米娅",
         "search_mode": "text",
+        "filters": {
+            "limit": 1,
+            "filter_technical": True,
+        },
         "total": 9,
         "results": [{"title": "阿米娅", "snippet": "罗德岛公开领袖。"}],
     }
@@ -400,6 +404,10 @@ def test_search_prts_empty_is_structured_empty(monkeypatch: pytest.MonkeyPatch) 
     assert data == {
         "query": "不存在",
         "search_mode": "text",
+        "filters": {
+            "limit": 5,
+            "filter_technical": True,
+        },
         "total": 0,
         "results": [],
     }
@@ -431,6 +439,30 @@ def test_search_prts_network_failure_is_content_only(
 
     assert result.structuredContent is None
     assert result.content[0].text == "搜索 PRTS 失败：network down"
+
+
+def test_unmigrated_search_stories_missing_zip_stays_str(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("STORYJSON_PATH", str(tmp_path / "missing.zip"))
+    app = FastMCP("story-test")
+    register_story_tools(app)
+
+    result = asyncio.run(
+        app._tool_manager.call_tool(
+            "search_stories", {"pattern": "博士"}, convert_result=True,
+        )
+    )
+
+    content, structured = result
+    assert structured == {
+        "result": (
+            "剧情数据未就绪。请设置 STORYJSON_PATH 环境变量指向 zh_CN.zip，"
+            "或等待服务器自动从 GitHub Release 下载完成后重试。"
+        )
+    }
+    assert content[0].text == structured["result"]
 
 
 def test_p2b_manifest_output_schema_shape() -> None:

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -37,6 +37,7 @@ EVENT_SUMMARIES_PATH = "zh_CN/event_summaries.json"
 FIRST_STORY_KEY = "activities/act_test/level_act_test_01_beg"
 SECOND_STORY_KEY = "activities/act_test/level_act_test_02_end"
 NO_SUMMARY_STORY_KEY = "activities/act_no_summary/level_act_no_summary_01"
+NO_SUMMARY_SECOND_STORY_KEY = "activities/act_no_summary/level_act_no_summary_02"
 NARRATION_STORY_KEY = "activities/act_narration/level_act_narration_01"
 MEMOIR_STORY_KEY = "memory/amiya/level_amiya_01"
 
@@ -78,6 +79,13 @@ def _story_files() -> dict[str, object]:
                         "storyName": "短章",
                         "avgTag": None,
                         "storySort": 1,
+                    },
+                    {
+                        "storyTxt": NO_SUMMARY_SECOND_STORY_KEY,
+                        "storyCode": "NS-2",
+                        "storyName": "无摘要章",
+                        "avgTag": None,
+                        "storySort": 2,
                     }
                 ],
             },
@@ -156,6 +164,16 @@ def _story_files() -> dict[str, object]:
                 {"prop": "name", "attributes": {"name": "阿米娅", "content": "短章台词。"}},
             ],
         },
+        _story_path(NO_SUMMARY_SECOND_STORY_KEY): {
+            "storyCode": "NS-2",
+            "storyName": "无摘要章",
+            "avgTag": None,
+            "eventName": "无长摘要活动",
+            "storyInfo": "",
+            "storyList": [
+                {"prop": "name", "attributes": {"name": "阿米娅", "content": "没有一句话梗概。"}},
+            ],
+        },
         _story_path(NARRATION_STORY_KEY): {
             "storyCode": "NAR-1",
             "storyName": "旁白章",
@@ -188,7 +206,7 @@ def test_list_story_events_golden_and_empty(story_zip: Path) -> None:
     }
     assert render_story_events_listing(data) == (
         "- [ACTIVITY] act_test：测试活动（2 章）\n"
-        "- [ACTIVITY] act_no_summary：无长摘要活动（1 章）\n"
+        "- [ACTIVITY] act_no_summary：无长摘要活动（2 章）\n"
         "- [ACTIVITY] act_narration：纯旁白活动（1 章）\n"
         "- [ACTIVITY] act_empty：空活动（0 章）"
     )
@@ -245,9 +263,11 @@ def test_list_stories_with_summaries_but_no_event_summary(story_zip: Path) -> No
     data = build_stories_listing(story_zip, "act_no_summary", include_summaries=True)
 
     assert "event_summary" not in data
+    assert data["chapters"][1]["summary"] == ""
     assert render_stories_listing(data) == (
         f"- NS-1 短章（key: {NO_SUMMARY_STORY_KEY}）\n"
-        "  无长摘要的一句话梗概"
+        "  无长摘要的一句话梗概\n"
+        f"- NS-2 无摘要章（key: {NO_SUMMARY_SECOND_STORY_KEY}）"
     )
 
 


### PR DESCRIPTION
## Summary
- Migrate `list_story_events`, `list_stories`, `get_operator_memoirs`, `find_character_appearances`, `find_speakers_in`, and `search_prts` to explicit `CallToolResult` delivery with structuredContent-capable build/render payloads.
- Preserve default markdown output while carrying chainable story/wiki IDs, raw story tags, filters, booleans, and MediaWiki `totalhits` on the structured channel.
- Keep true errors content-only, including invalid search modes, missing story data, and PRTS network failures.

## Test plan
- `python/tests/test_story_output_channel.py -q` -> 18 passed
- `cd python && E:\Anaconda3\envs\python311\python.exe -m pytest tests -q` -> 280 passed, 2 skipped
- `./scripts/check-runtime.ps1 -Full` -> 0 failures, 2 existing environment warnings
- `git diff --check` -> clean

## 未尽事宜
- `search_stories` remains intentionally unmigrated for PR3 with the unified search envelope design.
- `search` remains intentionally unmigrated for PR3.
- `prts_page` structural actions remain content-only per the 2.0 output-channel plan.