### PR TITLE
feat(python): search output-channel structuredContent

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -70,6 +70,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   page of results. Legitimate empty results carry `{total:0}` on the
   structured channel while preserving the existing markdown text; invalid
   parameters, missing story data, and PRTS network failures remain content-only.
+- **Search structuredContent (2.0, P3).** The remaining Python search tools
+  (`search` and `search_stories`) migrated to explicit `CallToolResult`
+  delivery with structured search envelopes. `search` now returns a stable
+  outer envelope (`scope`, `pattern`, `total`, `results`) while keeping
+  scope-specific entries for operators, enemies, stages, and items; each entry
+  carries chainable IDs and the fields needed to re-render the existing
+  markdown cards. `search_stories` now exposes raw filters and structured
+  context lines with `is_match` flags plus `story_key` for follow-up reads.
+  Legitimate no-match searches carry `{total:0, results:[]}` on the structured
+  channel; invalid regexes, invalid filters, and missing data remain
+  content-only. The all-tool outputSchema invariant is left to the dedicated
+  PR4 test-layer follow-up.
 
 ### Changed
 

--- a/python/src/prts_mcp/data/enemy.py
+++ b/python/src/prts_mcp/data/enemy.py
@@ -26,6 +26,7 @@ _DATABASE_FILE = "enemy_database.json"
 
 @dataclass(frozen=True)
 class _EnemySearchRecord:
+    enemy_id: str
     info: dict[str, Any]
     search_text: str
 
@@ -553,6 +554,14 @@ def get_enemy_info(name: str) -> str:
 
 def search_enemies(pattern: str, max_results: int = 30) -> str:
     """Regex search across enemy names and descriptions."""
+    data = build_enemy_search(pattern, max_results=max_results)
+    if isinstance(data, str):
+        return data
+    return render_enemy_search(data)
+
+
+def build_enemy_search(pattern: str, max_results: int = 30) -> dict | str:
+    """Build the structured payload for enemy handbook search."""
     if not _has_enemy_data():
         return _missing_data_message()
     if max_results < 1:
@@ -565,25 +574,95 @@ def search_enemies(pattern: str, max_results: int = 30) -> str:
     except re.error as exc:
         return f"正则表达式无效：{exc}"
 
-    matches: list[dict] = []
+    matches: list[_EnemySearchRecord] = []
     try:
         records = _enemy_search_records()
     except FileNotFoundError as exc:
         return str(exc)
     for record in records:
         if regex.search(record.search_text):
-            matches.append(record.info)
+            matches.append(record)
         if len(matches) >= max_results:
             break
 
-    if not matches:
+    return {
+        "scope": "enemies",
+        "pattern": pattern,
+        "total": len(matches),
+        "results": [_enemy_search_entry(record) for record in matches],
+    }
+
+
+def render_enemy_search(data: dict) -> str:
+    """Render an enemy search payload to markdown."""
+    pattern = data["pattern"]
+    results = data["results"]
+    if not results:
         return f"未找到匹配 '{pattern}' 的敌人。"
 
-    lines: list[str] = [f"# 搜索结果：{pattern}（共 {len(matches)} 个）\n"]
-    for info in matches:
-        lines.append(_fmt_enemy(info))
+    lines: list[str] = [f"# 搜索结果：{pattern}（共 {data['total']} 个）\n"]
+    for entry in results:
+        lines.append(_render_enemy_search_card(entry))
         lines.append("")
     return "\n".join(lines).strip()
+
+
+def _enemy_search_entry(record: _EnemySearchRecord) -> dict[str, Any]:
+    info = record.info
+    level_raw = info.get("enemyLevel", "")
+    damage_types_raw: list[str] = info.get("damageType") or []
+    return {
+        "enemy_id": record.enemy_id,
+        "name": info.get("name", ""),
+        "enemy_index": info.get("enemyIndex", ""),
+        "level_raw": level_raw,
+        "level_label": _ENEMY_LEVEL_ZH.get(level_raw, level_raw),
+        "description": info.get("description", ""),
+        "attack_type": info.get("attackType") or "",
+        "ability": info.get("ability") or "",
+        "damage_types_raw": damage_types_raw,
+        "damage_types_label": "、".join(
+            _DAMAGE_TYPE_ZH.get(dt, dt) for dt in damage_types_raw
+        ),
+        "enemy_tags": info.get("enemyTags") or [],
+    }
+
+
+def _render_enemy_search_card(entry: dict) -> str:
+    lines: list[str] = []
+    name = entry["name"]
+    if name:
+        lines.append(f"# {name} - 敌人图鉴\n")
+
+    enemy_index = entry["enemy_index"]
+    if enemy_index:
+        lines.append(f"- **编号**：{enemy_index}")
+
+    level_label = entry["level_label"]
+    if level_label:
+        lines.append(f"- **威胁等级**：{level_label}")
+
+    desc = entry["description"]
+    if desc:
+        lines.append(f"- **描述**：{desc}")
+
+    attack = entry["attack_type"]
+    if attack:
+        lines.append(f"- **攻击方式**：{attack}")
+
+    ability = entry["ability"]
+    if ability:
+        lines.append(f"- **特殊能力**：{ability}")
+
+    damage_label = entry["damage_types_label"]
+    if damage_label:
+        lines.append(f"- **伤害类型**：{damage_label}")
+
+    enemy_tags = entry["enemy_tags"]
+    if enemy_tags:
+        lines.append(f"- **标签**：{'、'.join(enemy_tags)}")
+
+    return "\n".join(lines)
 
 
 @lru_cache(maxsize=1)
@@ -600,5 +679,9 @@ def _enemy_search_records() -> tuple[_EnemySearchRecord, ...]:
             info.get("ability") or "",
             " ".join(info.get("enemyTags") or []),
         ])
-        records.append(_EnemySearchRecord(info=info, search_text=search_text))
+        records.append(_EnemySearchRecord(
+            enemy_id=_eid,
+            info=info,
+            search_text=search_text,
+        ))
     return tuple(records)

--- a/python/src/prts_mcp/data/item.py
+++ b/python/src/prts_mcp/data/item.py
@@ -375,6 +375,14 @@ def get_item_info(name: str) -> str:
 
 def search_items(pattern: str, max_results: int = 30) -> str:
     """Regex search across item names, descriptions, usage, obtain sources, and types."""
+    data = build_item_search(pattern, max_results=max_results)
+    if isinstance(data, str):
+        return data
+    return render_item_search(data)
+
+
+def build_item_search(pattern: str, max_results: int = 30) -> dict | str:
+    """Build the structured payload for item search."""
     if max_results < 1:
         return "max_results 必须 >= 1。"
     if max_results > 100:
@@ -396,25 +404,49 @@ def search_items(pattern: str, max_results: int = 30) -> str:
             if len(results) >= max_results:
                 break
 
+    return {
+        "scope": "items",
+        "pattern": pattern,
+        "total": len(results),
+        "results": [_item_search_entry(record) for record in results],
+    }
+
+
+def render_item_search(data: dict) -> str:
+    """Render an item search payload to markdown."""
+    pattern = data["pattern"]
+    results = data["results"]
     if not results:
         return f"未找到匹配 '{pattern}' 的物品。"
 
-    lines = [f"# 搜索结果：{pattern}（共 {len(results)} 个）"]
-    for record in results:
-        item_id = record.item_id
-        info = record.info
-        item_name = info.get("name") or "（无名）"
-        classify = _classify_label(str(info.get("classifyType") or ""))
-        item_type = info.get("itemType") or "-"
-        rarity = _rarity_label(str(info.get("rarity") or ""))
-        usage = _short_text(str(info.get("usage") or info.get("description") or ""), 120)
-        lines.append(f"\n## {item_name} [{classify}/{item_type}] {rarity}（id: {item_id}）")
+    lines = [f"# 搜索结果：{pattern}（共 {data['total']} 个）"]
+    for item in results:
+        lines.append(
+            f"\n## {item['name']} [{item['classify_label']}/{item['item_type']}] "
+            f"{item['rarity_label']}（id: {item['item_id']}）"
+        )
+        usage = item["usage"]
         if usage:
             lines.append(f"- **用途**：{usage}")
-        obtain = info.get("obtainApproach")
+        obtain = item["obtain_approach"]
         if obtain:
             lines.append(f"- **获取方式**：{obtain}")
     return "\n".join(lines)
+
+
+def _item_search_entry(record: _ItemSearchRecord) -> dict[str, Any]:
+    info = record.info
+    return {
+        "item_id": record.item_id,
+        "name": info.get("name") or "（无名）",
+        "classify_raw": str(info.get("classifyType") or ""),
+        "classify_label": _classify_label(str(info.get("classifyType") or "")),
+        "item_type": info.get("itemType") or "-",
+        "rarity_raw": str(info.get("rarity") or ""),
+        "rarity_label": _rarity_label(str(info.get("rarity") or "")),
+        "usage": _short_text(str(info.get("usage") or info.get("description") or ""), 120),
+        "obtain_approach": info.get("obtainApproach") or "",
+    }
 
 
 @lru_cache(maxsize=1)

--- a/python/src/prts_mcp/data/search.py
+++ b/python/src/prts_mcp/data/search.py
@@ -34,6 +34,14 @@ def search_operator_data(pattern: str, max_results: int = 30) -> str:
 
     Case-insensitive.  Returns a formatted multi-block string.
     """
+    data = build_operator_search(pattern, max_results=max_results)
+    if isinstance(data, str):
+        return data
+    return render_operator_search(data)
+
+
+def build_operator_search(pattern: str, max_results: int = 30) -> dict | str:
+    """Build the structured payload for operator-data search."""
     if max_results < 1:
         return "max_results 必须 >= 1。"
     if max_results > 100:
@@ -60,19 +68,77 @@ def search_operator_data(pattern: str, max_results: int = 30) -> str:
             if len(results) >= max_results:
                 break
 
+    return {
+        "scope": "operators",
+        "pattern": pattern,
+        "total": len(results),
+        "results": [
+            {
+                "operator": r.operator,
+                "category": r.category,
+                "field": r.field,
+                "text": r.text,
+            }
+            for r in results
+        ],
+    }
+
+
+def render_operator_search(data: dict) -> str:
+    """Render an operator search payload to markdown."""
+    pattern = data["pattern"]
+    results = data["results"]
     if not results:
         return f"未找到匹配 '{pattern}' 的干员数据。"
 
-    blocks = [f"# 搜索 \"{pattern}\" 的结果（共 {len(results)} 条）"]
+    blocks = [f"# 搜索 \"{pattern}\" 的结果（共 {data['total']} 条）"]
     for r in results:
         blocks.append(
             f"\n---\n\n"
-            f"[operators/{r.category}/{r.operator}]\n"
-            f"匹配：{r.field}\n"
-            f"{r.text}"
+            f"[operators/{r['category']}/{r['operator']}]\n"
+            f"匹配：{r['field']}\n"
+            f"{r['text']}"
         )
-
     return "".join(blocks)
+
+
+def build_search(scope: str, pattern: str, max_results: int = 30) -> dict | str:
+    """Build the structured payload for the unified gamedata search tool."""
+    if scope == "operators":
+        return build_operator_search(pattern, max_results=max_results)
+    if scope == "enemies":
+        from prts_mcp.data.enemy import build_enemy_search
+
+        return build_enemy_search(pattern, max_results=max_results)
+    if scope == "stages":
+        from prts_mcp.data.stage import build_stage_search
+
+        return build_stage_search(pattern, max_results=max_results)
+    if scope == "items":
+        from prts_mcp.data.item import build_item_search
+
+        return build_item_search(pattern, max_results=max_results)
+    return f"不支持的搜索域：{scope!r}。可选：operators、enemies、stages、items。"
+
+
+def render_search(data: dict) -> str:
+    """Render a unified gamedata search payload to markdown."""
+    scope = data["scope"]
+    if scope == "operators":
+        return render_operator_search(data)
+    if scope == "enemies":
+        from prts_mcp.data.enemy import render_enemy_search
+
+        return render_enemy_search(data)
+    if scope == "stages":
+        from prts_mcp.data.stage import render_stage_search
+
+        return render_stage_search(data)
+    if scope == "items":
+        from prts_mcp.data.item import render_item_search
+
+        return render_item_search(data)
+    raise ValueError(f"不支持的搜索域：{scope!r}。")
 
 
 @lru_cache(maxsize=1)

--- a/python/src/prts_mcp/data/stage.py
+++ b/python/src/prts_mcp/data/stage.py
@@ -408,6 +408,14 @@ def get_stage_info(stage_id: str) -> str:
 
 def search_stages(pattern: str, max_results: int = 30) -> str:
     """Regex search across stage names, codes, and descriptions."""
+    data = build_stage_search(pattern, max_results=max_results)
+    if isinstance(data, str):
+        return data
+    return render_stage_search(data)
+
+
+def build_stage_search(pattern: str, max_results: int = 30) -> dict | str:
+    """Build the structured payload for stage search."""
     if max_results < 1:
         return "max_results 必须 >= 1。"
     if max_results > 100:
@@ -429,31 +437,56 @@ def search_stages(pattern: str, max_results: int = 30) -> str:
             if len(matched) >= max_results:
                 break
 
-    if not matched:
+    return {
+        "scope": "stages",
+        "pattern": pattern,
+        "total": len(matched),
+        "results": [_stage_search_entry(record) for record in matched],
+    }
+
+
+def render_stage_search(data: dict) -> str:
+    """Render a stage search payload to markdown."""
+    pattern = data["pattern"]
+    results = data["results"]
+    if not results:
         return f"未找到匹配 '{pattern}' 的关卡。"
 
-    lines = [f"# 搜索结果：{pattern}（共 {len(matched)} 个）"]
-    for record in matched:
-        e = record.entry
-        name = e.get("name") or "（无名）"
-        code = e.get("code") or "?"
-        t_label = _stage_type_label(e.get("stageType", ""))
-        d_label = _difficulty_label(e.get("difficulty", ""))
-        zd = _zone_display(e.get("zoneId", ""))
-        _ap = e.get("apCost")
-        ap = _ap if _ap is not None else "?"
-        raw_desc = e.get("description") or ""
-        cdesc = _clean_description(raw_desc)
-
-        sid = record.stage_id
-        lines.append(f"\n## {name} [{t_label}] {code}（id: {sid}）")
-        lines.append(f"- **区域**：{zd}")
-        lines.append(f"- **难度**：{d_label}")
-        lines.append(f"- **理智**：{ap}")
-        if cdesc:
-            lines.append(f"- **描述**：{cdesc[:120]}{'...' if len(cdesc) > 120 else ''}")
+    lines = [f"# 搜索结果：{pattern}（共 {data['total']} 个）"]
+    for entry in results:
+        lines.append(
+            f"\n## {entry['name']} [{entry['type_label']}] "
+            f"{entry['code']}（id: {entry['stage_id']}）"
+        )
+        lines.append(f"- **区域**：{entry['zone_display']}")
+        lines.append(f"- **难度**：{entry['difficulty_label']}")
+        lines.append(f"- **理智**：{entry['ap']}")
+        desc = entry["description"]
+        if desc:
+            lines.append(f"- **描述**：{desc[:120]}{'...' if len(desc) > 120 else ''}")
 
     return "\n".join(lines)
+
+
+def _stage_search_entry(record: _StageSearchRecord) -> dict:
+    e = record.entry
+    type_raw = e.get("stageType", "")
+    difficulty_raw = e.get("difficulty", "")
+    zone_id = e.get("zoneId", "")
+    ap = e.get("apCost")
+    return {
+        "stage_id": record.stage_id,
+        "name": e.get("name") or "（无名）",
+        "code": e.get("code") or "?",
+        "type": type_raw,
+        "type_label": _stage_type_label(type_raw),
+        "difficulty": difficulty_raw,
+        "difficulty_label": _difficulty_label(difficulty_raw),
+        "zone_id": zone_id,
+        "zone_display": _zone_display(zone_id),
+        "ap": ap if ap is not None else "?",
+        "description": _clean_description(e.get("description") or ""),
+    }
 
 
 @_lru_cache(maxsize=1)

--- a/python/src/prts_mcp/data/stage.py
+++ b/python/src/prts_mcp/data/stage.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re as _re
 from dataclasses import dataclass as _dataclass
 from functools import lru_cache as _lru_cache
+from typing import Any
 
 from prts_mcp.config import Config as _Config
 from prts_mcp.data.item import get_item_name_by_id as _get_item_name_by_id
@@ -468,7 +469,7 @@ def render_stage_search(data: dict) -> str:
     return "\n".join(lines)
 
 
-def _stage_search_entry(record: _StageSearchRecord) -> dict:
+def _stage_search_entry(record: _StageSearchRecord) -> dict[str, Any]:
     e = record.entry
     type_raw = e.get("stageType", "")
     difficulty_raw = e.get("difficulty", "")

--- a/python/src/prts_mcp/data/story.py
+++ b/python/src/prts_mcp/data/story.py
@@ -43,6 +43,9 @@ from prts_mcp.data.story_reader import (
     render_story_events_listing,
 )
 from prts_mcp.data.story_search import (
+    build_story_search,
+    build_story_search_from_store,
+    render_story_search,
     search_stories,
     search_stories_from_store,
 )
@@ -107,6 +110,9 @@ __all__ = [
     "read_activity",
     "read_activity_from_store",
     # Search
+    "build_story_search",
+    "build_story_search_from_store",
+    "render_story_search",
     "search_stories",
     "search_stories_from_store",
     # Memoir

--- a/python/src/prts_mcp/data/story_search.py
+++ b/python/src/prts_mcp/data/story_search.py
@@ -87,8 +87,32 @@ def search_stories(
     Convenience wrapper around search_stories_from_store that auto-creates
     a ZipStore from *zip_path*.
     """
+    data = build_story_search(
+        zip_path,
+        pattern,
+        character=character,
+        line_type=line_type,
+        context_lines=context_lines,
+        max_results=max_results,
+        event_id=event_id,
+    )
+    if isinstance(data, str):
+        return data
+    return render_story_search(data)
+
+
+def build_story_search(
+    zip_path: Path,
+    pattern: str,
+    character: str | None = None,
+    line_type: str | None = None,
+    context_lines: int = 1,
+    max_results: int = 30,
+    event_id: str | None = None,
+) -> dict | str:
+    """Build the structured payload for story text search."""
     with story_store(zip_path) as store:
-        return search_stories_from_store(
+        return build_story_search_from_store(
             store,
             pattern,
             character=character,
@@ -127,6 +151,30 @@ def search_stories_from_store(
     Returns:
         Formatted multi-block search result string.
     """
+    data = build_story_search_from_store(
+        store,
+        pattern,
+        character=character,
+        line_type=line_type,
+        context_lines=context_lines,
+        max_results=max_results,
+        event_id=event_id,
+    )
+    if isinstance(data, str):
+        return data
+    return render_story_search(data)
+
+
+def build_story_search_from_store(
+    store: JsonStore,
+    pattern: str,
+    character: str | None = None,
+    line_type: str | None = None,
+    context_lines: int = 1,
+    max_results: int = 30,
+    event_id: str | None = None,
+) -> dict | str:
+    """Build a story-search payload using a JSON store."""
     if max_results < 1:
         return "max_results 必须 >= 1。"
     if max_results > 100:
@@ -172,35 +220,60 @@ def search_stories_from_store(
 
         start = max(0, record.line_index - context_lines)
         end = min(len(chapter.lines), record.line_index + context_lines + 1)
-        ctx_parts: list[str] = []
+        ctx_parts: list[dict[str, object]] = []
         for j in range(start, end):
-            prefix = ">>> " if j == record.line_index else "    "
-            ctx_parts.append(prefix + _format_story_line(chapter.lines[j]))
+            ctx_parts.append({
+                "text": _format_story_line(chapter.lines[j]),
+                "is_match": j == record.line_index,
+            })
 
         results.append({
             "event_id": chapter.event_id,
+            "story_key": chapter.story_key,
             "story_code": chapter.story_code,
             "line_number": record.line_index + 1,
-            "context": "\n".join(ctx_parts),
+            "context": ctx_parts,
         })
 
+    return {
+        "pattern": pattern,
+        "filters": {
+            "character": character,
+            "line_type": line_type,
+            "context_lines": context_lines,
+            "event_id": event_id,
+        },
+        "total": len(results),
+        "results": results,
+    }
+
+
+def render_story_search(data: dict) -> str:
+    """Render a story-search payload to markdown."""
+    pattern = data["pattern"]
+    results = data["results"]
     if not results:
+        filters = data["filters"]
         filter_desc = "。".join(
             f for f in [
-                f"event_id={event_id!r}" if event_id else "",
-                f"character={character!r}" if character else "",
-                f"line_type={line_type!r}" if line_type else "",
+                f"event_id={filters['event_id']!r}" if filters["event_id"] else "",
+                f"character={filters['character']!r}" if filters["character"] else "",
+                f"line_type={filters['line_type']!r}" if filters["line_type"] else "",
             ] if f
         )
         filter_suffix = f"（过滤条件：{filter_desc}）" if filter_desc else ""
         return f"未找到匹配 '{pattern}' 的剧情台词。{filter_suffix}"
 
-    parts = [f"# 搜索 \"{pattern}\" 的结果（共 {len(results)} 条）"]
+    parts = [f"# 搜索 \"{pattern}\" 的结果（共 {data['total']} 条）"]
     for r in results:
+        context = "\n".join(
+            (">>> " if item["is_match"] else "    ") + str(item["text"])
+            for item in r["context"]
+        )
         parts.append(
             f"\n---\n\n"
             f"[stories/{r['event_id']}/{r['story_code']} L{r['line_number']}]\n"
-            f"{r['context']}"
+            f"{context}"
         )
 
     return "\n".join(parts)

--- a/python/src/prts_mcp/tools_gamedata.py
+++ b/python/src/prts_mcp/tools_gamedata.py
@@ -20,21 +20,18 @@ from prts_mcp.data.enemy import (
     render_enemies_listing as _render_enemies_listing,
     build_enemy_info as _build_enemy_info,
     render_enemy_info as _render_enemy_info,
-    search_enemies as _search_enemies,
 )
 from prts_mcp.data.stage import (
     build_stages_listing as _build_stages_listing,
     render_stages_listing as _render_stages_listing,
     build_stage_info as _build_stage_info,
     render_stage_info as _render_stage_info,
-    search_stages as _search_stages,
 )
 from prts_mcp.data.item import (
     build_items_listing as _build_items_listing,
     render_items_listing as _render_items_listing,
     build_item_info as _build_item_info,
     render_item_info as _render_item_info,
-    search_items as _search_items,
 )
 from prts_mcp.data.stage_enemy import (
     build_stage_enemies as _build_stage_enemies,
@@ -43,7 +40,10 @@ from prts_mcp.data.stage_enemy import (
     render_enemy_appearances as _render_enemy_appearances,
     get_enemy_stage_info as _get_enemy_stage_info,
 )
-from prts_mcp.data.search import search_operator_data as _search_operator_data
+from prts_mcp.data.search import (
+    build_search as _build_search,
+    render_search as _render_search,
+)
 from prts_mcp.output import render_result, text_result
 
 
@@ -242,20 +242,14 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         scope: Annotated[Literal["operators", "enemies", "stages", "items"], Field(description="搜索域（必填）：operators（干员）/ enemies（敌人）/ stages（关卡）/ items（物品）。")],
         pattern: Annotated[str, Field(description="正则表达式搜索模式，大小写不敏感。")],
         max_results: Annotated[int, Field(default=30, ge=1, le=100, description="返回结果数量上限，默认 30。")] = 30,
-    ) -> str:
+    ) -> object:
         """在指定数据域中执行全文正则搜索。
 
         scope 选择搜索域：operators（名称/属性/档案/语音）、enemies（图鉴）、
         stages（关卡）、items（物品/材料）。返回带域标签的匹配结果。
         剧情台词搜索见 search_stories。
         """
-        searchers = {
-            "operators": _search_operator_data,
-            "enemies": _search_enemies,
-            "stages": _search_stages,
-            "items": _search_items,
-        }
-        fn = searchers.get(scope)
-        if fn is None:
-            return f"不支持的搜索域：{scope!r}。可选：operators、enemies、stages、items。"
-        return fn(pattern, max_results=max_results)
+        data = _build_search(scope, pattern, max_results=max_results)
+        if isinstance(data, str):
+            return text_result(data)
+        return render_result(data, _render_search(data))

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -16,7 +16,8 @@ from prts_mcp.data.story import (
     render_stories_listing as _render_stories_listing,
     read_story as _read_story,
     read_activity as _read_activity,
-    search_stories as _search_stories,
+    build_story_search as _build_story_search,
+    render_story_search as _render_story_search,
     get_story_summary as _get_story_summary,
     build_operator_memoirs as _build_operator_memoirs,
     render_operator_memoirs as _render_operator_memoirs,
@@ -206,7 +207,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         context_lines: Annotated[int, Field(default=1, ge=0, le=5, description="匹配行前后的上下文行数，默认 1。设 0 则只返回匹配行本身。")] = 1,
         max_results: Annotated[int, Field(default=30, ge=1, le=100, description="最多返回条数，默认 30。")] = 30,
         event_id: Annotated[str | None, Field(default=None, description="限定活动 ID，如「act31side」。不填则搜索全部活动。")] = None,
-    ) -> str:
+    ) -> object:
         """在剧情台词中执行全文正则搜索，支持角色和台词类型过滤。
 
         返回格式：以 `[stories/活动ID/章节编号 L行号]` 标注位置，命中行前缀 `>>> ` 标记，
@@ -217,10 +218,10 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         try:
             zip_path = _require_story_zip(cfg)
         except RuntimeError as e:
-            return str(e)
+            return text_result(str(e))
 
         try:
-            return _search_stories(
+            data = _build_story_search(
                 zip_path,
                 pattern,
                 character=character,
@@ -230,7 +231,10 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
                 event_id=event_id,
             )
         except Exception as e:
-            return f"剧情搜索失败：{e}"
+            return text_result(f"剧情搜索失败：{e}")
+        if isinstance(data, str):
+            return text_result(data)
+        return render_result(data, _render_story_search(data))
 
     @mcp.tool()
     def get_operator_memoirs(

--- a/python/tests/test_enemy.py
+++ b/python/tests/test_enemy.py
@@ -9,12 +9,14 @@ from unittest.mock import patch
 import pytest
 
 from prts_mcp.data.enemy import (
+    build_enemy_search,
     build_enemy_info,
     build_enemies_listing,
     clear_enemy_caches,
     list_enemies,
     get_enemy_info,
     render_enemy_info,
+    render_enemy_search,
     search_enemies,
 )
 from prts_mcp.output import render_result
@@ -319,6 +321,38 @@ class TestSearchEnemies:
     def test_match_by_description(self, gamedata):
         out = search_enemies("整合运动")
         assert "霜星" in out
+
+    def test_structured_golden(self, gamedata):
+        data = build_enemy_search("整合运动")
+        assert isinstance(data, dict)
+        assert data["scope"] == "enemies"
+        assert data["pattern"] == "整合运动"
+        assert data["total"] == 1
+        assert data["results"][0] == {
+            "enemy_id": "enemy_1505_frstar",
+            "name": "霜星",
+            "enemy_index": "FN",
+            "level_raw": "BOSS",
+            "level_label": "领袖",
+            "description": "整合运动法术部队干部。",
+            "attack_type": "",
+            "ability": "",
+            "damage_types_raw": ["MAGIC"],
+            "damage_types_label": "法术",
+            "enemy_tags": [],
+        }
+        expected = (
+            "# 搜索结果：整合运动（共 1 个）\n\n"
+            "# 霜星 - 敌人图鉴\n\n"
+            "- **编号**：FN\n"
+            "- **威胁等级**：领袖\n"
+            "- **描述**：整合运动法术部队干部。\n"
+            "- **伤害类型**：法术"
+        )
+        assert render_enemy_search(data) == expected
+        assert search_enemies("整合运动") == expected
+        r = render_result(data, expected, channel="both")
+        assert r.structuredContent == data
 
     def test_no_match(self, gamedata):
         out = search_enemies("绝对不存在的关键词")

--- a/python/tests/test_item.py
+++ b/python/tests/test_item.py
@@ -8,11 +8,13 @@ from pathlib import Path
 import pytest
 
 from prts_mcp.data.item import (
+    build_item_search,
     build_items_listing,
     clear_item_caches,
     get_item_info,
     get_item_name_by_id,
     list_items,
+    render_item_search,
     search_items,
 )
 from prts_mcp.output import render_result
@@ -226,6 +228,35 @@ def test_search_items(gamedata: str) -> None:
     out = search_items("公开渠道")
     assert "招聘许可" in out
     assert "搜索结果" in out
+
+
+def test_search_items_structured_golden(gamedata: str) -> None:
+    data = build_item_search("公开渠道")
+    assert isinstance(data, dict)
+    assert data["scope"] == "items"
+    assert data["pattern"] == "公开渠道"
+    assert data["total"] == 1
+    assert data["results"][0] == {
+        "item_id": "7001",
+        "name": "招聘许可",
+        "classify_raw": "NORMAL",
+        "classify_label": "普通",
+        "item_type": "TKT_RECRUIT",
+        "rarity_raw": "TIER_4",
+        "rarity_label": "T4",
+        "usage": "可从公开渠道招聘一位干员。",
+        "obtain_approach": "采购中心、任务奖励",
+    }
+    expected = (
+        "# 搜索结果：公开渠道（共 1 个）\n\n"
+        "## 招聘许可 [普通/TKT_RECRUIT] T4（id: 7001）\n"
+        "- **用途**：可从公开渠道招聘一位干员。\n"
+        "- **获取方式**：采购中心、任务奖励"
+    )
+    assert render_item_search(data) == expected
+    assert search_items("公开渠道") == expected
+    r = render_result(data, expected, channel="both")
+    assert r.structuredContent == data
 
 
 def test_search_items_invalid_regex(gamedata: str) -> None:

--- a/python/tests/test_search.py
+++ b/python/tests/test_search.py
@@ -1,15 +1,31 @@
 """Tests for search tools — operator search and story search."""
 from __future__ import annotations
 
+import asyncio
 import json
 import zipfile
 from pathlib import Path
 
 import pytest
 
-from prts_mcp.data.search import search_operator_data
+from mcp.server.fastmcp import FastMCP
+
+from prts_mcp.data.search import (
+    build_operator_search,
+    build_search,
+    render_operator_search,
+    render_search,
+    search_operator_data,
+)
 from prts_mcp.data.stores import DirectoryStore, ZipStore
-from prts_mcp.data.story import search_stories_from_store
+from prts_mcp.data.story import (
+    build_story_search_from_store,
+    render_story_search,
+    search_stories_from_store,
+)
+from prts_mcp.output import render_result
+from prts_mcp.tools_gamedata import register_gamedata_tools
+from prts_mcp.tools_story import register_story_tools
 
 
 # ---------------------------------------------------------------------------
@@ -159,6 +175,37 @@ class TestSearchOperatorData:
         result = search_operator_data(".", max_results=101)
         assert "max_results 必须 <= 100" in result
 
+    def test_structured_golden(self) -> None:
+        data = build_operator_search("阿米娅", max_results=1)
+        assert data == {
+            "scope": "operators",
+            "pattern": "阿米娅",
+            "total": 1,
+            "results": [
+                {
+                    "operator": "阿米娅",
+                    "category": "basic",
+                    "field": "干员名称",
+                    "text": "阿米娅",
+                }
+            ],
+        }
+        assert render_operator_search(data) == (
+            "# 搜索 \"阿米娅\" 的结果（共 1 条）"
+            "\n---\n\n"
+            "[operators/basic/阿米娅]\n"
+            "匹配：干员名称\n"
+            "阿米娅"
+        )
+        result = render_result(data, render_operator_search(data), channel="both")
+        assert result.structuredContent == data
+
+    def test_unified_search_dispatch(self) -> None:
+        data = build_search("operators", "阿米娅", max_results=1)
+        assert isinstance(data, dict)
+        assert data["scope"] == "operators"
+        assert render_search(data) == render_operator_search(data)
+
 
 # ---------------------------------------------------------------------------
 # Story search tests
@@ -255,3 +302,52 @@ class TestSearchStories:
         store = _story_store(store_kind, tmp_path)
         result = search_stories_from_store(store, ".", context_lines=-1)
         assert "context_lines 必须 >= 0" in result
+
+    def test_structured_context_golden(self, tmp_path: Path) -> None:
+        store = _story_store("directory", tmp_path)
+        data = build_story_search_from_store(store, "你好")
+
+        assert data == {
+            "pattern": "你好",
+            "filters": {
+                "character": None,
+                "line_type": None,
+                "context_lines": 1,
+                "event_id": None,
+            },
+            "total": 1,
+            "results": [
+                {
+                    "event_id": "act_test",
+                    "story_key": FIRST_STORY_KEY,
+                    "story_code": "TEST-1",
+                    "line_number": 1,
+                    "context": [
+                        {"text": "阿米娅：你好，博士。", "is_match": True},
+                        {"text": "*罗德岛走廊*", "is_match": False},
+                    ],
+                }
+            ],
+        }
+        expected = (
+            "# 搜索 \"你好\" 的结果（共 1 条）\n\n"
+            "---\n\n"
+            "[stories/act_test/TEST-1 L1]\n"
+            ">>> 阿米娅：你好，博士。\n"
+            "    *罗德岛走廊*"
+        )
+        assert render_story_search(data) == expected
+        assert search_stories_from_store(store, "你好") == expected
+        result = render_result(data, expected, channel="both")
+        assert result.structuredContent == data
+
+
+def test_p3_search_tool_manifest_output_schema_none() -> None:
+    app = FastMCP("search-manifest")
+    register_gamedata_tools(app)
+    register_story_tools(app)
+
+    tools = {tool.name: tool for tool in asyncio.run(app.list_tools())}
+
+    assert tools["search"].outputSchema is None
+    assert tools["search_stories"].outputSchema is None

--- a/python/tests/test_stage.py
+++ b/python/tests/test_stage.py
@@ -8,10 +8,12 @@ from pathlib import Path
 import pytest
 
 from prts_mcp.data.stage import (
+    build_stage_search,
     build_stages_listing,
     clear_stage_caches,
     list_stages,
     get_stage_info,
+    render_stage_search,
     render_stages_listing,
     search_stages,
 )
@@ -429,6 +431,38 @@ class TestSearchStages:
         assert "坍塌" in out
         assert "坍塌·突袭" in out
         assert "搜索结果" in out
+
+    def test_structured_golden(self, gamedata: str) -> None:
+        data = build_stage_search("先锋")
+        assert isinstance(data, dict)
+        assert data["scope"] == "stages"
+        assert data["pattern"] == "先锋"
+        assert data["total"] == 1
+        assert data["results"][0] == {
+            "stage_id": "main_00-01",
+            "name": "坍塌",
+            "code": "0-1",
+            "type": "MAIN",
+            "type_label": "主线",
+            "difficulty": "NORMAL",
+            "difficulty_label": "普通",
+            "zone_id": "main_0",
+            "zone_display": "序章-黑暗时代·上",
+            "ap": 6,
+            "description": "三点方向出现了敌人的先锋部队。",
+        }
+        expected = (
+            "# 搜索结果：先锋（共 1 个）\n\n"
+            "## 坍塌 [主线] 0-1（id: main_00-01）\n"
+            "- **区域**：序章-黑暗时代·上\n"
+            "- **难度**：普通\n"
+            "- **理智**：6\n"
+            "- **描述**：三点方向出现了敌人的先锋部队。"
+        )
+        assert render_stage_search(data) == expected
+        assert search_stages("先锋") == expected
+        r = render_result(data, expected, channel="both")
+        assert r.structuredContent == data
 
     def test_by_code(self, gamedata: str) -> None:
         out = search_stages("AS-1")

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -461,7 +461,7 @@ def test_search_prts_network_failure_is_content_only(
     assert result.content[0].text == "搜索 PRTS 失败：network down"
 
 
-def test_unmigrated_search_stories_missing_zip_stays_str(
+def test_search_stories_missing_zip_is_content_only(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -475,14 +475,11 @@ def test_unmigrated_search_stories_missing_zip_stays_str(
         )
     )
 
-    content, structured = result
-    assert structured == {
-        "result": (
-            "剧情数据未就绪。请设置 STORYJSON_PATH 环境变量指向 zh_CN.zip，"
-            "或等待服务器自动从 GitHub Release 下载完成后重试。"
-        )
-    }
-    assert content[0].text == structured["result"]
+    assert result.structuredContent is None
+    assert result.content[0].text == (
+        "剧情数据未就绪。请设置 STORYJSON_PATH 环境变量指向 zh_CN.zip，"
+        "或等待服务器自动从 GitHub Release 下载完成后重试。"
+    )
 
 
 def test_p2b_manifest_output_schema_shape() -> None:
@@ -498,7 +495,6 @@ def test_p2b_manifest_output_schema_shape() -> None:
         "find_character_appearances",
         "find_speakers_in",
         "search_prts",
+        "search_stories",
     }:
         assert tools[name].outputSchema is None, f"{name} still has outputSchema"
-
-    assert tools["search_stories"].outputSchema is not None


### PR DESCRIPTION
## Summary
- Migrate Python `search` and `search_stories` to explicit `CallToolResult` delivery with structuredContent envelopes.
- Preserve default markdown output while exposing scope-specific search entries and structured story context lines.
- Keep invalid regex/filter/missing-data paths content-only; no-match searches return structured `{total:0, results:[]}`.

## Test plan
- `python/tests/test_search.py python/tests/test_enemy.py python/tests/test_stage.py python/tests/test_item.py python/tests/test_story_output_channel.py -q` -> 130 passed
- `cd python && E:\Anaconda3\envs\python311\python.exe -m pytest tests -q` -> 288 passed, 2 skipped
- `./scripts/check-runtime.ps1 -Full` -> 0 failures, existing environment warnings only
- `git diff --check` -> clean

## 未尽事宜
- Full all-tool `outputSchema=None` invariant remains intentionally deferred to PR4.
- `prts_page` structural actions remain content-only per output-channel plan.
- TS migration remains a separate track.