### PR TITLE
test(python): audit output-channel test coverage

### DIFF
--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -38,7 +38,7 @@ mcp = FastMCP("PRTS_Wiki_Assistant")
 
 
 def _register_tools() -> None:
-    """Register all 30 MCP tools via the focused tool modules."""
+    """Register MCP tools via the focused tool modules."""
     from prts_mcp.tools_prts import register_prts_tools
     from prts_mcp.tools_gamedata import register_gamedata_tools
     from prts_mcp.tools_story import register_story_tools

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -2,11 +2,9 @@
 from __future__ import annotations
 
 import os
-from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
+import prts_mcp.config as config_module
 from prts_mcp.config import Config
 
 
@@ -32,25 +30,17 @@ class TestEffectiveStoryjsonZip:
 
     def test_has_story_data_false_by_default(self, tmp_path):
         # No env vars, no bundled zip at default paths
-        with patch.dict(os.environ, {"GAMEDATA_PATH": str(tmp_path)}, clear=False):
-            os.environ.pop("STORYJSON_PATH", None)
-            cfg = Config.load()
+        missing_default = tmp_path / "storyjson" / "zh_CN.zip"
+        missing_docker = tmp_path / "docker" / "zh_CN.zip"
+        missing_bundled = tmp_path / "bundled" / "zh_CN.zip"
+        with patch.dict(os.environ, {"GAMEDATA_PATH": str(tmp_path)}, clear=True):
+            with patch.object(config_module, "_DEFAULT_STORYJSON_ZIP", missing_default):
+                with patch.object(config_module, "_DOCKER_STORYJSON_ZIP", missing_docker):
+                    with patch.object(config_module, "_BUNDLED_STORYJSON_ZIP", missing_bundled):
+                        cfg = Config.load()
 
-        # On a dev machine without bundled docker paths, should be False
-        # (unless local zip happens to exist at default path)
-        assert isinstance(cfg.has_story_data, bool)
-
-    def test_local_zip_resolves(self):
-        """If the local dev zip exists, effective path should point to it."""
-        local_zip = Path(r"F:\2026-Spring\ArknightsStoryJson\zh_CN.zip")
-        if not local_zip.is_file():
-            pytest.skip("Local zip not available")
-
-        with patch.dict(os.environ, {"STORYJSON_PATH": str(local_zip)}):
-            cfg = Config.load()
-
-        assert cfg.effective_storyjson_zip == local_zip
-        assert cfg.has_story_data is True
+        assert cfg.effective_storyjson_zip is None
+        assert cfg.has_story_data is False
 
 
 class TestEffectiveLevelsPath:

--- a/python/tests/test_enemy.py
+++ b/python/tests/test_enemy.py
@@ -10,12 +10,10 @@ import pytest
 
 from prts_mcp.data.enemy import (
     build_enemy_search,
-    build_enemy_info,
     build_enemies_listing,
     clear_enemy_caches,
     list_enemies,
     get_enemy_info,
-    render_enemy_info,
     render_enemy_search,
     search_enemies,
 )
@@ -142,12 +140,6 @@ def split_levels_gamedata(tmp_path: Path):
 
 
 class TestListEnemies:
-    def test_default_filters_hidden(self, gamedata):
-        out = list_enemies(limit=10)
-        assert "霜星" in out
-        assert "源石虫" in out
-        assert "隐藏敌人" not in out
-
     def test_golden_default_listing(self, gamedata):
         # Golden: exact full markdown for the default listing against the
         # fixture. Stronger than substring asserts — catches build-layer
@@ -180,27 +172,9 @@ class TestListEnemies:
         r = render_result(data, list_enemies(offset=999), channel="structured")
         assert r.structuredContent == data
 
-    def test_both_channel_attaches_structured_content(self, gamedata):
-        # Verify the tool wiring actually populates structuredContent in the
-        # both channel (the build dict rides the structured axis).
-        data = build_enemies_listing()
-        assert isinstance(data, dict)
-        r = render_result(data, list_enemies(), channel="both")
-        assert r.structuredContent == data
-        assert r.content[0].text == list_enemies()
-
-    def test_threat_level_filter(self, gamedata):
-        out = list_enemies(threat_level="boss", limit=10)
-        assert "霜星" in out
-        assert "源石虫" not in out
-
     def test_threat_level_invalid_returns_error(self, gamedata):
         out = list_enemies(threat_level="INVALID")
         assert "无效的 threat_level" in out
-
-    def test_offset_beyond_total(self, gamedata):
-        out = list_enemies(offset=999)
-        assert "超出范围" in out
 
     def test_invalid_limit(self, gamedata):
         out = list_enemies(limit=0)
@@ -229,11 +203,7 @@ class TestListEnemies:
         )
         clear_enemy_caches()
         out = list_enemies(limit=5)
-        # Description line must not contain a literal newline mid-bullet.
-        for line in out.split("\n"):
-            if line.startswith("- **测试**"):
-                assert "\n" not in line
-                break
+        assert "- **测试** [普通] (T1) — 第一行 第二行" in out
 
 
 class TestGetEnemyInfo:
@@ -296,16 +266,6 @@ class TestGetEnemyInfo:
             "- **ArcticBlast**（冷却 8.5s）: duration=8.0，atk_scale=1.5"
         )
 
-    def test_build_render_round_trip_is_exact(self, gamedata):
-        # The build/render split must be byte-for-byte equivalent to the
-        # public get_enemy_info — including the single-newline boundary
-        # between the handbook block and the 战斗属性 section (a regression
-        # here catches a spurious blank line from "\n".join + leading "\n").
-        for name in ("霜星", "源石虫"):
-            data = build_enemy_info(name)
-            assert isinstance(data, dict), f"{name}: expected dict, got error"
-            assert render_enemy_info(data) == get_enemy_info(name), f"{name}: round-trip mismatch"
-
     def test_handbook_to_stats_boundary_is_single_newline(self, gamedata):
         out = get_enemy_info("霜星")
         #霜星 has combat stats; the section heading must follow the last
@@ -318,10 +278,6 @@ class TestGetEnemyInfo:
 
 
 class TestSearchEnemies:
-    def test_match_by_description(self, gamedata):
-        out = search_enemies("整合运动")
-        assert "霜星" in out
-
     def test_structured_golden(self, gamedata):
         data = build_enemy_search("整合运动")
         assert isinstance(data, dict)
@@ -355,8 +311,18 @@ class TestSearchEnemies:
         assert r.structuredContent == data
 
     def test_no_match(self, gamedata):
-        out = search_enemies("绝对不存在的关键词")
-        assert "未找到匹配" in out
+        data = build_enemy_search("绝对不存在的关键词")
+        assert data == {
+            "scope": "enemies",
+            "pattern": "绝对不存在的关键词",
+            "total": 0,
+            "results": [],
+        }
+        expected = "未找到匹配 '绝对不存在的关键词' 的敌人。"
+        assert render_enemy_search(data) == expected
+        assert search_enemies("绝对不存在的关键词") == expected
+        r = render_result(data, expected, channel="structured")
+        assert r.structuredContent == data
 
     def test_invalid_regex(self, gamedata):
         out = search_enemies("[unclosed")

--- a/python/tests/test_item.py
+++ b/python/tests/test_item.py
@@ -115,15 +115,6 @@ def gamedata() -> str:
     os.environ.pop("GAMEDATA_PATH", None)
 
 
-def test_list_items_default(gamedata: str) -> None:
-    out = list_items()
-    assert "物品列表" in out
-    assert "源岩" in out
-    assert "招聘许可" in out
-    assert "隐藏物品" not in out
-    assert "共 2 个" in out
-
-
 def test_list_items_golden_default(gamedata: str) -> None:
     # Golden: exact full markdown. Hardcoded expectation (not a tautology),
     # catches build-layer field omissions, ordering, and label regressions.
@@ -145,14 +136,6 @@ def test_list_items_golden_category_filter(gamedata: str) -> None:
     )
 
 
-def test_list_items_both_channel(gamedata: str) -> None:
-    data = build_items_listing()
-    assert isinstance(data, dict)
-    r = render_result(data, list_items(), channel="both")
-    assert r.structuredContent == data
-    assert r.content[0].text == list_items()
-
-
 def test_list_items_empty_match_is_structured_not_error(gamedata: str) -> None:
     # Empty-result contract (P2b plan §3.4): a legitimate-but-empty result
     # (filter no-match) is a normal structured payload {total:0, items:[]},
@@ -168,23 +151,6 @@ def test_list_items_empty_match_is_structured_not_error(gamedata: str) -> None:
     # structured channel carries the empty payload
     r = render_result(data, list_items(category="NONEXISTENT"), channel="structured")
     assert r.structuredContent == data
-
-
-def test_list_items_category_filter(gamedata: str) -> None:
-    out = list_items(category="MATERIAL")
-    assert "源岩" in out
-    assert "招聘许可" not in out
-    assert "共 1 个" in out
-
-
-def test_get_item_info_by_name(gamedata: str) -> None:
-    out = get_item_info("源岩")
-    assert "# 源岩" in out
-    assert "ID**：30011" in out
-    assert "T1" in out
-    assert "可用于多种强化场合" in out
-    assert "main_00-01（固定）" in out
-    assert "main_00-02（小概率）" in out
 
 
 def test_get_item_info_golden(gamedata: str) -> None:
@@ -224,12 +190,6 @@ def test_get_item_name_by_id(gamedata: str) -> None:
     assert get_item_name_by_id("missing") is None
 
 
-def test_search_items(gamedata: str) -> None:
-    out = search_items("公开渠道")
-    assert "招聘许可" in out
-    assert "搜索结果" in out
-
-
 def test_search_items_structured_golden(gamedata: str) -> None:
     data = build_item_search("公开渠道")
     assert isinstance(data, dict)
@@ -256,6 +216,21 @@ def test_search_items_structured_golden(gamedata: str) -> None:
     assert render_item_search(data) == expected
     assert search_items("公开渠道") == expected
     r = render_result(data, expected, channel="both")
+    assert r.structuredContent == data
+
+
+def test_search_items_no_match_is_structured_empty(gamedata: str) -> None:
+    data = build_item_search("绝对不存在的物品")
+    assert data == {
+        "scope": "items",
+        "pattern": "绝对不存在的物品",
+        "total": 0,
+        "results": [],
+    }
+    expected = "未找到匹配 '绝对不存在的物品' 的物品。"
+    assert render_item_search(data) == expected
+    assert search_items("绝对不存在的物品") == expected
+    r = render_result(data, expected, channel="structured")
     assert r.structuredContent == data
 
 

--- a/python/tests/test_output.py
+++ b/python/tests/test_output.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 
 from mcp.types import CallToolResult
 
@@ -37,17 +38,25 @@ def test_parse_channel_rejects_unknown_and_falls_back() -> None:
 
 def test_module_constant_reads_env_at_import(monkeypatch) -> None:
     # OUTPUT_CHANNEL is a connection-level constant resolved at import time.
-    monkeypatch.setenv("PRTS_OUTPUT_CHANNEL", "structured")
-    assert importlib.reload(output_module).OUTPUT_CHANNEL == "structured"
+    original_raw = os.environ.get("PRTS_OUTPUT_CHANNEL")
+    try:
+        monkeypatch.setenv("PRTS_OUTPUT_CHANNEL", "structured")
+        assert importlib.reload(output_module).OUTPUT_CHANNEL == "structured"
 
-    monkeypatch.setenv("PRTS_OUTPUT_CHANNEL", " Both ")
-    assert importlib.reload(output_module).OUTPUT_CHANNEL == "both"
+        monkeypatch.setenv("PRTS_OUTPUT_CHANNEL", " Both ")
+        assert importlib.reload(output_module).OUTPUT_CHANNEL == "both"
 
-    monkeypatch.setenv("PRTS_OUTPUT_CHANNEL", "bad")
-    assert importlib.reload(output_module).OUTPUT_CHANNEL == "content"
+        monkeypatch.setenv("PRTS_OUTPUT_CHANNEL", "bad")
+        assert importlib.reload(output_module).OUTPUT_CHANNEL == "content"
 
-    monkeypatch.delenv("PRTS_OUTPUT_CHANNEL", raising=False)
-    importlib.reload(output_module)
+        monkeypatch.delenv("PRTS_OUTPUT_CHANNEL", raising=False)
+        assert importlib.reload(output_module).OUTPUT_CHANNEL == "content"
+    finally:
+        if original_raw is None:
+            monkeypatch.delenv("PRTS_OUTPUT_CHANNEL", raising=False)
+        else:
+            monkeypatch.setenv("PRTS_OUTPUT_CHANNEL", original_raw)
+        importlib.reload(output_module)
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_output.py
+++ b/python/tests/test_output.py
@@ -1,10 +1,12 @@
 """Tests for the output-channel renderer (2.0 structuredContent support)."""
 from __future__ import annotations
 
+import importlib
+
 from mcp.types import CallToolResult
 
+import prts_mcp.output as output_module
 from prts_mcp.output import (
-    OUTPUT_CHANNEL,
     _parse_channel,
     render_result,
     text_result,
@@ -33,12 +35,19 @@ def test_parse_channel_rejects_unknown_and_falls_back() -> None:
     assert _parse_channel("json") == "content"  # deliberately not a channel
 
 
-def test_module_constant_reads_env_at_import() -> None:
-    # OUTPUT_CHANNEL (the parsed-value constant) is resolved at import time
-    # from the PRTS_OUTPUT_CHANNEL env var. We can't re-import here cheaply,
-    # so just assert it is one of the valid values regardless of the ambient
-    # environment.
-    assert OUTPUT_CHANNEL in {"content", "structured", "both"}
+def test_module_constant_reads_env_at_import(monkeypatch) -> None:
+    # OUTPUT_CHANNEL is a connection-level constant resolved at import time.
+    monkeypatch.setenv("PRTS_OUTPUT_CHANNEL", "structured")
+    assert importlib.reload(output_module).OUTPUT_CHANNEL == "structured"
+
+    monkeypatch.setenv("PRTS_OUTPUT_CHANNEL", " Both ")
+    assert importlib.reload(output_module).OUTPUT_CHANNEL == "both"
+
+    monkeypatch.setenv("PRTS_OUTPUT_CHANNEL", "bad")
+    assert importlib.reload(output_module).OUTPUT_CHANNEL == "content"
+
+    monkeypatch.delenv("PRTS_OUTPUT_CHANNEL", raising=False)
+    importlib.reload(output_module)
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_search.py
+++ b/python/tests/test_search.py
@@ -1,14 +1,11 @@
 """Tests for search tools — operator search and story search."""
 from __future__ import annotations
 
-import asyncio
 import json
 import zipfile
 from pathlib import Path
 
 import pytest
-
-from mcp.server.fastmcp import FastMCP
 
 from prts_mcp.data.search import (
     build_operator_search,
@@ -24,8 +21,6 @@ from prts_mcp.data.story import (
     search_stories_from_store,
 )
 from prts_mcp.output import render_result
-from prts_mcp.tools_gamedata import register_gamedata_tools
-from prts_mcp.tools_story import register_story_tools
 
 
 # ---------------------------------------------------------------------------
@@ -153,8 +148,18 @@ class TestSearchOperatorData:
         assert "匹配：任命助理" in result
 
     def test_no_match(self) -> None:
-        result = search_operator_data("ZZZZZZZ")
-        assert "未找到匹配" in result
+        data = build_operator_search("ZZZZZZZ")
+        assert data == {
+            "scope": "operators",
+            "pattern": "ZZZZZZZ",
+            "total": 0,
+            "results": [],
+        }
+        expected = "未找到匹配 'ZZZZZZZ' 的干员数据。"
+        assert render_operator_search(data) == expected
+        assert search_operator_data("ZZZZZZZ") == expected
+        result = render_result(data, expected, channel="structured")
+        assert result.structuredContent == data
 
     def test_invalid_regex(self) -> None:
         result = search_operator_data("[")
@@ -264,8 +269,23 @@ class TestSearchStories:
     @pytest.mark.parametrize("store_kind", ["directory", "zip"])
     def test_no_match(self, tmp_path: Path, store_kind: str) -> None:
         store = _story_store(store_kind, tmp_path)
-        result = search_stories_from_store(store, "ZZZZZZ")
-        assert "未找到匹配" in result
+        data = build_story_search_from_store(store, "ZZZZZZ")
+        assert data == {
+            "pattern": "ZZZZZZ",
+            "filters": {
+                "character": None,
+                "line_type": None,
+                "context_lines": 1,
+                "event_id": None,
+            },
+            "total": 0,
+            "results": [],
+        }
+        expected = "未找到匹配 'ZZZZZZ' 的剧情台词。"
+        assert render_story_search(data) == expected
+        assert search_stories_from_store(store, "ZZZZZZ") == expected
+        result = render_result(data, expected, channel="structured")
+        assert result.structuredContent == data
 
     @pytest.mark.parametrize("store_kind", ["directory", "zip"])
     def test_invalid_regex(self, tmp_path: Path, store_kind: str) -> None:
@@ -340,14 +360,3 @@ class TestSearchStories:
         assert search_stories_from_store(store, "你好") == expected
         result = render_result(data, expected, channel="both")
         assert result.structuredContent == data
-
-
-def test_p3_search_tool_manifest_output_schema_none() -> None:
-    app = FastMCP("search-manifest")
-    register_gamedata_tools(app)
-    register_story_tools(app)
-
-    tools = {tool.name: tool for tool in asyncio.run(app.list_tools())}
-
-    assert tools["search"].outputSchema is None
-    assert tools["search_stories"].outputSchema is None

--- a/python/tests/test_stage.py
+++ b/python/tests/test_stage.py
@@ -14,7 +14,6 @@ from prts_mcp.data.stage import (
     list_stages,
     get_stage_info,
     render_stage_search,
-    render_stages_listing,
     search_stages,
 )
 from prts_mcp.output import render_result
@@ -277,13 +276,6 @@ class TestStagesBuildRender:
         assert isinstance(build_stages_listing(chapter="missing"), str)
         assert isinstance(build_stages_listing(offset=999), str)
 
-    def test_render_is_inverse_of_build(self, gamedata: str) -> None:
-        # list_stages() must equal render(build(...)) exactly — the
-        # byte-for-byte equivalence contract of the refactor.
-        data = build_stages_listing(chapter="main_0")
-        assert isinstance(data, dict)
-        assert render_stages_listing(data) == list_stages(chapter="main_0")
-
     def test_build_respects_filters_and_pagination(self, gamedata: str) -> None:
         data = build_stages_listing(type="DAILY")
         assert isinstance(data, dict)
@@ -297,65 +289,12 @@ class TestStagesBuildRender:
         assert len(page["stages"]) == 2
 
 
-class TestStagesOutputChannels:
-    """The three output_channel modes via the render_result helper."""
-
-    def _build(self, gamedata: str) -> dict:
-        data = build_stages_listing()
-        assert isinstance(data, dict)
-        return data
-
-    def test_content_channel_text_only(self, gamedata: str) -> None:
-        data = self._build(gamedata)
-        md = render_stages_listing(data)
-        r = render_result(data, md, channel="content")
-        assert r.structuredContent is None
-        assert [c.text for c in r.content] == [md]
-
-    def test_both_channel_emits_both(self, gamedata: str) -> None:
-        data = self._build(gamedata)
-        md = render_stages_listing(data)
-        r = render_result(data, md, channel="both")
-        assert [c.text for c in r.content] == [md]
-        assert r.structuredContent == data
-
-    def test_structured_channel_summary_and_payload(self, gamedata: str) -> None:
-        data = self._build(gamedata)
-        md = render_stages_listing(data)
-        r = render_result(data, md, channel="structured")
-        # content is the one-line summary, not the full markdown.
-        assert r.content[0].text != md
-        assert "4" in r.content[0].text  # total count appears in summary
-        assert r.structuredContent == data
-
-    def test_error_path_is_content_only_in_every_channel(self, gamedata: str) -> None:
-        err = build_stages_listing(limit=0)
-        assert isinstance(err, str)
-        for ch in ("content", "structured", "both"):
-            r = render_result(None, err, channel=ch)  # type: ignore[arg-type]
-            assert [c.text for c in r.content] == [err], f"channel={ch}"
-            assert r.structuredContent is None, f"channel={ch}"
-
-
 # ---------------------------------------------------------------------------
 # get_stage_info
 # ---------------------------------------------------------------------------
 
 
 class TestGetStageInfo:
-    def test_full_info(self, gamedata: str) -> None:
-        out = get_stage_info("main_00-01")
-        assert "坍塌" in out
-        assert "0-1" in out
-        assert "主线" in out
-        assert "普通" in out
-        assert "序章-黑暗时代·上" in out
-        assert "6" in out
-        assert "三点方向" in out
-        assert "招聘许可（7001）" in out
-        assert "无条件" in out
-        assert "main_00-01#f#" in out
-
     def test_golden_full_output(self, gamedata: str) -> None:
         # Golden: exact full markdown for main_00-01 against the fixture.
         # Stronger than substring asserts — catches build-layer field
@@ -473,12 +412,29 @@ class TestSearchStages:
         assert "坍塌" in out
 
     def test_multiple_matches(self, gamedata: str) -> None:
-        out = search_stages(".")
-        assert "共 " in out
+        data = build_stage_search(".")
+        assert isinstance(data, dict)
+        assert data["total"] == 4
+        assert [entry["stage_id"] for entry in data["results"]] == [
+            "act31side_01",
+            "daily_01",
+            "main_00-01",
+            "main_00-01#f#",
+        ]
 
     def test_no_match(self, gamedata: str) -> None:
-        out = search_stages("ZZZZNOMATCH")
-        assert "未找到匹配" in out
+        data = build_stage_search("ZZZZNOMATCH")
+        assert data == {
+            "scope": "stages",
+            "pattern": "ZZZZNOMATCH",
+            "total": 0,
+            "results": [],
+        }
+        expected = "未找到匹配 'ZZZZNOMATCH' 的关卡。"
+        assert render_stage_search(data) == expected
+        assert search_stages("ZZZZNOMATCH") == expected
+        r = render_result(data, expected, channel="structured")
+        assert r.structuredContent == data
 
     def test_invalid_regex(self, gamedata: str) -> None:
         out = search_stages("[invalid")

--- a/python/tests/test_stage_enemy.py
+++ b/python/tests/test_stage_enemy.py
@@ -8,14 +8,11 @@ from unittest.mock import patch
 import pytest
 
 from prts_mcp.data.stage_enemy import (
-    build_enemy_appearances,
-    build_stage_enemies,
     clear_stage_enemy_caches,
     get_enemy_appearances,
     get_enemy_stage_info,
     get_stage_enemies,
 )
-from prts_mcp.output import render_result
 
 
 def _write_fixture(root: Path) -> None:
@@ -175,20 +172,6 @@ def gamedata(tmp_path: Path):
     clear_stage_enemy_caches()
 
 
-def test_get_stage_enemies_uses_spawn_actions_and_overrides(gamedata: Path) -> None:
-    out = get_stage_enemies("main_00-01")
-    assert "坍塌 0-1" in out
-    assert "源石虫" in out
-    assert "出场数量**：6" in out
-    assert "士兵" in out
-    assert "出场数量**：1" in out
-    assert "DEF 30" in out
-    assert "关卡特化敌人" in out
-    assert "HP 1,234" in out
-    assert "ATK 321" in out
-    assert "未出场敌人" not in out
-
-
 def test_get_stage_enemies_golden(gamedata: Path) -> None:
     # Golden: exact full markdown for main_00-01 against the fixture.
     # Hardcoded (not tautology) — catches build-layer field omissions,
@@ -215,22 +198,6 @@ def test_get_stage_enemies_golden(gamedata: Path) -> None:
     )
 
 
-def test_get_stage_enemies_both_channel(gamedata: Path) -> None:
-    data = build_stage_enemies("main_00-01")
-    assert isinstance(data, dict)
-    r = render_result(data, get_stage_enemies("main_00-01"), channel="both")
-    assert r.structuredContent == data
-    assert r.content[0].text == get_stage_enemies("main_00-01")
-
-
-def test_get_enemy_appearances(gamedata: Path) -> None:
-    out = get_enemy_appearances("源石虫")
-    assert "源石虫" in out
-    assert "坍塌" in out
-    assert "main_00-01" in out
-    assert "6 个" in out
-
-
 def test_get_enemy_appearances_golden(gamedata: Path) -> None:
     # Golden: exact full markdown. Hardcoded (not tautology) — catches
     # build-layer field omissions and header/pagination regressions.
@@ -240,14 +207,6 @@ def test_get_enemy_appearances_golden(gamedata: Path) -> None:
         "\n"
         "（显示第 1–1 条，共 1 条。使用 offset=50 查看下一页）"
     )
-
-
-def test_get_enemy_appearances_both_channel(gamedata: Path) -> None:
-    data = build_enemy_appearances("源石虫")
-    assert isinstance(data, dict)
-    r = render_result(data, get_enemy_appearances("源石虫"), channel="both")
-    assert r.structuredContent == data
-    assert r.content[0].text == get_enemy_appearances("源石虫")
 
 
 def test_get_enemy_stage_info(gamedata: Path) -> None:

--- a/python/tests/test_story.py
+++ b/python/tests/test_story.py
@@ -7,10 +7,8 @@ from pathlib import Path
 import pytest
 
 from prts_mcp.data.story import (
-    ActivityResult,
     ChapterSummary,
     EventInfo,
-    StoryChapter,
     StoryLine,
     _clean_text,
     _parse_story_list,
@@ -56,8 +54,7 @@ class TestParseStoryList:
     def test_dialog_empty_speaker(self):
         items = [{"id": 1, "prop": "name", "attributes": {"name": "", "content": "旁白文字"}}]
         lines = _parse_story_list(items)
-        assert lines[0].role is None
-        assert lines[0].type == "dialog"
+        assert lines == [StoryLine(type="dialog", role=None, text="旁白文字")]
 
     def test_dialog_empty_content_skipped(self):
         items = [{"id": 1, "prop": "name", "attributes": {"name": "阿米娅", "content": ""}}]
@@ -72,12 +69,12 @@ class TestParseStoryList:
     def test_narration_subtitle(self):
         items = [{"id": 1, "prop": "subtitle", "attributes": {"content": "字幕文字"}}]
         lines = _parse_story_list(items)
-        assert lines[0].type == "narration"
+        assert lines == [StoryLine(type="narration", role=None, text="字幕文字")]
 
     def test_narration_animtext(self):
         items = [{"id": 1, "prop": "animtext", "attributes": {"content": "动画文字"}}]
         lines = _parse_story_list(items)
-        assert lines[0].type == "narration"
+        assert lines == [StoryLine(type="narration", role=None, text="动画文字")]
 
     def test_non_text_props_skipped(self):
         items = [
@@ -100,9 +97,10 @@ class TestParseStoryList:
             {"id": 4, "prop": "Dialog", "attributes": {}},
         ]
         lines = _parse_story_list(items)
-        assert len(lines) == 2
-        assert lines[0].type == "dialog"
-        assert lines[1].type == "narration"
+        assert lines == [
+            StoryLine(type="dialog", role="黍", text="你好"),
+            StoryLine(type="narration", role=None, text="某处"),
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -111,12 +109,6 @@ class TestParseStoryList:
 
 
 class TestListStoryEvents:
-    def test_returns_list(self, story_zip):
-        events = list_story_events(story_zip)
-        assert isinstance(events, list)
-        assert len(events) > 0
-        assert all(isinstance(e, EventInfo) for e in events)
-
     def test_category_main(self, story_zip):
         events = list_story_events(story_zip, category="main")
         assert all(e.entry_type == "MAINLINE" for e in events)
@@ -133,11 +125,11 @@ class TestListStoryEvents:
         assert len(all_events) > len(main_events)
 
     def test_event_fields(self, story_zip):
-        events = list_story_events(story_zip, category="main")
-        e = events[0]
-        assert e.event_id
-        assert e.name
-        assert e.story_count > 0
+        events = list_story_events(story_zip, category="activities")
+        act31side = next(e for e in events if e.event_id == "act31side")
+        assert isinstance(act31side, EventInfo)
+        assert act31side.entry_type == "ACTIVITY"
+        assert act31side.story_count == len(list_stories(story_zip, "act31side"))
 
     def test_act31side_present(self, story_zip):
         events = list_story_events(story_zip, category="activities")
@@ -148,20 +140,14 @@ class TestListStoryEvents:
 class TestListStories:
     def test_act31side_chapters(self, story_zip):
         chapters = list_stories(story_zip, "act31side")
-        assert len(chapters) > 0
+        assert chapters
         assert all(isinstance(c, ChapterSummary) for c in chapters)
+        assert all(c.story_key.startswith("activities/act31side/") for c in chapters)
 
     def test_sorted_by_sort_order(self, story_zip):
         chapters = list_stories(story_zip, "act31side")
         orders = [c.sort_order for c in chapters]
         assert orders == sorted(orders)
-
-    def test_chapter_fields(self, story_zip):
-        chapters = list_stories(story_zip, "act31side")
-        c = chapters[0]
-        assert c.story_key
-        assert c.story_code
-        assert c.story_name
 
     def test_story_key_format(self, story_zip):
         chapters = list_stories(story_zip, "act31side")
@@ -174,11 +160,6 @@ class TestListStories:
 
 
 class TestReadStory:
-    def test_returns_story_chapter(self, story_zip):
-        key = "activities/act31side/level_act31side_01_beg"
-        chapter = read_story(story_zip, key)
-        assert isinstance(chapter, StoryChapter)
-
     def test_metadata(self, story_zip):
         key = "activities/act31side/level_act31side_01_beg"
         chapter = read_story(story_zip, key)
@@ -191,6 +172,7 @@ class TestReadStory:
         chapter = read_story(story_zip, key)
         dialogs = [ln for ln in chapter.lines if ln.type == "dialog"]
         assert len(dialogs) > 10
+        assert all(ln.text for ln in dialogs[:5])
 
     def test_include_narration_true(self, story_zip):
         # 幕间章节有旁白行
@@ -218,15 +200,10 @@ class TestReadStory:
 
 
 class TestReadActivity:
-    def test_returns_activity_result(self, story_zip):
-        result = read_activity(story_zip, "act31side")
-        assert isinstance(result, ActivityResult)
-        assert hasattr(result, "chapters")
-        assert hasattr(result, "total_chapters")
-
     def test_total_chapters(self, story_zip):
         chapters = list_stories(story_zip, "act31side")
         result = read_activity(story_zip, "act31side")
+        assert result.event_id == "act31side"
         assert result.total_chapters == len(chapters)
 
     def test_no_page_returns_all(self, story_zip):
@@ -245,10 +222,10 @@ class TestReadActivity:
         result = read_activity(story_zip, "act31side", page=last_page, page_size=5)
         assert result.has_more is False
 
-    def test_chapters_are_story_chapters(self, story_zip):
+    def test_page_contains_expected_chapters(self, story_zip):
         result = read_activity(story_zip, "act31side", page=1, page_size=2)
-        for ch in result.chapters:
-            assert isinstance(ch, StoryChapter)
+        assert len(result.chapters) == 2
+        assert all(ch.story_key.startswith("activities/act31side/") for ch in result.chapters)
 
     def test_unknown_event_raises(self, story_zip):
         with pytest.raises(KeyError):

--- a/python/tests/test_story.py
+++ b/python/tests/test_story.py
@@ -126,7 +126,8 @@ class TestListStoryEvents:
 
     def test_event_fields(self, story_zip):
         events = list_story_events(story_zip, category="activities")
-        act31side = next(e for e in events if e.event_id == "act31side")
+        act31side = next((e for e in events if e.event_id == "act31side"), None)
+        assert act31side is not None
         assert isinstance(act31side, EventInfo)
         assert act31side.entry_type == "ACTIVITY"
         assert act31side.story_count == len(list_stories(story_zip, "act31side"))

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -21,7 +21,6 @@ from prts_mcp.data.story import (
     render_stories_listing,
     render_story_events_listing,
 )
-from prts_mcp.output import render_result
 from prts_mcp.tools_prts import (
     _build_prts_search,
     _render_prts_search,
@@ -345,32 +344,6 @@ def test_find_speakers_in_golden_and_empty(story_zip: Path) -> None:
     assert render_speakers_in_event(empty) == "活动 'act_narration' 暂无对话发言者数据。"
 
 
-@pytest.mark.parametrize(
-    ("builder", "renderer", "args"),
-    [
-        (build_story_events_listing, render_story_events_listing, ("activities",)),
-        (build_stories_listing, render_stories_listing, ("act_test",)),
-        (build_operator_memoirs, render_operator_memoirs, ("阿米娅",)),
-        (build_character_appearances, render_character_appearances, ("博士",)),
-        (build_speakers_in_event, render_speakers_in_event, ("act_test",)),
-    ],
-)
-def test_story_payloads_emit_structured_content_in_both_channel(
-    story_zip: Path,
-    builder,
-    renderer,
-    args,
-) -> None:
-    data = builder(story_zip, *args)
-    markdown = renderer(data)
-
-    result = render_result(data, markdown, channel="both")
-
-    assert result.structuredContent == data
-    assert len(result.content) == 1
-    assert result.content[0].text == markdown
-
-
 async def _fake_search_prts(
     query: str,
     limit: int = 5,
@@ -403,8 +376,35 @@ def test_search_prts_build_render_and_totalhits(monkeypatch: pytest.MonkeyPatch)
         "**阿米娅**\n"
         "罗德岛公开领袖。"
     )
-    result = render_result(data, _render_prts_search(data), channel="both")
-    assert result.structuredContent == data
+
+
+async def _fake_filtered_empty_search_prts(
+    query: str,
+    limit: int = 5,
+    search_mode: str = "text",
+    filter_technical: bool = True,
+) -> dict:
+    return {"totalhits": 9, "results": []}
+
+
+def test_search_prts_filtered_empty_keeps_totalhits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("prts_mcp.tools_prts._search_prts", _fake_filtered_empty_search_prts)
+
+    data = asyncio.run(_build_prts_search("阿米娅", limit=1))
+
+    assert data == {
+        "query": "阿米娅",
+        "search_mode": "text",
+        "filters": {
+            "limit": 1,
+            "filter_technical": True,
+        },
+        "total": 9,
+        "results": [],
+    }
+    assert _render_prts_search(data) == "未找到与 '阿米娅' 相关的词条。"
 
 
 async def _fake_empty_search_prts(
@@ -480,21 +480,3 @@ def test_search_stories_missing_zip_is_content_only(
         "剧情数据未就绪。请设置 STORYJSON_PATH 环境变量指向 zh_CN.zip，"
         "或等待服务器自动从 GitHub Release 下载完成后重试。"
     )
-
-
-def test_p2b_manifest_output_schema_shape() -> None:
-    app = FastMCP("manifest-test")
-    register_story_tools(app)
-    register_prts_tools(app)
-
-    tools = {tool.name: tool for tool in asyncio.run(app.list_tools())}
-    for name in {
-        "list_story_events",
-        "list_stories",
-        "get_operator_memoirs",
-        "find_character_appearances",
-        "find_speakers_in",
-        "search_prts",
-        "search_stories",
-    }:
-        assert tools[name].outputSchema is None, f"{name} still has outputSchema"

--- a/python/tests/test_sync_release.py
+++ b/python/tests/test_sync_release.py
@@ -100,7 +100,8 @@ class TestSyncRelease:
             result = sync_release(spec)
 
         assert result.status == "updated"
-        mock_dl.assert_called_once()
+        assert result.commit_sha == "newsha1234"
+        mock_dl.assert_called_once_with(spec, tag, asset_url)
 
     def test_up_to_date_when_sha_matches(self, tmp_path):
         spec = _make_spec(tmp_path)

--- a/python/tests/test_tool_surface.py
+++ b/python/tests/test_tool_surface.py
@@ -1,7 +1,14 @@
 from __future__ import annotations
 
+import asyncio
 import ast
 from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from prts_mcp.tools_gamedata import register_gamedata_tools
+from prts_mcp.tools_prts import register_prts_tools
+from prts_mcp.tools_story import register_story_tools
 
 
 EXPECTED_TOOL_SURFACE = {
@@ -31,6 +38,14 @@ EXPECTED_TOOL_SURFACE = {
 }
 
 
+def _build_registered_app() -> FastMCP:
+    app = FastMCP("tool-surface-test")
+    register_prts_tools(app)
+    register_gamedata_tools(app)
+    register_story_tools(app)
+    return app
+
+
 def _collect_tool_functions() -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
     """Parse all tools_*.py modules under src/prts_mcp/ for tool function definitions.
 
@@ -48,6 +63,12 @@ def _collect_tool_functions() -> dict[str, ast.FunctionDef | ast.AsyncFunctionDe
     return functions
 
 
+def _return_annotation(fn: ast.FunctionDef | ast.AsyncFunctionDef) -> str | None:
+    if fn.returns is None:
+        return None
+    return ast.unparse(fn.returns)
+
+
 def test_python_tool_function_signatures_are_frozen() -> None:
     # Alpha hardening intentionally freezes required and optional parameters.
     # Relax this before 1.0 final if additive optional parameters become policy.
@@ -58,3 +79,24 @@ def test_python_tool_function_signatures_are_frozen() -> None:
         fn = functions[name]
         params = [arg.arg for arg in fn.args.args]
         assert tuple(params) == expected_params, f"Signature mismatch for {name!r}"
+
+
+def test_python_tool_functions_return_explicit_call_tool_results() -> None:
+    functions = _collect_tool_functions()
+
+    for name in EXPECTED_TOOL_SURFACE:
+        assert name in functions, f"Tool {name!r} not found in any tools_*.py module"
+        assert _return_annotation(functions[name]) == "object", (
+            f"Tool {name!r} must stay annotated as -> object so FastMCP does "
+            "not derive an outputSchema that breaks explicit CallToolResult."
+        )
+
+
+def test_registered_tool_manifest_has_no_output_schema() -> None:
+    app = _build_registered_app()
+
+    tools = {tool.name: tool for tool in asyncio.run(app.list_tools())}
+    assert set(tools) == set(EXPECTED_TOOL_SURFACE)
+
+    for name, tool in tools.items():
+        assert tool.outputSchema is None, f"{name} still has outputSchema"


### PR DESCRIPTION
## Summary
- Consolidate Python tool-surface guards so all 23 registered tools are checked for `outputSchema is None` and `-> object` return annotations.
- Remove tautological/duplicate helper tests and strengthen weak assertions for output-channel, search empty-result, config, story parser, and sync-release paths.
- Keep production behavior unchanged; only update a stale server registration docstring from a hard-coded tool count.

## Test plan
- `python/tests/test_tool_surface.py python/tests/test_output.py python/tests/test_search.py python/tests/test_enemy.py python/tests/test_item.py python/tests/test_stage.py python/tests/test_stage_enemy.py python/tests/test_story_output_channel.py python/tests/test_story.py python/tests/test_config.py python/tests/test_sync_release.py -q` -> 186 passed
- `python/tests/test_story.py python/tests/test_tool_surface.py python/tests/test_search.py python/tests/test_story_output_channel.py -q` -> 91 passed after independent CR adjustment
- `cd python && E:\Anaconda3\envs\python311\python.exe -m pytest tests -q` -> 259 passed, 2 skipped
- `./scripts/check-runtime.ps1 -Full` -> 0 failures, existing environment warnings only
- `git diff --check` -> clean

## Review notes
- Spawned parallel audit agents for Phase 1 coverage and one independent code-review agent for this diff.
- Addressed the independent CR should-fix by avoiding exact golden assertions against the external/local `zh_CN.zip` story data.
- Did not add a failing regression for the suspected `get_stage_enemies` overwritten `name=null` production bug; that remains a separate behavior-fix candidate.

## 未尽事宜
- `list_stages` legal empty-result behavior still returns content-only strings in current production code; this PR does not change production behavior.
- e2e fixture expansion remains intentionally out of scope per the P4 handoff.