### PR TITLE
feat(ts): add output-channel list-stages pilot

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -18,9 +18,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   wrapper with explicit `CallToolResult` delivery, so capable clients no
   longer receive duplicate markdown unless `both` is selected. `list_stages`
   is the pilot tool; its `structuredContent` carries both raw enums (e.g.
-  `type=ACTIVITY`) and rendered labels (`type_label=活动`). The remaining
-  structural tools and the TypeScript implementation follow in subsequent
-  commits. Note: `structured` mode is intended for deployments known to use a
+  `type=ACTIVITY`) and rendered labels (`type_label=活动`), and legitimate empty
+  pages (filter no-match / offset past end) return structured empty payloads
+  while preserving the original markdown text. The remaining structural tools
+  and the TypeScript implementation follow in subsequent commits. Note:
+  `structured` mode is intended for deployments known to use a
   structuredContent-capable client — an incapable client (e.g. Chatbox)
   receives only a one-line summary, so leave the default `content` unless the
   client is confirmed capable.

--- a/python/src/prts_mcp/data/stage.py
+++ b/python/src/prts_mcp/data/stage.py
@@ -189,9 +189,9 @@ def build_stages_listing(
 ) -> dict | str:
     """Build the structured payload for a stages listing.
 
-    Returns the dict payload on success, or a markdown error string on a
-    user-input / missing-data / empty-result path. The dict is the single
-    source of truth that ``render_stages_listing`` consumes.
+    Returns the dict payload on success, including legitimate empty results,
+    or a markdown error string on user-input / missing-data paths. The dict is
+    the single source of truth that ``render_stages_listing`` consumes.
     """
     if limit < 1:
         return "limit 必须 >= 1。"
@@ -218,16 +218,6 @@ def build_stages_listing(
 
     total = len(filtered)
     page = filtered[offset : offset + limit]
-
-    if not page:
-        if total == 0:
-            filters: list[str] = []
-            if chapter:
-                filters.append(f"zoneId={chapter}")
-            if type:
-                filters.append(f"stageType={type.upper()}")
-            return f"没有匹配的关卡（filter: {', '.join(filters) or 'none'}）。"
-        return f"offset {offset} 超出范围（共 {total} 条）。"
 
     entries = []
     for e in page:
@@ -267,6 +257,17 @@ def render_stages_listing(data: dict) -> str:
     offset = data["offset"]
     limit = data["limit"]
     stages = data["stages"]
+
+    if not stages:
+        if total == 0:
+            filters: list[str] = []
+            f = data["filters"]
+            if f["chapter"]:
+                filters.append(f"zoneId={f['chapter']}")
+            if f["type"]:
+                filters.append(f"stageType={f['type']}")
+            return f"没有匹配的关卡（filter: {', '.join(filters) or 'none'}）。"
+        return f"offset {offset} 超出范围（共 {total} 条）。"
 
     lines = [f"# 关卡列表（共 {total} 个）"]
     for s in stages:

--- a/python/tests/test_stage.py
+++ b/python/tests/test_stage.py
@@ -13,6 +13,7 @@ from prts_mcp.data.stage import (
     clear_stage_caches,
     list_stages,
     get_stage_info,
+    render_stages_listing,
     render_stage_search,
     search_stages,
 )
@@ -287,12 +288,26 @@ class TestStagesBuildRender:
             "list_stages_page.json"
         )
 
+    def test_empty_payload_matches_shared_parity_fixture(self, gamedata: str) -> None:
+        data = build_stages_listing(chapter="nonexistent")
+        assert data == _load_parity_fixture("list_stages_empty.json")
+        expected = "没有匹配的关卡（filter: zoneId=nonexistent）。"
+        assert render_stages_listing(data) == expected
+        assert list_stages(chapter="nonexistent") == expected
+
+    def test_offset_empty_payload_matches_shared_parity_fixture(
+        self, gamedata: str
+    ) -> None:
+        data = build_stages_listing(offset=100)
+        assert data == _load_parity_fixture("list_stages_offset_empty.json")
+        expected = "offset 100 超出范围（共 4 条）。"
+        assert render_stages_listing(data) == expected
+        assert list_stages(offset=100) == expected
+
     def test_build_error_paths_return_str(self, gamedata: str) -> None:
         assert isinstance(build_stages_listing(limit=0), str)
         assert isinstance(build_stages_listing(offset=-1), str)
         assert isinstance(build_stages_listing(type="NOPE"), str)
-        assert isinstance(build_stages_listing(chapter="missing"), str)
-        assert isinstance(build_stages_listing(offset=999), str)
 
     def test_build_respects_filters_and_pagination(self, gamedata: str) -> None:
         data = build_stages_listing(type="DAILY")

--- a/python/tests/test_stage.py
+++ b/python/tests/test_stage.py
@@ -164,6 +164,11 @@ def _make_fixture(root: Path) -> None:
     )
 
 
+def _load_parity_fixture(name: str) -> dict:
+    path = Path(__file__).parents[2] / "tests" / "parity-fixtures" / name
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 @pytest.fixture(autouse=True)
 def _reset_caches() -> None:
     clear_stage_caches()
@@ -268,6 +273,9 @@ class TestStagesBuildRender:
         assert first["type"] == "ACTIVITY"
         assert first["type_label"] == "活动"
         assert first["difficulty_label"] == "普通"
+
+    def test_matches_shared_parity_fixture(self, gamedata: str) -> None:
+        assert build_stages_listing() == _load_parity_fixture("list_stages.json")
 
     def test_build_error_paths_return_str(self, gamedata: str) -> None:
         assert isinstance(build_stages_listing(limit=0), str)

--- a/python/tests/test_stage.py
+++ b/python/tests/test_stage.py
@@ -277,6 +277,16 @@ class TestStagesBuildRender:
     def test_matches_shared_parity_fixture(self, gamedata: str) -> None:
         assert build_stages_listing() == _load_parity_fixture("list_stages.json")
 
+    def test_filtered_payload_matches_shared_parity_fixture(self, gamedata: str) -> None:
+        assert build_stages_listing(type="daily") == _load_parity_fixture(
+            "list_stages_daily.json"
+        )
+
+    def test_page_payload_matches_shared_parity_fixture(self, gamedata: str) -> None:
+        assert build_stages_listing(limit=2) == _load_parity_fixture(
+            "list_stages_page.json"
+        )
+
     def test_build_error_paths_return_str(self, gamedata: str) -> None:
         assert isinstance(build_stages_listing(limit=0), str)
         assert isinstance(build_stages_listing(offset=-1), str)

--- a/tests/parity-fixtures/list_stages.json
+++ b/tests/parity-fixtures/list_stages.json
@@ -1,0 +1,51 @@
+{
+  "total": 4,
+  "offset": 0,
+  "limit": 50,
+  "filters": {
+    "chapter": null,
+    "type": null
+  },
+  "stages": [
+    {
+      "stage_id": "act31side_01",
+      "name": "测试活动关",
+      "code": "AS-1",
+      "type": "ACTIVITY",
+      "type_label": "活动",
+      "difficulty_label": "普通",
+      "zone_id": "act31side_zone1",
+      "zone_display": "火山旅梦"
+    },
+    {
+      "stage_id": "daily_01",
+      "name": "货物运送",
+      "code": "CE-5",
+      "type": "DAILY",
+      "type_label": "每日",
+      "difficulty_label": "普通",
+      "zone_id": "daily_zone1",
+      "zone_display": "daily_zone1"
+    },
+    {
+      "stage_id": "main_00-01",
+      "name": "坍塌",
+      "code": "0-1",
+      "type": "MAIN",
+      "type_label": "主线",
+      "difficulty_label": "普通",
+      "zone_id": "main_0",
+      "zone_display": "序章-黑暗时代·上"
+    },
+    {
+      "stage_id": "main_00-01#f#",
+      "name": "坍塌·突袭",
+      "code": "TR-1",
+      "type": "MAIN",
+      "type_label": "主线",
+      "difficulty_label": "突袭",
+      "zone_id": "main_0",
+      "zone_display": "序章-黑暗时代·上"
+    }
+  ]
+}

--- a/tests/parity-fixtures/list_stages_daily.json
+++ b/tests/parity-fixtures/list_stages_daily.json
@@ -1,0 +1,21 @@
+{
+  "total": 1,
+  "offset": 0,
+  "limit": 50,
+  "filters": {
+    "chapter": null,
+    "type": "DAILY"
+  },
+  "stages": [
+    {
+      "stage_id": "daily_01",
+      "name": "货物运送",
+      "code": "CE-5",
+      "type": "DAILY",
+      "type_label": "每日",
+      "difficulty_label": "普通",
+      "zone_id": "daily_zone1",
+      "zone_display": "daily_zone1"
+    }
+  ]
+}

--- a/tests/parity-fixtures/list_stages_empty.json
+++ b/tests/parity-fixtures/list_stages_empty.json
@@ -1,0 +1,10 @@
+{
+  "total": 0,
+  "offset": 0,
+  "limit": 50,
+  "filters": {
+    "chapter": "nonexistent",
+    "type": null
+  },
+  "stages": []
+}

--- a/tests/parity-fixtures/list_stages_offset_empty.json
+++ b/tests/parity-fixtures/list_stages_offset_empty.json
@@ -1,0 +1,10 @@
+{
+  "total": 4,
+  "offset": 100,
+  "limit": 50,
+  "filters": {
+    "chapter": null,
+    "type": null
+  },
+  "stages": []
+}

--- a/tests/parity-fixtures/list_stages_page.json
+++ b/tests/parity-fixtures/list_stages_page.json
@@ -1,0 +1,31 @@
+{
+  "total": 4,
+  "offset": 0,
+  "limit": 2,
+  "filters": {
+    "chapter": null,
+    "type": null
+  },
+  "stages": [
+    {
+      "stage_id": "act31side_01",
+      "name": "测试活动关",
+      "code": "AS-1",
+      "type": "ACTIVITY",
+      "type_label": "活动",
+      "difficulty_label": "普通",
+      "zone_id": "act31side_zone1",
+      "zone_display": "火山旅梦"
+    },
+    {
+      "stage_id": "daily_01",
+      "name": "货物运送",
+      "code": "CE-5",
+      "type": "DAILY",
+      "type_label": "每日",
+      "difficulty_label": "普通",
+      "zone_id": "daily_zone1",
+      "zone_display": "daily_zone1"
+    }
+  ]
+}

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Output channel pilot (2.0).** Streamable HTTP sessions can opt into
+  `output_channel=structured` or `output_channel=both` via query string,
+  `x-prts-output-channel` header, or `PRTS_OUTPUT_CHANNEL`. This first TS
+  migration slice enables structuredContent for `list_stages` while preserving
+  the default content-only markdown output.
+
 ### Changed
 
 - **Parameter naming normalization (2.0, breaking).** Operator tools

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -12,7 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   `output_channel=structured` or `output_channel=both` via query string,
   `x-prts-output-channel` header, or `PRTS_OUTPUT_CHANNEL`. This first TS
   migration slice enables structuredContent for `list_stages` while preserving
-  the default content-only markdown output.
+  the default content-only markdown output, including legitimate empty pages
+  (filter no-match / offset past end) as structured empty payloads.
 
 ### Changed
 

--- a/ts/src/data/stage.ts
+++ b/ts/src/data/stage.ts
@@ -250,10 +250,10 @@ export function buildStagesListing(
   }
 
   const filtered: StageEntry[] = [];
-  for (const [sid, entry] of Object.entries(stages).sort(([a], [b]) => a.localeCompare(b))) {
+  for (const [, entry] of Object.entries(stages).sort(([a], [b]) => a.localeCompare(b))) {
     if (chapter != null && entry.zoneId !== chapter) continue;
     if (type != null && entry.stageType !== type.toUpperCase()) continue;
-    filtered.push({ ...entry, stageId: entry.stageId ?? sid });
+    filtered.push(entry);
   }
 
   const total = filtered.length;

--- a/ts/src/data/stage.ts
+++ b/ts/src/data/stage.ts
@@ -51,7 +51,7 @@ export interface StageListingEntry {
   zone_display: string;
 }
 
-export interface StagesListingPayload extends Record<string, unknown> {
+export interface StagesListingPayload {
   total: number;
   offset: number;
   limit: number;
@@ -259,16 +259,6 @@ export function buildStagesListing(
   const total = filtered.length;
   const page = filtered.slice(offset, offset + limit);
 
-  if (page.length === 0) {
-    if (total === 0) {
-      const filters: string[] = [];
-      if (chapter) filters.push(`zoneId=${chapter}`);
-      if (type) filters.push(`stageType=${type.toUpperCase()}`);
-      return `没有匹配的关卡（filter: ${filters.join(", ") || "none"}）。`;
-    }
-    return `offset ${offset} 超出范围（共 ${total} 条）。`;
-  }
-
   const entries: StageListingEntry[] = page.map((e) => {
     const typeRaw = e.stageType ?? "";
     const zoneId = e.zoneId ?? "";
@@ -297,6 +287,16 @@ export function buildStagesListing(
 }
 
 export function renderStagesListing(data: StagesListingPayload): string {
+  if (data.stages.length === 0) {
+    if (data.total === 0) {
+      const filters: string[] = [];
+      if (data.filters.chapter) filters.push(`zoneId=${data.filters.chapter}`);
+      if (data.filters.type) filters.push(`stageType=${data.filters.type}`);
+      return `没有匹配的关卡（filter: ${filters.join(", ") || "none"}）。`;
+    }
+    return `offset ${data.offset} 超出范围（共 ${data.total} 条）。`;
+  }
+
   const lines = [`# 关卡列表（共 ${data.total} 个）`];
   for (const s of data.stages) {
     lines.push(

--- a/ts/src/data/stage.ts
+++ b/ts/src/data/stage.ts
@@ -40,6 +40,28 @@ interface StageSearchRecord {
   searchText: string;
 }
 
+export interface StageListingEntry {
+  stage_id: string;
+  name: string;
+  code: string;
+  type: string;
+  type_label: string;
+  difficulty_label: string;
+  zone_id: string;
+  zone_display: string;
+}
+
+export interface StagesListingPayload extends Record<string, unknown> {
+  total: number;
+  offset: number;
+  limit: number;
+  filters: {
+    chapter: string | null;
+    type: string | null;
+  };
+  stages: StageListingEntry[];
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -201,7 +223,19 @@ export function listStages(
   limit: number = 50,
   offset: number = 0,
 ): string {
+  const data = buildStagesListing(chapter, type, limit, offset);
+  if (typeof data === "string") return data;
+  return renderStagesListing(data);
+}
+
+export function buildStagesListing(
+  chapter?: string | null,
+  type?: string | null,
+  limit: number = 50,
+  offset: number = 0,
+): StagesListingPayload | string {
   if (limit < 1) return "limit 必须 >= 1。";
+  if (limit > 200) return "limit 必须 <= 200。";
   if (offset < 0) return "offset 必须 >= 0。";
   if (type != null && !(type.toUpperCase() in STAGE_TYPE_LABELS)) {
     const allowed = Object.keys(STAGE_TYPE_LABELS).join("、");
@@ -219,7 +253,7 @@ export function listStages(
   for (const [sid, entry] of Object.entries(stages).sort(([a], [b]) => a.localeCompare(b))) {
     if (chapter != null && entry.zoneId !== chapter) continue;
     if (type != null && entry.stageType !== type.toUpperCase()) continue;
-    filtered.push(entry);
+    filtered.push({ ...entry, stageId: entry.stageId ?? sid });
   }
 
   const total = filtered.length;
@@ -235,17 +269,43 @@ export function listStages(
     return `offset ${offset} 超出范围（共 ${total} 条）。`;
   }
 
-  const lines = [`# 关卡列表（共 ${total} 个）`];
-  for (const e of page) {
-    const tLabel = stageTypeLabel(e.stageType ?? "");
-    const dLabel = difficultyLabel(e.difficulty ?? "");
-    const zd = zoneDisplay(e.zoneId ?? "");
-    const name = e.name || "（无名）";
-    const code = e.code || "?";
-    const sid = e.stageId ?? "";
-    lines.push(`- **${name}** [${tLabel}] ${code} — ${dLabel} — ${zd}（id: ${sid}）`);
+  const entries: StageListingEntry[] = page.map((e) => {
+    const typeRaw = e.stageType ?? "";
+    const zoneId = e.zoneId ?? "";
+    return {
+      stage_id: e.stageId ?? "",
+      name: e.name || "（无名）",
+      code: e.code || "?",
+      type: typeRaw,
+      type_label: stageTypeLabel(typeRaw),
+      difficulty_label: difficultyLabel(e.difficulty ?? ""),
+      zone_id: zoneId,
+      zone_display: zoneDisplay(zoneId),
+    };
+  });
+
+  return {
+    total,
+    offset,
+    limit,
+    filters: {
+      chapter: chapter ?? null,
+      type: type ? type.toUpperCase() : null,
+    },
+    stages: entries,
+  };
+}
+
+export function renderStagesListing(data: StagesListingPayload): string {
+  const lines = [`# 关卡列表（共 ${data.total} 个）`];
+  for (const s of data.stages) {
+    lines.push(
+      `- **${s.name}** [${s.type_label}] ${s.code} — ` +
+      `${s.difficulty_label} — ${s.zone_display}（id: ${s.stage_id}）`,
+    );
   }
 
+  const { offset, limit, total } = data;
   const start = offset + 1;
   const end = Math.min(offset + limit, total);
   lines.push(

--- a/ts/src/output.ts
+++ b/ts/src/output.ts
@@ -3,34 +3,37 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 export type OutputChannel = "content" | "structured" | "both";
 
 const VALID_CHANNELS = new Set<OutputChannel>(["content", "structured", "both"]);
+type StructuredContent = NonNullable<CallToolResult["structuredContent"]>;
 
 function text(markdown: string): CallToolResult["content"][number] {
   return { type: "text", text: markdown };
 }
 
-export function parseChannel(raw: string | undefined, source: string = "PRTS_OUTPUT_CHANNEL"): OutputChannel {
+export function parseChannel(
+  raw: string | undefined,
+  source: string = "PRTS_OUTPUT_CHANNEL",
+  warn: (message: string) => void = console.warn,
+): OutputChannel {
   if (!raw) return "content";
   const value = raw.trim().toLowerCase();
   if (VALID_CHANNELS.has(value as OutputChannel)) {
     return value as OutputChannel;
   }
-  console.warn(
-    `${source}=${JSON.stringify(raw)} 不合法（可选 content/structured/both），回退到 content。`,
-  );
+  warn(`${source}=${JSON.stringify(raw)} 不合法（可选 content/structured/both），回退到 content。`);
   return "content";
 }
 
-function summarize(data: Record<string, unknown>, summary?: string): string {
+function summarize<T extends object>(data: T, summary?: string): string {
   if (summary) return summary;
-  const total = data["total"];
+  const total = (data as { total?: unknown }).total;
   if (typeof total === "number" && Number.isInteger(total)) {
     return `（结构化结果共 ${total} 条，详见 structuredContent）`;
   }
   return "（结构化结果详见 structuredContent）";
 }
 
-export function renderResult(
-  data: Record<string, unknown> | null,
+export function renderResult<T extends object>(
+  data: T | null,
   markdown: string,
   channel: OutputChannel,
   summary?: string,
@@ -38,10 +41,11 @@ export function renderResult(
   if (data === null || channel === "content") {
     return { content: [text(markdown)] };
   }
+  const structuredContent = data as StructuredContent;
   if (channel === "both") {
-    return { content: [text(markdown)], structuredContent: data };
+    return { content: [text(markdown)], structuredContent };
   }
-  return { content: [text(summarize(data, summary))], structuredContent: data };
+  return { content: [text(summarize(data, summary))], structuredContent };
 }
 
 export function textResult(markdown: string): CallToolResult {

--- a/ts/src/output.ts
+++ b/ts/src/output.ts
@@ -1,0 +1,49 @@
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+export type OutputChannel = "content" | "structured" | "both";
+
+const VALID_CHANNELS = new Set<OutputChannel>(["content", "structured", "both"]);
+
+function text(markdown: string): CallToolResult["content"][number] {
+  return { type: "text", text: markdown };
+}
+
+export function parseChannel(raw: string | undefined): OutputChannel {
+  if (!raw) return "content";
+  const value = raw.trim().toLowerCase();
+  if (VALID_CHANNELS.has(value as OutputChannel)) {
+    return value as OutputChannel;
+  }
+  console.warn(
+    `PRTS_OUTPUT_CHANNEL=${JSON.stringify(raw)} 不合法（可选 content/structured/both），回退到 content。`,
+  );
+  return "content";
+}
+
+function summarize(data: Record<string, unknown>, summary?: string): string {
+  if (summary) return summary;
+  const total = data["total"];
+  if (typeof total === "number" && Number.isInteger(total)) {
+    return `（结构化结果共 ${total} 条，详见 structuredContent）`;
+  }
+  return "（结构化结果详见 structuredContent）";
+}
+
+export function renderResult(
+  data: Record<string, unknown> | null,
+  markdown: string,
+  channel: OutputChannel,
+  summary?: string,
+): CallToolResult {
+  if (data === null || channel === "content") {
+    return { content: [text(markdown)] };
+  }
+  if (channel === "both") {
+    return { content: [text(markdown)], structuredContent: data };
+  }
+  return { content: [text(summarize(data, summary))], structuredContent: data };
+}
+
+export function textResult(markdown: string): CallToolResult {
+  return { content: [text(markdown)] };
+}

--- a/ts/src/output.ts
+++ b/ts/src/output.ts
@@ -8,14 +8,14 @@ function text(markdown: string): CallToolResult["content"][number] {
   return { type: "text", text: markdown };
 }
 
-export function parseChannel(raw: string | undefined): OutputChannel {
+export function parseChannel(raw: string | undefined, source: string = "PRTS_OUTPUT_CHANNEL"): OutputChannel {
   if (!raw) return "content";
   const value = raw.trim().toLowerCase();
   if (VALID_CHANNELS.has(value as OutputChannel)) {
     return value as OutputChannel;
   }
   console.warn(
-    `PRTS_OUTPUT_CHANNEL=${JSON.stringify(raw)} 不合法（可选 content/structured/both），回退到 content。`,
+    `${source}=${JSON.stringify(raw)} 不合法（可选 content/structured/both），回退到 content。`,
   );
   return "content";
 }

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -63,9 +63,10 @@ function firstString(value: unknown): string | undefined {
 function resolveOutputChannel(req: express.Request): OutputChannel {
   const queryValue = firstString(req.query["output_channel"]);
   const headerValue = firstString(req.headers["x-prts-output-channel"]);
-  if (queryValue !== undefined) return parseChannel(queryValue, "output_channel");
-  if (headerValue !== undefined) return parseChannel(headerValue, "x-prts-output-channel");
-  return parseChannel(process.env["PRTS_OUTPUT_CHANNEL"], "PRTS_OUTPUT_CHANNEL");
+  const warn = (message: string) => log("WARN", message);
+  if (queryValue !== undefined) return parseChannel(queryValue, "output_channel", warn);
+  if (headerValue !== undefined) return parseChannel(headerValue, "x-prts-output-channel", warn);
+  return parseChannel(process.env["PRTS_OUTPUT_CHANNEL"], "PRTS_OUTPUT_CHANNEL", warn);
 }
 
 // ---------------------------------------------------------------------------

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -19,6 +19,7 @@ import { registerPrtsTools } from "./tools/prtsTools.js";
 import { registerGamedataTools } from "./tools/gamedataTools.js";
 import { registerStoryTools } from "./tools/storyTools.js";
 import { runStartupSync } from "./startupSync.js";
+import { parseChannel, type OutputChannel } from "./output.js";
 
 // ---------------------------------------------------------------------------
 // Logging + version
@@ -37,17 +38,32 @@ function log(level: "INFO" | "WARN" | "ERROR", msg: string): void {
 // MCP Server factory — one instance per session
 // ---------------------------------------------------------------------------
 
-function createMcpServer(): McpServer {
+function createMcpServer(channel: OutputChannel): McpServer {
   const server = new McpServer({
     name: "PRTS_Wiki_Assistant",
     version: SERVER_VERSION,
   });
 
-  registerPrtsTools(server);
-  registerGamedataTools(server);
-  registerStoryTools(server);
+  registerPrtsTools(server, channel);
+  registerGamedataTools(server, channel);
+  registerStoryTools(server, channel);
 
   return server;
+}
+
+function firstString(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    const first = value.find((item) => typeof item === "string");
+    return typeof first === "string" ? first : undefined;
+  }
+  return undefined;
+}
+
+function resolveOutputChannel(req: express.Request): OutputChannel {
+  const queryValue = firstString(req.query["output_channel"]);
+  const headerValue = firstString(req.headers["x-prts-output-channel"]);
+  return parseChannel(queryValue ?? headerValue ?? process.env["PRTS_OUTPUT_CHANNEL"]);
 }
 
 // ---------------------------------------------------------------------------
@@ -162,7 +178,8 @@ app.all("/mcp", async (req, res) => {
       }
     };
     try {
-      const server = createMcpServer();
+      const channel = resolveOutputChannel(req);
+      const server = createMcpServer(channel);
       await server.connect(newTransport);
     } catch (err) {
       log("ERROR", `Failed to connect MCP server to transport: ${err instanceof Error ? err.message : String(err)}`);

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -63,7 +63,9 @@ function firstString(value: unknown): string | undefined {
 function resolveOutputChannel(req: express.Request): OutputChannel {
   const queryValue = firstString(req.query["output_channel"]);
   const headerValue = firstString(req.headers["x-prts-output-channel"]);
-  return parseChannel(queryValue ?? headerValue ?? process.env["PRTS_OUTPUT_CHANNEL"]);
+  if (queryValue !== undefined) return parseChannel(queryValue, "output_channel");
+  if (headerValue !== undefined) return parseChannel(headerValue, "x-prts-output-channel");
+  return parseChannel(process.env["PRTS_OUTPUT_CHANNEL"], "PRTS_OUTPUT_CHANNEL");
 }
 
 // ---------------------------------------------------------------------------

--- a/ts/src/tools/gamedataTools.ts
+++ b/ts/src/tools/gamedataTools.ts
@@ -9,12 +9,13 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { getOperatorArchives, getOperatorVoicelines, getOperatorBasicInfo } from "../data/operator.js";
 import { listEnemies, getEnemyInfo, searchEnemies } from "../data/enemy.js";
-import { listStages, getStageInfo, searchStages } from "../data/stage.js";
+import { buildStagesListing, getStageInfo, renderStagesListing, searchStages } from "../data/stage.js";
 import { listItems, getItemInfo, searchItems } from "../data/item.js";
 import { getStageEnemies, getEnemyAppearances, getEnemyStageInfo } from "../data/stageEnemy.js";
 import { searchOperatorData } from "../data/search.js";
+import { renderResult, textResult, type OutputChannel } from "../output.js";
 
-export function registerGamedataTools(server: McpServer): void {
+export function registerGamedataTools(server: McpServer, channel: OutputChannel = "content"): void {
   server.tool(
     "get_operator_archives",
     [
@@ -137,9 +138,12 @@ export function registerGamedataTools(server: McpServer): void {
       limit: z.number().int().min(1).max(200).default(50).describe("返回数量上限，默认 50。"),
       offset: z.number().int().min(0).default(0).describe("分页偏移量，默认 0。"),
     },
-    ({ chapter, type, limit, offset }) => ({
-      content: [{ type: "text", text: listStages(chapter ?? null, type ?? null, limit, offset) }],
-    })
+    ({ chapter, type, limit, offset }) => {
+      const data = buildStagesListing(chapter ?? null, type ?? null, limit, offset);
+      if (typeof data === "string") return textResult(data);
+      const markdown = renderStagesListing(data);
+      return renderResult(data, markdown, channel);
+    }
   );
 
   server.tool(

--- a/ts/src/tools/prtsTools.ts
+++ b/ts/src/tools/prtsTools.ts
@@ -15,8 +15,9 @@ import {
   getLinks,
   getTemplateData,
 } from "../api/prtsWiki.js";
+import type { OutputChannel } from "../output.js";
 
-export function registerPrtsTools(server: McpServer): void {
+export function registerPrtsTools(server: McpServer, _channel: OutputChannel = "content"): void {
   server.tool(
     "search_prts",
     [

--- a/ts/src/tools/storyTools.ts
+++ b/ts/src/tools/storyTools.ts
@@ -23,6 +23,7 @@ import {
   type StoryChapter,
   type StoryLine,
 } from "../data/story.js";
+import type { OutputChannel } from "../output.js";
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -64,7 +65,7 @@ function formatChapter(chapter: StoryChapter): string {
 // Tool registration
 // ---------------------------------------------------------------------------
 
-export function registerStoryTools(server: McpServer): void {
+export function registerStoryTools(server: McpServer, _channel: OutputChannel = "content"): void {
   server.tool(
     "list_story_events",
     [

--- a/ts/tests/output.test.ts
+++ b/ts/tests/output.test.ts
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseChannel, renderResult, textResult } from "../src/output.js";
+
+test("parseChannel accepts valid channels", () => {
+  assert.equal(parseChannel(undefined), "content");
+  assert.equal(parseChannel(""), "content");
+  assert.equal(parseChannel("content"), "content");
+  assert.equal(parseChannel(" STRUCTURED "), "structured");
+  assert.equal(parseChannel("Both"), "both");
+});
+
+test("parseChannel falls back on invalid values", () => {
+  const warn = console.warn;
+  const messages: unknown[] = [];
+  console.warn = (message?: unknown) => { messages.push(message); };
+  try {
+    assert.equal(parseChannel("json"), "content");
+  } finally {
+    console.warn = warn;
+  }
+  assert.equal(messages.length, 1);
+});
+
+test("renderResult emits content-only markdown by default", () => {
+  const data = { total: 2, results: [{ id: "a" }] };
+  assert.deepStrictEqual(renderResult(data, "# markdown", "content"), {
+    content: [{ type: "text", text: "# markdown" }],
+  });
+});
+
+test("renderResult emits structured summary", () => {
+  const data = { total: 2, results: [{ id: "a" }] };
+  assert.deepStrictEqual(renderResult(data, "# markdown", "structured"), {
+    content: [{ type: "text", text: "（结构化结果共 2 条，详见 structuredContent）" }],
+    structuredContent: data,
+  });
+});
+
+test("renderResult supports both channels", () => {
+  const data = { total: 2, results: [{ id: "a" }] };
+  assert.deepStrictEqual(renderResult(data, "# markdown", "both"), {
+    content: [{ type: "text", text: "# markdown" }],
+    structuredContent: data,
+  });
+});
+
+test("renderResult keeps null data content-only", () => {
+  assert.deepStrictEqual(renderResult(null, "错误", "structured"), {
+    content: [{ type: "text", text: "错误" }],
+  });
+});
+
+test("textResult is always content-only", () => {
+  assert.deepStrictEqual(textResult("plain"), {
+    content: [{ type: "text", text: "plain" }],
+  });
+});

--- a/ts/tests/output.test.ts
+++ b/ts/tests/output.test.ts
@@ -11,16 +11,13 @@ test("parseChannel accepts valid channels", () => {
 });
 
 test("parseChannel falls back on invalid values", () => {
-  const warn = console.warn;
-  const messages: unknown[] = [];
-  console.warn = (message?: unknown) => { messages.push(message); };
-  try {
-    assert.equal(parseChannel("json", "output_channel"), "content");
-  } finally {
-    console.warn = warn;
-  }
+  const messages: string[] = [];
+  assert.equal(
+    parseChannel("json", "output_channel", (message) => { messages.push(message); }),
+    "content",
+  );
   assert.equal(messages.length, 1);
-  assert.match(String(messages[0]), /^output_channel="json" 不合法/);
+  assert.match(messages[0], /^output_channel="json" 不合法/);
 });
 
 test("renderResult emits content-only markdown by default", () => {

--- a/ts/tests/output.test.ts
+++ b/ts/tests/output.test.ts
@@ -15,11 +15,12 @@ test("parseChannel falls back on invalid values", () => {
   const messages: unknown[] = [];
   console.warn = (message?: unknown) => { messages.push(message); };
   try {
-    assert.equal(parseChannel("json"), "content");
+    assert.equal(parseChannel("json", "output_channel"), "content");
   } finally {
     console.warn = warn;
   }
   assert.equal(messages.length, 1);
+  assert.match(String(messages[0]), /^output_channel="json" 不合法/);
 });
 
 test("renderResult emits content-only markdown by default", () => {

--- a/ts/tests/serverOutputChannel.test.ts
+++ b/ts/tests/serverOutputChannel.test.ts
@@ -161,13 +161,18 @@ test("output_channel is resolved once per session by query/header/env priority",
       headers,
     );
 
-  const callListStages = (sessionId: string, query = "", headers: Record<string, string> = {}) =>
+  const callListStages = (
+    sessionId: string,
+    args: Record<string, unknown> = {},
+    query = "",
+    headers: Record<string, string> = {},
+  ) =>
     mcpPost(
       origin,
       {
         jsonrpc: "2.0",
         method: "tools/call",
-        params: { name: "list_stages", arguments: {} },
+        params: { name: "list_stages", arguments: args },
         id: id++,
       },
       sessionId,
@@ -227,6 +232,7 @@ test("output_channel is resolved once per session by query/header/env priority",
 
   const fixedResult = await callListStages(
     queryInit.sessionId,
+    {},
     "?output_channel=content",
     { "x-prts-output-channel": "content" },
   );
@@ -235,6 +241,20 @@ test("output_channel is resolved once per session by query/header/env priority",
   assert.equal(
     ((fixedToolResult.content as Array<{ text: string }>)[0]).text,
     "（结构化结果共 1 条，详见 structuredContent）",
+  );
+
+  const emptyResult = await callListStages(queryInit.sessionId, { chapter: "nonexistent" });
+  const emptyToolResult = emptyResult.body.result as Record<string, unknown>;
+  assert.deepStrictEqual(emptyToolResult.structuredContent, {
+    total: 0,
+    offset: 0,
+    limit: 50,
+    filters: { chapter: "nonexistent", type: null },
+    stages: [],
+  });
+  assert.equal(
+    ((emptyToolResult.content as Array<{ text: string }>)[0]).text,
+    "（结构化结果共 0 条，详见 structuredContent）",
   );
 
   const invalidInit = await initialize("?output_channel=nope");

--- a/ts/tests/serverOutputChannel.test.ts
+++ b/ts/tests/serverOutputChannel.test.ts
@@ -45,10 +45,12 @@ async function mcpPost(
   body: unknown,
   sessionId?: string,
   query = "",
+  extraHeaders: Record<string, string> = {},
 ): Promise<McpResponse> {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
     Accept: "application/json, text/event-stream",
+    ...extraHeaders,
   };
   if (sessionId) headers["Mcp-Session-Id"] = sessionId;
 
@@ -112,7 +114,7 @@ function writeGamedata(root: string): void {
   );
 }
 
-test("output_channel query fixes structured mode for the session", async (t) => {
+test("output_channel is resolved once per session by query/header/env priority", async (t) => {
   const port = await getFreePort();
   const origin = `http://127.0.0.1:${port}`;
   const gamedata = mkdtempSync(join(tmpdir(), "prts-output-channel-"));
@@ -131,6 +133,7 @@ test("output_channel query fixes structured mode for the session", async (t) => 
       XDG_DATA_HOME: dataHome,
       LOCALAPPDATA: localAppData,
       GITHUB_MIRRORS: "",
+      PRTS_OUTPUT_CHANNEL: "both",
       SESSION_IDLE_TIMEOUT_MS: "30000",
     },
     stdio: ["ignore", "pipe", "pipe"],
@@ -139,38 +142,67 @@ test("output_channel query fixes structured mode for the session", async (t) => 
 
   await waitForHealth(origin);
 
-  const init = await mcpPost(
-    origin,
-    {
-      jsonrpc: "2.0",
-      method: "initialize",
-      params: {
-        protocolVersion: "2025-03-26",
-        capabilities: {},
-        clientInfo: { name: "output-channel-test", version: "1.0" },
+  let id = 1;
+  const initialize = (query = "", headers: Record<string, string> = {}) =>
+    mcpPost(
+      origin,
+      {
+        jsonrpc: "2.0",
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "output-channel-test", version: "1.0" },
+        },
+        id: id++,
       },
-      id: 1,
-    },
-    undefined,
-    "?output_channel=structured",
+      undefined,
+      query,
+      headers,
+    );
+
+  const callListStages = (sessionId: string, query = "", headers: Record<string, string> = {}) =>
+    mcpPost(
+      origin,
+      {
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { name: "list_stages", arguments: {} },
+        id: id++,
+      },
+      sessionId,
+      query,
+      headers,
+    );
+
+  const envInit = await initialize();
+  assert.equal(envInit.status, 200);
+  assert.ok(envInit.sessionId);
+  const envResult = await callListStages(envInit.sessionId);
+  const envToolResult = envResult.body.result as Record<string, unknown>;
+  assert.ok(envToolResult.structuredContent);
+  assert.match(((envToolResult.content as Array<{ text: string }>)[0]).text, /^# 关卡列表/);
+
+  const headerInit = await initialize("", { "x-prts-output-channel": "structured" });
+  assert.equal(headerInit.status, 200);
+  assert.ok(headerInit.sessionId);
+  const headerResult = await callListStages(headerInit.sessionId);
+  const headerToolResult = headerResult.body.result as Record<string, unknown>;
+  assert.ok(headerToolResult.structuredContent);
+  assert.equal(
+    ((headerToolResult.content as Array<{ text: string }>)[0]).text,
+    "（结构化结果共 1 条，详见 structuredContent）",
   );
 
-  assert.equal(init.status, 200);
-  assert.ok(init.sessionId);
+  const queryInit = await initialize("?output_channel=structured", {
+    "x-prts-output-channel": "both",
+  });
+  assert.equal(queryInit.status, 200);
+  assert.ok(queryInit.sessionId);
 
-  const result = await mcpPost(
-    origin,
-    {
-      jsonrpc: "2.0",
-      method: "tools/call",
-      params: { name: "list_stages", arguments: {} },
-      id: 2,
-    },
-    init.sessionId!,
-  );
-
-  assert.equal(result.status, 200);
-  const toolResult = result.body.result as Record<string, unknown>;
+  const queryResult = await callListStages(queryInit.sessionId);
+  assert.equal(queryResult.status, 200);
+  const toolResult = queryResult.body.result as Record<string, unknown>;
   assert.deepStrictEqual(toolResult.structuredContent, {
     total: 1,
     offset: 0,
@@ -192,4 +224,24 @@ test("output_channel query fixes structured mode for the session", async (t) => 
 
   const content = toolResult.content as Array<{ text: string }>;
   assert.equal(content[0].text, "（结构化结果共 1 条，详见 structuredContent）");
+
+  const fixedResult = await callListStages(
+    queryInit.sessionId,
+    "?output_channel=content",
+    { "x-prts-output-channel": "content" },
+  );
+  const fixedToolResult = fixedResult.body.result as Record<string, unknown>;
+  assert.ok(fixedToolResult.structuredContent, "existing session should keep structured channel");
+  assert.equal(
+    ((fixedToolResult.content as Array<{ text: string }>)[0]).text,
+    "（结构化结果共 1 条，详见 structuredContent）",
+  );
+
+  const invalidInit = await initialize("?output_channel=nope");
+  assert.equal(invalidInit.status, 200);
+  assert.ok(invalidInit.sessionId);
+  const invalidResult = await callListStages(invalidInit.sessionId);
+  const invalidToolResult = invalidResult.body.result as Record<string, unknown>;
+  assert.equal(invalidToolResult.structuredContent, undefined);
+  assert.match(((invalidToolResult.content as Array<{ text: string }>)[0]).text, /^# 关卡列表/);
 });

--- a/ts/tests/serverOutputChannel.test.ts
+++ b/ts/tests/serverOutputChannel.test.ts
@@ -136,7 +136,7 @@ test("output_channel is resolved once per session by query/header/env priority",
       PRTS_OUTPUT_CHANNEL: "both",
       SESSION_IDLE_TIMEOUT_MS: "30000",
     },
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: ["ignore", "ignore", "ignore"],
   });
   t.after(() => { child.kill(); });
 

--- a/ts/tests/serverOutputChannel.test.ts
+++ b/ts/tests/serverOutputChannel.test.ts
@@ -1,0 +1,195 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      server.close(() => {
+        if (addr && typeof addr === "object") resolve(addr.port);
+        else reject(new Error("no port"));
+      });
+    });
+  });
+}
+
+async function waitForHealth(origin: string): Promise<void> {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${origin}/health`, { signal: AbortSignal.timeout(300) });
+      if (res.ok) return;
+    } catch {
+      // Retry until the child has finished booting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error("health check timeout");
+}
+
+interface McpResponse {
+  status: number;
+  body: Record<string, unknown>;
+  sessionId: string | null;
+}
+
+async function mcpPost(
+  origin: string,
+  body: unknown,
+  sessionId?: string,
+  query = "",
+): Promise<McpResponse> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+  if (sessionId) headers["Mcp-Session-Id"] = sessionId;
+
+  const res = await fetch(`${origin}/mcp${query}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  const raw = await res.text();
+  const sseMatch = raw.match(/^data:\s*(\{[\s\S]*\})/m);
+  const parsed = JSON.parse(sseMatch ? sseMatch[1] : raw) as Record<string, unknown>;
+  return {
+    status: res.status,
+    body: parsed,
+    sessionId: res.headers.get("mcp-session-id"),
+  };
+}
+
+function writeGamedata(root: string): void {
+  const excel = join(root, "zh_CN", "gamedata", "excel");
+  mkdirSync(excel, { recursive: true });
+
+  for (const file of [
+    "character_table.json",
+    "handbook_info_table.json",
+    "charword_table.json",
+    "story_review_table.json",
+  ]) {
+    writeFileSync(join(excel, file), "{}", "utf-8");
+  }
+
+  writeFileSync(
+    join(excel, "stage_table.json"),
+    JSON.stringify({
+      stages: {
+        "main_00-01": {
+          stageId: "main_00-01",
+          code: "0-1",
+          name: "坍塌",
+          stageType: "MAIN",
+          difficulty: "NORMAL",
+          zoneId: "main_0",
+        },
+      },
+    }),
+    "utf-8",
+  );
+  writeFileSync(
+    join(excel, "zone_table.json"),
+    JSON.stringify({
+      zones: {
+        main_0: {
+          zoneID: "main_0",
+          zoneNameFirst: "序章",
+          zoneNameSecond: "黑暗时代·上",
+        },
+      },
+    }),
+    "utf-8",
+  );
+}
+
+test("output_channel query fixes structured mode for the session", async (t) => {
+  const port = await getFreePort();
+  const origin = `http://127.0.0.1:${port}`;
+  const gamedata = mkdtempSync(join(tmpdir(), "prts-output-channel-"));
+  const dataHome = mkdtempSync(join(tmpdir(), "prts-output-home-"));
+  const localAppData = join(dataHome, "LocalAppData");
+  mkdirSync(localAppData, { recursive: true });
+  writeGamedata(gamedata);
+
+  const child = spawn(process.execPath, ["--import", "tsx", "src/server.ts"], {
+    cwd: join(import.meta.dirname, ".."),
+    env: {
+      ...process.env,
+      PORT: String(port),
+      HOST: "127.0.0.1",
+      GAMEDATA_PATH: gamedata,
+      XDG_DATA_HOME: dataHome,
+      LOCALAPPDATA: localAppData,
+      GITHUB_MIRRORS: "",
+      SESSION_IDLE_TIMEOUT_MS: "30000",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  t.after(() => { child.kill(); });
+
+  await waitForHealth(origin);
+
+  const init = await mcpPost(
+    origin,
+    {
+      jsonrpc: "2.0",
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "output-channel-test", version: "1.0" },
+      },
+      id: 1,
+    },
+    undefined,
+    "?output_channel=structured",
+  );
+
+  assert.equal(init.status, 200);
+  assert.ok(init.sessionId);
+
+  const result = await mcpPost(
+    origin,
+    {
+      jsonrpc: "2.0",
+      method: "tools/call",
+      params: { name: "list_stages", arguments: {} },
+      id: 2,
+    },
+    init.sessionId!,
+  );
+
+  assert.equal(result.status, 200);
+  const toolResult = result.body.result as Record<string, unknown>;
+  assert.deepStrictEqual(toolResult.structuredContent, {
+    total: 1,
+    offset: 0,
+    limit: 50,
+    filters: { chapter: null, type: null },
+    stages: [
+      {
+        stage_id: "main_00-01",
+        name: "坍塌",
+        code: "0-1",
+        type: "MAIN",
+        type_label: "主线",
+        difficulty_label: "普通",
+        zone_id: "main_0",
+        zone_display: "序章-黑暗时代·上",
+      },
+    ],
+  });
+
+  const content = toolResult.content as Array<{ text: string }>;
+  assert.equal(content[0].text, "（结构化结果共 1 条，详见 structuredContent）");
+});

--- a/ts/tests/stage.test.ts
+++ b/ts/tests/stage.test.ts
@@ -291,14 +291,23 @@ test("buildStagesListing page payload matches shared parity fixture", async () =
   assert.deepStrictEqual(data, loadParityFixture("list_stages_page.json"));
 });
 
-test("renderStagesListing preserves listStages markdown", async () => {
+test("listStages preserves default markdown golden", async () => {
   const root = tempGamedataRoot();
   process.env["GAMEDATA_PATH"] = root;
   writeFixtures(root);
   const stage = await loadStageModule();
-  const data = stage.buildStagesListing();
-  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
-  assert.equal(stage.renderStagesListing(data), stage.listStages());
+  assert.equal(
+    stage.listStages(),
+    [
+      "# 关卡列表（共 4 个）",
+      "- **测试活动关** [活动] AS-1 — 普通 — 火山旅梦（id: act31side_01）",
+      "- **货物运送** [每日] CE-5 — 普通 — daily_zone1（id: daily_01）",
+      "- **坍塌** [主线] 0-1 — 普通 — 序章-黑暗时代·上（id: main_00-01）",
+      "- **坍塌·突袭** [主线] TR-1 — 突袭 — 序章-黑暗时代·上（id: main_00-01#f#）",
+      "",
+      "（显示第 1–4 条，共 4 条。使用 offset=50 查看下一页）",
+    ].join("\n"),
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/ts/tests/stage.test.ts
+++ b/ts/tests/stage.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -142,6 +142,12 @@ function writeFixtures(root: string): void {
   );
 }
 
+function loadParityFixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(join(import.meta.dirname, "..", "..", "tests", "parity-fixtures", name), "utf-8"),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // listStages
 // ---------------------------------------------------------------------------
@@ -247,6 +253,34 @@ test("listStages invalid limit", async () => {
   const stage = await loadStageModule();
   const out = stage.listStages(null, null, 0);
   assert.match(out, /limit 必须 >= 1/);
+});
+
+test("listStages max limit", async () => {
+  const root = tempGamedataRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  writeFixtures(root);
+  const stage = await loadStageModule();
+  const out = stage.listStages(null, null, 201);
+  assert.match(out, /limit 必须 <= 200/);
+});
+
+test("buildStagesListing matches shared parity fixture", async () => {
+  const root = tempGamedataRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  writeFixtures(root);
+  const stage = await loadStageModule();
+  const data = stage.buildStagesListing();
+  assert.deepStrictEqual(data, loadParityFixture("list_stages.json"));
+});
+
+test("renderStagesListing preserves listStages markdown", async () => {
+  const root = tempGamedataRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  writeFixtures(root);
+  const stage = await loadStageModule();
+  const data = stage.buildStagesListing();
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  assert.equal(stage.renderStagesListing(data), stage.listStages());
 });
 
 // ---------------------------------------------------------------------------

--- a/ts/tests/stage.test.ts
+++ b/ts/tests/stage.test.ts
@@ -273,6 +273,24 @@ test("buildStagesListing matches shared parity fixture", async () => {
   assert.deepStrictEqual(data, loadParityFixture("list_stages.json"));
 });
 
+test("buildStagesListing filtered payload matches shared parity fixture", async () => {
+  const root = tempGamedataRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  writeFixtures(root);
+  const stage = await loadStageModule();
+  const data = stage.buildStagesListing(null, "daily");
+  assert.deepStrictEqual(data, loadParityFixture("list_stages_daily.json"));
+});
+
+test("buildStagesListing page payload matches shared parity fixture", async () => {
+  const root = tempGamedataRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  writeFixtures(root);
+  const stage = await loadStageModule();
+  const data = stage.buildStagesListing(null, null, 2);
+  assert.deepStrictEqual(data, loadParityFixture("list_stages_page.json"));
+});
+
 test("renderStagesListing preserves listStages markdown", async () => {
   const root = tempGamedataRoot();
   process.env["GAMEDATA_PATH"] = root;

--- a/ts/tests/stage.test.ts
+++ b/ts/tests/stage.test.ts
@@ -291,6 +291,32 @@ test("buildStagesListing page payload matches shared parity fixture", async () =
   assert.deepStrictEqual(data, loadParityFixture("list_stages_page.json"));
 });
 
+test("buildStagesListing empty payload matches shared parity fixture", async () => {
+  const root = tempGamedataRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  writeFixtures(root);
+  const stage = await loadStageModule();
+  const data = stage.buildStagesListing("nonexistent");
+  assert.deepStrictEqual(data, loadParityFixture("list_stages_empty.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  const expected = "没有匹配的关卡（filter: zoneId=nonexistent）。";
+  assert.equal(stage.renderStagesListing(data), expected);
+  assert.equal(stage.listStages("nonexistent"), expected);
+});
+
+test("buildStagesListing offset empty payload matches shared parity fixture", async () => {
+  const root = tempGamedataRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  writeFixtures(root);
+  const stage = await loadStageModule();
+  const data = stage.buildStagesListing(null, null, 50, 100);
+  assert.deepStrictEqual(data, loadParityFixture("list_stages_offset_empty.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  const expected = "offset 100 超出范围（共 4 条）。";
+  assert.equal(stage.renderStagesListing(data), expected);
+  assert.equal(stage.listStages(null, null, 50, 100), expected);
+});
+
 test("listStages preserves default markdown golden", async () => {
   const root = tempGamedataRoot();
   process.env["GAMEDATA_PATH"] = root;


### PR DESCRIPTION
## Summary

- add TS output-channel helpers and session-level resolution from query/header/env
- split TS `list_stages` into build/render and wire it through `structuredContent` for structured/both channels
- align the Python + TS `list_stages` pilot with the structured-empty contract for legal empty pages (filter no-match / offset past end)
- add shared `list_stages` parity fixtures, including default, filtered, paginated, and empty-page payloads
- cover output helper behavior and session-level `?output_channel=structured` over HTTP

## Test plan

- `npm.cmd test -- tests/stage.test.ts tests/output.test.ts tests/serverOutputChannel.test.ts`
- `$env:PYTHONPATH='F:\2026-Spring\PRTS-MCP\python\src'; & 'E:\Anaconda3\envs\python311\python.exe' -m pytest python\tests\test_stage.py -q`
- `npm.cmd run typecheck`
- `git diff --check`
- `.\scripts\check-runtime.ps1 -Full`

## Python-side note

This PR intentionally touches Python `list_stages` even though it is the TS PR1. The rework checklist settled the shared rule that legal empty results should return structured empty payloads while keeping rendered markdown unchanged. Updating the Python pilot here makes the shared parity fixtures the correct truth source before TS PR2/PR3 copy the pattern.

## 未尽事宜

- Python empty-result alignment for the remaining list/navigation tools should happen in a separate follow-up PR.
- TS PR2 will migrate the remaining structured game-data/story tools.
- TS PR3 will migrate search tools and add full structured/content-only invariants.