### PR TITLE
feat(ts): migrate structured data output tools

### DIFF
--- a/python/tests/test_enemy.py
+++ b/python/tests/test_enemy.py
@@ -9,15 +9,22 @@ from unittest.mock import patch
 import pytest
 
 from prts_mcp.data.enemy import (
+    build_enemy_info,
     build_enemy_search,
     build_enemies_listing,
     clear_enemy_caches,
     list_enemies,
     get_enemy_info,
+    render_enemy_info,
     render_enemy_search,
     search_enemies,
 )
 from prts_mcp.output import render_result
+
+
+def _load_parity_fixture(name: str) -> dict:
+    path = Path(__file__).parents[2] / "tests" / "parity-fixtures" / name
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def _write_handbook(excel: Path) -> None:
@@ -150,6 +157,7 @@ class TestListEnemies:
             "- **源石虫** [普通] (B1) — 野生的被感染生物。\n"
             "- **霜星** [领袖] (FN) — 整合运动法术部队干部。"
         )
+        assert build_enemies_listing() == _load_parity_fixture("list_enemies.json")
 
     def test_golden_boss_filter(self, gamedata):
         assert list_enemies(threat_level="boss") == (
@@ -162,7 +170,7 @@ class TestListEnemies:
         # legitimate-but-empty structured payload, not a content-only error.
         # Content stays byte-for-byte (the original header + out-of-range msg).
         data = build_enemies_listing(offset=999)
-        assert isinstance(data, dict)
+        assert data == _load_parity_fixture("list_enemies_offset_empty.json")
         assert data["enemies"] == []
         assert data["empty_reason"] == "offset_out_of_range"
         assert list_enemies(offset=999) == (
@@ -232,6 +240,9 @@ class TestGetEnemyInfo:
         out = get_enemy_info("源石虫")
         assert "源石虫" in out
         assert "**最大生命**" not in out
+        data = build_enemy_info("源石虫")
+        assert data == _load_parity_fixture("enemy_info.json")
+        assert render_enemy_info(data) == out
 
     def test_unknown_name(self, gamedata):
         assert "未找到敌人" in get_enemy_info("不存在的敌人")

--- a/python/tests/test_enemy.py
+++ b/python/tests/test_enemy.py
@@ -229,6 +229,9 @@ class TestGetEnemyInfo:
         # Skills
         assert "ArcticBlast" in out
         assert "duration=8.0" in out
+        data = build_enemy_info("霜星")
+        assert data == _load_parity_fixture("enemy_info_with_stats.json")
+        assert render_enemy_info(data) == out
 
     def test_reads_database_from_sibling_levels_path(self, split_levels_gamedata):
         out = get_enemy_info("霜星")

--- a/python/tests/test_item.py
+++ b/python/tests/test_item.py
@@ -8,16 +8,24 @@ from pathlib import Path
 import pytest
 
 from prts_mcp.data.item import (
+    build_item_info,
     build_item_search,
     build_items_listing,
     clear_item_caches,
     get_item_info,
     get_item_name_by_id,
     list_items,
+    render_item_info,
     render_item_search,
+    render_items_listing,
     search_items,
 )
 from prts_mcp.output import render_result
+
+
+def _load_parity_fixture(name: str) -> dict:
+    path = Path(__file__).parents[2] / "tests" / "parity-fixtures" / name
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def _write_sentinels(excel: Path) -> None:
@@ -125,6 +133,7 @@ def test_list_items_golden_default(gamedata: str) -> None:
         "\n"
         "（显示第 1–2 条，共 2 条。使用 offset=50 查看下一页）"
     )
+    assert build_items_listing() == _load_parity_fixture("list_items.json")
 
 
 def test_list_items_golden_category_filter(gamedata: str) -> None:
@@ -142,12 +151,10 @@ def test_list_items_empty_match_is_structured_not_error(gamedata: str) -> None:
     # NOT a content-only error — structured consumers can rely on it. The
     # content channel still emits the original "没有匹配" message verbatim.
     data = build_items_listing(category="NONEXISTENT")
-    assert isinstance(data, dict)
-    assert data["total"] == 0
-    assert data["items"] == []
-    assert data["empty_reason"] == "no_match"
+    assert data == _load_parity_fixture("list_items_empty.json")
     # content stays byte-for-byte (the original message)
     assert list_items(category="NONEXISTENT") == "没有匹配的物品（category=NONEXISTENT）。"
+    assert render_items_listing(data) == "没有匹配的物品（category=NONEXISTENT）。"
     # structured channel carries the empty payload
     r = render_result(data, list_items(category="NONEXISTENT"), channel="structured")
     assert r.structuredContent == data
@@ -176,6 +183,9 @@ def test_get_item_info_golden(gamedata: str) -> None:
         "- main_00-01（固定）\n"
         "- main_00-02（小概率）"
     )
+    data = build_item_info("源岩")
+    assert data == _load_parity_fixture("item_info.json")
+    assert render_item_info(data) == get_item_info("源岩")
 
 
 def test_get_item_info_by_id(gamedata: str) -> None:

--- a/python/tests/test_item.py
+++ b/python/tests/test_item.py
@@ -195,6 +195,14 @@ def test_get_item_info_by_id(gamedata: str) -> None:
     assert "shopId=credit" in out
 
 
+def test_get_item_info_missing_optional_lists_are_null(gamedata: str) -> None:
+    data = build_item_info("隐藏物品")
+    assert isinstance(data, dict)
+    assert data["building_product_list"] is None
+    assert data["shop_relate_list"] is None
+    assert data["voucher_relate_list"] is None
+
+
 def test_get_item_name_by_id(gamedata: str) -> None:
     assert get_item_name_by_id("30011") == "源岩"
     assert get_item_name_by_id("missing") is None

--- a/python/tests/test_operator_data.py
+++ b/python/tests/test_operator_data.py
@@ -1,11 +1,14 @@
 """Tests for operator data loading against changing local game data."""
 from __future__ import annotations
 
+import json
 import os
+from pathlib import Path
 from unittest.mock import patch
 
 from prts_mcp.data import operator
 from prts_mcp.data.operator import (
+    build_operator_basic_info,
     clear_operator_caches,
     get_operator_archives,
     get_operator_basic_info,
@@ -13,6 +16,11 @@ from prts_mcp.data.operator import (
 )
 
 from tests.fixtures import write_minimal_gamedata
+
+
+def _load_parity_fixture(name: str) -> dict:
+    path = Path(__file__).parents[2] / "tests" / "parity-fixtures" / name
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def setup_function() -> None:
@@ -71,6 +79,9 @@ class TestOperatorDataRefresh:
                 "\n"
                 "## 天赋\n"
                 "- **情绪吸收**：攻击回复技力"
+            )
+            assert build_operator_basic_info("阿米娅") == _load_parity_fixture(
+                "operator_basic_info.json"
             )
 
     def test_table_caches_can_be_cleared_explicitly(self, tmp_path):

--- a/python/tests/test_stage.py
+++ b/python/tests/test_stage.py
@@ -92,7 +92,6 @@ def _make_fixture(root: Path) -> None:
             "apCost": 12,
             "dangerLevel": "NORMAL",
             "description": "",
-            "stageDropInfo": {"displayRewards": []},
             "unlockCondition": [
                 {"stageId": "act31side_02", "completeState": "PASS"},
             ],
@@ -386,6 +385,9 @@ class TestGetStageInfo:
     def test_empty_drops(self, gamedata: str) -> None:
         out = get_stage_info("act31side_01")
         assert "（无）" in out
+        data = build_stage_info("act31side_01")
+        assert isinstance(data, dict)
+        assert data["drop_info"] is None
 
     def test_multi_drops(self, gamedata: str) -> None:
         out = get_stage_info("daily_01")

--- a/python/tests/test_stage.py
+++ b/python/tests/test_stage.py
@@ -8,11 +8,13 @@ from pathlib import Path
 import pytest
 
 from prts_mcp.data.stage import (
+    build_stage_info,
     build_stage_search,
     build_stages_listing,
     clear_stage_caches,
     list_stages,
     get_stage_info,
+    render_stage_info,
     render_stages_listing,
     render_stage_search,
     search_stages,
@@ -356,6 +358,9 @@ class TestGetStageInfo:
             "## 关联关卡\n"
             "- 突袭模式：main_00-01#f#（坍塌·突袭）"
         )
+        data = build_stage_info("main_00-01")
+        assert data == _load_parity_fixture("stage_info.json")
+        assert render_stage_info(data) == get_stage_info("main_00-01")
 
     def test_four_star_variant(self, gamedata: str) -> None:
         out = get_stage_info("main_00-01#f#")

--- a/python/tests/test_stage_enemy.py
+++ b/python/tests/test_stage_enemy.py
@@ -8,11 +8,20 @@ from unittest.mock import patch
 import pytest
 
 from prts_mcp.data.stage_enemy import (
+    build_enemy_appearances,
+    build_stage_enemies,
     clear_stage_enemy_caches,
     get_enemy_appearances,
     get_enemy_stage_info,
     get_stage_enemies,
+    render_enemy_appearances,
+    render_stage_enemies,
 )
+
+
+def _load_parity_fixture(name: str) -> dict:
+    path = Path(__file__).parents[2] / "tests" / "parity-fixtures" / name
+    return json.loads(path.read_text(encoding="utf-8"))
 
 
 def _write_fixture(root: Path) -> None:
@@ -196,6 +205,9 @@ def test_get_stage_enemies_golden(gamedata: Path) -> None:
         "- **关卡覆盖**：是\n"
         "- **战斗属性**：HP 1,234；ATK 321；DEF 45；RES 10"
     )
+    data = build_stage_enemies("main_00-01")
+    assert data == _load_parity_fixture("stage_enemies.json")
+    assert render_stage_enemies(data) == get_stage_enemies("main_00-01")
 
 
 def test_get_enemy_appearances_golden(gamedata: Path) -> None:
@@ -206,6 +218,17 @@ def test_get_enemy_appearances_golden(gamedata: Path) -> None:
         "- **坍塌** 0-1（main_00-01）：6 个\n"
         "\n"
         "（显示第 1–1 条，共 1 条。使用 offset=50 查看下一页）"
+    )
+    data = build_enemy_appearances("源石虫")
+    assert data == _load_parity_fixture("enemy_appearances.json")
+    assert render_enemy_appearances(data) == get_enemy_appearances("源石虫")
+
+
+def test_get_enemy_appearances_empty_is_structured(gamedata: Path) -> None:
+    data = build_enemy_appearances("未出场敌人")
+    assert data == _load_parity_fixture("enemy_appearances_empty.json")
+    assert render_enemy_appearances(data) == (
+        "未找到 未出场敌人（enemy_unused）的实际出场关卡。"
     )
 
 

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -45,6 +45,11 @@ def _story_path(story_key: str) -> str:
     return f"zh_CN/gamedata/story/{story_key}.json"
 
 
+def _load_parity_fixture(name: str) -> dict:
+    path = Path(__file__).parents[2] / "tests" / "parity-fixtures" / name
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def _story_files() -> dict[str, object]:
     return {
         STORY_REVIEW_PATH: {
@@ -198,6 +203,7 @@ def story_zip(tmp_path: Path) -> Path:
 def test_list_story_events_golden_and_empty(story_zip: Path) -> None:
     data = build_story_events_listing(story_zip, category="activities")
 
+    assert data == _load_parity_fixture("story_events_activities.json")
     assert data["total"] == 4
     assert data["filters"] == {
         "category": "activities",
@@ -211,6 +217,7 @@ def test_list_story_events_golden_and_empty(story_zip: Path) -> None:
     )
 
     empty = build_story_events_listing(story_zip, category="main")
+    assert empty == _load_parity_fixture("story_events_empty.json")
     assert empty["total"] == 0
     assert empty["events"] == []
     assert render_story_events_listing(empty) == "未找到符合条件的活动（category='main'）。"
@@ -219,6 +226,7 @@ def test_list_story_events_golden_and_empty(story_zip: Path) -> None:
 def test_list_stories_without_summaries_golden(story_zip: Path) -> None:
     data = build_stories_listing(story_zip, "act_test", include_summaries=False)
 
+    assert data == _load_parity_fixture("list_stories.json")
     assert data == {
         "event_id": "act_test",
         "total": 2,
@@ -247,6 +255,7 @@ def test_list_stories_without_summaries_golden(story_zip: Path) -> None:
 def test_list_stories_with_summaries_golden(story_zip: Path) -> None:
     data = build_stories_listing(story_zip, "act_test", include_summaries=True)
 
+    assert data == _load_parity_fixture("list_stories_with_summaries.json")
     assert data["event_summary"] == "活动总览"
     assert data["chapters"][0]["summary"] == "第一章梗概"
     assert render_stories_listing(data) == (
@@ -261,6 +270,7 @@ def test_list_stories_with_summaries_golden(story_zip: Path) -> None:
 def test_list_stories_with_summaries_but_no_event_summary(story_zip: Path) -> None:
     data = build_stories_listing(story_zip, "act_no_summary", include_summaries=True)
 
+    assert data == _load_parity_fixture("list_stories_no_summary.json")
     assert "event_summary" not in data
     assert data["chapters"][1]["summary"] == ""
     assert render_stories_listing(data) == (
@@ -273,6 +283,7 @@ def test_list_stories_with_summaries_but_no_event_summary(story_zip: Path) -> No
 def test_list_stories_empty_event_is_structured_empty(story_zip: Path) -> None:
     data = build_stories_listing(story_zip, "act_empty")
 
+    assert data == _load_parity_fixture("list_stories_empty_event.json")
     assert data["total"] == 0
     assert data["chapters"] == []
     assert render_stories_listing(data) == "活动 'act_empty' 暂无剧情章节。"
@@ -281,6 +292,7 @@ def test_list_stories_empty_event_is_structured_empty(story_zip: Path) -> None:
 def test_get_operator_memoirs_golden(story_zip: Path) -> None:
     data = build_operator_memoirs(story_zip, "阿米娅")
 
+    assert data == _load_parity_fixture("operator_memoirs.json")
     assert data == {
         "operator_name": "阿米娅",
         "internal_code": "amiya",
@@ -304,6 +316,7 @@ def test_get_operator_memoirs_golden(story_zip: Path) -> None:
 def test_find_character_appearances_golden_and_empty(story_zip: Path) -> None:
     data = build_character_appearances(story_zip, "博士")
 
+    assert data == _load_parity_fixture("character_appearances.json")
     assert data["total"] == 2
     assert data["appearances"][0]["speaks"] is True
     assert data["appearances"][0]["mentioned"] is True
@@ -314,6 +327,7 @@ def test_find_character_appearances_golden_and_empty(story_zip: Path) -> None:
     )
 
     empty = build_character_appearances(story_zip, "不存在", scope="act_test")
+    assert empty == _load_parity_fixture("character_appearances_empty.json")
     assert empty["total"] == 0
     assert empty["appearances"] == []
     assert render_character_appearances(empty) == (
@@ -324,6 +338,7 @@ def test_find_character_appearances_golden_and_empty(story_zip: Path) -> None:
 def test_find_speakers_in_golden_and_empty(story_zip: Path) -> None:
     data = build_speakers_in_event(story_zip, "act_test")
 
+    assert data == _load_parity_fixture("speakers_in_event.json")
     assert data == {
         "event_id": "act_test",
         "total": 2,
@@ -339,6 +354,7 @@ def test_find_speakers_in_golden_and_empty(story_zip: Path) -> None:
     )
 
     empty = build_speakers_in_event(story_zip, "act_narration")
+    assert empty == _load_parity_fixture("speakers_in_event_empty.json")
     assert empty["total"] == 0
     assert empty["speakers"] == []
     assert render_speakers_in_event(empty) == "活动 'act_narration' 暂无对话发言者数据。"

--- a/tests/parity-fixtures/character_appearances.json
+++ b/tests/parity-fixtures/character_appearances.json
@@ -1,0 +1,25 @@
+{
+  "name": "博士",
+  "total": 2,
+  "filters": {
+    "scope": null
+  },
+  "appearances": [
+    {
+      "event_id": "act_test",
+      "story_code": "TEST-1",
+      "story_name": "开端",
+      "story_key": "activities/act_test/level_act_test_01_beg",
+      "speaks": true,
+      "mentioned": true
+    },
+    {
+      "event_id": "act_test",
+      "story_code": "TEST-2",
+      "story_name": "终章",
+      "story_key": "activities/act_test/level_act_test_02_end",
+      "speaks": true,
+      "mentioned": false
+    }
+  ]
+}

--- a/tests/parity-fixtures/character_appearances_empty.json
+++ b/tests/parity-fixtures/character_appearances_empty.json
@@ -1,0 +1,8 @@
+{
+  "name": "不存在",
+  "total": 0,
+  "filters": {
+    "scope": "act_test"
+  },
+  "appearances": []
+}

--- a/tests/parity-fixtures/enemy_appearances.json
+++ b/tests/parity-fixtures/enemy_appearances.json
@@ -1,0 +1,15 @@
+{
+  "enemy_id": "enemy_1007_slime",
+  "enemy_name": "源石虫",
+  "total": 1,
+  "offset": 0,
+  "limit": 50,
+  "stages": [
+    {
+      "stage_id": "main_00-01",
+      "stage_name": "坍塌",
+      "code": "0-1",
+      "count": 6
+    }
+  ]
+}

--- a/tests/parity-fixtures/enemy_appearances_empty.json
+++ b/tests/parity-fixtures/enemy_appearances_empty.json
@@ -1,0 +1,9 @@
+{
+  "enemy_id": "enemy_unused",
+  "enemy_name": "未出场敌人",
+  "total": 0,
+  "offset": 0,
+  "limit": 50,
+  "stages": [],
+  "empty_reason": "no_match"
+}

--- a/tests/parity-fixtures/enemy_info.json
+++ b/tests/parity-fixtures/enemy_info.json
@@ -1,0 +1,17 @@
+{
+  "name": "源石虫",
+  "enemy_id": "enemy_1004_mslime",
+  "enemy_index": "B1",
+  "level_raw": "NORMAL",
+  "level_label": "普通",
+  "description": "野生的被感染生物。",
+  "attack_type": "",
+  "ability": "",
+  "damage_types_raw": [
+    "PHYSIC",
+    "MAGIC"
+  ],
+  "damage_types_label": "物理、法术",
+  "enemy_tags": [],
+  "stats": null
+}

--- a/tests/parity-fixtures/enemy_info_with_stats.json
+++ b/tests/parity-fixtures/enemy_info_with_stats.json
@@ -1,0 +1,38 @@
+{
+  "name": "霜星",
+  "enemy_id": "enemy_1505_frstar",
+  "enemy_index": "FN",
+  "level_raw": "BOSS",
+  "level_label": "领袖",
+  "description": "整合运动法术部队干部。",
+  "attack_type": "",
+  "ability": "",
+  "damage_types_raw": [
+    "MAGIC"
+  ],
+  "damage_types_label": "法术",
+  "enemy_tags": [],
+  "stats": {
+    "max_hp": "25,000",
+    "atk": "420",
+    "def": "250",
+    "resistance": "50.0",
+    "move_speed": "0.5",
+    "attack_interval": "3.7s",
+    "attack_speed": null,
+    "mass_level": null,
+    "hp_recovery_per_sec": null,
+    "immunities": [
+      "眩晕",
+      "冻结"
+    ],
+    "life_point_reduce": null,
+    "skills": [
+      {
+        "prefab": "ArcticBlast",
+        "timing": "冷却 8.5s",
+        "blackboard": "duration=8.0，atk_scale=1.5"
+      }
+    ]
+  }
+}

--- a/tests/parity-fixtures/item_info.json
+++ b/tests/parity-fixtures/item_info.json
@@ -1,0 +1,28 @@
+{
+  "name": "源岩",
+  "item_id": "30011",
+  "rarity_raw": "TIER_1",
+  "rarity_label": "T1",
+  "classify_raw": "MATERIAL",
+  "classify_label": "材料",
+  "item_type": "MATERIAL",
+  "icon_id": "MTL_SL_G1",
+  "obtain_approach": null,
+  "description": "常见于源石挥发殆尽后的地区。",
+  "usage": "可用于多种强化场合。",
+  "stage_drop_list": [
+    {
+      "stageId": "main_00-01",
+      "occPer": "ALWAYS",
+      "sortId": 0
+    },
+    {
+      "stageId": "main_00-02",
+      "occPer": "SOMETIMES",
+      "sortId": 1
+    }
+  ],
+  "building_product_list": [],
+  "shop_relate_list": null,
+  "voucher_relate_list": null
+}

--- a/tests/parity-fixtures/list_enemies.json
+++ b/tests/parity-fixtures/list_enemies.json
@@ -1,0 +1,28 @@
+{
+  "total": 2,
+  "offset": 0,
+  "limit": 50,
+  "full": false,
+  "filters": {
+    "threat_level": null,
+    "threat_level_filter": null
+  },
+  "enemies": [
+    {
+      "enemy_id": "enemy_1004_mslime",
+      "name": "源石虫",
+      "enemy_index": "B1",
+      "level_raw": "NORMAL",
+      "level_label": "普通",
+      "description_excerpt": "野生的被感染生物。"
+    },
+    {
+      "enemy_id": "enemy_1505_frstar",
+      "name": "霜星",
+      "enemy_index": "FN",
+      "level_raw": "BOSS",
+      "level_label": "领袖",
+      "description_excerpt": "整合运动法术部队干部。"
+    }
+  ]
+}

--- a/tests/parity-fixtures/list_enemies_offset_empty.json
+++ b/tests/parity-fixtures/list_enemies_offset_empty.json
@@ -1,0 +1,12 @@
+{
+  "total": 2,
+  "offset": 999,
+  "limit": 50,
+  "full": false,
+  "filters": {
+    "threat_level": null,
+    "threat_level_filter": null
+  },
+  "enemies": [],
+  "empty_reason": "offset_out_of_range"
+}

--- a/tests/parity-fixtures/list_items.json
+++ b/tests/parity-fixtures/list_items.json
@@ -1,0 +1,31 @@
+{
+  "total": 2,
+  "offset": 0,
+  "limit": 50,
+  "filters": {
+    "category": null,
+    "category_filter": null
+  },
+  "items": [
+    {
+      "item_id": "7001",
+      "name": "招聘许可",
+      "rarity_raw": "TIER_4",
+      "rarity_label": "T4",
+      "classify_raw": "NORMAL",
+      "classify_label": "普通",
+      "item_type": "TKT_RECRUIT",
+      "usage_excerpt": "可从公开渠道招聘一位干员。"
+    },
+    {
+      "item_id": "30011",
+      "name": "源岩",
+      "rarity_raw": "TIER_1",
+      "rarity_label": "T1",
+      "classify_raw": "MATERIAL",
+      "classify_label": "材料",
+      "item_type": "MATERIAL",
+      "usage_excerpt": "可用于多种强化场合。"
+    }
+  ]
+}

--- a/tests/parity-fixtures/list_items_empty.json
+++ b/tests/parity-fixtures/list_items_empty.json
@@ -1,0 +1,11 @@
+{
+  "total": 0,
+  "offset": 0,
+  "limit": 50,
+  "filters": {
+    "category": "NONEXISTENT",
+    "category_filter": "NONEXISTENT"
+  },
+  "items": [],
+  "empty_reason": "no_match"
+}

--- a/tests/parity-fixtures/list_stories.json
+++ b/tests/parity-fixtures/list_stories.json
@@ -1,0 +1,19 @@
+{
+  "event_id": "act_test",
+  "total": 2,
+  "include_summaries": false,
+  "chapters": [
+    {
+      "story_code": "TEST-1",
+      "story_name": "开端",
+      "story_key": "activities/act_test/level_act_test_01_beg",
+      "avg_tag": "BEG"
+    },
+    {
+      "story_code": "TEST-2",
+      "story_name": "终章",
+      "story_key": "activities/act_test/level_act_test_02_end",
+      "avg_tag": "END"
+    }
+  ]
+}

--- a/tests/parity-fixtures/list_stories_empty_event.json
+++ b/tests/parity-fixtures/list_stories_empty_event.json
@@ -1,0 +1,6 @@
+{
+  "event_id": "act_empty",
+  "total": 0,
+  "include_summaries": false,
+  "chapters": []
+}

--- a/tests/parity-fixtures/list_stories_no_summary.json
+++ b/tests/parity-fixtures/list_stories_no_summary.json
@@ -1,0 +1,21 @@
+{
+  "event_id": "act_no_summary",
+  "total": 2,
+  "include_summaries": true,
+  "chapters": [
+    {
+      "story_code": "NS-1",
+      "story_name": "短章",
+      "story_key": "activities/act_no_summary/level_act_no_summary_01",
+      "avg_tag": null,
+      "summary": "无长摘要的一句话梗概"
+    },
+    {
+      "story_code": "NS-2",
+      "story_name": "无摘要章",
+      "story_key": "activities/act_no_summary/level_act_no_summary_02",
+      "avg_tag": null,
+      "summary": ""
+    }
+  ]
+}

--- a/tests/parity-fixtures/list_stories_with_summaries.json
+++ b/tests/parity-fixtures/list_stories_with_summaries.json
@@ -1,0 +1,22 @@
+{
+  "event_id": "act_test",
+  "total": 2,
+  "include_summaries": true,
+  "chapters": [
+    {
+      "story_code": "TEST-1",
+      "story_name": "开端",
+      "story_key": "activities/act_test/level_act_test_01_beg",
+      "avg_tag": "BEG",
+      "summary": "第一章梗概"
+    },
+    {
+      "story_code": "TEST-2",
+      "story_name": "终章",
+      "story_key": "activities/act_test/level_act_test_02_end",
+      "avg_tag": "END",
+      "summary": "第二章梗概"
+    }
+  ],
+  "event_summary": "活动总览"
+}

--- a/tests/parity-fixtures/operator_basic_info.json
+++ b/tests/parity-fixtures/operator_basic_info.json
@@ -1,0 +1,27 @@
+{
+  "name": "阿米娅",
+  "display_number": "R001",
+  "appellation": "Amiya",
+  "rarity": "5★",
+  "rarity_raw": "TIER_5",
+  "profession": "术师",
+  "profession_raw": "CASTER",
+  "sub_profession_id": "corecaster",
+  "position": "远程",
+  "position_raw": "RANGED",
+  "affiliation": "rhodes",
+  "tag_list": [
+    "输出",
+    "支援"
+  ],
+  "attack_attribute": "法术伤害",
+  "item_usage": "罗德岛的公开领袖。",
+  "item_desc": "阿米娅的信物。",
+  "item_obtain": "主线获得",
+  "talents": [
+    {
+      "name": "情绪吸收",
+      "description": "攻击回复技力"
+    }
+  ]
+}

--- a/tests/parity-fixtures/operator_memoirs.json
+++ b/tests/parity-fixtures/operator_memoirs.json
@@ -1,0 +1,13 @@
+{
+  "operator_name": "阿米娅",
+  "internal_code": "amiya",
+  "operator_id": "char_002_amiya",
+  "total": 1,
+  "chapters": [
+    {
+      "story_code": "AM-1",
+      "story_name": "出发",
+      "story_key": "memory/amiya/level_amiya_01"
+    }
+  ]
+}

--- a/tests/parity-fixtures/speakers_in_event.json
+++ b/tests/parity-fixtures/speakers_in_event.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "act_test",
+  "total": 2,
+  "speakers": [
+    {
+      "name": "博士",
+      "line_count": 2
+    },
+    {
+      "name": "阿米娅",
+      "line_count": 1
+    }
+  ]
+}

--- a/tests/parity-fixtures/speakers_in_event_empty.json
+++ b/tests/parity-fixtures/speakers_in_event_empty.json
@@ -1,0 +1,5 @@
+{
+  "event_id": "act_narration",
+  "total": 0,
+  "speakers": []
+}

--- a/tests/parity-fixtures/stage_enemies.json
+++ b/tests/parity-fixtures/stage_enemies.json
@@ -1,0 +1,31 @@
+{
+  "stage_id": "main_00-01",
+  "stage_label": "坍塌 0-1（main_00-01）",
+  "total": 3,
+  "enemies": [
+    {
+      "enemy_id": "enemy_1007_slime",
+      "name": "源石虫",
+      "count": 6,
+      "level": 0,
+      "overwritten": false,
+      "stats_text": "HP 550；ATK 130；DEF 0；RES 0；移速 1.0；攻击间隔 1.7s"
+    },
+    {
+      "enemy_id": "enemy_1002_nsabr",
+      "name": "士兵",
+      "count": 1,
+      "level": 0,
+      "overwritten": true,
+      "stats_text": "HP 1,650；ATK 200；DEF 30；RES 0"
+    },
+    {
+      "enemy_id": "enemy_custom",
+      "name": "关卡特化敌人",
+      "count": 1,
+      "level": 0,
+      "overwritten": true,
+      "stats_text": "HP 1,234；ATK 321；DEF 45；RES 10"
+    }
+  ]
+}

--- a/tests/parity-fixtures/stage_info.json
+++ b/tests/parity-fixtures/stage_info.json
@@ -1,0 +1,34 @@
+{
+  "stage_id": "main_00-01",
+  "name": "坍塌",
+  "code": "0-1",
+  "type_raw": "MAIN",
+  "type_label": "主线",
+  "difficulty_raw": "NORMAL",
+  "difficulty_label": "普通",
+  "zone_id": "main_0",
+  "zone_display": "序章-黑暗时代·上",
+  "ap_cost": 6,
+  "danger_level": "LV.1",
+  "boss_mark": false,
+  "description": "三点方向出现了敌人的先锋部队。",
+  "drop_info": {
+    "displayRewards": [
+      {
+        "type": "TKT_RECRUIT",
+        "id": "7001",
+        "dropType": "ONCE"
+      }
+    ]
+  },
+  "unlock_conditions": [],
+  "level_id": "Obt/Main/level_main_00-01",
+  "hard_stage": {
+    "id": "main_00-01#f#",
+    "name": "坍塌·突袭"
+  },
+  "six_star_stage": {
+    "id": null,
+    "name": null
+  }
+}

--- a/tests/parity-fixtures/story_events_activities.json
+++ b/tests/parity-fixtures/story_events_activities.json
@@ -1,0 +1,33 @@
+{
+  "total": 4,
+  "filters": {
+    "category": "activities",
+    "category_normalized": "activities"
+  },
+  "events": [
+    {
+      "event_id": "act_test",
+      "name": "测试活动",
+      "entry_type": "ACTIVITY",
+      "story_count": 2
+    },
+    {
+      "event_id": "act_no_summary",
+      "name": "无长摘要活动",
+      "entry_type": "ACTIVITY",
+      "story_count": 2
+    },
+    {
+      "event_id": "act_narration",
+      "name": "纯旁白活动",
+      "entry_type": "ACTIVITY",
+      "story_count": 1
+    },
+    {
+      "event_id": "act_empty",
+      "name": "空活动",
+      "entry_type": "ACTIVITY",
+      "story_count": 0
+    }
+  ]
+}

--- a/tests/parity-fixtures/story_events_empty.json
+++ b/tests/parity-fixtures/story_events_empty.json
@@ -1,0 +1,8 @@
+{
+  "total": 0,
+  "filters": {
+    "category": "main",
+    "category_normalized": "main"
+  },
+  "events": []
+}

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   migration slice enables structuredContent for `list_stages` while preserving
   the default content-only markdown output, including legitimate empty pages
   (filter no-match / offset past end) as structured empty payloads.
+- **Output channel coverage for structured data tools (2.0).** The remaining
+  game-data and story navigation tools now support structuredContent in TS:
+  operator/item/enemy/stage details and listings, stage-enemy fusion,
+  story event/chapter listings, operator memoirs, character appearances, and
+  event speaker counts. Search-family tools remain content-only until the final
+  output-channel migration slice.
 
 ### Changed
 

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -48,6 +48,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   cross-reference, parameter semantics kept in the parameter schema) and trimmed
   ~20% to reduce context budget on smaller-context models. No change to tool
   names, parameters, or output format.
+- **Story empty-result wording aligned with Python (2.0).** TS story navigation
+  tools now use the Python-compatible empty messages for event/chapter listings,
+  character appearances, and speaker counts (including Python-style quoted
+  filter values). This is an intentional TS-dev text change in otherwise
+  content-compatible output-channel migration paths.
 
 ### Removed
 

--- a/ts/src/data/enemy.ts
+++ b/ts/src/data/enemy.ts
@@ -108,6 +108,60 @@ interface EnemySearchRecord {
   searchText: string;
 }
 
+export interface EnemiesListingPayload {
+  total: number;
+  offset: number;
+  limit: number;
+  full: boolean;
+  filters: {
+    threat_level: string | null;
+    threat_level_filter: string | null;
+  };
+  enemies: Array<{
+    enemy_id: string;
+    name: string;
+    enemy_index: string;
+    level_raw: string;
+    level_label: string;
+    description_excerpt: string;
+  }>;
+  empty_reason?: "offset_out_of_range";
+}
+
+export interface EnemyStatsPayload {
+  max_hp: string | null;
+  atk: string | null;
+  def: string | null;
+  resistance: string | null;
+  move_speed: string | null;
+  attack_interval: string | null;
+  attack_speed: string | null;
+  mass_level: string | null;
+  hp_recovery_per_sec: string | null;
+  immunities: string[];
+  life_point_reduce: string | null;
+  skills: Array<{
+    prefab: string;
+    timing: string;
+    blackboard: string;
+  }>;
+}
+
+export interface EnemyInfoPayload {
+  name: string;
+  enemy_id: string;
+  enemy_index: string;
+  level_raw: string;
+  level_label: string;
+  description: string;
+  attack_type: string;
+  ability: string;
+  damage_types_raw: string[];
+  damage_types_label: string;
+  enemy_tags: string[];
+  stats: EnemyStatsPayload | null;
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -201,6 +255,12 @@ const ENEMY_LEVEL_ZH: Record<string, string> = {
   BOSS: "领袖",
   ELITE: "精英",
   NORMAL: "普通",
+};
+
+const DAMAGE_TYPE_ZH: Record<string, string> = {
+  PHYSIC: "物理",
+  MAGIC: "法术",
+  HEAL: "治疗",
 };
 
 const IMMUNITY_LABELS: Record<string, string> = {
@@ -326,6 +386,17 @@ export function listEnemies(
   offset = 0,
   full = false,
 ): string {
+  const data = buildEnemiesListing(threatLevel, limit, offset, full);
+  if (typeof data === "string") return data;
+  return renderEnemiesListing(data);
+}
+
+export function buildEnemiesListing(
+  threatLevel?: string | null,
+  limit = 50,
+  offset = 0,
+  full = false,
+): EnemiesListingPayload | string {
   if (!hasEnemyData()) return missingDataMessage();
 
   if (limit < 1) return `无效的 limit 参数：${limit}，需 ≥ 1。`;
@@ -356,22 +427,55 @@ export function listEnemies(
   });
 
   const total = entries.length;
+  const filters = { threat_level: threatLevel ?? null, threat_level_filter: threatLevel ? threatLevel.toUpperCase() : null };
 
   if (!full && offset >= total && total > 0) {
-    return `# 敌人图鉴（共 ${total} 个）\n\noffset=${offset} 超出范围（总计 ${total} 条）。`;
+    return {
+      total,
+      offset,
+      limit,
+      full,
+      filters,
+      enemies: [],
+      empty_reason: "offset_out_of_range",
+    };
   }
 
   const displayed = full ? entries : entries.slice(offset, offset + limit);
 
-  let out = `# 敌人图鉴（共 ${total} 个）\n`;
-  for (const [, info] of displayed) {
-    const level = info.enemyLevel ?? "";
-    const levelZh = ENEMY_LEVEL_ZH[level] ?? level;
-    const index = info.enemyIndex ?? "";
-    const name = info.name ?? "";
+  const enemies = displayed.map(([enemyId, info]) => {
+    const levelRaw = info.enemyLevel ?? "";
     const desc = (info.description ?? "").replace(/\n/g, " ").slice(0, 60);
-    let line = `- **${name}** [${levelZh}] (${index})`;
-    if (desc) line += ` — ${desc}`;
+    return {
+      enemy_id: enemyId,
+      name: info.name ?? "",
+      enemy_index: info.enemyIndex ?? "",
+      level_raw: levelRaw,
+      level_label: ENEMY_LEVEL_ZH[levelRaw] ?? levelRaw,
+      description_excerpt: desc,
+    };
+  });
+
+  return {
+    total,
+    offset,
+    limit,
+    full,
+    filters,
+    enemies,
+  };
+}
+
+export function renderEnemiesListing(data: EnemiesListingPayload): string {
+  if (data.empty_reason === "offset_out_of_range") {
+    return `# 敌人图鉴（共 ${data.total} 个）\n\noffset=${data.offset} 超出范围（总计 ${data.total} 条）。`;
+  }
+
+  const { total, offset, limit, full } = data;
+  let out = `# 敌人图鉴（共 ${total} 个）\n`;
+  for (const enemy of data.enemies) {
+    let line = `- **${enemy.name}** [${enemy.level_label}] (${enemy.enemy_index})`;
+    if (enemy.description_excerpt) line += ` — ${enemy.description_excerpt}`;
     out += line + "\n";
   }
 
@@ -383,6 +487,12 @@ export function listEnemies(
 }
 
 export function getEnemyInfo(name: string): string {
+  const data = buildEnemyInfo(name);
+  if (typeof data === "string") return data;
+  return renderEnemyInfo(data);
+}
+
+export function buildEnemyInfo(name: string): EnemyInfoPayload | string {
   if (!hasEnemyData()) return missingDataMessage();
 
   let eid: string | null;
@@ -399,14 +509,137 @@ export function getEnemyInfo(name: string): string {
   const info = raw.enemyData?.[eid];
   if (!info) return `敌人 '${name}' 暂无详细信息。`;
 
-  let result = fmtEnemy(info, true);
+  const levelRaw = info.enemyLevel ?? "";
+  const damageTypesRaw = info.damageType ?? [];
+  const payload: EnemyInfoPayload = {
+    name: info.name ?? "",
+    enemy_id: info.enemyId ?? "",
+    enemy_index: info.enemyIndex ?? "",
+    level_raw: levelRaw,
+    level_label: ENEMY_LEVEL_ZH[levelRaw] ?? levelRaw,
+    description: info.description ?? "",
+    attack_type: info.attackType ?? "",
+    ability: info.ability ?? "",
+    damage_types_raw: damageTypesRaw,
+    damage_types_label: damageTypesRaw.map((dt) => DAMAGE_TYPE_ZH[dt] ?? dt).join("、"),
+    enemy_tags: info.enemyTags ?? [],
+    stats: null,
+  };
 
-  // Merge combat stats
   const dbIndex = getDbIndex();
   const dbEntry = dbIndex[eid];
-  if (dbEntry) result += fmtStats(dbEntry);
+  if (dbEntry) payload.stats = extractEnemyStats(dbEntry);
 
-  return result;
+  return payload;
+}
+
+function pythonFloatString(n: number): string {
+  return Number.isInteger(n) ? `${n}.0` : String(n);
+}
+
+function extractEnemyStats(dbEntry: EnemyDbEntry): EnemyStatsPayload {
+  const attrs = dbEntry.attributes ?? {};
+  const hp = mValue<number>(attrs.maxHp, 0) ?? 0;
+  const atk = mValue<number>(attrs.atk, 0) ?? 0;
+  const def = mValue<number>(attrs.def, 0) ?? 0;
+  const res = mValue<number>(attrs.magicResistance);
+  const speed = mValue<number>(attrs.moveSpeed, 0) ?? 0;
+  const atkTime = mValue<number>(attrs.baseAttackTime, 0) ?? 0;
+  const atkSpeed = mValue<number>(attrs.attackSpeed, 100) ?? 100;
+  const mass = mValue<number>(attrs.massLevel, 0) ?? 0;
+  const hpRec = mValue<number>(attrs.hpRecoveryPerSec, 0) ?? 0;
+  const lpr = mValue<number>(attrs.lifePointReduce, 0) ?? 0;
+
+  const immunities: string[] = [];
+  for (const [key, label] of Object.entries(IMMUNITY_LABELS)) {
+    if (mValue<boolean>(attrs[key], false)) immunities.push(label);
+  }
+
+  const skills = (dbEntry.skills ?? []).map((s) => {
+    const prefab = s.prefabKey ?? "未知";
+    const cd = s.cooldown;
+    const initCd = s.initCooldown;
+    const spCost = mValue<number>(s.spData?.spCost);
+    const cdParts: string[] = [];
+    if (cd) cdParts.push(`冷却 ${cd}s`);
+    if (initCd && initCd !== cd) cdParts.push(`初始 ${initCd}s`);
+    if (spCost) cdParts.push(`SP ${spCost}`);
+    const bbStrs = (s.blackboard ?? [])
+      .slice(0, 6)
+      .filter((b) => b.value != null)
+      .map((b) => {
+        const value = typeof b.value === "number" ? pythonFloatString(b.value) : b.value;
+        return `${b.key ?? ""}=${value}`;
+      });
+    return {
+      prefab,
+      timing: cdParts.join("，"),
+      blackboard: bbStrs.join("，"),
+    };
+  });
+
+  return {
+    max_hp: hp ? formatNumber(hp) : null,
+    atk: atk ? String(atk) : null,
+    def: def ? String(def) : null,
+    resistance: res !== undefined && res !== null ? pythonFloatString(res) : null,
+    move_speed: speed ? pythonFloatString(speed) : null,
+    attack_interval: atkTime ? `${pythonFloatString(atkTime)}s` : null,
+    attack_speed: atkSpeed !== 100 ? pythonFloatString(atkSpeed) : null,
+    mass_level: mass ? String(mass) : null,
+    hp_recovery_per_sec: hpRec ? pythonFloatString(hpRec) : null,
+    immunities,
+    life_point_reduce: lpr ? String(lpr) : null,
+    skills,
+  };
+}
+
+export function renderEnemyInfo(data: EnemyInfoPayload): string {
+  const lines: string[] = [];
+  if (data.name) {
+    lines.push(`# ${data.name} - 敌人图鉴\n`);
+    lines.push(`- **ID**：${data.enemy_id}`);
+  }
+
+  if (data.enemy_index) lines.push(`- **编号**：${data.enemy_index}`);
+  if (data.level_label) lines.push(`- **威胁等级**：${data.level_label}`);
+  if (data.description) lines.push(`- **描述**：${data.description}`);
+  if (data.attack_type) lines.push(`- **攻击方式**：${data.attack_type}`);
+  if (data.ability) lines.push(`- **特殊能力**：${data.ability}`);
+  if (data.damage_types_label) lines.push(`- **伤害类型**：${data.damage_types_label}`);
+  if (data.enemy_tags.length > 0) lines.push(`- **标签**：${data.enemy_tags.join("、")}`);
+
+  const stats = data.stats;
+  if (stats) {
+    lines.push("## 战斗属性");
+    for (const [field, label] of [
+      ["max_hp", "最大生命"],
+      ["atk", "攻击力"],
+      ["def", "防御力"],
+      ["resistance", "法术抗性"],
+      ["move_speed", "移动速度"],
+      ["attack_interval", "攻击间隔"],
+      ["attack_speed", "攻击速度"],
+      ["mass_level", "重量等级"],
+      ["hp_recovery_per_sec", "每秒生命回复"],
+    ] as const) {
+      const val = stats[field];
+      if (val) lines.push(`- **${label}**：${val}`);
+    }
+    if (stats.immunities.length > 0) lines.push(`- **免疫**：${stats.immunities.join("、")}`);
+    if (stats.life_point_reduce) lines.push(`- **生命值扣除**：${stats.life_point_reduce}`);
+    if (stats.skills.length > 0) {
+      lines.push("\n## 技能");
+      for (const skill of stats.skills) {
+        const parts = [`- **${skill.prefab}**`];
+        if (skill.timing) parts.push(`（${skill.timing}）`);
+        if (skill.blackboard) parts.push(": " + skill.blackboard);
+        lines.push(parts.join(""));
+      }
+    }
+  }
+
+  return lines.join("\n");
 }
 
 export function searchEnemies(pattern: string, maxResults = 30): string {

--- a/ts/src/data/enemy.ts
+++ b/ts/src/data/enemy.ts
@@ -312,70 +312,6 @@ function formatNumber(n: number): string {
   return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
 
-function fmtStats(dbEntry: EnemyDbEntry): string {
-  const attrs = dbEntry.attributes ?? {};
-  const hp = mValue<number>(attrs.maxHp, 0) ?? 0;
-  const atk = mValue<number>(attrs.atk, 0) ?? 0;
-  const def = mValue<number>(attrs.def, 0) ?? 0;
-  const res = mValue<number>(attrs.magicResistance);
-  const speed = mValue<number>(attrs.moveSpeed, 0) ?? 0;
-  const atkTime = mValue<number>(attrs.baseAttackTime, 0) ?? 0;
-  const atkSpeed = mValue<number>(attrs.attackSpeed, 100) ?? 100;
-  const mass = mValue<number>(attrs.massLevel, 0) ?? 0;
-  const hpRec = mValue<number>(attrs.hpRecoveryPerSec, 0) ?? 0;
-  const lpr = mValue<number>(attrs.lifePointReduce, 0) ?? 0;
-
-  const lines: string[] = [];
-  lines.push("\n## 战斗属性");
-  if (hp) lines.push(`- **最大生命**：${formatNumber(hp)}`);
-  if (atk) lines.push(`- **攻击力**：${atk}`);
-  if (def) lines.push(`- **防御力**：${def}`);
-  if (res !== undefined && res !== null) lines.push(`- **法术抗性**：${res}`);
-  if (speed) lines.push(`- **移动速度**：${speed}`);
-  if (atkTime) lines.push(`- **攻击间隔**：${atkTime}s`);
-  if (atkSpeed !== 100) lines.push(`- **攻击速度**：${atkSpeed}`);
-  if (mass) lines.push(`- **重量等级**：${mass}`);
-  if (hpRec) lines.push(`- **每秒生命回复**：${hpRec}`);
-
-  const immunities: string[] = [];
-  for (const [key, label] of Object.entries(IMMUNITY_LABELS)) {
-    if (mValue<boolean>(attrs[key], false)) immunities.push(label);
-  }
-  if (immunities.length > 0) lines.push(`- **免疫**：${immunities.join("、")}`);
-
-  if (lpr) lines.push(`- **生命值扣除**：${lpr}`);
-
-  const skills = dbEntry.skills ?? [];
-  if (skills.length > 0) {
-    lines.push("\n## 技能");
-    for (const s of skills) {
-      const prefab = s.prefabKey ?? "未知";
-      const cd = s.cooldown;
-      const initCd = s.initCooldown;
-      const spCost = mValue<number>(s.spData?.spCost);
-
-      const parts: string[] = [`- **${prefab}**`];
-      const cdParts: string[] = [];
-      if (cd) cdParts.push(`冷却 ${cd}s`);
-      if (initCd && initCd !== cd) cdParts.push(`初始 ${initCd}s`);
-      if (spCost) cdParts.push(`SP ${spCost}`);
-      if (cdParts.length > 0) parts.push(`（${cdParts.join("，")}）`);
-
-      const bb = s.blackboard ?? [];
-      if (bb.length > 0) {
-        const bbStrs = bb
-          .slice(0, 6)
-          .filter((b) => b.value != null)
-          .map((b) => `${b.key}=${b.value}`);
-        if (bbStrs.length > 0) parts.push(": " + bbStrs.join("，"));
-      }
-      lines.push(parts.join(""));
-    }
-  }
-
-  return lines.join("\n");
-}
-
 // ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
@@ -594,6 +530,24 @@ function extractEnemyStats(dbEntry: EnemyDbEntry): EnemyStatsPayload {
   };
 }
 
+function hasEnemyStatsContent(stats: EnemyStatsPayload): boolean {
+  const scalarFields = [
+    "max_hp",
+    "atk",
+    "def",
+    "resistance",
+    "move_speed",
+    "attack_interval",
+    "attack_speed",
+    "mass_level",
+    "hp_recovery_per_sec",
+    "life_point_reduce",
+  ] as const;
+  return scalarFields.some((field) => Boolean(stats[field])) ||
+    stats.immunities.length > 0 ||
+    stats.skills.length > 0;
+}
+
 export function renderEnemyInfo(data: EnemyInfoPayload): string {
   const lines: string[] = [];
   if (data.name) {
@@ -610,7 +564,7 @@ export function renderEnemyInfo(data: EnemyInfoPayload): string {
   if (data.enemy_tags.length > 0) lines.push(`- **标签**：${data.enemy_tags.join("、")}`);
 
   const stats = data.stats;
-  if (stats) {
+  if (stats && hasEnemyStatsContent(stats)) {
     lines.push("## 战斗属性");
     for (const [field, label] of [
       ["max_hp", "最大生命"],

--- a/ts/src/data/item.ts
+++ b/ts/src/data/item.ts
@@ -104,9 +104,9 @@ export interface ItemInfoPayload {
   description: string | null;
   usage: string | null;
   stage_drop_list: StageDrop[];
-  building_product_list?: Record<string, unknown>[] | null;
-  shop_relate_list?: Record<string, unknown>[] | null;
-  voucher_relate_list?: Record<string, unknown>[] | null;
+  building_product_list: Record<string, unknown>[] | null;
+  shop_relate_list: Record<string, unknown>[] | null;
+  voucher_relate_list: Record<string, unknown>[] | null;
 }
 
 let itemTable: Record<string, ItemEntry> | null = null;
@@ -357,9 +357,9 @@ export function buildItemInfo(name: string): ItemInfoPayload | string {
     description: info.description || null,
     usage: info.usage || null,
     stage_drop_list: info.stageDropList ?? [],
-    building_product_list: info.buildingProductList,
-    shop_relate_list: info.shopRelateInfoList,
-    voucher_relate_list: info.voucherRelateList,
+    building_product_list: info.buildingProductList ?? null,
+    shop_relate_list: info.shopRelateInfoList ?? null,
+    voucher_relate_list: info.voucherRelateList ?? null,
   };
 }
 

--- a/ts/src/data/item.ts
+++ b/ts/src/data/item.ts
@@ -70,6 +70,45 @@ interface ItemSearchRecord {
   searchText: string;
 }
 
+export interface ItemsListingPayload {
+  total: number;
+  offset: number;
+  limit: number;
+  filters: {
+    category: string | null;
+    category_filter: string | null;
+  };
+  items: Array<{
+    item_id: string;
+    name: string;
+    rarity_raw: string;
+    rarity_label: string;
+    classify_raw: string;
+    classify_label: string;
+    item_type: string;
+    usage_excerpt: string;
+  }>;
+  empty_reason?: "no_match" | "offset_out_of_range";
+}
+
+export interface ItemInfoPayload {
+  name: string;
+  item_id: string;
+  rarity_raw: string;
+  rarity_label: string;
+  classify_raw: string;
+  classify_label: string;
+  item_type: string;
+  icon_id: string | null;
+  obtain_approach: string | null;
+  description: string | null;
+  usage: string | null;
+  stage_drop_list: StageDrop[];
+  building_product_list?: Record<string, unknown>[] | null;
+  shop_relate_list?: Record<string, unknown>[] | null;
+  voucher_relate_list?: Record<string, unknown>[] | null;
+}
+
 let itemTable: Record<string, ItemEntry> | null = null;
 let itemLookup: Map<string, string> | null = null;
 let itemSearchRecords: ItemSearchRecord[] | null = null;
@@ -192,6 +231,16 @@ export function listItems(
   limit = 50,
   offset = 0,
 ): string {
+  const data = buildItemsListing(category, limit, offset);
+  if (typeof data === "string") return data;
+  return renderItemsListing(data);
+}
+
+export function buildItemsListing(
+  category?: string | null,
+  limit = 50,
+  offset = 0,
+): ItemsListingPayload | string {
   if (limit < 1) return "limit 必须 >= 1。";
   if (limit > 200) return "limit 必须 <= 200。";
   if (offset < 0) return "offset 必须 >= 0。";
@@ -220,22 +269,51 @@ export function listItems(
   const page = entries.slice(offset, offset + limit);
 
   if (page.length === 0) {
-    if (total === 0) return `没有匹配的物品（category=${category ?? "none"}）。`;
-    return `offset ${offset} 超出范围（共 ${total} 条）。`;
+    return {
+      total,
+      offset,
+      limit,
+      filters: { category: category ?? null, category_filter: categoryFilter },
+      items: [],
+      empty_reason: total === 0 ? "no_match" : "offset_out_of_range",
+    };
   }
 
-  const title = category
-    ? `# 物品列表：${category}（共 ${total} 个）`
-    : `# 物品列表（共 ${total} 个）`;
+  const items = page.map(([itemId, info]) => ({
+    item_id: itemId,
+    name: info.name || "（无名）",
+    rarity_raw: String(info.rarity ?? ""),
+    rarity_label: rarityLabel(info.rarity ?? ""),
+    classify_raw: String(info.classifyType ?? ""),
+    classify_label: classifyLabel(info.classifyType ?? ""),
+    item_type: info.itemType ?? "-",
+    usage_excerpt: shortText(info.usage ?? info.description ?? ""),
+  }));
+
+  return {
+    total,
+    offset,
+    limit,
+    filters: { category: category ?? null, category_filter: categoryFilter },
+    items,
+  };
+}
+
+export function renderItemsListing(data: ItemsListingPayload): string {
+  if (data.empty_reason === "no_match") {
+    return `没有匹配的物品（category=${data.filters.category ?? "none"}）。`;
+  }
+  if (data.empty_reason === "offset_out_of_range") {
+    return `offset ${data.offset} 超出范围（共 ${data.total} 条）。`;
+  }
+
+  const { total, offset, limit } = data;
+  const category = data.filters.category;
+  const title = category ? `# 物品列表：${category}（共 ${total} 个）` : `# 物品列表（共 ${total} 个）`;
   const lines = [title];
-  for (const [itemId, info] of page) {
-    const name = info.name || "（无名）";
-    const rarity = rarityLabel(info.rarity ?? "");
-    const classify = classifyLabel(info.classifyType ?? "");
-    const itemType = info.itemType ?? "-";
-    const usage = shortText(info.usage ?? info.description ?? "");
-    let line = `- **${name}** [${classify}/${itemType}] ${rarity}（id: ${itemId}）`;
-    if (usage) line += ` — ${usage}`;
+  for (const item of data.items) {
+    let line = `- **${item.name}** [${item.classify_label}/${item.item_type}] ${item.rarity_label}（id: ${item.item_id}）`;
+    if (item.usage_excerpt) line += ` — ${item.usage_excerpt}`;
     lines.push(line);
   }
 
@@ -249,6 +327,12 @@ export function listItems(
 }
 
 export function getItemInfo(name: string): string {
+  const data = buildItemInfo(name);
+  if (typeof data === "string") return data;
+  return renderItemInfo(data);
+}
+
+export function buildItemInfo(name: string): ItemInfoPayload | string {
   let itemId: string | null;
   try {
     itemId = resolveItemId(name);
@@ -260,22 +344,41 @@ export function getItemInfo(name: string): string {
   const info = loadItems()[itemId];
   if (!info) return `物品 ${JSON.stringify(name)} 暂无详细信息。`;
 
-  const itemName = info.name || name;
-  const parts: string[] = [`# ${itemName} — 物品信息`, "", "## 基本信息"];
-  parts.push(`- **ID**：${itemId}`);
-  parts.push(`- **稀有度**：${rarityLabel(info.rarity ?? "")}`);
-  parts.push(`- **分类**：${classifyLabel(info.classifyType ?? "")}`);
-  parts.push(`- **类型**：${info.itemType ?? "-"}`);
-  if (info.iconId) parts.push(`- **图标**：${info.iconId}`);
-  if (info.obtainApproach) parts.push(`- **获取方式**：${info.obtainApproach}`);
+  return {
+    name: info.name || name,
+    item_id: itemId,
+    rarity_raw: String(info.rarity ?? ""),
+    rarity_label: rarityLabel(info.rarity ?? ""),
+    classify_raw: String(info.classifyType ?? ""),
+    classify_label: classifyLabel(info.classifyType ?? ""),
+    item_type: info.itemType ?? "-",
+    icon_id: info.iconId || null,
+    obtain_approach: info.obtainApproach || null,
+    description: info.description || null,
+    usage: info.usage || null,
+    stage_drop_list: info.stageDropList ?? [],
+    building_product_list: info.buildingProductList,
+    shop_relate_list: info.shopRelateInfoList,
+    voucher_relate_list: info.voucherRelateList,
+  };
+}
 
-  if (info.description) parts.push("", "## 描述", info.description);
-  if (info.usage) parts.push("", "## 用途", info.usage);
+export function renderItemInfo(data: ItemInfoPayload): string {
+  const parts: string[] = [`# ${data.name} — 物品信息`, "", "## 基本信息"];
+  parts.push(`- **ID**：${data.item_id}`);
+  parts.push(`- **稀有度**：${data.rarity_label}`);
+  parts.push(`- **分类**：${data.classify_label}`);
+  parts.push(`- **类型**：${data.item_type}`);
+  if (data.icon_id) parts.push(`- **图标**：${data.icon_id}`);
+  if (data.obtain_approach) parts.push(`- **获取方式**：${data.obtain_approach}`);
 
-  parts.push("", "## 掉落关卡", formatStageDrops(info.stageDropList));
-  parts.push(...formatRelated("基建产出", info.buildingProductList));
-  parts.push(...formatRelated("商店关联", info.shopRelateInfoList));
-  parts.push(...formatRelated("凭证关联", info.voucherRelateList));
+  if (data.description) parts.push("", "## 描述", data.description);
+  if (data.usage) parts.push("", "## 用途", data.usage);
+
+  parts.push("", "## 掉落关卡", formatStageDrops(data.stage_drop_list));
+  parts.push(...formatRelated("基建产出", data.building_product_list));
+  parts.push(...formatRelated("商店关联", data.shop_relate_list));
+  parts.push(...formatRelated("凭证关联", data.voucher_relate_list));
   return parts.join("\n");
 }
 

--- a/ts/src/data/operator.ts
+++ b/ts/src/data/operator.ts
@@ -91,6 +91,31 @@ interface CharwordTable {
   charWords?: Record<string, CharwordEntry>;
 }
 
+export interface OperatorTalentPayload {
+  name: string;
+  description: string;
+}
+
+export interface OperatorBasicInfoPayload {
+  name: string;
+  display_number: string;
+  appellation: string;
+  rarity: string;
+  rarity_raw: string;
+  profession: string;
+  profession_raw: string;
+  sub_profession_id: string;
+  position: string;
+  position_raw: string;
+  affiliation: string;
+  tag_list: string[];
+  attack_attribute: string | null;
+  item_usage: string | null;
+  item_desc: string | null;
+  item_obtain: string | null;
+  talents: OperatorTalentPayload[];
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -264,6 +289,12 @@ const POSITION_ZH: Record<string, string> = {
 
 /** Return basic profile info for an operator by Chinese name. */
 export function getOperatorBasicInfo(name: string): string {
+  const data = buildOperatorBasicInfo(name);
+  if (typeof data === "string") return data;
+  return renderOperatorBasicInfo(data);
+}
+
+export function buildOperatorBasicInfo(name: string): OperatorBasicInfoPayload | string {
   const cfg = loadConfig();
   if (!hasOperatorData(cfg)) return missingDataMessage();
 
@@ -297,47 +328,74 @@ export function getOperatorBasicInfo(name: string): string {
   const affiliationParts = [info.nationId, info.groupId, info.teamId].filter(Boolean) as string[];
   const affiliation = affiliationParts.length > 0 ? affiliationParts.join(" / ") : "-";
 
-  const lines: string[] = [`# ${name} - 干员基本信息\n`];
-  lines.push(`- **编号**：${info.displayNumber ?? ""}`);
-  lines.push(`- **英文名**：${info.appellation ?? ""}`);
-  lines.push(`- **稀有度**：${rarity}`);
-  lines.push(`- **职业**：${profession}（${info.subProfessionId ?? ""}）`);
-  lines.push(`- **站位**：${position}`);
-  lines.push(`- **所属**：${affiliation}`);
-  if (info.tagList && info.tagList.length > 0) {
-    lines.push(`- **招募标签**：${info.tagList.join("、")}`);
-  }
-  if (info.description) {
-    lines.push(`- **攻击属性**：${stripWikitext(info.description)}`);
-  }
-  if (info.itemUsage) {
-    lines.push(`\n**图鉴**：${info.itemUsage}`);
-  }
-  if (info.itemDesc) {
-    lines.push(`\n> ${info.itemDesc}`);
-  }
-  if (info.itemObtainApproach) {
-    lines.push(`\n**获取方式**：${info.itemObtainApproach}`);
-  }
-
-  const talents = info.talents ?? [];
-  if (talents.length > 0) {
-    lines.push("\n## 天赋");
-    for (const slot of talents) {
-      const candidates = slot.candidates ?? [];
-      let chosen: TalentCandidate | undefined;
-      for (let i = candidates.length - 1; i >= 0; i--) {
-        const c = candidates[i];
-        if (c.name && c.name !== "？？？") {
-          chosen = c;
-          break;
-        }
+  const talents: OperatorTalentPayload[] = [];
+  for (const slot of info.talents ?? []) {
+    const candidates = slot.candidates ?? [];
+    let chosen: TalentCandidate | undefined;
+    for (let i = candidates.length - 1; i >= 0; i--) {
+      const c = candidates[i];
+      if (c.name && c.name !== "？？？") {
+        chosen = c;
+        break;
       }
-      if (chosen) {
-        lines.push(`- **${chosen.name ?? ""}**：${stripWikitext(chosen.description ?? "")}`);
-      }
+    }
+    if (chosen) {
+      talents.push({
+        name: chosen.name ?? "",
+        description: stripWikitext(chosen.description ?? ""),
+      });
     }
   }
 
+  return {
+    name,
+    display_number: info.displayNumber ?? "",
+    appellation: info.appellation ?? "",
+    rarity,
+    rarity_raw: rarityRaw,
+    profession,
+    profession_raw: info.profession ?? "",
+    sub_profession_id: info.subProfessionId ?? "",
+    position,
+    position_raw: info.position ?? "",
+    affiliation,
+    tag_list: info.tagList ?? [],
+    attack_attribute: info.description ? stripWikitext(info.description) : null,
+    item_usage: info.itemUsage || null,
+    item_desc: info.itemDesc || null,
+    item_obtain: info.itemObtainApproach || null,
+    talents,
+  };
+}
+
+export function renderOperatorBasicInfo(data: OperatorBasicInfoPayload): string {
+  const lines: string[] = [`# ${data.name} - 干员基本信息\n`];
+  lines.push(`- **编号**：${data.display_number}`);
+  lines.push(`- **英文名**：${data.appellation}`);
+  lines.push(`- **稀有度**：${data.rarity}`);
+  lines.push(`- **职业**：${data.profession}（${data.sub_profession_id}）`);
+  lines.push(`- **站位**：${data.position}`);
+  lines.push(`- **所属**：${data.affiliation}`);
+  if (data.tag_list.length > 0) {
+    lines.push(`- **招募标签**：${data.tag_list.join("、")}`);
+  }
+  if (data.attack_attribute !== null) {
+    lines.push(`- **攻击属性**：${data.attack_attribute}`);
+  }
+  if (data.item_usage) {
+    lines.push(`\n**图鉴**：${data.item_usage}`);
+  }
+  if (data.item_desc) {
+    lines.push(`\n> ${data.item_desc}`);
+  }
+  if (data.item_obtain) {
+    lines.push(`\n**获取方式**：${data.item_obtain}`);
+  }
+  if (data.talents.length > 0) {
+    lines.push("\n## 天赋");
+    for (const talent of data.talents) {
+      lines.push(`- **${talent.name}**：${talent.description}`);
+    }
+  }
   return lines.join("\n");
 }

--- a/ts/src/data/stage.ts
+++ b/ts/src/data/stage.ts
@@ -76,7 +76,7 @@ export interface StageInfoPayload {
   danger_level: string;
   boss_mark: boolean;
   description: string;
-  drop_info: Record<string, unknown> | null | undefined;
+  drop_info: Record<string, unknown> | null;
   unlock_conditions: { stageId: string; completeState: string }[];
   level_id: string | null;
   hard_stage: { id: string | null; name: string | null };
@@ -385,7 +385,7 @@ export function buildStageInfo(stageId: string): StageInfoPayload | string {
     danger_level: danger,
     boss_mark: boss,
     description: desc,
-    drop_info: drops,
+    drop_info: drops ?? null,
     unlock_conditions: unlocks,
     level_id: levelId ?? null,
     hard_stage: { id: hardId ?? null, name: hardEntry?.name ?? null },

--- a/ts/src/data/stage.ts
+++ b/ts/src/data/stage.ts
@@ -62,6 +62,27 @@ export interface StagesListingPayload {
   stages: StageListingEntry[];
 }
 
+export interface StageInfoPayload {
+  stage_id: string;
+  name: string;
+  code: string;
+  type_raw: string;
+  type_label: string;
+  difficulty_raw: string;
+  difficulty_label: string;
+  zone_id: string;
+  zone_display: string;
+  ap_cost: number | string;
+  danger_level: string;
+  boss_mark: boolean;
+  description: string;
+  drop_info: Record<string, unknown> | null | undefined;
+  unlock_conditions: { stageId: string; completeState: string }[];
+  level_id: string | null;
+  hard_stage: { id: string | null; name: string | null };
+  six_star_stage: { id: string | null; name: string | null };
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -316,6 +337,12 @@ export function renderStagesListing(data: StagesListingPayload): string {
 }
 
 export function getStageInfo(stageId: string): string {
+  const data = buildStageInfo(stageId);
+  if (typeof data === "string") return data;
+  return renderStageInfo(data);
+}
+
+export function buildStageInfo(stageId: string): StageInfoPayload | string {
   let stages: StageTable;
   try {
     stages = getStageTable();
@@ -340,35 +367,62 @@ export function getStageInfo(stageId: string): string {
   const unlocks = entry.unlockCondition ?? [];
   const hardId = entry.hardStagedId;
   const levelId = entry.levelId;
+  const sixStarId = entry.sixStarStageId;
+  const hardEntry = hardId ? stages[hardId] : undefined;
+  const sixStarEntry = sixStarId ? stages[sixStarId] : undefined;
 
-  const parts: string[] = [`# ${name} — 关卡详情`, "", "## 基本信息"];
-  parts.push(`- **ID**：${stageId}`);
-  parts.push(`- **编号**：${code}`);
-  parts.push(`- **类型**：${tLabel}`);
-  parts.push(`- **难度**：${dLabel}`);
-  parts.push(`- **所属区域**：${zd}`);
-  parts.push(`- **理智消耗**：${ap}`);
-  parts.push(`- **危险等级**：${danger}`);
-  if (boss) parts.push("- **BOSS标记**：是");
-  if (levelId) parts.push(`- **关卡数据**：${levelId}`);
+  return {
+    stage_id: stageId,
+    name,
+    code,
+    type_raw: entry.stageType ?? "",
+    type_label: tLabel,
+    difficulty_raw: entry.difficulty ?? "",
+    difficulty_label: dLabel,
+    zone_id: entry.zoneId ?? "",
+    zone_display: zd,
+    ap_cost: ap,
+    danger_level: danger,
+    boss_mark: boss,
+    description: desc,
+    drop_info: drops,
+    unlock_conditions: unlocks,
+    level_id: levelId ?? null,
+    hard_stage: { id: hardId ?? null, name: hardEntry?.name ?? null },
+    six_star_stage: { id: sixStarId ?? null, name: sixStarEntry?.name ?? null },
+  };
+}
 
-  parts.push("", "## 描述", desc);
-  parts.push("", "## 掉落信息", formatDrops(drops));
-  parts.push("", "## 解锁条件", formatUnlock(unlocks));
+export function renderStageInfo(data: StageInfoPayload): string {
+  const parts: string[] = [`# ${data.name} — 关卡详情`, "", "## 基本信息"];
+  parts.push(`- **ID**：${data.stage_id}`);
+  parts.push(`- **编号**：${data.code}`);
+  parts.push(`- **类型**：${data.type_label}`);
+  parts.push(`- **难度**：${data.difficulty_label}`);
+  parts.push(`- **所属区域**：${data.zone_display}`);
+  parts.push(`- **理智消耗**：${data.ap_cost}`);
+  parts.push(`- **危险等级**：${data.danger_level}`);
+  if (data.boss_mark) parts.push("- **BOSS标记**：是");
+  if (data.level_id) parts.push(`- **关卡数据**：${data.level_id}`);
+
+  parts.push("", "## 描述", data.description);
+  parts.push("", "## 掉落信息", formatDrops(data.drop_info));
+  parts.push("", "## 解锁条件", formatUnlock(data.unlock_conditions));
 
   parts.push("", "## 关联关卡");
-  if (hardId) {
-    const hEntry = stages[hardId];
-    const hName = hEntry?.name;
-    parts.push(`- 突袭模式：${hardId}` + (hName ? `（${hName}）` : ""));
+  if (data.hard_stage.id) {
+    parts.push(
+      `- 突袭模式：${data.hard_stage.id}` +
+      (data.hard_stage.name ? `（${data.hard_stage.name}）` : ""),
+    );
   } else {
     parts.push("- 突袭模式：无");
   }
-  const ssid = entry.sixStarStageId;
-  if (ssid) {
-    const sEntry = stages[ssid];
-    const sName = sEntry?.name;
-    parts.push(`- 六星模式：${ssid}` + (sName ? `（${sName}）` : ""));
+  if (data.six_star_stage.id) {
+    parts.push(
+      `- 六星模式：${data.six_star_stage.id}` +
+      (data.six_star_stage.name ? `（${data.six_star_stage.name}）` : ""),
+    );
   }
 
   return parts.join("\n");

--- a/ts/src/data/stageEnemy.ts
+++ b/ts/src/data/stageEnemy.ts
@@ -62,6 +62,36 @@ interface LevelJson {
   }>;
 }
 
+export interface StageEnemiesPayload {
+  stage_id: string;
+  stage_label: string;
+  total: number;
+  enemies: Array<{
+    enemy_id: string;
+    name: string;
+    count: number;
+    level: number;
+    overwritten: boolean;
+    stats_text: string;
+  }>;
+  empty_reason?: "no_match";
+}
+
+export interface EnemyAppearancesPayload {
+  enemy_id: string;
+  enemy_name: string;
+  total: number;
+  offset: number;
+  limit: number;
+  stages: Array<{
+    stage_id: string;
+    stage_name: string;
+    code: string;
+    count: number;
+  }>;
+  empty_reason?: "no_match" | "offset_out_of_range";
+}
+
 let stageTable: Record<string, StageEntry> | null = null;
 let enemyHandbook: Record<string, EnemyHandbookEntry> | null = null;
 let enemyDatabase: Record<string, Record<number, EnemyData>> | null = null;
@@ -249,6 +279,11 @@ function formatNumber(value: unknown): string {
   return String(value ?? 0);
 }
 
+function formatFloatLike(value: unknown): string {
+  if (typeof value === "number" && Number.isInteger(value)) return `${value}.0`;
+  return String(value ?? 0);
+}
+
 function formatStats(enemyData: EnemyData | null): string {
   if (!enemyData) return "战斗属性：无数据库记录";
   const attrs = enemyData.attributes ?? {};
@@ -259,8 +294,8 @@ function formatStats(enemyData: EnemyData | null): string {
   const speed = mValue(attrs.moveSpeed, 0);
   const atkTime = mValue(attrs.baseAttackTime, 0);
   const parts = [`HP ${formatNumber(hp)}`, `ATK ${atk}`, `DEF ${defense}`, `RES ${res}`];
-  if (speed) parts.push(`移速 ${speed}`);
-  if (atkTime) parts.push(`攻击间隔 ${atkTime}s`);
+  if (speed) parts.push(`移速 ${formatFloatLike(speed)}`);
+  if (atkTime) parts.push(`攻击间隔 ${formatFloatLike(atkTime)}s`);
   return parts.join("；");
 }
 
@@ -269,6 +304,12 @@ function sortedCounts(counts: Map<string, number>): Array<[string, number]> {
 }
 
 export function getStageEnemies(stageId: string): string {
+  const data = buildStageEnemies(stageId);
+  if (typeof data === "string") return data;
+  return renderStageEnemies(data);
+}
+
+export function buildStageEnemies(stageId: string): StageEnemiesPayload | string {
   if (!hasLevelsData(loadConfig())) return missingLevelsMessage();
   let stage: StageEntry | undefined;
   let level: LevelJson | string;
@@ -285,19 +326,51 @@ export function getStageEnemies(stageId: string): string {
     return `读取关卡敌人失败：${err instanceof Error ? err.message : String(err)}`;
   }
 
-  if (counts.size === 0) return `关卡 ${JSON.stringify(stageId)} 未解析到实际出怪。`;
+  if (counts.size === 0) {
+    return {
+      stage_id: stageId,
+      stage_label: stageLabel(stage, stageId),
+      total: 0,
+      enemies: [],
+      empty_reason: "no_match",
+    };
+  }
 
-  const lines = [`# ${stageLabel(stage, stageId)} — 敌人列表`];
-  for (const [enemyId, count] of sortedCounts(counts)) {
+  const enemies = sortedCounts(counts).map(([enemyId, count]) => {
     const ref = refs.get(enemyId);
     const levelNo = parseLevel(ref?.level);
     const data = stageSpecificEnemyData(enemyId, levelNo, ref?.overwrittenData);
     const name = overwrittenEnemyName(ref?.overwrittenData) ?? handbookName(enemyId);
-    lines.push(`\n## ${name}（${enemyId}）`);
-    lines.push(`- **出场数量**：${count}`);
-    lines.push(`- **敌人等级**：${levelNo}`);
-    if (ref?.overwrittenData) lines.push("- **关卡覆盖**：是");
-    lines.push(`- **战斗属性**：${formatStats(data)}`);
+    return {
+      enemy_id: enemyId,
+      name,
+      count,
+      level: levelNo,
+      overwritten: Boolean(ref?.overwrittenData),
+      stats_text: formatStats(data),
+    };
+  });
+
+  return {
+    stage_id: stageId,
+    stage_label: stageLabel(stage, stageId),
+    total: enemies.length,
+    enemies,
+  };
+}
+
+export function renderStageEnemies(data: StageEnemiesPayload): string {
+  if (data.empty_reason === "no_match") {
+    return `关卡 ${JSON.stringify(data.stage_id)} 未解析到实际出怪。`;
+  }
+
+  const lines = [`# ${data.stage_label} — 敌人列表`];
+  for (const enemy of data.enemies) {
+    lines.push(`\n## ${enemy.name}（${enemy.enemy_id}）`);
+    lines.push(`- **出场数量**：${enemy.count}`);
+    lines.push(`- **敌人等级**：${enemy.level}`);
+    if (enemy.overwritten) lines.push("- **关卡覆盖**：是");
+    lines.push(`- **战斗属性**：${enemy.stats_text}`);
   }
   return lines.join("\n");
 }
@@ -332,6 +405,12 @@ function resolveEnemyId(name: string): string | null {
 }
 
 export function getEnemyAppearances(name: string, limit = 50, offset = 0): string {
+  const data = buildEnemyAppearances(name, limit, offset);
+  if (typeof data === "string") return data;
+  return renderEnemyAppearances(data);
+}
+
+export function buildEnemyAppearances(name: string, limit = 50, offset = 0): EnemyAppearancesPayload | string {
   if (limit < 1) return "limit 必须 >= 1。";
   if (limit > 200) return "limit 必须 <= 200。";
   if (offset < 0) return "offset 必须 >= 0。";
@@ -353,17 +432,50 @@ export function getEnemyAppearances(name: string, limit = 50, offset = 0): strin
   const page = appearances.slice(offset, offset + limit);
   const enemyName = handbookName(enemyId);
   if (page.length === 0) {
-    if (total === 0) return `未找到 ${enemyName}（${enemyId}）的实际出场关卡。`;
-    return `offset ${offset} 超出范围（共 ${total} 条）。`;
+    return {
+      enemy_id: enemyId,
+      enemy_name: enemyName,
+      total,
+      offset,
+      limit,
+      stages: [],
+      empty_reason: total === 0 ? "no_match" : "offset_out_of_range",
+    };
   }
 
-  const lines = [`# ${enemyName}（${enemyId}）— 出场关卡（共 ${total} 个）`];
-  for (const [stageId, count] of page) {
+  const stageEntries = page.map(([stageId, count]) => {
     const stage = stages[stageId] ?? {};
-    const code = stage.code || stageId;
-    const stageName = stage.name || "（无名）";
-    lines.push(`- **${stageName}** ${code}（${stageId}）：${count} 个`);
+    return {
+      stage_id: stageId,
+      stage_name: stage.name || "（无名）",
+      code: stage.code || stageId,
+      count,
+    };
+  });
+
+  return {
+    enemy_id: enemyId,
+    enemy_name: enemyName,
+    total,
+    offset,
+    limit,
+    stages: stageEntries,
+  };
+}
+
+export function renderEnemyAppearances(data: EnemyAppearancesPayload): string {
+  if (data.empty_reason === "no_match") {
+    return `未找到 ${data.enemy_name}（${data.enemy_id}）的实际出场关卡。`;
   }
+  if (data.empty_reason === "offset_out_of_range") {
+    return `offset ${data.offset} 超出范围（共 ${data.total} 条）。`;
+  }
+
+  const lines = [`# ${data.enemy_name}（${data.enemy_id}）— 出场关卡（共 ${data.total} 个）`];
+  for (const stage of data.stages) {
+    lines.push(`- **${stage.stage_name}** ${stage.code}（${stage.stage_id}）：${stage.count} 个`);
+  }
+  const { offset, limit, total } = data;
   const start = offset + 1;
   const end = Math.min(offset + limit, total);
   lines.push(`\n（显示第 ${start}–${end} 条，共 ${total} 条。使用 offset=${offset + limit} 查看下一页）`);

--- a/ts/src/data/story.ts
+++ b/ts/src/data/story.ts
@@ -31,6 +31,10 @@ export type {
 
 // Public reader functions from storyReader
 export {
+  buildStoriesListing,
+  buildStoriesListingFromStore,
+  buildStoryEventsListing,
+  buildStoryEventsListingFromStore,
   listStoryEvents,
   listStoryEventsFromStore,
   listStories,
@@ -39,6 +43,8 @@ export {
   readStoryFromStore,
   readActivity,
   readActivityFromStore,
+  renderStoriesListing,
+  renderStoryEventsListing,
 } from "./storyReader.js";
 
 // Search
@@ -49,8 +55,11 @@ export {
 
 // Memoir
 export {
+  buildOperatorMemoirs,
+  buildOperatorMemoirsFromStore,
   getOperatorMemoirs,
   getOperatorMemoirsFromStore,
+  renderOperatorMemoirs,
 } from "./storyMemoir.js";
 
 // Summary
@@ -61,10 +70,16 @@ export {
 
 // Character tracking
 export {
+  buildCharacterAppearances,
+  buildCharacterAppearancesFromStore,
+  buildSpeakersInEvent,
+  buildSpeakersInEventFromStore,
   findCharacterAppearances,
   findCharacterAppearancesFromStore,
   findSpeakersIn,
   findSpeakersInFromStore,
+  renderCharacterAppearances,
+  renderSpeakersInEvent,
 } from "./storyCharacter.js";
 
 // Cache management

--- a/ts/src/data/storyCharacter.ts
+++ b/ts/src/data/storyCharacter.ts
@@ -20,6 +20,7 @@ import { type JsonStore } from "./stores.js";
 import {
   type CharacterAppearance,
   type CharacterAppearanceResult,
+  pyRepr,
   type SpeakerCount,
   withStoryStore,
 } from "./storyReader.js";
@@ -48,11 +49,6 @@ export interface SpeakersInEventPayload {
     name: string;
     line_count: number;
   }>;
-}
-
-function pyRepr(value: string | null | undefined): string {
-  if (value === null || value === undefined) return "None";
-  return `'${value}'`;
 }
 
 // ---------------------------------------------------------------------------

--- a/ts/src/data/storyCharacter.ts
+++ b/ts/src/data/storyCharacter.ts
@@ -25,6 +25,36 @@ import {
 } from "./storyReader.js";
 import { storySearchIndex, type StorySearchChapter } from "./storySearch.js";
 
+export interface CharacterAppearancesPayload {
+  name: string;
+  total: number;
+  filters: {
+    scope: string | null;
+  };
+  appearances: Array<{
+    event_id: string;
+    story_code: string;
+    story_name: string;
+    story_key: string;
+    speaks: boolean;
+    mentioned: boolean;
+  }>;
+}
+
+export interface SpeakersInEventPayload {
+  event_id: string;
+  total: number;
+  speakers: Array<{
+    name: string;
+    line_count: number;
+  }>;
+}
+
+function pyRepr(value: string | null | undefined): string {
+  if (value === null || value === undefined) return "None";
+  return `'${value}'`;
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -71,6 +101,35 @@ export function findCharacterAppearances(
   );
 }
 
+export function buildCharacterAppearances(
+  zipPath: string,
+  name: string,
+  scope?: string,
+  maxEvents = 50,
+): CharacterAppearancesPayload {
+  return withStoryStore(zipPath, (store) =>
+    buildCharacterAppearancesFromStore(store, name, scope, maxEvents),
+  );
+}
+
+export function renderCharacterAppearances(data: CharacterAppearancesPayload): string {
+  if (data.appearances.length === 0) {
+    const scope = data.filters.scope;
+    const scopeNote = scope ? `（限定活动：${pyRepr(scope)}）` : "";
+    return `未找到「${data.name}」的出场记录。${scopeNote}`;
+  }
+
+  const parts = [`# 「${data.name}」的出场（共 ${data.total} 章）`];
+  for (const ap of data.appearances) {
+    const tags: string[] = [];
+    if (ap.speaks) tags.push("speaks");
+    if (ap.mentioned) tags.push("mentioned");
+    const nameDisp = `${ap.story_code} ${ap.story_name}`.trim();
+    parts.push(`- [${tags.join("+")}] ${ap.event_id} / ${nameDisp}（key: ${ap.story_key}）`);
+  }
+  return parts.join("\n");
+}
+
 export function findSpeakersIn(
   zipPath: string,
   eventId: string,
@@ -78,6 +137,25 @@ export function findSpeakersIn(
   return withStoryStore(zipPath, (store) =>
     findSpeakersInFromStore(store, eventId),
   );
+}
+
+export function buildSpeakersInEvent(
+  zipPath: string,
+  eventId: string,
+): SpeakersInEventPayload {
+  return withStoryStore(zipPath, (store) => buildSpeakersInEventFromStore(store, eventId));
+}
+
+export function renderSpeakersInEvent(data: SpeakersInEventPayload): string {
+  if (data.speakers.length === 0) {
+    return `活动 ${pyRepr(data.event_id)} 暂无对话发言者数据。`;
+  }
+
+  const parts = [`# ${data.event_id} 的发言角色（共 ${data.total} 位）`];
+  for (const sp of data.speakers) {
+    parts.push(`- ${sp.name}（${sp.line_count} 句）`);
+  }
+  return parts.join("\n");
 }
 
 // ---------------------------------------------------------------------------
@@ -125,6 +203,28 @@ export function findCharacterAppearancesFromStore(
   };
 }
 
+export function buildCharacterAppearancesFromStore(
+  store: JsonStore,
+  name: string,
+  scope?: string,
+  maxEvents = 50,
+): CharacterAppearancesPayload {
+  const result = findCharacterAppearancesFromStore(store, name, scope, maxEvents);
+  return {
+    name: result.name,
+    total: result.totalChapters,
+    filters: { scope: scope ?? null },
+    appearances: result.appearances.map((ap) => ({
+      event_id: ap.eventId,
+      story_code: ap.storyCode,
+      story_name: ap.storyName,
+      story_key: ap.storyKey,
+      speaks: ap.speaks,
+      mentioned: ap.mentioned,
+    })),
+  };
+}
+
 export function findSpeakersInFromStore(
   store: JsonStore,
   eventId: string,
@@ -153,4 +253,19 @@ export function findSpeakersInFromStore(
   // the Python implementation's `(-line_count, name)` tuple sort.
   speakers.sort((a, b) => b.lineCount - a.lineCount || (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
   return speakers;
+}
+
+export function buildSpeakersInEventFromStore(
+  store: JsonStore,
+  eventId: string,
+): SpeakersInEventPayload {
+  const speakers = findSpeakersInFromStore(store, eventId);
+  return {
+    event_id: eventId,
+    total: speakers.length,
+    speakers: speakers.map((sp) => ({
+      name: sp.name,
+      line_count: sp.lineCount,
+    })),
+  };
 }

--- a/ts/src/data/storyMemoir.ts
+++ b/ts/src/data/storyMemoir.ts
@@ -19,6 +19,18 @@ import {
   withStoryStore,
 } from "./storyReader.js";
 
+export interface OperatorMemoirsPayload {
+  operator_name: string;
+  internal_code: string;
+  operator_id: string;
+  total: number;
+  chapters: Array<{
+    story_code: string;
+    story_name: string;
+    story_key: string;
+  }>;
+}
+
 // ---------------------------------------------------------------------------
 // Chardict types + cache
 // ---------------------------------------------------------------------------
@@ -102,6 +114,24 @@ export function getOperatorMemoirs(
   return withStoryStore(zipPath, (store) => getOperatorMemoirsFromStore(store, operatorName));
 }
 
+export function buildOperatorMemoirs(
+  zipPath: string,
+  operatorName: string,
+): OperatorMemoirsPayload {
+  return withStoryStore(zipPath, (store) => buildOperatorMemoirsFromStore(store, operatorName));
+}
+
+export function renderOperatorMemoirs(data: OperatorMemoirsPayload): string {
+  const lines: string[] = [
+    `# ${data.operator_name}（code: ${data.internal_code}，id: ${data.operator_id}）`,
+    `共 ${data.total} 章密录\n`,
+  ];
+  for (const ch of data.chapters) {
+    lines.push(`- ${ch.story_code} ${ch.story_name}（key: ${ch.story_key}）`);
+  }
+  return lines.join("\n");
+}
+
 // ---------------------------------------------------------------------------
 // Public API — store-based
 // ---------------------------------------------------------------------------
@@ -161,5 +191,23 @@ export function getOperatorMemoirsFromStore(
     operatorId,
     totalChapters: chapters.length,
     chapters,
+  };
+}
+
+export function buildOperatorMemoirsFromStore(
+  store: JsonStore,
+  operatorName: string,
+): OperatorMemoirsPayload {
+  const result = getOperatorMemoirsFromStore(store, operatorName);
+  return {
+    operator_name: result.operatorName,
+    internal_code: result.internalCode,
+    operator_id: result.operatorId,
+    total: result.totalChapters,
+    chapters: result.chapters.map((ch) => ({
+      story_code: ch.storyCode,
+      story_name: ch.storyName,
+      story_key: ch.storyKey,
+    })),
   };
 }

--- a/ts/src/data/storyReader.ts
+++ b/ts/src/data/storyReader.ts
@@ -16,6 +16,7 @@ import { JsonStore, ZipStore } from "./stores.js";
 export const STORY_REVIEW_TABLE = "zh_CN/gamedata/excel/story_review_table.json";
 export const STORYINFO = "zh_CN/storyinfo.json";
 export const SUMMARIES = "zh_CN/summaries.json";
+export const EVENT_SUMMARIES = "zh_CN/event_summaries.json";
 export const CHARDICT = "zh_CN/chardict.json";
 
 export function storyZipPath(storyKey: string): string {
@@ -160,6 +161,34 @@ export interface SpeakerCount {
   lineCount: number;
 }
 
+export interface StoryEventsListingPayload {
+  total: number;
+  filters: {
+    category: string | null;
+    category_normalized: string | null;
+  };
+  events: Array<{
+    event_id: string;
+    name: string;
+    entry_type: string;
+    story_count: number;
+  }>;
+}
+
+export interface StoriesListingPayload {
+  event_id: string;
+  total: number;
+  include_summaries: boolean;
+  chapters: Array<{
+    story_code: string;
+    story_name: string;
+    story_key: string;
+    avg_tag: string | null;
+    summary?: string;
+  }>;
+  event_summary?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Store helpers
 // ---------------------------------------------------------------------------
@@ -236,11 +265,62 @@ export function listStoryEvents(
   return withStoryStore(zipPath, (store) => listStoryEventsFromStore(store, category));
 }
 
+export function buildStoryEventsListing(
+  zipPath: string,
+  category?: string,
+): StoryEventsListingPayload {
+  return withStoryStore(zipPath, (store) => buildStoryEventsListingFromStore(store, category));
+}
+
+function pyRepr(value: string | null | undefined): string {
+  if (value === null || value === undefined) return "None";
+  return `'${value}'`;
+}
+
+export function renderStoryEventsListing(data: StoryEventsListingPayload): string {
+  if (data.events.length === 0) {
+    return `未找到符合条件的活动（category=${pyRepr(data.filters.category)}）。`;
+  }
+
+  return data.events
+    .map((ev) => `- [${ev.entry_type}] ${ev.event_id}：${ev.name}（${ev.story_count} 章）`)
+    .join("\n");
+}
+
 export function listStories(
   zipPath: string,
   eventId: string
 ): ChapterSummary[] {
   return withStoryStore(zipPath, (store) => listStoriesFromStore(store, eventId));
+}
+
+export function buildStoriesListing(
+  zipPath: string,
+  eventId: string,
+  includeSummaries = false,
+): StoriesListingPayload {
+  return withStoryStore(zipPath, (store) =>
+    buildStoriesListingFromStore(store, eventId, includeSummaries),
+  );
+}
+
+export function renderStoriesListing(data: StoriesListingPayload): string {
+  if (data.chapters.length === 0) {
+    return `活动 ${pyRepr(data.event_id)} 暂无剧情章节。`;
+  }
+
+  const lines: string[] = [];
+  if (data.event_summary) {
+    lines.push(data.event_summary, "");
+  }
+  for (const ch of data.chapters) {
+    const tag = ch.avg_tag ? `[${ch.avg_tag}] ` : "";
+    lines.push(`- ${ch.story_code} ${tag}${ch.story_name}（key: ${ch.story_key}）`);
+    if (data.include_summaries && ch.summary) {
+      lines.push(`  ${ch.summary}`);
+    }
+  }
+  return lines.join("\n");
 }
 
 export function readStory(
@@ -299,6 +379,27 @@ export function listStoryEventsFromStore(
   return events;
 }
 
+export function buildStoryEventsListingFromStore(
+  store: JsonStore,
+  category?: string,
+): StoryEventsListingPayload {
+  const events = listStoryEventsFromStore(store, category);
+  const categoryNormalized = category && category in CATEGORY_MAP ? category : null;
+  return {
+    total: events.length,
+    filters: {
+      category: category ?? null,
+      category_normalized: categoryNormalized,
+    },
+    events: events.map((ev) => ({
+      event_id: ev.eventId,
+      name: ev.name,
+      entry_type: ev.entryType,
+      story_count: ev.storyCount,
+    })),
+  };
+}
+
 export function listStoriesFromStore(
   store: JsonStore,
   eventId: string
@@ -323,6 +424,52 @@ export function listStoriesFromStore(
     });
   }
   return chapters;
+}
+
+export function buildStoriesListingFromStore(
+  store: JsonStore,
+  eventId: string,
+  includeSummaries = false,
+): StoriesListingPayload {
+  const chapters = listStoriesFromStore(store, eventId);
+  let chapterSummaries: Record<string, string> = {};
+  let eventSummaryText = "";
+
+  if (includeSummaries) {
+    try {
+      if (store.exists(STORYINFO)) {
+        const raw = store.readJson<Record<string, unknown>>(STORYINFO);
+        chapterSummaries = Object.fromEntries(
+          Object.entries(raw)
+            .filter(([, value]) => Boolean(value))
+            .map(([key, value]) => [key, String(value)]),
+        );
+      }
+      if (store.exists(EVENT_SUMMARIES)) {
+        const rawEvents = store.readJson<Record<string, unknown>>(EVENT_SUMMARIES);
+        const text = rawEvents[eventId];
+        if (typeof text === "string") eventSummaryText = text.trim();
+      }
+    } catch {
+      chapterSummaries = {};
+      eventSummaryText = "";
+    }
+  }
+
+  const data: StoriesListingPayload = {
+    event_id: eventId,
+    total: chapters.length,
+    include_summaries: includeSummaries,
+    chapters: chapters.map((ch) => ({
+      story_code: ch.storyCode,
+      story_name: ch.storyName,
+      story_key: ch.storyKey,
+      avg_tag: ch.avgTag,
+      ...(includeSummaries ? { summary: chapterSummaries[ch.storyKey] ?? "" } : {}),
+    })),
+  };
+  if (eventSummaryText) data.event_summary = eventSummaryText;
+  return data;
 }
 
 export function readStoryFromStore(

--- a/ts/src/data/storyReader.ts
+++ b/ts/src/data/storyReader.ts
@@ -272,7 +272,7 @@ export function buildStoryEventsListing(
   return withStoryStore(zipPath, (store) => buildStoryEventsListingFromStore(store, category));
 }
 
-function pyRepr(value: string | null | undefined): string {
+export function pyRepr(value: string | null | undefined): string {
   if (value === null || value === undefined) return "None";
   return `'${value}'`;
 }

--- a/ts/src/tools/gamedataTools.ts
+++ b/ts/src/tools/gamedataTools.ts
@@ -88,7 +88,7 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
         data,
         renderOperatorBasicInfo(data),
         channel,
-        `（结构化结果：${data.name} 干员基本信息，详见 structuredContent）`,
+        `干员『${data.name}』的基本信息`,
       );
     }
   );
@@ -134,7 +134,7 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
         data,
         renderEnemyInfo(data),
         channel,
-        `（结构化结果：${data.name} 敌人信息，详见 structuredContent）`,
+        `敌人『${data.name}』的图鉴`,
       );
     }
   );
@@ -152,7 +152,12 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
     ({ stage_id }) => {
       const data = buildStageEnemies(stage_id);
       if (typeof data === "string") return textResult(data);
-      return renderResult(data, renderStageEnemies(data), channel);
+      return renderResult(
+        data,
+        renderStageEnemies(data),
+        channel,
+        `${data.stage_label} 的敌人列表（共 ${data.total} 种）`,
+      );
     }
   );
 
@@ -208,7 +213,7 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
         data,
         renderStageInfo(data),
         channel,
-        `（结构化结果：${data.name} 关卡信息，详见 structuredContent）`,
+        `关卡『${data.name}』的详情`,
       );
     }
   );
@@ -249,7 +254,7 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
         data,
         renderItemInfo(data),
         channel,
-        `（结构化结果：${data.name} 物品信息，详见 structuredContent）`,
+        `物品『${data.name}』的详情`,
       );
     }
   );

--- a/ts/src/tools/gamedataTools.ts
+++ b/ts/src/tools/gamedataTools.ts
@@ -7,11 +7,40 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { getOperatorArchives, getOperatorVoicelines, getOperatorBasicInfo } from "../data/operator.js";
-import { listEnemies, getEnemyInfo, searchEnemies } from "../data/enemy.js";
-import { buildStagesListing, getStageInfo, renderStagesListing, searchStages } from "../data/stage.js";
-import { listItems, getItemInfo, searchItems } from "../data/item.js";
-import { getStageEnemies, getEnemyAppearances, getEnemyStageInfo } from "../data/stageEnemy.js";
+import {
+  buildOperatorBasicInfo,
+  getOperatorArchives,
+  getOperatorVoicelines,
+  renderOperatorBasicInfo,
+} from "../data/operator.js";
+import {
+  buildEnemiesListing,
+  buildEnemyInfo,
+  renderEnemiesListing,
+  renderEnemyInfo,
+  searchEnemies,
+} from "../data/enemy.js";
+import {
+  buildStageInfo,
+  buildStagesListing,
+  renderStageInfo,
+  renderStagesListing,
+  searchStages,
+} from "../data/stage.js";
+import {
+  buildItemInfo,
+  buildItemsListing,
+  renderItemInfo,
+  renderItemsListing,
+  searchItems,
+} from "../data/item.js";
+import {
+  buildEnemyAppearances,
+  buildStageEnemies,
+  getEnemyStageInfo,
+  renderEnemyAppearances,
+  renderStageEnemies,
+} from "../data/stageEnemy.js";
 import { searchOperatorData } from "../data/search.js";
 import { renderResult, textResult, type OutputChannel } from "../output.js";
 
@@ -53,8 +82,14 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
     ].join(" "),
     { name: z.string().describe("干员的游戏内中文名，如「阿米娅」、「能天使」。") },
     ({ name }) => {
-      const text = getOperatorBasicInfo(name);
-      return { content: [{ type: "text", text }] };
+      const data = buildOperatorBasicInfo(name);
+      if (typeof data === "string") return textResult(data);
+      return renderResult(
+        data,
+        renderOperatorBasicInfo(data),
+        channel,
+        `（结构化结果：${data.name} 干员基本信息，详见 structuredContent）`,
+      );
     }
   );
 
@@ -73,9 +108,11 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
       offset: z.number().int().min(0).default(0).describe("分页偏移量，默认 0。"),
       full: z.boolean().default(false).describe("返回全部敌人（忽略 limit/offset）。不推荐常规使用。"),
     },
-    ({ threat_level, limit, offset, full }) => ({
-      content: [{ type: "text", text: listEnemies(threat_level ?? null, limit, offset, full) }],
-    })
+    ({ threat_level, limit, offset, full }) => {
+      const data = buildEnemiesListing(threat_level ?? null, limit, offset, full);
+      if (typeof data === "string") return textResult(data);
+      return renderResult(data, renderEnemiesListing(data), channel);
+    }
   );
 
   server.tool(
@@ -89,9 +126,17 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
       name: z.string().describe("敌人的游戏内中文名，如「源石虫」、「霜星」。"),
       stage_id: z.string().optional().describe("可选关卡 ID；设置后返回该关卡内的敌人等级/覆盖后的战斗属性。"),
     },
-    ({ name, stage_id }) => ({
-      content: [{ type: "text", text: stage_id ? getEnemyStageInfo(name, stage_id) : getEnemyInfo(name) }],
-    })
+    ({ name, stage_id }) => {
+      if (stage_id) return textResult(getEnemyStageInfo(name, stage_id));
+      const data = buildEnemyInfo(name);
+      if (typeof data === "string") return textResult(data);
+      return renderResult(
+        data,
+        renderEnemyInfo(data),
+        channel,
+        `（结构化结果：${data.name} 敌人信息，详见 structuredContent）`,
+      );
+    }
   );
 
   server.tool(
@@ -104,7 +149,11 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
     {
       stage_id: z.string().describe("关卡 ID，如 'main_00-01'（可从 list_stages 获取）。"),
     },
-    ({ stage_id }) => ({ content: [{ type: "text", text: getStageEnemies(stage_id) }] })
+    ({ stage_id }) => {
+      const data = buildStageEnemies(stage_id);
+      if (typeof data === "string") return textResult(data);
+      return renderResult(data, renderStageEnemies(data), channel);
+    }
   );
 
   server.tool(
@@ -118,9 +167,11 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
       limit: z.number().int().min(1).max(200).default(50).describe("返回数量上限，默认 50。"),
       offset: z.number().int().min(0).default(0).describe("分页偏移量，默认 0。"),
     },
-    ({ name, limit, offset }) => ({
-      content: [{ type: "text", text: getEnemyAppearances(name, limit, offset) }],
-    })
+    ({ name, limit, offset }) => {
+      const data = buildEnemyAppearances(name, limit, offset);
+      if (typeof data === "string") return textResult(data);
+      return renderResult(data, renderEnemyAppearances(data), channel);
+    }
   );
 
   // --- Stage tools ---
@@ -150,7 +201,16 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
     "get_stage_info",
     "获取指定关卡的详细信息。返回关卡的编号、类型、难度、所属区域、理智消耗、掉落奖励、解锁条件等。关卡实际出场的敌人见 get_stage_enemies。",
     { stage_id: z.string().describe("关卡 ID，如 'main_00-01'（可从 list_stages 获取）。") },
-    ({ stage_id }) => ({ content: [{ type: "text", text: getStageInfo(stage_id) }] })
+    ({ stage_id }) => {
+      const data = buildStageInfo(stage_id);
+      if (typeof data === "string") return textResult(data);
+      return renderResult(
+        data,
+        renderStageInfo(data),
+        channel,
+        `（结构化结果：${data.name} 关卡信息，详见 structuredContent）`,
+      );
+    }
   );
 
   // --- Item tools ---
@@ -166,9 +226,11 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
       limit: z.number().int().min(1).max(200).default(50).describe("返回数量上限，默认 50。"),
       offset: z.number().int().min(0).default(0).describe("分页偏移量，默认 0。"),
     },
-    ({ category, limit, offset }) => ({
-      content: [{ type: "text", text: listItems(category ?? null, limit, offset) }],
-    })
+    ({ category, limit, offset }) => {
+      const data = buildItemsListing(category ?? null, limit, offset);
+      if (typeof data === "string") return textResult(data);
+      return renderResult(data, renderItemsListing(data), channel);
+    }
   );
 
   server.tool(
@@ -180,7 +242,16 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
     {
       name: z.string().describe("物品中文名或 itemId，如「固源岩」、「招聘许可」或 \"30012\"。"),
     },
-    ({ name }) => ({ content: [{ type: "text", text: getItemInfo(name) }] })
+    ({ name }) => {
+      const data = buildItemInfo(name);
+      if (typeof data === "string") return textResult(data);
+      return renderResult(
+        data,
+        renderItemInfo(data),
+        channel,
+        `（结构化结果：${data.name} 物品信息，详见 structuredContent）`,
+      );
+    }
   );
 
   // --- Search tools ---

--- a/ts/src/tools/storyTools.ts
+++ b/ts/src/tools/storyTools.ts
@@ -320,7 +320,7 @@ export function registerStoryTools(server: McpServer, channel: OutputChannel = "
           data,
           renderOperatorMemoirs(data),
           channel,
-          `（结构化结果：${data.operator_name} 干员密录，详见 structuredContent）`,
+          `${data.operator_name} 的密录列表（共 ${data.total} 章）`,
         );
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);

--- a/ts/src/tools/storyTools.ts
+++ b/ts/src/tools/storyTools.ts
@@ -8,22 +8,26 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { ZipStore } from "../data/stores.js";
 import { loadConfig, hasStoryData } from "../config.js";
 import {
-  listStoryEvents as _listStoryEvents,
-  listStories as _listStories,
+  buildCharacterAppearances as _buildCharacterAppearances,
+  buildOperatorMemoirs as _buildOperatorMemoirs,
+  buildSpeakersInEvent as _buildSpeakersInEvent,
+  buildStoriesListing as _buildStoriesListing,
+  buildStoryEventsListing as _buildStoryEventsListing,
+  renderCharacterAppearances,
+  renderOperatorMemoirs,
+  renderSpeakersInEvent,
+  renderStoriesListing,
+  renderStoryEventsListing,
   readStory as _readStory,
   readActivity as _readActivity,
   searchStories as _searchStories,
   getStorySummary as _getStorySummary,
-  getOperatorMemoirs as _getOperatorMemoirs,
-  findCharacterAppearances as _findCharacterAppearances,
-  findSpeakersIn as _findSpeakersIn,
   type StoryChapter,
   type StoryLine,
 } from "../data/story.js";
-import type { OutputChannel } from "../output.js";
+import { renderResult, textResult, type OutputChannel } from "../output.js";
 
 // ---------------------------------------------------------------------------
 // Shared helpers
@@ -65,7 +69,7 @@ function formatChapter(chapter: StoryChapter): string {
 // Tool registration
 // ---------------------------------------------------------------------------
 
-export function registerStoryTools(server: McpServer, _channel: OutputChannel = "content"): void {
+export function registerStoryTools(server: McpServer, channel: OutputChannel = "content"): void {
   server.tool(
     "list_story_events",
     [
@@ -79,19 +83,13 @@ export function registerStoryTools(server: McpServer, _channel: OutputChannel = 
       try {
         zipPath = requireStoryZip();
       } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+        return textResult(e instanceof Error ? e.message : String(e));
       }
       try {
-        const events = _listStoryEvents(zipPath, category);
-        if (events.length === 0) {
-          return { content: [{ type: "text", text: "未找到匹配的活动。" }] };
-        }
-        const lines = events.map(
-          (ev) => `- [${ev.entryType}] ${ev.eventId}：${ev.name}（${ev.storyCount} 章）`
-        );
-        return { content: [{ type: "text", text: lines.join("\n") }] };
+        const data = _buildStoryEventsListing(zipPath, category);
+        return renderResult(data, renderStoryEventsListing(data), channel);
       } catch (e) {
-        return { content: [{ type: "text", text: `读取剧情数据失败：${e instanceof Error ? e.message : String(e)}` }] };
+        return textResult(`读取剧情数据失败：${e instanceof Error ? e.message : String(e)}`);
       }
     }
   );
@@ -112,64 +110,17 @@ export function registerStoryTools(server: McpServer, _channel: OutputChannel = 
       try {
         zipPath = requireStoryZip();
       } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+        return textResult(e instanceof Error ? e.message : String(e));
       }
       try {
-        const chapters = _listStories(zipPath, event_id);
-        if (chapters.length === 0) {
-          return { content: [{ type: "text", text: `活动 "${event_id}" 没有章节数据。` }] };
-        }
-
-        // Load summaries if requested
-        let summaries: Record<string, string> = {};
-        let eventSummaryText = "";
-        if (include_summaries) {
-          const store = new ZipStore(zipPath);
-          try {
-            if (store.exists("zh_CN/storyinfo.json")) {
-              const raw = store.readJson<Record<string, unknown>>("zh_CN/storyinfo.json");
-              for (const [k, v] of Object.entries(raw)) {
-                if (v) summaries[k] = String(v);
-              }
-            }
-            if (store.exists("zh_CN/event_summaries.json")) {
-              const rawEv = store.readJson<Record<string, unknown>>("zh_CN/event_summaries.json");
-              const text = rawEv[event_id];
-              if (typeof text === "string") eventSummaryText = text.trim();
-            }
-          } catch {
-            // summary indexes are optional
-          } finally {
-            store.close();
-          }
-        }
-
-        const lines: string[] = [];
-        if (eventSummaryText) {
-          lines.push(eventSummaryText, "");
-        }
-        for (const ch of chapters) {
-          const tag = ch.avgTag ? `[${ch.avgTag}] ` : "";
-          lines.push(`- ${ch.storyCode} ${tag}${ch.storyName}（key: ${ch.storyKey}）`);
-          if (include_summaries) {
-            const summary = summaries[ch.storyKey] ?? "";
-            if (summary) lines.push(`  ${summary}`);
-          }
-        }
-        return { content: [{ type: "text", text: lines.join("\n") }] };
+        const data = _buildStoriesListing(zipPath, event_id, include_summaries);
+        return renderResult(data, renderStoriesListing(data), channel);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         if (msg.includes("not found")) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `未找到活动："${event_id}"。请先调用 list_story_events 确认活动 ID。`,
-              },
-            ],
-          };
+          return textResult(`未找到活动："${event_id}"。请先调用 list_story_events 确认活动 ID。`);
         }
-        return { content: [{ type: "text", text: `读取章节列表失败：${msg}` }] };
+        return textResult(`读取章节列表失败：${msg}`);
       }
     }
   );
@@ -187,17 +138,17 @@ export function registerStoryTools(server: McpServer, _channel: OutputChannel = 
       try {
         zipPath = requireStoryZip();
       } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+        return textResult(e instanceof Error ? e.message : String(e));
       }
       try {
         const text = _getStorySummary(zipPath, story_key);
-        return { content: [{ type: "text", text }] };
+        return textResult(text);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         if (msg.includes("not found")) {
-          return { content: [{ type: "text", text: `未找到剧情章节："${story_key}"。请通过 list_stories 确认章节 key。` }] };
+          return textResult(`未找到剧情章节："${story_key}"。请通过 list_stories 确认章节 key。`);
         }
-        return { content: [{ type: "text", text: `读取梗概失败：${msg}` }] };
+        return textResult(`读取梗概失败：${msg}`);
       }
     }
   );
@@ -361,24 +312,22 @@ export function registerStoryTools(server: McpServer, _channel: OutputChannel = 
       try {
         zipPath = requireStoryZip();
       } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+        return textResult(e instanceof Error ? e.message : String(e));
       }
       try {
-        const result = _getOperatorMemoirs(zipPath, name);
-        const lines: string[] = [
-          `# ${result.operatorName}（code: ${result.internalCode}，id: ${result.operatorId}）`,
-          `共 ${result.totalChapters} 章密录\n`,
-        ];
-        for (const ch of result.chapters) {
-          lines.push(`- ${ch.storyCode} ${ch.storyName}（key: ${ch.storyKey}）`);
-        }
-        return { content: [{ type: "text", text: lines.join("\n") }] };
+        const data = _buildOperatorMemoirs(zipPath, name);
+        return renderResult(
+          data,
+          renderOperatorMemoirs(data),
+          channel,
+          `（结构化结果：${data.operator_name} 干员密录，详见 structuredContent）`,
+        );
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         if (msg.includes("未找到干员名称") || msg.includes("暂无密录数据")) {
-          return { content: [{ type: "text", text: msg }] };
+          return textResult(msg);
         }
-        return { content: [{ type: "text", text: `查询干员密录失败：${msg}` }] };
+        return textResult(`查询干员密录失败：${msg}`);
       }
     }
   );
@@ -400,30 +349,17 @@ export function registerStoryTools(server: McpServer, _channel: OutputChannel = 
       try {
         zipPath = requireStoryZip();
       } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+        return textResult(e instanceof Error ? e.message : String(e));
       }
       try {
-        const result = _findCharacterAppearances(zipPath, name, scope, max_events);
-        if (result.appearances.length === 0) {
-          const scopeNote = scope ? `（限定活动：${JSON.stringify(scope)}）` : "";
-          return { content: [{ type: "text", text: `未找到「${name}」的出场记录。${scopeNote}` }] };
-        }
-        const parts: string[] = [`# 「${result.name}」的出场（共 ${result.totalChapters} 章）`];
-        for (const ap of result.appearances) {
-          const tags: string[] = [];
-          if (ap.speaks) tags.push("speaks");
-          if (ap.mentioned) tags.push("mentioned");
-          const tag = tags.join("+");
-          const nameDisp = `${ap.storyCode} ${ap.storyName}`.trim();
-          parts.push(`- [${tag}] ${ap.eventId} / ${nameDisp}（key: ${ap.storyKey}）`);
-        }
-        return { content: [{ type: "text", text: parts.join("\n") }] };
+        const data = _buildCharacterAppearances(zipPath, name, scope, max_events);
+        return renderResult(data, renderCharacterAppearances(data), channel);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         // Validation errors (不能为空 / 必须) and not-found (未找到) are
         // user-facing messages returned bare; only unexpected errors get a prefix.
         const isUserFacing = msg.includes("未找到") || msg.includes("不能为空") || msg.includes("必须");
-        return { content: [{ type: "text", text: isUserFacing ? msg : `查询角色出场失败：${msg}` }] };
+        return textResult(isUserFacing ? msg : `查询角色出场失败：${msg}`);
       }
     }
   );
@@ -443,21 +379,14 @@ export function registerStoryTools(server: McpServer, _channel: OutputChannel = 
       try {
         zipPath = requireStoryZip();
       } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+        return textResult(e instanceof Error ? e.message : String(e));
       }
       try {
-        const speakers = _findSpeakersIn(zipPath, event_id);
-        if (speakers.length === 0) {
-          return { content: [{ type: "text", text: `活动 "${event_id}" 暂无对话发言者数据。` }] };
-        }
-        const parts: string[] = [`# ${event_id} 的发言角色（共 ${speakers.length} 位）`];
-        for (const sp of speakers) {
-          parts.push(`- ${sp.name}（${sp.lineCount} 句）`);
-        }
-        return { content: [{ type: "text", text: parts.join("\n") }] };
+        const data = _buildSpeakersInEvent(zipPath, event_id);
+        return renderResult(data, renderSpeakersInEvent(data), channel);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
-        return { content: [{ type: "text", text: msg.includes("未找到") ? msg : `查询发言角色失败：${msg}` }] };
+        return textResult(msg.includes("未找到") ? msg : `查询发言角色失败：${msg}`);
       }
     }
   );

--- a/ts/tests/enemy.test.ts
+++ b/ts/tests/enemy.test.ts
@@ -225,7 +225,8 @@ test("get_enemy_info merges handbook and database", async () => {
   assert.match(out, /\*\*法术抗性\*\*：50/);
   assert.match(out, /\*\*免疫\*\*：眩晕、冻结/);
   assert.match(out, /ArcticBlast/);
-  assert.match(out, /duration=8/);
+  assert.match(out, /duration=8\.0/);
+  assert.deepStrictEqual(enemy.buildEnemyInfo("霜星"), loadParityFixture("enemy_info_with_stats.json"));
 });
 
 test("get_enemy_info reads database from sibling levels path", async () => {

--- a/ts/tests/enemy.test.ts
+++ b/ts/tests/enemy.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -10,6 +10,12 @@ function tempGamedataRoot(): string {
 
 async function loadEnemyModule(): Promise<typeof import("../src/data/enemy.js")> {
   return import(`../src/data/enemy.ts?cacheBust=${Date.now()}-${Math.random()}`);
+}
+
+function loadParityFixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(join(import.meta.dirname, "..", "..", "tests", "parity-fixtures", name), "utf-8"),
+  );
 }
 
 function writeFixtures(root: string, levelsRoot?: string): void {
@@ -116,6 +122,7 @@ test("list_enemies default filters hidden entries", async () => {
   assert.match(out, /霜星/);
   assert.match(out, /源石虫/);
   assert.doesNotMatch(out, /隐藏敌人/);
+  assert.deepEqual(enemy.buildEnemiesListing(), loadParityFixture("list_enemies.json"));
 });
 
 test("list_enemies threat_level filters", async () => {
@@ -144,6 +151,7 @@ test("list_enemies offset beyond total returns range error", async () => {
   const enemy = await loadEnemyModule();
   const out = enemy.listEnemies(null, 50, 999);
   assert.match(out, /超出范围/);
+  assert.deepEqual(enemy.buildEnemiesListing(null, 50, 999), loadParityFixture("list_enemies_offset_empty.json"));
 });
 
 test("list_enemies invalid limit/offset", async () => {
@@ -240,6 +248,7 @@ test("get_enemy_info handbook-only when no database entry", async () => {
   const out = enemy.getEnemyInfo("源石虫");
   assert.match(out, /源石虫/);
   assert.doesNotMatch(out, /\*\*最大生命\*\*/);
+  assert.deepEqual(enemy.buildEnemyInfo("源石虫"), loadParityFixture("enemy_info.json"));
 });
 
 test("get_enemy_info uses ideographic separator for damage types", async () => {

--- a/ts/tests/item.test.ts
+++ b/ts/tests/item.test.ts
@@ -158,6 +158,18 @@ test("getItemInfo by id", async () => {
   assert.match(out, /shopId=credit/);
 });
 
+test("getItemInfo keeps missing optional lists as null", async () => {
+  const root = tempGamedataRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  writeFixtures(root);
+  const item = await loadItemModule();
+  const data = item.buildItemInfo("隐藏物品");
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  assert.equal(data.building_product_list, null);
+  assert.equal(data.shop_relate_list, null);
+  assert.equal(data.voucher_relate_list, null);
+});
+
 test("getItemNameById", async () => {
   const root = tempGamedataRoot();
   process.env["GAMEDATA_PATH"] = root;

--- a/ts/tests/item.test.ts
+++ b/ts/tests/item.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -10,6 +10,12 @@ function tempGamedataRoot(): string {
 
 async function loadItemModule(): Promise<typeof import("../src/data/item.js")> {
   return import(`../src/data/item.ts?cacheBust=${Date.now()}-${Math.random()}`);
+}
+
+function loadParityFixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(join(import.meta.dirname, "..", "..", "tests", "parity-fixtures", name), "utf-8"),
+  );
 }
 
 const SENTINEL_FILES = [
@@ -100,6 +106,7 @@ test("listItems default", async () => {
   assert.match(out, /招聘许可/);
   assert.doesNotMatch(out, /隐藏物品/);
   assert.match(out, /共 2 个/);
+  assert.deepStrictEqual(item.buildItemsListing(), loadParityFixture("list_items.json"));
 });
 
 test("listItems category filter", async () => {
@@ -125,6 +132,19 @@ test("getItemInfo by name", async () => {
   assert.match(out, /可用于多种强化场合/);
   assert.match(out, /main_00-01（固定）/);
   assert.match(out, /main_00-02（小概率）/);
+  assert.deepStrictEqual(item.buildItemInfo("源岩"), loadParityFixture("item_info.json"));
+});
+
+test("listItems empty payload matches shared parity fixture", async () => {
+  const root = tempGamedataRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  writeFixtures(root);
+  const item = await loadItemModule();
+  const data = item.buildItemsListing("NONEXISTENT");
+  assert.deepStrictEqual(data, loadParityFixture("list_items_empty.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  assert.equal(item.renderItemsListing(data), "没有匹配的物品（category=NONEXISTENT）。");
+  assert.equal(item.listItems("NONEXISTENT"), "没有匹配的物品（category=NONEXISTENT）。");
 });
 
 test("getItemInfo by id", async () => {

--- a/ts/tests/operator.test.ts
+++ b/ts/tests/operator.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -14,6 +14,12 @@ function tempGamedataRoot(): string {
 
 async function loadOperatorModule(): Promise<typeof import("../src/data/operator.js")> {
   return import(`../src/data/operator.ts?cacheBust=${Date.now()}-${Math.random()}`);
+}
+
+function loadParityFixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(join(import.meta.dirname, "..", "..", "tests", "parity-fixtures", name), "utf-8"),
+  );
 }
 
 test("same process sees data written after initial miss", async () => {
@@ -78,6 +84,10 @@ test("core operator tools read the shared minimal fixture", async () => {
       "## 天赋",
       "- **情绪吸收**：攻击回复技力",
     ].join("\n"),
+  );
+  assert.deepStrictEqual(
+    operator.buildOperatorBasicInfo("阿米娅"),
+    loadParityFixture("operator_basic_info.json"),
   );
 });
 

--- a/ts/tests/serverOutputChannel.test.ts
+++ b/ts/tests/serverOutputChannel.test.ts
@@ -180,6 +180,22 @@ test("output_channel is resolved once per session by query/header/env priority",
       headers,
     );
 
+  const callTool = (
+    sessionId: string,
+    name: string,
+    args: Record<string, unknown> = {},
+  ) =>
+    mcpPost(
+      origin,
+      {
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: { name, arguments: args },
+        id: id++,
+      },
+      sessionId,
+    );
+
   const envInit = await initialize();
   assert.equal(envInit.status, 200);
   assert.ok(envInit.sessionId);
@@ -229,6 +245,19 @@ test("output_channel is resolved once per session by query/header/env priority",
 
   const content = toolResult.content as Array<{ text: string }>;
   assert.equal(content[0].text, "（结构化结果共 1 条，详见 structuredContent）");
+
+  const stageInfoResult = await callTool(queryInit.sessionId, "get_stage_info", {
+    stage_id: "main_00-01",
+  });
+  const stageInfoToolResult = stageInfoResult.body.result as Record<string, unknown>;
+  assert.equal(
+    ((stageInfoToolResult.content as Array<{ text: string }>)[0]).text,
+    "关卡『坍塌』的详情",
+  );
+  assert.equal(
+    (stageInfoToolResult.structuredContent as Record<string, unknown>).stage_id,
+    "main_00-01",
+  );
 
   const fixedResult = await callListStages(
     queryInit.sessionId,

--- a/ts/tests/stage.test.ts
+++ b/ts/tests/stage.test.ts
@@ -74,7 +74,6 @@ function writeFixtures(root: string): void {
         apCost: 12,
         dangerLevel: "NORMAL",
         description: "",
-        stageDropInfo: { displayRewards: [] },
         unlockCondition: [{ stageId: "act31side_02", completeState: "PASS" }],
         hardStagedId: null,
         bossMark: false,
@@ -402,6 +401,9 @@ test("getStageInfo empty drops", async () => {
   const stage = await loadStageModule();
   const out = stage.getStageInfo("act31side_01");
   assert.match(out, /（无）/);
+  const data = stage.buildStageInfo("act31side_01");
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  assert.equal(data.drop_info, null);
 });
 
 test("getStageInfo multi drops", async () => {

--- a/ts/tests/stage.test.ts
+++ b/ts/tests/stage.test.ts
@@ -356,6 +356,10 @@ test("getStageInfo full info", async () => {
   assert.match(out, /招聘许可（7001）/);
   assert.match(out, /无条件/);
   assert.match(out, /main_00-01#f#/);
+  const data = stage.buildStageInfo("main_00-01");
+  assert.deepStrictEqual(data, loadParityFixture("stage_info.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  assert.equal(stage.renderStageInfo(data), out);
 });
 
 test("getStageInfo four star variant strips markup", async () => {

--- a/ts/tests/stageEnemy.test.ts
+++ b/ts/tests/stageEnemy.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -15,6 +15,12 @@ async function loadModule(): Promise<typeof import("../src/data/stageEnemy.js")>
 function writeJson(path: string, data: unknown): void {
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(data), "utf-8");
+}
+
+function loadParityFixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(join(import.meta.dirname, "..", "..", "tests", "parity-fixtures", name), "utf-8"),
+  );
 }
 
 function writeFixture(root: string): string {
@@ -161,6 +167,10 @@ test("getStageEnemies uses spawn actions and overrides", async () => {
   assert.match(out, /ATK 321/);
   assert.doesNotMatch(out, /NaN/);
   assert.doesNotMatch(out, /未出场敌人/);
+  const data = mod.buildStageEnemies("main_00-01");
+  assert.deepStrictEqual(data, loadParityFixture("stage_enemies.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  assert.equal(mod.renderStageEnemies(data), out);
 });
 
 test("getEnemyAppearances", async () => {
@@ -172,6 +182,20 @@ test("getEnemyAppearances", async () => {
   assert.match(out, /坍塌/);
   assert.match(out, /main_00-01/);
   assert.match(out, /6 个/);
+  const data = mod.buildEnemyAppearances("源石虫");
+  assert.deepStrictEqual(data, loadParityFixture("enemy_appearances.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  assert.equal(mod.renderEnemyAppearances(data), out);
+});
+
+test("getEnemyAppearances empty payload matches shared parity fixture", async () => {
+  const root = tempRoot();
+  process.env["GAMEDATA_PATH"] = writeFixture(root);
+  const mod = await loadModule();
+  const data = mod.buildEnemyAppearances("未出场敌人");
+  assert.deepStrictEqual(data, loadParityFixture("enemy_appearances_empty.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  assert.equal(mod.renderEnemyAppearances(data), "未找到 未出场敌人（enemy_unused）的实际出场关卡。");
 });
 
 test("getEnemyStageInfo", async () => {

--- a/ts/tests/storyOutputChannel.test.ts
+++ b/ts/tests/storyOutputChannel.test.ts
@@ -1,0 +1,241 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import AdmZip from "adm-zip";
+import {
+  buildCharacterAppearances,
+  buildOperatorMemoirs,
+  buildSpeakersInEvent,
+  buildStoriesListing,
+  buildStoryEventsListing,
+  renderCharacterAppearances,
+  renderOperatorMemoirs,
+  renderSpeakersInEvent,
+  renderStoriesListing,
+  renderStoryEventsListing,
+} from "../src/data/story.ts";
+
+const STORY_REVIEW_PATH = "zh_CN/gamedata/excel/story_review_table.json";
+const CHARDICT_PATH = "zh_CN/chardict.json";
+const STORYINFO_PATH = "zh_CN/storyinfo.json";
+const EVENT_SUMMARIES_PATH = "zh_CN/event_summaries.json";
+
+const FIRST_STORY_KEY = "activities/act_test/level_act_test_01_beg";
+const SECOND_STORY_KEY = "activities/act_test/level_act_test_02_end";
+const NO_SUMMARY_STORY_KEY = "activities/act_no_summary/level_act_no_summary_01";
+const NO_SUMMARY_SECOND_STORY_KEY = "activities/act_no_summary/level_act_no_summary_02";
+const NARRATION_STORY_KEY = "activities/act_narration/level_act_narration_01";
+const MEMOIR_STORY_KEY = "memory/amiya/level_amiya_01";
+
+function storyPath(storyKey: string): string {
+  return `zh_CN/gamedata/story/${storyKey}.json`;
+}
+
+function loadParityFixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(join(import.meta.dirname, "..", "..", "tests", "parity-fixtures", name), "utf-8"),
+  );
+}
+
+function storyFiles(): Record<string, unknown> {
+  return {
+    [STORY_REVIEW_PATH]: {
+      act_test: {
+        name: "测试活动",
+        entryType: "ACTIVITY",
+        infoUnlockDatas: [
+          { storyTxt: FIRST_STORY_KEY, storyCode: "TEST-1", storyName: "开端", avgTag: "BEG", storySort: 1 },
+          { storyTxt: SECOND_STORY_KEY, storyCode: "TEST-2", storyName: "终章", avgTag: "END", storySort: 2 },
+        ],
+      },
+      act_no_summary: {
+        name: "无长摘要活动",
+        entryType: "ACTIVITY",
+        infoUnlockDatas: [
+          { storyTxt: NO_SUMMARY_STORY_KEY, storyCode: "NS-1", storyName: "短章", avgTag: null, storySort: 1 },
+          { storyTxt: NO_SUMMARY_SECOND_STORY_KEY, storyCode: "NS-2", storyName: "无摘要章", avgTag: null, storySort: 2 },
+        ],
+      },
+      act_narration: {
+        name: "纯旁白活动",
+        entryType: "ACTIVITY",
+        infoUnlockDatas: [
+          { storyTxt: NARRATION_STORY_KEY, storyCode: "NAR-1", storyName: "旁白章", avgTag: null, storySort: 1 },
+        ],
+      },
+      act_empty: {
+        name: "空活动",
+        entryType: "ACTIVITY",
+        infoUnlockDatas: [],
+      },
+      story_amiya_set_1: {
+        name: "阿米娅密录",
+        entryType: "NONE",
+        infoUnlockDatas: [
+          { storyTxt: MEMOIR_STORY_KEY, storyCode: "AM-1", storyName: "出发", avgTag: null, storySort: 1 },
+        ],
+      },
+    },
+    [STORYINFO_PATH]: {
+      [FIRST_STORY_KEY]: "第一章梗概",
+      [SECOND_STORY_KEY]: "第二章梗概",
+      [NO_SUMMARY_STORY_KEY]: "无长摘要的一句话梗概",
+    },
+    [EVENT_SUMMARIES_PATH]: {
+      act_test: "活动总览",
+    },
+    [CHARDICT_PATH]: {
+      amiya: { name: "阿米娅", id: "char_002_amiya" },
+    },
+    [storyPath(FIRST_STORY_KEY)]: {
+      storyCode: "TEST-1",
+      storyName: "开端",
+      avgTag: "BEG",
+      eventName: "测试活动",
+      storyInfo: "第一章梗概",
+      storyList: [
+        { prop: "name", attributes: { name: "阿米娅", content: "你好，博士。" } },
+        { prop: "sticker", attributes: { content: "罗德岛走廊" } },
+        { prop: "name", attributes: { name: "博士", content: "我们出发吧。" } },
+      ],
+    },
+    [storyPath(SECOND_STORY_KEY)]: {
+      storyCode: "TEST-2",
+      storyName: "终章",
+      avgTag: "END",
+      eventName: "测试活动",
+      storyInfo: "第二章梗概",
+      storyList: [
+        { prop: "name", attributes: { name: "博士", content: "任务完成。阿米娅干得不错。" } },
+      ],
+    },
+    [storyPath(NO_SUMMARY_STORY_KEY)]: {
+      storyCode: "NS-1",
+      storyName: "短章",
+      avgTag: null,
+      eventName: "无长摘要活动",
+      storyInfo: "无长摘要的一句话梗概",
+      storyList: [
+        { prop: "name", attributes: { name: "阿米娅", content: "短章台词。" } },
+      ],
+    },
+    [storyPath(NO_SUMMARY_SECOND_STORY_KEY)]: {
+      storyCode: "NS-2",
+      storyName: "无摘要章",
+      avgTag: null,
+      eventName: "无长摘要活动",
+      storyInfo: "",
+      storyList: [
+        { prop: "name", attributes: { name: "阿米娅", content: "没有一句话梗概。" } },
+      ],
+    },
+    [storyPath(NARRATION_STORY_KEY)]: {
+      storyCode: "NAR-1",
+      storyName: "旁白章",
+      avgTag: null,
+      eventName: "纯旁白活动",
+      storyInfo: "",
+      storyList: [
+        { prop: "sticker", attributes: { content: "只有旁白文本。" } },
+      ],
+    },
+  };
+}
+
+function writeStoryZip(): string {
+  const zipPath = join(mkdtempSync(join(tmpdir(), "prts-story-output-test-")), "zh_CN.zip");
+  const zip = new AdmZip();
+  for (const [innerPath, data] of Object.entries(storyFiles())) {
+    zip.addFile(innerPath, Buffer.from(JSON.stringify(data), "utf-8"));
+  }
+  zip.writeZip(zipPath);
+  return zipPath;
+}
+
+test("story structural payloads match shared parity fixtures", () => {
+  const zipPath = writeStoryZip();
+
+  let data = buildStoryEventsListing(zipPath, "activities");
+  assert.deepStrictEqual(data, loadParityFixture("story_events_activities.json"));
+  assert.equal(
+    renderStoryEventsListing(data),
+    "- [ACTIVITY] act_test：测试活动（2 章）\n" +
+      "- [ACTIVITY] act_no_summary：无长摘要活动（2 章）\n" +
+      "- [ACTIVITY] act_narration：纯旁白活动（1 章）\n" +
+      "- [ACTIVITY] act_empty：空活动（0 章）",
+  );
+
+  data = buildStoryEventsListing(zipPath, "main");
+  assert.deepStrictEqual(data, loadParityFixture("story_events_empty.json"));
+  assert.equal(renderStoryEventsListing(data), "未找到符合条件的活动（category='main'）。");
+
+  const stories = buildStoriesListing(zipPath, "act_test", false);
+  assert.deepStrictEqual(stories, loadParityFixture("list_stories.json"));
+  assert.equal(
+    renderStoriesListing(stories),
+    `- TEST-1 [BEG] 开端（key: ${FIRST_STORY_KEY}）\n` +
+      `- TEST-2 [END] 终章（key: ${SECOND_STORY_KEY}）`,
+  );
+
+  const storiesWithSummaries = buildStoriesListing(zipPath, "act_test", true);
+  assert.deepStrictEqual(storiesWithSummaries, loadParityFixture("list_stories_with_summaries.json"));
+  assert.equal(
+    renderStoriesListing(storiesWithSummaries),
+    "活动总览\n\n" +
+      `- TEST-1 [BEG] 开端（key: ${FIRST_STORY_KEY}）\n` +
+      "  第一章梗概\n" +
+      `- TEST-2 [END] 终章（key: ${SECOND_STORY_KEY}）\n` +
+      "  第二章梗概",
+  );
+
+  const noSummary = buildStoriesListing(zipPath, "act_no_summary", true);
+  assert.deepStrictEqual(noSummary, loadParityFixture("list_stories_no_summary.json"));
+  assert.equal(
+    renderStoriesListing(noSummary),
+    `- NS-1 短章（key: ${NO_SUMMARY_STORY_KEY}）\n` +
+      "  无长摘要的一句话梗概\n" +
+      `- NS-2 无摘要章（key: ${NO_SUMMARY_SECOND_STORY_KEY}）`,
+  );
+
+  const emptyStories = buildStoriesListing(zipPath, "act_empty");
+  assert.deepStrictEqual(emptyStories, loadParityFixture("list_stories_empty_event.json"));
+  assert.equal(renderStoriesListing(emptyStories), "活动 'act_empty' 暂无剧情章节。");
+
+  const memoirs = buildOperatorMemoirs(zipPath, "阿米娅");
+  assert.deepStrictEqual(memoirs, loadParityFixture("operator_memoirs.json"));
+  assert.equal(
+    renderOperatorMemoirs(memoirs),
+    "# 阿米娅（code: amiya，id: char_002_amiya）\n" +
+      "共 1 章密录\n\n" +
+      `- AM-1 出发（key: ${MEMOIR_STORY_KEY}）`,
+  );
+
+  const appearances = buildCharacterAppearances(zipPath, "博士");
+  assert.deepStrictEqual(appearances, loadParityFixture("character_appearances.json"));
+  assert.equal(
+    renderCharacterAppearances(appearances),
+    "# 「博士」的出场（共 2 章）\n" +
+      `- [speaks+mentioned] act_test / TEST-1 开端（key: ${FIRST_STORY_KEY}）\n` +
+      `- [speaks] act_test / TEST-2 终章（key: ${SECOND_STORY_KEY}）`,
+  );
+
+  const emptyAppearances = buildCharacterAppearances(zipPath, "不存在", "act_test");
+  assert.deepStrictEqual(emptyAppearances, loadParityFixture("character_appearances_empty.json"));
+  assert.equal(
+    renderCharacterAppearances(emptyAppearances),
+    "未找到「不存在」的出场记录。（限定活动：'act_test'）",
+  );
+
+  const speakers = buildSpeakersInEvent(zipPath, "act_test");
+  assert.deepStrictEqual(speakers, loadParityFixture("speakers_in_event.json"));
+  assert.equal(
+    renderSpeakersInEvent(speakers),
+    "# act_test 的发言角色（共 2 位）\n- 博士（2 句）\n- 阿米娅（1 句）",
+  );
+
+  const emptySpeakers = buildSpeakersInEvent(zipPath, "act_narration");
+  assert.deepStrictEqual(emptySpeakers, loadParityFixture("speakers_in_event_empty.json"));
+  assert.equal(renderSpeakersInEvent(emptySpeakers), "活动 'act_narration' 暂无对话发言者数据。");
+});


### PR DESCRIPTION
## Summary
- migrate the remaining TS game-data structural tools to build/render payloads and `renderResult` output-channel wiring
- migrate TS story navigation/memoir/character structural tools while leaving narrative and search-family tools content-only for PR3
- add shared parity fixtures consumed by both TS and Python tests to lock structuredContent payload shapes, including structured-empty cases, the `list_stories` missing-summary branch, and DB-backed enemy stats
- address review parity gaps: Python-aligned structured summaries, explicit `null` optional payload fields, enemy stat float/string fixture coverage, and story empty-result disclosure

## Test plan
- `git diff --check`
- `.\scripts\check-runtime.ps1 -Full`
  - Python: 266 passed, 2 skipped
  - TypeScript: 181 passed, 2 skipped
  - TypeScript typecheck: OK

## Notes
- Python production code is intentionally unchanged in this TS-track PR. Python-side edits are limited to tests that read the shared parity fixtures so TS payloads stay aligned with the already-migrated Python contract.
- The review-fix commit adds Python test assertions for the new shared enemy-stats fixture and optional-field parity; this is test-only cross-implementation coverage, not a Python runtime behavior change.
- Search-family structured output remains for the planned PR3: unified `search`, `search_stories`, and `search_prts`.