### PR TITLE
feat(ts): complete output-channel search migration

### DIFF
--- a/python/tests/test_enemy.py
+++ b/python/tests/test_enemy.py
@@ -295,22 +295,7 @@ class TestSearchEnemies:
     def test_structured_golden(self, gamedata):
         data = build_enemy_search("整合运动")
         assert isinstance(data, dict)
-        assert data["scope"] == "enemies"
-        assert data["pattern"] == "整合运动"
-        assert data["total"] == 1
-        assert data["results"][0] == {
-            "enemy_id": "enemy_1505_frstar",
-            "name": "霜星",
-            "enemy_index": "FN",
-            "level_raw": "BOSS",
-            "level_label": "领袖",
-            "description": "整合运动法术部队干部。",
-            "attack_type": "",
-            "ability": "",
-            "damage_types_raw": ["MAGIC"],
-            "damage_types_label": "法术",
-            "enemy_tags": [],
-        }
+        assert data == _load_parity_fixture("search_enemies.json")
         expected = (
             "# 搜索结果：整合运动（共 1 个）\n\n"
             "# 霜星 - 敌人图鉴\n\n"
@@ -326,12 +311,11 @@ class TestSearchEnemies:
 
     def test_no_match(self, gamedata):
         data = build_enemy_search("绝对不存在的关键词")
-        assert data == {
-            "scope": "enemies",
-            "pattern": "绝对不存在的关键词",
-            "total": 0,
-            "results": [],
-        }
+        assert data["total"] == 0
+        assert data["results"] == []
+        assert build_enemy_search("ZZZZZZZ") == _load_parity_fixture(
+            "search_enemies_empty.json"
+        )
         expected = "未找到匹配 '绝对不存在的关键词' 的敌人。"
         assert render_enemy_search(data) == expected
         assert search_enemies("绝对不存在的关键词") == expected

--- a/python/tests/test_item.py
+++ b/python/tests/test_item.py
@@ -211,20 +211,7 @@ def test_get_item_name_by_id(gamedata: str) -> None:
 def test_search_items_structured_golden(gamedata: str) -> None:
     data = build_item_search("公开渠道")
     assert isinstance(data, dict)
-    assert data["scope"] == "items"
-    assert data["pattern"] == "公开渠道"
-    assert data["total"] == 1
-    assert data["results"][0] == {
-        "item_id": "7001",
-        "name": "招聘许可",
-        "classify_raw": "NORMAL",
-        "classify_label": "普通",
-        "item_type": "TKT_RECRUIT",
-        "rarity_raw": "TIER_4",
-        "rarity_label": "T4",
-        "usage": "可从公开渠道招聘一位干员。",
-        "obtain_approach": "采购中心、任务奖励",
-    }
+    assert data == _load_parity_fixture("search_items.json")
     expected = (
         "# 搜索结果：公开渠道（共 1 个）\n\n"
         "## 招聘许可 [普通/TKT_RECRUIT] T4（id: 7001）\n"
@@ -250,6 +237,9 @@ def test_search_items_no_match_is_structured_empty(gamedata: str) -> None:
     assert search_items("绝对不存在的物品") == expected
     r = render_result(data, expected, channel="structured")
     assert r.structuredContent == data
+    assert build_item_search("ZZZZNOMATCH") == _load_parity_fixture(
+        "search_items_empty.json"
+    )
 
 
 def test_search_items_invalid_regex(gamedata: str) -> None:

--- a/python/tests/test_search.py
+++ b/python/tests/test_search.py
@@ -32,6 +32,11 @@ FIRST_STORY_KEY = "activities/act_test/level_act_test_01_beg"
 SECOND_STORY_KEY = "activities/act_test/level_act_test_02_end"
 
 
+def _load_parity_fixture(name: str) -> dict:
+    path = Path(__file__).parents[2] / "tests" / "parity-fixtures" / name
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
 def _story_path(story_key: str) -> str:
     return f"zh_CN/gamedata/story/{story_key}.json"
 
@@ -149,12 +154,7 @@ class TestSearchOperatorData:
 
     def test_no_match(self) -> None:
         data = build_operator_search("ZZZZZZZ")
-        assert data == {
-            "scope": "operators",
-            "pattern": "ZZZZZZZ",
-            "total": 0,
-            "results": [],
-        }
+        assert data == _load_parity_fixture("search_operators_empty.json")
         expected = "未找到匹配 'ZZZZZZZ' 的干员数据。"
         assert render_operator_search(data) == expected
         assert search_operator_data("ZZZZZZZ") == expected
@@ -181,26 +181,18 @@ class TestSearchOperatorData:
         assert "max_results 必须 <= 100" in result
 
     def test_structured_golden(self) -> None:
-        data = build_operator_search("阿米娅", max_results=1)
-        assert data == {
-            "scope": "operators",
-            "pattern": "阿米娅",
-            "total": 1,
-            "results": [
-                {
-                    "operator": "阿米娅",
-                    "category": "basic",
-                    "field": "干员名称",
-                    "text": "阿米娅",
-                }
-            ],
-        }
+        data = build_operator_search("阿米娅")
+        assert data == _load_parity_fixture("search_operators.json")
         assert render_operator_search(data) == (
-            "# 搜索 \"阿米娅\" 的结果（共 1 条）"
+            "# 搜索 \"阿米娅\" 的结果（共 2 条）"
             "\n---\n\n"
             "[operators/basic/阿米娅]\n"
             "匹配：干员名称\n"
             "阿米娅"
+            "\n---\n\n"
+            "[operators/archives/阿米娅]\n"
+            "匹配：档案资料一\n"
+            "阿米娅的档案文本。"
         )
         result = render_result(data, render_operator_search(data), channel="both")
         assert result.structuredContent == data
@@ -270,17 +262,7 @@ class TestSearchStories:
     def test_no_match(self, tmp_path: Path, store_kind: str) -> None:
         store = _story_store(store_kind, tmp_path)
         data = build_story_search_from_store(store, "ZZZZZZ")
-        assert data == {
-            "pattern": "ZZZZZZ",
-            "filters": {
-                "character": None,
-                "line_type": None,
-                "context_lines": 1,
-                "event_id": None,
-            },
-            "total": 0,
-            "results": [],
-        }
+        assert data == _load_parity_fixture("search_stories_empty.json")
         expected = "未找到匹配 'ZZZZZZ' 的剧情台词。"
         assert render_story_search(data) == expected
         assert search_stories_from_store(store, "ZZZZZZ") == expected
@@ -327,28 +309,7 @@ class TestSearchStories:
         store = _story_store("directory", tmp_path)
         data = build_story_search_from_store(store, "你好")
 
-        assert data == {
-            "pattern": "你好",
-            "filters": {
-                "character": None,
-                "line_type": None,
-                "context_lines": 1,
-                "event_id": None,
-            },
-            "total": 1,
-            "results": [
-                {
-                    "event_id": "act_test",
-                    "story_key": FIRST_STORY_KEY,
-                    "story_code": "TEST-1",
-                    "line_number": 1,
-                    "context": [
-                        {"text": "阿米娅：你好，博士。", "is_match": True},
-                        {"text": "*罗德岛走廊*", "is_match": False},
-                    ],
-                }
-            ],
-        }
+        assert data == _load_parity_fixture("search_stories.json")
         expected = (
             "# 搜索 \"你好\" 的结果（共 1 条）\n\n"
             "---\n\n"

--- a/python/tests/test_search.py
+++ b/python/tests/test_search.py
@@ -251,6 +251,12 @@ class TestSearchStories:
         assert "未找到匹配的活动" in result
 
     @pytest.mark.parametrize("store_kind", ["directory", "zip"])
+    def test_missing_event_id_repr(self, tmp_path: Path, store_kind: str) -> None:
+        store = _story_store(store_kind, tmp_path)
+        result = search_stories_from_store(store, ".", event_id="a\nb")
+        assert result == "未找到匹配的活动：'a\\nb'。"
+
+    @pytest.mark.parametrize("store_kind", ["directory", "zip"])
     def test_context_zero(self, tmp_path: Path, store_kind: str) -> None:
         store = _story_store(store_kind, tmp_path)
         result = search_stories_from_store(store, "你好", context_lines=0)
@@ -278,8 +284,8 @@ class TestSearchStories:
     @pytest.mark.parametrize("store_kind", ["directory", "zip"])
     def test_invalid_line_type(self, tmp_path: Path, store_kind: str) -> None:
         store = _story_store(store_kind, tmp_path)
-        result = search_stories_from_store(store, ".", line_type="invalid")
-        assert "无效的 line_type" in result
+        result = search_stories_from_store(store, ".", line_type="bad'value")
+        assert result == "无效的 line_type：\"bad'value\"，可选值：choice, dialog, narration"
 
     @pytest.mark.parametrize("store_kind", ["directory", "zip"])
     def test_max_results_cap(self, tmp_path: Path, store_kind: str) -> None:

--- a/python/tests/test_stage.py
+++ b/python/tests/test_stage.py
@@ -414,22 +414,7 @@ class TestSearchStages:
     def test_structured_golden(self, gamedata: str) -> None:
         data = build_stage_search("先锋")
         assert isinstance(data, dict)
-        assert data["scope"] == "stages"
-        assert data["pattern"] == "先锋"
-        assert data["total"] == 1
-        assert data["results"][0] == {
-            "stage_id": "main_00-01",
-            "name": "坍塌",
-            "code": "0-1",
-            "type": "MAIN",
-            "type_label": "主线",
-            "difficulty": "NORMAL",
-            "difficulty_label": "普通",
-            "zone_id": "main_0",
-            "zone_display": "序章-黑暗时代·上",
-            "ap": 6,
-            "description": "三点方向出现了敌人的先锋部队。",
-        }
+        assert data == _load_parity_fixture("search_stages.json")
         expected = (
             "# 搜索结果：先锋（共 1 个）\n\n"
             "## 坍塌 [主线] 0-1（id: main_00-01）\n"
@@ -464,12 +449,7 @@ class TestSearchStages:
 
     def test_no_match(self, gamedata: str) -> None:
         data = build_stage_search("ZZZZNOMATCH")
-        assert data == {
-            "scope": "stages",
-            "pattern": "ZZZZNOMATCH",
-            "total": 0,
-            "results": [],
-        }
+        assert data == _load_parity_fixture("search_stages_empty.json")
         expected = "未找到匹配 'ZZZZNOMATCH' 的关卡。"
         assert render_stage_search(data) == expected
         assert search_stages("ZZZZNOMATCH") == expected

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -377,16 +377,7 @@ def test_search_prts_build_render_and_totalhits(monkeypatch: pytest.MonkeyPatch)
 
     data = asyncio.run(_build_prts_search("阿米娅", limit=1))
 
-    assert data == {
-        "query": "阿米娅",
-        "search_mode": "text",
-        "filters": {
-            "limit": 1,
-            "filter_technical": True,
-        },
-        "total": 9,
-        "results": [{"title": "阿米娅", "snippet": "罗德岛公开领袖。"}],
-    }
+    assert data == _load_parity_fixture("search_prts.json")
     assert _render_prts_search(data) == (
         "# 搜索 \"阿米娅\"（共 9 条匹配）\n"
         "**阿米娅**\n"
@@ -437,16 +428,7 @@ def test_search_prts_empty_is_structured_empty(monkeypatch: pytest.MonkeyPatch) 
 
     data = asyncio.run(_build_prts_search("不存在"))
 
-    assert data == {
-        "query": "不存在",
-        "search_mode": "text",
-        "filters": {
-            "limit": 5,
-            "filter_technical": True,
-        },
-        "total": 0,
-        "results": [],
-    }
+    assert data == _load_parity_fixture("search_prts_empty.json")
     assert _render_prts_search(data) == "未找到与 '不存在' 相关的词条。"
 
 

--- a/tests/parity-fixtures/search_enemies.json
+++ b/tests/parity-fixtures/search_enemies.json
@@ -1,0 +1,22 @@
+{
+  "scope": "enemies",
+  "pattern": "整合运动",
+  "total": 1,
+  "results": [
+    {
+      "enemy_id": "enemy_1505_frstar",
+      "name": "霜星",
+      "enemy_index": "FN",
+      "level_raw": "BOSS",
+      "level_label": "领袖",
+      "description": "整合运动法术部队干部。",
+      "attack_type": "",
+      "ability": "",
+      "damage_types_raw": [
+        "MAGIC"
+      ],
+      "damage_types_label": "法术",
+      "enemy_tags": []
+    }
+  ]
+}

--- a/tests/parity-fixtures/search_enemies_empty.json
+++ b/tests/parity-fixtures/search_enemies_empty.json
@@ -1,0 +1,6 @@
+{
+  "scope": "enemies",
+  "pattern": "ZZZZZZZ",
+  "total": 0,
+  "results": []
+}

--- a/tests/parity-fixtures/search_items.json
+++ b/tests/parity-fixtures/search_items.json
@@ -1,0 +1,18 @@
+{
+  "scope": "items",
+  "pattern": "公开渠道",
+  "total": 1,
+  "results": [
+    {
+      "item_id": "7001",
+      "name": "招聘许可",
+      "classify_raw": "NORMAL",
+      "classify_label": "普通",
+      "item_type": "TKT_RECRUIT",
+      "rarity_raw": "TIER_4",
+      "rarity_label": "T4",
+      "usage": "可从公开渠道招聘一位干员。",
+      "obtain_approach": "采购中心、任务奖励"
+    }
+  ]
+}

--- a/tests/parity-fixtures/search_items_empty.json
+++ b/tests/parity-fixtures/search_items_empty.json
@@ -1,0 +1,6 @@
+{
+  "scope": "items",
+  "pattern": "ZZZZNOMATCH",
+  "total": 0,
+  "results": []
+}

--- a/tests/parity-fixtures/search_operators.json
+++ b/tests/parity-fixtures/search_operators.json
@@ -1,0 +1,19 @@
+{
+  "scope": "operators",
+  "pattern": "阿米娅",
+  "total": 2,
+  "results": [
+    {
+      "operator": "阿米娅",
+      "category": "basic",
+      "field": "干员名称",
+      "text": "阿米娅"
+    },
+    {
+      "operator": "阿米娅",
+      "category": "archives",
+      "field": "档案资料一",
+      "text": "阿米娅的档案文本。"
+    }
+  ]
+}

--- a/tests/parity-fixtures/search_operators_empty.json
+++ b/tests/parity-fixtures/search_operators_empty.json
@@ -1,0 +1,6 @@
+{
+  "scope": "operators",
+  "pattern": "ZZZZZZZ",
+  "total": 0,
+  "results": []
+}

--- a/tests/parity-fixtures/search_prts.json
+++ b/tests/parity-fixtures/search_prts.json
@@ -1,0 +1,15 @@
+{
+  "query": "阿米娅",
+  "search_mode": "text",
+  "filters": {
+    "limit": 1,
+    "filter_technical": true
+  },
+  "total": 9,
+  "results": [
+    {
+      "title": "阿米娅",
+      "snippet": "罗德岛公开领袖。"
+    }
+  ]
+}

--- a/tests/parity-fixtures/search_prts_empty.json
+++ b/tests/parity-fixtures/search_prts_empty.json
@@ -1,0 +1,10 @@
+{
+  "query": "不存在",
+  "search_mode": "text",
+  "filters": {
+    "limit": 5,
+    "filter_technical": true
+  },
+  "total": 0,
+  "results": []
+}

--- a/tests/parity-fixtures/search_stages.json
+++ b/tests/parity-fixtures/search_stages.json
@@ -1,0 +1,20 @@
+{
+  "scope": "stages",
+  "pattern": "先锋",
+  "total": 1,
+  "results": [
+    {
+      "stage_id": "main_00-01",
+      "name": "坍塌",
+      "code": "0-1",
+      "type": "MAIN",
+      "type_label": "主线",
+      "difficulty": "NORMAL",
+      "difficulty_label": "普通",
+      "zone_id": "main_0",
+      "zone_display": "序章-黑暗时代·上",
+      "ap": 6,
+      "description": "三点方向出现了敌人的先锋部队。"
+    }
+  ]
+}

--- a/tests/parity-fixtures/search_stages_empty.json
+++ b/tests/parity-fixtures/search_stages_empty.json
@@ -1,0 +1,6 @@
+{
+  "scope": "stages",
+  "pattern": "ZZZZNOMATCH",
+  "total": 0,
+  "results": []
+}

--- a/tests/parity-fixtures/search_stories.json
+++ b/tests/parity-fixtures/search_stories.json
@@ -1,0 +1,28 @@
+{
+  "pattern": "你好",
+  "filters": {
+    "character": null,
+    "line_type": null,
+    "context_lines": 1,
+    "event_id": null
+  },
+  "total": 1,
+  "results": [
+    {
+      "event_id": "act_test",
+      "story_key": "activities/act_test/level_act_test_01_beg",
+      "story_code": "TEST-1",
+      "line_number": 1,
+      "context": [
+        {
+          "text": "阿米娅：你好，博士。",
+          "is_match": true
+        },
+        {
+          "text": "*罗德岛走廊*",
+          "is_match": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/parity-fixtures/search_stories_empty.json
+++ b/tests/parity-fixtures/search_stories_empty.json
@@ -1,0 +1,11 @@
+{
+  "pattern": "ZZZZZZ",
+  "filters": {
+    "character": null,
+    "line_type": null,
+    "context_lines": 1,
+    "event_id": null
+  },
+  "total": 0,
+  "results": []
+}

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -18,8 +18,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   game-data and story navigation tools now support structuredContent in TS:
   operator/item/enemy/stage details and listings, stage-enemy fusion,
   story event/chapter listings, operator memoirs, character appearances, and
-  event speaker counts. Search-family tools remain content-only until the final
-  output-channel migration slice.
+  event speaker counts.
+- **Output channel coverage for search tools (2.0).** The TS `search`,
+  `search_stories`, and `search_prts` tools now emit structuredContent in
+  `structured`/`both` channels, including structured-empty payloads for legal
+  no-match results and parity fixtures shared with the Python implementation.
 
 ### Changed
 

--- a/ts/src/data/enemy.ts
+++ b/ts/src/data/enemy.ts
@@ -104,6 +104,7 @@ interface EnemyDatabase {
 }
 
 interface EnemySearchRecord {
+  enemyId: string;
   info: EnemyHandbookEntry;
   searchText: string;
 }
@@ -160,6 +161,25 @@ export interface EnemyInfoPayload {
   damage_types_label: string;
   enemy_tags: string[];
   stats: EnemyStatsPayload | null;
+}
+
+export interface EnemySearchPayload {
+  scope: "enemies";
+  pattern: string;
+  total: number;
+  results: Array<{
+    enemy_id: string;
+    name: string;
+    enemy_index: string;
+    level_raw: string;
+    level_label: string;
+    description: string;
+    attack_type: string;
+    ability: string;
+    damage_types_raw: string[];
+    damage_types_label: string;
+    enemy_tags: string[];
+  }>;
 }
 
 // ---------------------------------------------------------------------------
@@ -597,6 +617,12 @@ export function renderEnemyInfo(data: EnemyInfoPayload): string {
 }
 
 export function searchEnemies(pattern: string, maxResults = 30): string {
+  const data = buildEnemySearch(pattern, maxResults);
+  if (typeof data === "string") return data;
+  return renderEnemySearch(data);
+}
+
+export function buildEnemySearch(pattern: string, maxResults = 30): EnemySearchPayload | string {
   if (!hasEnemyData()) return missingDataMessage();
   if (maxResults < 1) return "max_results 必须 >= 1。";
   if (maxResults > 100) return "max_results 必须 <= 100。";
@@ -611,27 +637,70 @@ export function searchEnemies(pattern: string, maxResults = 30): string {
     return err instanceof Error ? err.message : String(err);
   }
 
-  const matches: EnemyHandbookEntry[] = [];
+  const matches: EnemySearchRecord[] = [];
   for (const record of records) {
     if (regex.test(record.searchText)) {
-      matches.push(record.info);
+      matches.push(record);
       if (matches.length >= maxResults) break;
     }
   }
 
-  if (matches.length === 0) return `未找到匹配 '${pattern}' 的敌人。`;
+  return {
+    scope: "enemies",
+    pattern,
+    total: matches.length,
+    results: matches.map(enemySearchEntry),
+  };
+}
 
-  const lines: string[] = [`# 搜索结果：${pattern}（共 ${matches.length} 个）\n`];
-  for (const info of matches) { lines.push(fmtEnemy(info)); lines.push(""); }
+export function renderEnemySearch(data: EnemySearchPayload): string {
+  const { pattern, results } = data;
+  if (results.length === 0) return `未找到匹配 '${pattern}' 的敌人。`;
+
+  const lines: string[] = [`# 搜索结果：${pattern}（共 ${data.total} 个）\n`];
+  for (const entry of results) { lines.push(renderEnemySearchCard(entry)); lines.push(""); }
   return lines.join("\n").trim();
+}
+
+function enemySearchEntry(record: EnemySearchRecord): EnemySearchPayload["results"][number] {
+  const info = record.info;
+  const levelRaw = info.enemyLevel ?? "";
+  const damageTypesRaw = info.damageType ?? [];
+  return {
+    enemy_id: record.enemyId,
+    name: info.name ?? "",
+    enemy_index: info.enemyIndex ?? "",
+    level_raw: levelRaw,
+    level_label: ENEMY_LEVEL_ZH[levelRaw] ?? levelRaw,
+    description: info.description ?? "",
+    attack_type: info.attackType ?? "",
+    ability: info.ability ?? "",
+    damage_types_raw: damageTypesRaw,
+    damage_types_label: damageTypesRaw.map((dt) => DAMAGE_TYPE_ZH[dt] ?? dt).join("、"),
+    enemy_tags: info.enemyTags ?? [],
+  };
+}
+
+function renderEnemySearchCard(entry: EnemySearchPayload["results"][number]): string {
+  const lines: string[] = [];
+  if (entry.name) lines.push(`# ${entry.name} - 敌人图鉴\n`);
+  if (entry.enemy_index) lines.push(`- **编号**：${entry.enemy_index}`);
+  if (entry.level_label) lines.push(`- **威胁等级**：${entry.level_label}`);
+  if (entry.description) lines.push(`- **描述**：${entry.description}`);
+  if (entry.attack_type) lines.push(`- **攻击方式**：${entry.attack_type}`);
+  if (entry.ability) lines.push(`- **特殊能力**：${entry.ability}`);
+  if (entry.damage_types_label) lines.push(`- **伤害类型**：${entry.damage_types_label}`);
+  if (entry.enemy_tags.length > 0) lines.push(`- **标签**：${entry.enemy_tags.join("、")}`);
+  return lines.join("\n");
 }
 
 function getEnemySearchRecords(): EnemySearchRecord[] {
   if (_enemySearchRecords !== null) return _enemySearchRecords;
   const ed = getHandbook().enemyData ?? {};
-  _enemySearchRecords = Object.values(ed)
-    .filter((info) => !info.hideInHandbook)
-    .map((info) => ({
+  _enemySearchRecords = Object.entries(ed)
+    .filter(([, info]) => !info.hideInHandbook)
+    .map(([enemyId, info]) => ({
+      enemyId,
       info,
       searchText: [
         info.name ?? "",

--- a/ts/src/data/item.ts
+++ b/ts/src/data/item.ts
@@ -109,6 +109,23 @@ export interface ItemInfoPayload {
   voucher_relate_list: Record<string, unknown>[] | null;
 }
 
+export interface ItemSearchPayload {
+  scope: "items";
+  pattern: string;
+  total: number;
+  results: Array<{
+    item_id: string;
+    name: string;
+    classify_raw: string;
+    classify_label: string;
+    item_type: string;
+    rarity_raw: string;
+    rarity_label: string;
+    usage: string;
+    obtain_approach: string;
+  }>;
+}
+
 let itemTable: Record<string, ItemEntry> | null = null;
 let itemLookup: Map<string, string> | null = null;
 let itemSearchRecords: ItemSearchRecord[] | null = null;
@@ -383,6 +400,12 @@ export function renderItemInfo(data: ItemInfoPayload): string {
 }
 
 export function searchItems(pattern: string, maxResults = 30): string {
+  const data = buildItemSearch(pattern, maxResults);
+  if (typeof data === "string") return data;
+  return renderItemSearch(data);
+}
+
+export function buildItemSearch(pattern: string, maxResults = 30): ItemSearchPayload | string {
   if (maxResults < 1) return "max_results 必须 >= 1。";
   if (maxResults > 100) return "max_results 必须 <= 100。";
 
@@ -408,22 +431,42 @@ export function searchItems(pattern: string, maxResults = 30): string {
     }
   }
 
+  return {
+    scope: "items",
+    pattern,
+    total: results.length,
+    results: results.map(itemSearchEntry),
+  };
+}
+
+export function renderItemSearch(data: ItemSearchPayload): string {
+  const { pattern, results } = data;
   if (results.length === 0) return `未找到匹配 '${pattern}' 的物品。`;
 
-  const lines = [`# 搜索结果：${pattern}（共 ${results.length} 个）`];
-  for (const record of results) {
-    const itemId = record.itemId;
-    const info = record.info;
-    const itemName = info.name || "（无名）";
-    const classify = classifyLabel(info.classifyType ?? "");
-    const itemType = info.itemType ?? "-";
-    const rarity = rarityLabel(info.rarity ?? "");
-    const usage = shortText(info.usage ?? info.description ?? "", 120);
-    lines.push(`\n## ${itemName} [${classify}/${itemType}] ${rarity}（id: ${itemId}）`);
-    if (usage) lines.push(`- **用途**：${usage}`);
-    if (info.obtainApproach) lines.push(`- **获取方式**：${info.obtainApproach}`);
+  const lines = [`# 搜索结果：${pattern}（共 ${data.total} 个）`];
+  for (const item of results) {
+    lines.push(
+      `\n## ${item.name} [${item.classify_label}/${item.item_type}] ${item.rarity_label}（id: ${item.item_id}）`,
+    );
+    if (item.usage) lines.push(`- **用途**：${item.usage}`);
+    if (item.obtain_approach) lines.push(`- **获取方式**：${item.obtain_approach}`);
   }
   return lines.join("\n");
+}
+
+function itemSearchEntry(record: ItemSearchRecord): ItemSearchPayload["results"][number] {
+  const info = record.info;
+  return {
+    item_id: record.itemId,
+    name: info.name || "（无名）",
+    classify_raw: String(info.classifyType ?? ""),
+    classify_label: classifyLabel(info.classifyType ?? ""),
+    item_type: info.itemType ?? "-",
+    rarity_raw: String(info.rarity ?? ""),
+    rarity_label: rarityLabel(info.rarity ?? ""),
+    usage: shortText(info.usage ?? info.description ?? "", 120),
+    obtain_approach: info.obtainApproach ?? "",
+  };
 }
 
 function getItemSearchRecords(): ItemSearchRecord[] {

--- a/ts/src/data/search.ts
+++ b/ts/src/data/search.ts
@@ -10,6 +10,9 @@ import {
   getHandbookTable,
   getCharwordTable,
 } from "./operator.js";
+import { buildEnemySearch, renderEnemySearch, type EnemySearchPayload } from "./enemy.js";
+import { buildStageSearch, renderStageSearch, type StageSearchPayload } from "./stage.js";
+import { buildItemSearch, renderItemSearch, type ItemSearchPayload } from "./item.js";
 
 // Reuse types from operator.ts
 interface StoryEntry {
@@ -35,20 +38,39 @@ interface CharwordTable {
   charWords?: Record<string, CharwordEntry>;
 }
 
-interface SearchResult {
+interface OperatorSearchEntry {
   operator: string;
   category: string;
   field: string;
   text: string;
 }
 
-let operatorSearchRecords: SearchResult[] | null = null;
+export interface OperatorSearchPayload {
+  scope: "operators";
+  pattern: string;
+  total: number;
+  results: OperatorSearchEntry[];
+}
+
+type SearchPayload =
+  | OperatorSearchPayload
+  | EnemySearchPayload
+  | StageSearchPayload
+  | ItemSearchPayload;
+
+let operatorSearchRecords: OperatorSearchEntry[] | null = null;
 
 export function clearSearchCaches(): void {
   operatorSearchRecords = null;
 }
 
 export function searchOperatorData(pattern: string, maxResults = 30): string {
+  const data = buildOperatorSearch(pattern, maxResults);
+  if (typeof data === "string") return data;
+  return renderOperatorSearch(data);
+}
+
+export function buildOperatorSearch(pattern: string, maxResults = 30): OperatorSearchPayload | string {
   if (maxResults < 1) return "max_results 必须 >= 1。";
   if (maxResults > 100) return "max_results 必须 <= 100。";
 
@@ -69,8 +91,8 @@ export function searchOperatorData(pattern: string, maxResults = 30): string {
     return `正则表达式无效：${exc instanceof Error ? exc.message : String(exc)}`;
   }
 
-  const results: SearchResult[] = [];
-  let records: SearchResult[];
+  const results: OperatorSearchEntry[] = [];
+  let records: OperatorSearchEntry[];
   try {
     records = getOperatorSearchRecords();
   } catch (err) {
@@ -83,12 +105,20 @@ export function searchOperatorData(pattern: string, maxResults = 30): string {
     }
   }
 
-  if (results.length === 0) {
-    return `未找到匹配 '${pattern}' 的干员数据。`;
-  }
+  return {
+    scope: "operators",
+    pattern,
+    total: results.length,
+    results,
+  };
+}
 
-  const blocks: string[] = [`# 搜索 "${pattern}" 的结果（共 ${results.length} 条）`];
-  for (const r of results) {
+export function renderOperatorSearch(data: OperatorSearchPayload): string {
+  const { pattern, results } = data;
+  if (results.length === 0) return `未找到匹配 '${pattern}' 的干员数据。`;
+
+  const blocks: string[] = [`# 搜索 "${pattern}" 的结果（共 ${data.total} 条）`];
+  for (const r of data.results) {
     blocks.push(
       `\n---\n\n[operators/${r.category}/${r.operator}]\n匹配：${r.field}\n${r.text}`
     );
@@ -97,7 +127,23 @@ export function searchOperatorData(pattern: string, maxResults = 30): string {
   return blocks.join("");
 }
 
-function getOperatorSearchRecords(): SearchResult[] {
+export function buildSearch(scope: string, pattern: string, maxResults = 30): SearchPayload | string {
+  if (scope === "operators") return buildOperatorSearch(pattern, maxResults);
+  if (scope === "enemies") return buildEnemySearch(pattern, maxResults);
+  if (scope === "stages") return buildStageSearch(pattern, maxResults);
+  if (scope === "items") return buildItemSearch(pattern, maxResults);
+  return `不支持的搜索域：'${scope}'。可选：operators、enemies、stages、items。`;
+}
+
+export function renderSearch(data: SearchPayload): string {
+  if (data.scope === "operators") return renderOperatorSearch(data);
+  if (data.scope === "enemies") return renderEnemySearch(data);
+  if (data.scope === "stages") return renderStageSearch(data);
+  if (data.scope === "items") return renderItemSearch(data);
+  throw new Error(`不支持的搜索域：${JSON.stringify((data as { scope?: unknown }).scope)}。`);
+}
+
+function getOperatorSearchRecords(): OperatorSearchEntry[] {
   if (operatorSearchRecords !== null) return operatorSearchRecords;
 
   const ct = getCharacterTable();
@@ -118,7 +164,7 @@ function getOperatorSearchRecords(): SearchResult[] {
     }
   }
 
-  const records: SearchResult[] = [];
+  const records: OperatorSearchEntry[] = [];
   for (const [name, charId] of nameToId) {
     const info = ct[charId];
     if (!info) continue;

--- a/ts/src/data/stage.ts
+++ b/ts/src/data/stage.ts
@@ -83,6 +83,25 @@ export interface StageInfoPayload {
   six_star_stage: { id: string | null; name: string | null };
 }
 
+export interface StageSearchPayload {
+  scope: "stages";
+  pattern: string;
+  total: number;
+  results: Array<{
+    stage_id: string;
+    name: string;
+    code: string;
+    type: string;
+    type_label: string;
+    difficulty: string;
+    difficulty_label: string;
+    zone_id: string;
+    zone_display: string;
+    ap: number | string;
+    description: string;
+  }>;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -429,6 +448,12 @@ export function renderStageInfo(data: StageInfoPayload): string {
 }
 
 export function searchStages(pattern: string, maxResults: number = 30): string {
+  const data = buildStageSearch(pattern, maxResults);
+  if (typeof data === "string") return data;
+  return renderStageSearch(data);
+}
+
+export function buildStageSearch(pattern: string, maxResults: number = 30): StageSearchPayload | string {
   if (maxResults < 1) return "max_results 必须 >= 1。";
   if (maxResults > 100) return "max_results 必须 <= 100。";
 
@@ -454,28 +479,53 @@ export function searchStages(pattern: string, maxResults: number = 30): string {
     }
   }
 
-  if (matched.length === 0) return `未找到匹配 '${pattern}' 的关卡。`;
+  return {
+    scope: "stages",
+    pattern,
+    total: matched.length,
+    results: matched.map(stageSearchEntry),
+  };
+}
 
-  const lines = [`# 搜索结果：${pattern}（共 ${matched.length} 个）`];
-  for (const record of matched) {
-    const e = record.entry;
-    const name = e.name || "（无名）";
-    const code = e.code || "?";
-    const tLabel = stageTypeLabel(e.stageType ?? "");
-    const dLabel = difficultyLabel(e.difficulty ?? "");
-    const zd = zoneDisplay(e.zoneId ?? "");
-    const ap = e.apCost ?? "?";
-    const cdesc = cleanDescription(e.description ?? "");
+export function renderStageSearch(data: StageSearchPayload): string {
+  const { pattern, results } = data;
+  if (results.length === 0) return `未找到匹配 '${pattern}' 的关卡。`;
 
-    const sid = record.stageId;
-    lines.push(`\n## ${name} [${tLabel}] ${code}（id: ${sid}）`);
-    lines.push(`- **区域**：${zd}`);
-    lines.push(`- **难度**：${dLabel}`);
-    lines.push(`- **理智**：${ap}`);
-    if (cdesc) lines.push(`- **描述**：${cdesc.slice(0, 120)}${cdesc.length > 120 ? "..." : ""}`);
+  const lines = [`# 搜索结果：${pattern}（共 ${data.total} 个）`];
+  for (const entry of results) {
+    lines.push(`\n## ${entry.name} [${entry.type_label}] ${entry.code}（id: ${entry.stage_id}）`);
+    lines.push(`- **区域**：${entry.zone_display}`);
+    lines.push(`- **难度**：${entry.difficulty_label}`);
+    lines.push(`- **理智**：${entry.ap}`);
+    if (entry.description) {
+      lines.push(
+        `- **描述**：${entry.description.slice(0, 120)}${entry.description.length > 120 ? "..." : ""}`,
+      );
+    }
   }
 
   return lines.join("\n");
+}
+
+function stageSearchEntry(record: StageSearchRecord): StageSearchPayload["results"][number] {
+  const e = record.entry;
+  const typeRaw = e.stageType ?? "";
+  const difficultyRaw = e.difficulty ?? "";
+  const zoneId = e.zoneId ?? "";
+  const ap = e.apCost;
+  return {
+    stage_id: record.stageId,
+    name: e.name || "（无名）",
+    code: e.code || "?",
+    type: typeRaw,
+    type_label: stageTypeLabel(typeRaw),
+    difficulty: difficultyRaw,
+    difficulty_label: difficultyLabel(difficultyRaw),
+    zone_id: zoneId,
+    zone_display: zoneDisplay(zoneId),
+    ap: ap ?? "?",
+    description: cleanDescription(e.description ?? ""),
+  };
 }
 
 function getStageSearchRecords(): StageSearchRecord[] {

--- a/ts/src/data/story.ts
+++ b/ts/src/data/story.ts
@@ -49,6 +49,9 @@ export {
 
 // Search
 export {
+  buildStorySearch,
+  buildStorySearchFromStore,
+  renderStorySearch,
   searchStories,
   searchStoriesFromStore,
 } from "./storySearch.js";

--- a/ts/src/data/storyReader.ts
+++ b/ts/src/data/storyReader.ts
@@ -274,7 +274,22 @@ export function buildStoryEventsListing(
 
 export function pyRepr(value: string | null | undefined): string {
   if (value === null || value === undefined) return "None";
-  return `'${value}'`;
+  const quote = value.includes("'") && !value.includes('"') ? '"' : "'";
+  let out = quote;
+  for (const ch of value) {
+    if (ch === "\\") out += "\\\\";
+    else if (ch === "\n") out += "\\n";
+    else if (ch === "\r") out += "\\r";
+    else if (ch === "\t") out += "\\t";
+    else if (ch === quote) out += `\\${quote}`;
+    else {
+      const code = ch.codePointAt(0) ?? 0;
+      out += code < 32 || code === 127
+        ? `\\x${code.toString(16).padStart(2, "0")}`
+        : ch;
+    }
+  }
+  return out + quote;
 }
 
 export function renderStoryEventsListing(data: StoryEventsListingPayload): string {

--- a/ts/src/data/storySearch.ts
+++ b/ts/src/data/storySearch.ts
@@ -14,6 +14,7 @@ import {
   type StoryLine,
   STORY_REVIEW_TABLE,
   isMemoirEvent,
+  pyRepr,
   readStoryFromStore,
   storyStore,
   withStoryStore,
@@ -42,6 +43,27 @@ export interface StorySearchIndex {
   eventIds: Set<string>;
   chapters: StorySearchChapter[];
   records: StorySearchRecord[];
+}
+
+export interface StorySearchPayload {
+  pattern: string;
+  filters: {
+    character: string | null;
+    line_type: string | null;
+    context_lines: number;
+    event_id: string | null;
+  };
+  total: number;
+  results: Array<{
+    event_id: string;
+    story_key: string;
+    story_code: string;
+    line_number: number;
+    context: Array<{
+      text: string;
+      is_match: boolean;
+    }>;
+  }>;
 }
 
 // ---------------------------------------------------------------------------
@@ -85,7 +107,21 @@ export function searchStories(
   maxResults = 30,
   eventId?: string,
 ): string {
-  return withStoryStore(zipPath, (store) => searchStoriesFromStore(
+  const data = buildStorySearch(zipPath, pattern, character, lineType, contextLines, maxResults, eventId);
+  if (typeof data === "string") return data;
+  return renderStorySearch(data);
+}
+
+export function buildStorySearch(
+  zipPath: string,
+  pattern: string,
+  character?: string,
+  lineType?: string,
+  contextLines = 1,
+  maxResults = 30,
+  eventId?: string,
+): StorySearchPayload | string {
+  return withStoryStore(zipPath, (store) => buildStorySearchFromStore(
     store,
     pattern,
     character,
@@ -94,13 +130,6 @@ export function searchStories(
     maxResults,
     eventId,
   ));
-}
-
-interface SearchResult {
-  eventId: string;
-  storyCode: string;
-  lineNumber: number;
-  context: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -116,6 +145,28 @@ export function searchStoriesFromStore(
   maxResults = 30,
   eventId?: string,
 ): string {
+  const data = buildStorySearchFromStore(
+    store,
+    pattern,
+    character,
+    lineType,
+    contextLines,
+    maxResults,
+    eventId,
+  );
+  if (typeof data === "string") return data;
+  return renderStorySearch(data);
+}
+
+export function buildStorySearchFromStore(
+  store: JsonStore,
+  pattern: string,
+  character?: string,
+  lineType?: string,
+  contextLines = 1,
+  maxResults = 30,
+  eventId?: string,
+): StorySearchPayload | string {
   if (maxResults < 1) return "max_results 必须 >= 1。";
   if (maxResults > 100) return "max_results 必须 <= 100。";
   if (contextLines < 0) return "context_lines 必须 >= 0。";
@@ -130,7 +181,7 @@ export function searchStoriesFromStore(
 
   if (lineType !== undefined && !VALID_LINE_TYPES.has(lineType)) {
     const valid = Array.from(VALID_LINE_TYPES).sort().join(", ");
-    return `无效的 line_type：${JSON.stringify(lineType)}，可选值：${valid}`;
+    return `无效的 line_type：${pyRepr(lineType)}，可选值：${valid}`;
   }
 
   let index: StorySearchIndex;
@@ -141,10 +192,10 @@ export function searchStoriesFromStore(
   }
 
   if (eventId !== undefined && !index.eventIds.has(eventId)) {
-    return `未找到匹配的活动：${JSON.stringify(eventId)}。`;
+    return `未找到匹配的活动：${pyRepr(eventId)}。`;
   }
 
-  const results: SearchResult[] = [];
+  const results: StorySearchPayload["results"] = [];
 
   for (const record of index.records) {
     if (results.length >= maxResults) break;
@@ -162,33 +213,56 @@ export function searchStoriesFromStore(
 
     const start = Math.max(0, record.lineIndex - contextLines);
     const end = Math.min(chapter.lines.length, record.lineIndex + contextLines + 1);
-    const ctxParts: string[] = [];
+    const context: StorySearchPayload["results"][number]["context"] = [];
     for (let j = start; j < end; j++) {
-      const prefix = j === record.lineIndex ? ">>> " : "    ";
-      ctxParts.push(prefix + formatStoryLine(chapter.lines[j]));
+      context.push({
+        text: formatStoryLine(chapter.lines[j]),
+        is_match: j === record.lineIndex,
+      });
     }
 
     results.push({
-      eventId: chapter.eventId,
-      storyCode: chapter.storyCode,
-      lineNumber: record.lineIndex + 1,
-      context: ctxParts.join("\n"),
+      event_id: chapter.eventId,
+      story_key: chapter.storyKey,
+      story_code: chapter.storyCode,
+      line_number: record.lineIndex + 1,
+      context,
     });
   }
 
+  return {
+    pattern,
+    filters: {
+      character: character ?? null,
+      line_type: lineType ?? null,
+      context_lines: contextLines,
+      event_id: eventId ?? null,
+    },
+    total: results.length,
+    results,
+  };
+}
+
+export function renderStorySearch(data: StorySearchPayload): string {
+  const { pattern, results } = data;
   if (results.length === 0) {
-    const filters: string[] = [];
-    if (eventId) filters.push(`event_id=${JSON.stringify(eventId)}`);
-    if (character) filters.push(`character=${JSON.stringify(character)}`);
-    if (lineType) filters.push(`line_type=${JSON.stringify(lineType)}`);
-    const filterSuffix = filters.length > 0 ? `（过滤条件：${filters.join("。")}）` : "";
+    const filters = data.filters;
+    const filterDesc = [
+      filters.event_id ? `event_id=${pyRepr(filters.event_id)}` : "",
+      filters.character ? `character=${pyRepr(filters.character)}` : "",
+      filters.line_type ? `line_type=${pyRepr(filters.line_type)}` : "",
+    ].filter(Boolean).join("。");
+    const filterSuffix = filterDesc ? `（过滤条件：${filterDesc}）` : "";
     return `未找到匹配 '${pattern}' 的剧情台词。${filterSuffix}`;
   }
 
-  const parts: string[] = [`# 搜索 "${pattern}" 的结果（共 ${results.length} 条）`];
+  const parts: string[] = [`# 搜索 "${pattern}" 的结果（共 ${data.total} 条）`];
   for (const r of results) {
+    const context = r.context
+      .map((item) => `${item.is_match ? ">>> " : "    "}${item.text}`)
+      .join("\n");
     parts.push(
-      `\n---\n\n[stories/${r.eventId}/${r.storyCode} L${r.lineNumber}]\n${r.context}`
+      `\n---\n\n[stories/${r.event_id}/${r.story_code} L${r.line_number}]\n${context}`
     );
   }
 

--- a/ts/src/tools/gamedataTools.ts
+++ b/ts/src/tools/gamedataTools.ts
@@ -18,21 +18,18 @@ import {
   buildEnemyInfo,
   renderEnemiesListing,
   renderEnemyInfo,
-  searchEnemies,
 } from "../data/enemy.js";
 import {
   buildStageInfo,
   buildStagesListing,
   renderStageInfo,
   renderStagesListing,
-  searchStages,
 } from "../data/stage.js";
 import {
   buildItemInfo,
   buildItemsListing,
   renderItemInfo,
   renderItemsListing,
-  searchItems,
 } from "../data/item.js";
 import {
   buildEnemyAppearances,
@@ -41,7 +38,7 @@ import {
   renderEnemyAppearances,
   renderStageEnemies,
 } from "../data/stageEnemy.js";
-import { searchOperatorData } from "../data/search.js";
+import { buildSearch, renderSearch } from "../data/search.js";
 import { renderResult, textResult, type OutputChannel } from "../output.js";
 
 export function registerGamedataTools(server: McpServer, channel: OutputChannel = "content"): void {
@@ -274,17 +271,9 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
       max_results: z.number().int().min(1).max(100).default(30).describe("返回结果数量上限，默认 30。"),
     },
     ({ scope, pattern, max_results }) => {
-      const searchers: Record<string, (p: string, n: number) => string> = {
-        operators: searchOperatorData,
-        enemies: searchEnemies,
-        stages: searchStages,
-        items: searchItems,
-      };
-      const fn = searchers[scope];
-      if (!fn) {
-        return { content: [{ type: "text", text: `不支持的搜索域：${JSON.stringify(scope)}。可选：operators、enemies、stages、items。` }] };
-      }
-      return { content: [{ type: "text", text: fn(pattern, max_results) }] };
+      const data = buildSearch(scope, pattern, max_results);
+      if (typeof data === "string") return textResult(data);
+      return renderResult(data, renderSearch(data), channel);
     }
   );
 }

--- a/ts/src/tools/prtsTools.ts
+++ b/ts/src/tools/prtsTools.ts
@@ -15,9 +15,58 @@ import {
   getLinks,
   getTemplateData,
 } from "../api/prtsWiki.js";
-import type { OutputChannel } from "../output.js";
+import { renderResult, textResult, type OutputChannel } from "../output.js";
 
-export function registerPrtsTools(server: McpServer, _channel: OutputChannel = "content"): void {
+export interface PrtsSearchPayload {
+  query: string;
+  search_mode: "text" | "title";
+  filters: {
+    limit: number;
+    filter_technical: boolean;
+  };
+  total: number;
+  results: Array<{
+    title: string;
+    snippet: string;
+  }>;
+}
+
+export async function buildPrtsSearch(
+  query: string,
+  limit = 5,
+  searchMode: "text" | "title" | string = "text",
+  filterTechnical = true,
+): Promise<PrtsSearchPayload | string> {
+  if (searchMode !== "text" && searchMode !== "title") {
+    return "无效的 search_mode 参数，可选值：text、title。";
+  }
+  const result = await searchPrts(query, limit, searchMode, filterTechnical);
+  return {
+    query,
+    search_mode: searchMode,
+    filters: {
+      limit,
+      filter_technical: filterTechnical,
+    },
+    total: result.totalHits,
+    results: result.results.map((r) => ({
+      title: r.title,
+      snippet: r.snippet,
+    })),
+  };
+}
+
+export function renderPrtsSearch(data: PrtsSearchPayload): string {
+  const { query, results } = data;
+  if (results.length === 0) return `未找到与 '${query}' 相关的词条。`;
+  const header = `# 搜索 "${query}"（共 ${data.total} 条匹配）\n`;
+  const body = results
+    .map((r) => `**${r.title}**\n${r.snippet}`)
+    .join("\n\n---\n\n");
+  return header + body;
+}
+
+export function registerPrtsTools(server: McpServer, channel: OutputChannel = "content"): void {
   server.tool(
     "search_prts",
     [
@@ -31,15 +80,13 @@ export function registerPrtsTools(server: McpServer, _channel: OutputChannel = "
       filter_technical: z.boolean().default(true).describe("是否过滤 /spine、/data 等技术页面，默认 true。"),
     },
     async ({ query, limit, search_mode, filter_technical }) => {
-      const result = await searchPrts(query, limit, search_mode, filter_technical);
-      if (result.results.length === 0) {
-        return { content: [{ type: "text", text: `未找到与 '${query}' 相关的词条。` }] };
+      try {
+        const data = await buildPrtsSearch(query, limit, search_mode, filter_technical);
+        if (typeof data === "string") return textResult(data);
+        return renderResult(data, renderPrtsSearch(data), channel);
+      } catch (e) {
+        return textResult(`搜索 PRTS 失败：${e instanceof Error ? e.message : String(e)}`);
       }
-      const header = `# 搜索 "${query}"（共 ${result.totalHits} 条匹配）\n`;
-      const body = result.results
-        .map((r) => `**${r.title}**\n${r.snippet}`)
-        .join("\n\n---\n\n");
-      return { content: [{ type: "text", text: header + body }] };
     }
   );
 
@@ -61,41 +108,41 @@ export function registerPrtsTools(server: McpServer, _channel: OutputChannel = "
       try {
         if (action === "read") {
           const text = await readPage(page_title, section_index);
-          return { content: [{ type: "text", text }] };
+          return textResult(text);
         }
         if (action === "sections") {
           const sections = await listSections(page_title);
           if (sections.length === 0) {
-            return { content: [{ type: "text", text: `页面 '${page_title}' 没有章节目录。` }] };
+            return textResult(`页面 '${page_title}' 没有章节目录。`);
           }
-          return { content: [{ type: "text", text: sections.map((s) => `[${s.index}] L${s.level} ${s.line}`).join("\n") }] };
+          return textResult(sections.map((s) => `[${s.index}] L${s.level} ${s.line}`).join("\n"));
         }
         if (action === "categories") {
           const cats = await getCategories(page_title);
           if (cats.length === 0) {
-            return { content: [{ type: "text", text: `页面 '${page_title}' 没有分类标签。` }] };
+            return textResult(`页面 '${page_title}' 没有分类标签。`);
           }
-          return { content: [{ type: "text", text: cats.map((c) => `- ${c}`).join("\n") }] };
+          return textResult(cats.map((c) => `- ${c}`).join("\n"));
         }
         if (action === "links") {
           const result = await getLinks(page_title, direction, limit);
           if (result.links.length === 0) {
             const dirLabel = direction === "outbound" ? "出站" : "入站";
-            return { content: [{ type: "text", text: `页面 '${page_title}' 没有${dirLabel}链接。` }] };
+            return textResult(`页面 '${page_title}' 没有${dirLabel}链接。`);
           }
           const suffix = result.hasMore
             ? `\n（共 ${result.total} 条，还有更多）`
             : `\n（共 ${result.total} 条）`;
-          return { content: [{ type: "text", text: result.links.map((ln) => `- ${ln}`).join("\n") + suffix }] };
+          return textResult(result.links.map((ln) => `- ${ln}`).join("\n") + suffix);
         }
         // action === "template"
         const templates = await getTemplateData(page_title);
         if (Object.keys(templates).length === 0) {
-          return { content: [{ type: "text", text: `页面 '${page_title}' 未找到可提取的模板数据。` }] };
+          return textResult(`页面 '${page_title}' 未找到可提取的模板数据。`);
         }
-        return { content: [{ type: "text", text: JSON.stringify(templates, null, 2) }] };
+        return textResult(JSON.stringify(templates, null, 2));
       } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+        return textResult(e instanceof Error ? e.message : String(e));
       }
     }
   );

--- a/ts/src/tools/storyTools.ts
+++ b/ts/src/tools/storyTools.ts
@@ -22,7 +22,8 @@ import {
   renderStoryEventsListing,
   readStory as _readStory,
   readActivity as _readActivity,
-  searchStories as _searchStories,
+  buildStorySearch as _buildStorySearch,
+  renderStorySearch,
   getStorySummary as _getStorySummary,
   type StoryChapter,
   type StoryLine,
@@ -281,7 +282,7 @@ export function registerStoryTools(server: McpServer, channel: OutputChannel = "
         return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
       }
       try {
-        const text = _searchStories(
+        const data = _buildStorySearch(
           zipPath,
           pattern,
           character,
@@ -290,9 +291,10 @@ export function registerStoryTools(server: McpServer, channel: OutputChannel = "
           max_results,
           event_id,
         );
-        return { content: [{ type: "text", text }] };
+        if (typeof data === "string") return textResult(data);
+        return renderResult(data, renderStorySearch(data), channel);
       } catch (e) {
-        return { content: [{ type: "text", text: `剧情搜索失败：${e instanceof Error ? e.message : String(e)}` }] };
+        return textResult(`剧情搜索失败：${e instanceof Error ? e.message : String(e)}`);
       }
     }
   );

--- a/ts/tests/enemy.test.ts
+++ b/ts/tests/enemy.test.ts
@@ -275,8 +275,21 @@ test("search_enemies matches by description", async () => {
   writeFixtures(root);
   const enemy = await loadEnemyModule();
   const out = enemy.searchEnemies("整合运动");
-  assert.match(out, /霜星/);
-  assert.deepStrictEqual(enemy.buildEnemySearch("整合运动"), loadParityFixture("search_enemies.json"));
+  const data = enemy.buildEnemySearch("整合运动");
+  assert.deepStrictEqual(data, loadParityFixture("search_enemies.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  const expected = [
+    "# 搜索结果：整合运动（共 1 个）",
+    "",
+    "# 霜星 - 敌人图鉴",
+    "",
+    "- **编号**：FN",
+    "- **威胁等级**：领袖",
+    "- **描述**：整合运动法术部队干部。",
+    "- **伤害类型**：法术",
+  ].join("\n");
+  assert.equal(enemy.renderEnemySearch(data), expected);
+  assert.equal(out, expected);
 });
 
 test("search_enemies no match", async () => {
@@ -285,8 +298,12 @@ test("search_enemies no match", async () => {
   writeFixtures(root);
   const enemy = await loadEnemyModule();
   const out = enemy.searchEnemies("绝对不存在的关键词");
-  assert.match(out, /未找到匹配/);
+  const data = enemy.buildEnemySearch("绝对不存在的关键词");
   assert.deepStrictEqual(enemy.buildEnemySearch("ZZZZZZZ"), loadParityFixture("search_enemies_empty.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  const expected = "未找到匹配 '绝对不存在的关键词' 的敌人。";
+  assert.equal(enemy.renderEnemySearch(data), expected);
+  assert.equal(out, expected);
 });
 
 test("search_enemies invalid regex", async () => {

--- a/ts/tests/enemy.test.ts
+++ b/ts/tests/enemy.test.ts
@@ -276,6 +276,7 @@ test("search_enemies matches by description", async () => {
   const enemy = await loadEnemyModule();
   const out = enemy.searchEnemies("整合运动");
   assert.match(out, /霜星/);
+  assert.deepStrictEqual(enemy.buildEnemySearch("整合运动"), loadParityFixture("search_enemies.json"));
 });
 
 test("search_enemies no match", async () => {
@@ -285,6 +286,7 @@ test("search_enemies no match", async () => {
   const enemy = await loadEnemyModule();
   const out = enemy.searchEnemies("绝对不存在的关键词");
   assert.match(out, /未找到匹配/);
+  assert.deepStrictEqual(enemy.buildEnemySearch("ZZZZZZZ"), loadParityFixture("search_enemies_empty.json"));
 });
 
 test("search_enemies invalid regex", async () => {

--- a/ts/tests/item.test.ts
+++ b/ts/tests/item.test.ts
@@ -185,9 +185,18 @@ test("searchItems", async () => {
   writeFixtures(root);
   const item = await loadItemModule();
   const out = item.searchItems("公开渠道");
-  assert.match(out, /招聘许可/);
-  assert.match(out, /搜索结果/);
-  assert.deepStrictEqual(item.buildItemSearch("公开渠道"), loadParityFixture("search_items.json"));
+  const data = item.buildItemSearch("公开渠道");
+  assert.deepStrictEqual(data, loadParityFixture("search_items.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  const expected = [
+    "# 搜索结果：公开渠道（共 1 个）",
+    "",
+    "## 招聘许可 [普通/TKT_RECRUIT] T4（id: 7001）",
+    "- **用途**：可从公开渠道招聘一位干员。",
+    "- **获取方式**：采购中心、任务奖励",
+  ].join("\n");
+  assert.equal(item.renderItemSearch(data), expected);
+  assert.equal(out, expected);
 });
 
 test("searchItems empty payload matches shared parity fixture", async () => {

--- a/ts/tests/item.test.ts
+++ b/ts/tests/item.test.ts
@@ -187,6 +187,18 @@ test("searchItems", async () => {
   const out = item.searchItems("公开渠道");
   assert.match(out, /招聘许可/);
   assert.match(out, /搜索结果/);
+  assert.deepStrictEqual(item.buildItemSearch("公开渠道"), loadParityFixture("search_items.json"));
+});
+
+test("searchItems empty payload matches shared parity fixture", async () => {
+  const root = tempGamedataRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  writeFixtures(root);
+  const item = await loadItemModule();
+  const data = item.buildItemSearch("ZZZZNOMATCH");
+  assert.deepStrictEqual(data, loadParityFixture("search_items_empty.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  assert.equal(item.renderItemSearch(data), "未找到匹配 'ZZZZNOMATCH' 的物品。");
 });
 
 test("searchItems invalid regex", async () => {

--- a/ts/tests/prtsTools.test.ts
+++ b/ts/tests/prtsTools.test.ts
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { buildPrtsSearch, renderPrtsSearch } from "../src/tools/prtsTools.ts";
+
+function loadParityFixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(join(import.meta.dirname, "..", "..", "tests", "parity-fixtures", name), "utf-8"),
+  );
+}
+
+function mockFetch(payload: unknown): () => void {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async () => ({
+    ok: true,
+    status: 200,
+    json: async () => payload,
+  })) as typeof fetch;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+test("buildPrtsSearch payload matches shared parity fixture", async () => {
+  const restore = mockFetch({
+    query: {
+      searchinfo: { totalhits: 9 },
+      search: [{ title: "阿米娅", snippet: "罗德岛公开领袖。" }],
+    },
+  });
+  try {
+    const data = await buildPrtsSearch("阿米娅", 1);
+    assert.deepStrictEqual(data, loadParityFixture("search_prts.json"));
+    if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+    assert.equal(
+      renderPrtsSearch(data),
+      "# 搜索 \"阿米娅\"（共 9 条匹配）\n**阿米娅**\n罗德岛公开领袖。",
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("buildPrtsSearch empty payload matches shared parity fixture", async () => {
+  const restore = mockFetch({
+    query: {
+      searchinfo: { totalhits: 0 },
+      search: [],
+    },
+  });
+  try {
+    const data = await buildPrtsSearch("不存在");
+    assert.deepStrictEqual(data, loadParityFixture("search_prts_empty.json"));
+    if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+    assert.equal(renderPrtsSearch(data), "未找到与 '不存在' 相关的词条。");
+  } finally {
+    restore();
+  }
+});
+
+test("buildPrtsSearch rejects invalid mode before network", async () => {
+  assert.equal(
+    await buildPrtsSearch("阿米娅", 5, "bad"),
+    "无效的 search_mode 参数，可选值：text、title。",
+  );
+});

--- a/ts/tests/search.test.ts
+++ b/ts/tests/search.test.ts
@@ -4,14 +4,14 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import AdmZip from "adm-zip";
 
 import { DirectoryStore, ZipStore, type JsonStore } from "../src/data/stores.ts";
-import { searchOperatorData } from "../src/data/search.ts";
-import { searchStoriesFromStore } from "../src/data/story.ts";
+import { buildOperatorSearch, renderOperatorSearch, searchOperatorData } from "../src/data/search.ts";
+import { buildStorySearchFromStore, renderStorySearch, searchStoriesFromStore } from "../src/data/story.ts";
 import { writeMinimalGamedata } from "./fixtures/operatorData.ts";
 
 // ---------------------------------------------------------------------------
@@ -115,6 +115,12 @@ function tempRoot(): string {
   return mkdtempSync(join(tmpdir(), "prts-search-test-"));
 }
 
+function loadParityFixture(name: string): unknown {
+  return JSON.parse(
+    readFileSync(join(import.meta.dirname, "..", "..", "tests", "parity-fixtures", name), "utf-8"),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Operator search tests
 // ---------------------------------------------------------------------------
@@ -174,8 +180,10 @@ test("search_operator_data no match", async () => {
   writeMinimalGamedata(root);
 
   const search = await loadSearchModule();
-  const result = search.searchOperatorData("ZZZZZZZ");
-  assert.match(result, /未找到匹配/);
+  const data = search.buildOperatorSearch("ZZZZZZZ");
+  assert.deepStrictEqual(data, loadParityFixture("search_operators_empty.json"));
+  assert.equal(search.renderOperatorSearch(data), "未找到匹配 'ZZZZZZZ' 的干员数据。");
+  assert.equal(search.searchOperatorData("ZZZZZZZ"), "未找到匹配 'ZZZZZZZ' 的干员数据。");
 });
 
 test("search_operator_data invalid regex", async () => {
@@ -219,6 +227,30 @@ test("search_operator_data max_results cap", async () => {
   const search = await loadSearchModule();
   const result = search.searchOperatorData(".", 101);
   assert.match(result, /max_results 必须 <= 100/);
+});
+
+test("search_operator_data payload matches shared parity fixture", async () => {
+  const root = tempRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  delete process.env["STORYJSON_PATH"];
+  writeMinimalGamedata(root);
+
+  const search = await loadSearchModule();
+  const data = search.buildOperatorSearch("阿米娅");
+  assert.deepStrictEqual(data, loadParityFixture("search_operators.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  assert.equal(
+    search.renderOperatorSearch(data),
+    "# 搜索 \"阿米娅\" 的结果（共 2 条）\n" +
+      "---\n\n" +
+      "[operators/basic/阿米娅]\n" +
+      "匹配：干员名称\n" +
+      "阿米娅\n" +
+      "---\n\n" +
+      "[operators/archives/阿米娅]\n" +
+      "匹配：档案资料一\n" +
+      "阿米娅的档案文本。",
+  );
 });
 
 // ---------------------------------------------------------------------------
@@ -284,8 +316,11 @@ for (const kind of ["directory", "zip"] as const) {
   test(`search_stories no match (${kind})`, () => {
     const root = tempRoot();
     const store = storyStore(kind, root);
-    const result = searchStoriesFromStore(store, "ZZZZZZ");
-    assert.match(result, /未找到匹配/);
+    const data = buildStorySearchFromStore(store, "ZZZZZZ");
+    assert.deepStrictEqual(data, loadParityFixture("search_stories_empty.json"));
+    if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+    assert.equal(renderStorySearch(data), "未找到匹配 'ZZZZZZ' 的剧情台词。");
+    assert.equal(searchStoriesFromStore(store, "ZZZZZZ"), "未找到匹配 'ZZZZZZ' 的剧情台词。");
   });
 
   test(`search_stories invalid regex (${kind})`, () => {
@@ -331,6 +366,22 @@ for (const kind of ["directory", "zip"] as const) {
   });
 }
 
+test("search_stories payload matches shared parity fixture", () => {
+  const root = tempRoot();
+  const store = storyStore("directory", root);
+  const data = buildStorySearchFromStore(store, "你好");
+  assert.deepStrictEqual(data, loadParityFixture("search_stories.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  assert.equal(
+    renderStorySearch(data),
+    "# 搜索 \"你好\" 的结果（共 1 条）\n\n" +
+      "---\n\n" +
+      "[stories/act_test/TEST-1 L1]\n" +
+      ">>> 阿米娅：你好，博士。\n" +
+      "    *罗德岛走廊*",
+  );
+});
+
 // ---------------------------------------------------------------------------
 // search module export sanity check
 // ---------------------------------------------------------------------------
@@ -339,5 +390,9 @@ test("search modules export the expected functions", () => {
   // Tool surface test already validates server.tool() calls, so here we
   // just verify the search modules export the expected functions.
   assert.equal(typeof searchOperatorData, "function");
+  assert.equal(typeof buildOperatorSearch, "function");
+  assert.equal(typeof renderOperatorSearch, "function");
   assert.equal(typeof searchStoriesFromStore, "function");
+  assert.equal(typeof buildStorySearchFromStore, "function");
+  assert.equal(typeof renderStorySearch, "function");
 });

--- a/ts/tests/search.test.ts
+++ b/ts/tests/search.test.ts
@@ -305,6 +305,13 @@ for (const kind of ["directory", "zip"] as const) {
     assert.match(result, /未找到匹配的活动/);
   });
 
+  test(`search_stories missing event_id uses Python repr (${kind})`, () => {
+    const root = tempRoot();
+    const store = storyStore(kind, root);
+    const result = searchStoriesFromStore(store, ".", undefined, undefined, 1, 30, "a\nb");
+    assert.equal(result, "未找到匹配的活动：'a\\nb'。");
+  });
+
   test(`search_stories context zero (${kind})`, () => {
     const root = tempRoot();
     const store = storyStore(kind, root);
@@ -333,8 +340,8 @@ for (const kind of ["directory", "zip"] as const) {
   test(`search_stories invalid line_type (${kind})`, () => {
     const root = tempRoot();
     const store = storyStore(kind, root);
-    const result = searchStoriesFromStore(store, ".", undefined, "invalid");
-    assert.match(result, /无效的 line_type/);
+    const result = searchStoriesFromStore(store, ".", undefined, "bad'value");
+    assert.equal(result, "无效的 line_type：\"bad'value\"，可选值：choice, dialog, narration");
   });
 
   test(`search_stories max_results cap (${kind})`, () => {

--- a/ts/tests/stage.test.ts
+++ b/ts/tests/stage.test.ts
@@ -456,6 +456,7 @@ test("searchStages by description", async () => {
   const stage = await loadStageModule();
   const out = stage.searchStages("先锋");
   assert.match(out, /坍塌/);
+  assert.deepStrictEqual(stage.buildStageSearch("先锋"), loadParityFixture("search_stages.json"));
 });
 
 test("searchStages multiple matches", async () => {
@@ -474,6 +475,7 @@ test("searchStages no match", async () => {
   const stage = await loadStageModule();
   const out = stage.searchStages("ZZZZNOMATCH");
   assert.match(out, /未找到匹配/);
+  assert.deepStrictEqual(stage.buildStageSearch("ZZZZNOMATCH"), loadParityFixture("search_stages_empty.json"));
 });
 
 test("searchStages invalid regex", async () => {

--- a/ts/tests/stage.test.ts
+++ b/ts/tests/stage.test.ts
@@ -455,8 +455,20 @@ test("searchStages by description", async () => {
   writeFixtures(root);
   const stage = await loadStageModule();
   const out = stage.searchStages("先锋");
-  assert.match(out, /坍塌/);
-  assert.deepStrictEqual(stage.buildStageSearch("先锋"), loadParityFixture("search_stages.json"));
+  const data = stage.buildStageSearch("先锋");
+  assert.deepStrictEqual(data, loadParityFixture("search_stages.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  const expected = [
+    "# 搜索结果：先锋（共 1 个）",
+    "",
+    "## 坍塌 [主线] 0-1（id: main_00-01）",
+    "- **区域**：序章-黑暗时代·上",
+    "- **难度**：普通",
+    "- **理智**：6",
+    "- **描述**：三点方向出现了敌人的先锋部队。",
+  ].join("\n");
+  assert.equal(stage.renderStageSearch(data), expected);
+  assert.equal(out, expected);
 });
 
 test("searchStages multiple matches", async () => {
@@ -474,8 +486,12 @@ test("searchStages no match", async () => {
   writeFixtures(root);
   const stage = await loadStageModule();
   const out = stage.searchStages("ZZZZNOMATCH");
-  assert.match(out, /未找到匹配/);
-  assert.deepStrictEqual(stage.buildStageSearch("ZZZZNOMATCH"), loadParityFixture("search_stages_empty.json"));
+  const data = stage.buildStageSearch("ZZZZNOMATCH");
+  assert.deepStrictEqual(data, loadParityFixture("search_stages_empty.json"));
+  if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+  const expected = "未找到匹配 'ZZZZNOMATCH' 的关卡。";
+  assert.equal(stage.renderStageSearch(data), expected);
+  assert.equal(out, expected);
 });
 
 test("searchStages invalid regex", async () => {

--- a/ts/tests/toolSurface.test.ts
+++ b/ts/tests/toolSurface.test.ts
@@ -308,6 +308,13 @@ async function callTool(
 }
 
 test("output-channel semantic invariant for structured and narrative tools", async () => {
+  const invariantTools = [
+    ...Object.keys(STRUCTURED_TOOL_ARGS),
+    ...Object.keys(NARRATIVE_TOOL_ARGS),
+  ];
+  assert.deepEqual([...new Set(invariantTools)].sort(), [...EXPECTED_TOOLS].sort());
+  assert.equal(new Set(invariantTools).size, invariantTools.length, "tool invariant args contain duplicates");
+
   const root = mkdtempSync(join(tmpdir(), "prts-tool-invariant-"));
   const storyZip = join(mkdtempSync(join(tmpdir(), "prts-tool-story-")), "zh_CN.zip");
   const oldGamedata = process.env["GAMEDATA_PATH"];

--- a/ts/tests/toolSurface.test.ts
+++ b/ts/tests/toolSurface.test.ts
@@ -1,7 +1,20 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readdirSync, readFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
+import AdmZip from "adm-zip";
+
+import { clearEnemyCaches } from "../src/data/enemy.ts";
+import { clearItemCaches } from "../src/data/item.ts";
+import { clearOperatorCaches } from "../src/data/operator.ts";
+import { clearStageCaches } from "../src/data/stage.ts";
+import { clearStageEnemyCaches } from "../src/data/stageEnemy.ts";
+import { clearStoryCaches } from "../src/data/story.ts";
+import { registerGamedataTools } from "../src/tools/gamedataTools.ts";
+import { registerPrtsTools } from "../src/tools/prtsTools.ts";
+import { registerStoryTools } from "../src/tools/storyTools.ts";
+import { writeMinimalGamedata } from "./fixtures/operatorData.ts";
 
 const EXPECTED_TOOLS = [
   "search_prts",
@@ -43,4 +56,292 @@ test("TypeScript MCP tool names are frozen", () => {
   // Compare as sets — tool registration order is not part of the frozen surface.
   assert.deepEqual(toolNames.sort(), [...EXPECTED_TOOLS].sort());
   assert.equal(toolNames.length, EXPECTED_TOOLS.length, "tool count mismatch");
+});
+
+type ToolHandler = (args: Record<string, unknown>) => unknown | Promise<unknown>;
+
+class CapturingServer {
+  tools = new Map<string, ToolHandler>();
+
+  tool(name: string, _description: unknown, _schema: unknown, handler: ToolHandler): void {
+    this.tools.set(name, handler);
+  }
+}
+
+function writeJson(path: string, data: unknown): void {
+  writeFileSync(path, JSON.stringify(data), "utf-8");
+}
+
+function writeInvariantGamedata(root: string): void {
+  writeMinimalGamedata(root);
+  const excel = join(root, "zh_CN", "gamedata", "excel");
+
+  writeJson(join(excel, "enemy_handbook_table.json"), {
+    enemyData: {
+      enemy_1007_slime: {
+        enemyId: "enemy_1007_slime",
+        enemyIndex: "B1",
+        name: "源石虫",
+        enemyLevel: "NORMAL",
+        sortId: 1,
+        description: "野生的被感染生物。",
+        damageType: ["PHYSIC"],
+        hideInHandbook: false,
+      },
+    },
+  });
+  writeJson(join(excel, "stage_table.json"), {
+    stages: {
+      "main_00-01": {
+        stageId: "main_00-01",
+        code: "0-1",
+        name: "坍塌",
+        stageType: "MAIN",
+        difficulty: "NORMAL",
+        zoneId: "main_0",
+        levelId: "Obt/Main/level_main_00-01",
+        apCost: 6,
+        dangerLevel: "LV.1",
+        description: "三点方向出现了敌人的先锋部队。",
+        stageDropInfo: { displayRewards: [{ type: "TKT_RECRUIT", id: "7001", dropType: "ONCE" }] },
+        unlockCondition: [],
+        bossMark: false,
+      },
+    },
+  });
+  writeJson(join(excel, "zone_table.json"), {
+    zones: {
+      main_0: {
+        zoneID: "main_0",
+        zoneNameFirst: "序章",
+        zoneNameSecond: "黑暗时代·上",
+      },
+    },
+  });
+  writeJson(join(excel, "item_table.json"), {
+    items: {
+      "7001": {
+        itemId: "7001",
+        name: "招聘许可",
+        description: "人事部颁发的许可书。",
+        rarity: "TIER_4",
+        iconId: "TKT_RECRUIT",
+        sortId: 40012,
+        usage: "可从公开渠道招聘一位干员。",
+        obtainApproach: "采购中心、任务奖励",
+        hideInItemGet: false,
+        classifyType: "NORMAL",
+        itemType: "TKT_RECRUIT",
+        stageDropList: [],
+      },
+    },
+  });
+
+  const levels = join(root, "zh_CN", "gamedata", "levels");
+  mkdirSync(join(levels, "enemydata"), { recursive: true });
+  mkdirSync(join(levels, "obt", "main"), { recursive: true });
+  writeJson(join(levels, "enemydata", "enemy_database.json"), {
+    enemies: [
+      {
+        Key: "enemy_1007_slime",
+        Value: [
+          {
+            level: 0,
+            enemyData: {
+              attributes: {
+                maxHp: { m_defined: true, m_value: 550 },
+                atk: { m_defined: true, m_value: 130 },
+                def: { m_defined: true, m_value: 0 },
+                magicResistance: { m_defined: true, m_value: 0 },
+              },
+            },
+          },
+        ],
+      },
+    ],
+  });
+  writeJson(join(levels, "obt", "main", "level_main_00-01.json"), {
+    enemyDbRefs: [{ id: "enemy_1007_slime", level: 0, overwrittenData: null }],
+    waves: [{ fragments: [{ actions: [{ actionType: "SPAWN", key: "enemy_1007_slime", count: 3 }] }] }],
+  });
+}
+
+function writeInvariantStoryZip(zipPath: string): void {
+  const zip = new AdmZip();
+  const firstStoryKey = "activities/act_test/level_act_test_01_beg";
+  const memoirStoryKey = "memory/amiya/level_amiya_01";
+  const files: Record<string, unknown> = {
+    "zh_CN/gamedata/excel/story_review_table.json": {
+      act_test: {
+        name: "测试活动",
+        entryType: "ACTIVITY",
+        infoUnlockDatas: [
+          { storyTxt: firstStoryKey, storyCode: "TEST-1", storyName: "开端", avgTag: "BEG", storySort: 1 },
+        ],
+      },
+      story_amiya_set_1: {
+        name: "阿米娅密录",
+        entryType: "NONE",
+        infoUnlockDatas: [
+          { storyTxt: memoirStoryKey, storyCode: "AM-1", storyName: "出发", avgTag: null, storySort: 1 },
+        ],
+      },
+    },
+    "zh_CN/chardict.json": {
+      amiya: { name: "阿米娅", id: "char_002_amiya" },
+    },
+    "zh_CN/storyinfo.json": {
+      [firstStoryKey]: "第一章梗概",
+      [memoirStoryKey]: "密录梗概",
+    },
+    [`zh_CN/gamedata/story/${firstStoryKey}.json`]: {
+      storyCode: "TEST-1",
+      storyName: "开端",
+      avgTag: "BEG",
+      eventName: "测试活动",
+      storyInfo: "第一章梗概",
+      storyList: [
+        { prop: "name", attributes: { name: "阿米娅", content: "你好，博士。" } },
+        { prop: "name", attributes: { name: "博士", content: "我们出发吧。" } },
+      ],
+    },
+    [`zh_CN/gamedata/story/${memoirStoryKey}.json`]: {
+      storyCode: "AM-1",
+      storyName: "出发",
+      avgTag: null,
+      eventName: "阿米娅密录",
+      storyInfo: "密录梗概",
+      storyList: [
+        { prop: "name", attributes: { name: "阿米娅", content: "继续前进。" } },
+      ],
+    },
+  };
+  for (const [innerPath, data] of Object.entries(files)) {
+    zip.addFile(innerPath, Buffer.from(JSON.stringify(data), "utf-8"));
+  }
+  mkdirSync(join(zipPath, ".."), { recursive: true });
+  zip.writeZip(zipPath);
+}
+
+function resetCaches(): void {
+  clearOperatorCaches();
+  clearEnemyCaches();
+  clearStageCaches();
+  clearItemCaches();
+  clearStageEnemyCaches();
+  clearStoryCaches();
+}
+
+function mockPrtsFetch(): () => void {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = new URL(String(input));
+    const list = url.searchParams.get("list");
+    const prop = url.searchParams.get("prop");
+    if (list === "search") {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          query: {
+            searchinfo: { totalhits: 1 },
+            search: [{ title: "阿米娅", snippet: "罗德岛公开领袖。" }],
+          },
+        }),
+      } as Response;
+    }
+    if (prop === "text") {
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ parse: { text: { "*": "<p>阿米娅页面正文。</p>" } } }),
+      } as Response;
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ parse: { sections: [{ index: "1", level: "2", line: "档案", fromtitle: "阿米娅" }] } }),
+    } as Response;
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+const STRUCTURED_TOOL_ARGS: Record<string, Record<string, unknown>> = {
+  get_operator_basic_info: { name: "阿米娅" },
+  list_enemies: { limit: 1, offset: 0, full: false },
+  get_enemy_info: { name: "源石虫" },
+  get_stage_enemies: { stage_id: "main_00-01" },
+  get_enemy_appearances: { name: "源石虫", limit: 10, offset: 0 },
+  list_stages: { limit: 1, offset: 0 },
+  get_stage_info: { stage_id: "main_00-01" },
+  list_items: { limit: 1, offset: 0 },
+  get_item_info: { name: "7001" },
+  list_story_events: { category: "activities" },
+  list_stories: { event_id: "act_test", include_summaries: true },
+  search: { scope: "operators", pattern: "阿米娅", max_results: 1 },
+  search_stories: { pattern: "你好" },
+  search_prts: { query: "阿米娅", limit: 1, search_mode: "text", filter_technical: true },
+  get_operator_memoirs: { name: "阿米娅" },
+  find_character_appearances: { name: "博士", max_events: 10 },
+  find_speakers_in: { event_id: "act_test" },
+};
+
+const NARRATIVE_TOOL_ARGS: Record<string, Record<string, unknown>> = {
+  get_operator_archives: { name: "阿米娅" },
+  get_operator_voicelines: { name: "阿米娅" },
+  read_story: { story_key: "activities/act_test/level_act_test_01_beg", include_narration: true },
+  read_activity: { event_id: "act_test", include_narration: true },
+  get_story_summary: { story_key: "activities/act_test/level_act_test_01_beg" },
+  prts_page: { page_title: "阿米娅", action: "read" },
+};
+
+async function callTool(
+  server: CapturingServer,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const handler = server.tools.get(name);
+  assert.ok(handler, `missing tool handler for ${name}`);
+  return await handler(args) as Record<string, unknown>;
+}
+
+test("output-channel semantic invariant for structured and narrative tools", async () => {
+  const root = mkdtempSync(join(tmpdir(), "prts-tool-invariant-"));
+  const storyZip = join(mkdtempSync(join(tmpdir(), "prts-tool-story-")), "zh_CN.zip");
+  const oldGamedata = process.env["GAMEDATA_PATH"];
+  const oldStory = process.env["STORYJSON_PATH"];
+  const restoreFetch = mockPrtsFetch();
+  process.env["GAMEDATA_PATH"] = root;
+  process.env["STORYJSON_PATH"] = storyZip;
+  writeInvariantGamedata(root);
+  writeInvariantStoryZip(storyZip);
+  resetCaches();
+
+  try {
+    for (const channel of ["structured", "both"] as const) {
+      const server = new CapturingServer();
+      registerPrtsTools(server as never, channel);
+      registerGamedataTools(server as never, channel);
+      registerStoryTools(server as never, channel);
+
+      for (const [name, args] of Object.entries(STRUCTURED_TOOL_ARGS)) {
+        const result = await callTool(server, name, args);
+        assert.ok(result["structuredContent"], `${name} should emit structuredContent in ${channel}`);
+      }
+
+      for (const [name, args] of Object.entries(NARRATIVE_TOOL_ARGS)) {
+        const result = await callTool(server, name, args);
+        assert.equal(result["structuredContent"], undefined, `${name} should remain content-only in ${channel}`);
+      }
+    }
+  } finally {
+    if (oldGamedata === undefined) delete process.env["GAMEDATA_PATH"];
+    else process.env["GAMEDATA_PATH"] = oldGamedata;
+    if (oldStory === undefined) delete process.env["STORYJSON_PATH"];
+    else process.env["STORYJSON_PATH"] = oldStory;
+    restoreFetch();
+    resetCaches();
+  }
 });


### PR DESCRIPTION
## Summary
- migrate TS `search`, `search_stories`, and `search_prts` to build/render payloads with `renderResult` structured/both output-channel support
- add Python-first shared parity fixtures for operator/enemy/stage/item/story/PRTS search payloads, including legal empty results and PRTS `totalhits > results.length`
- add TS semantic output-channel invariant coverage: structural tools emit structuredContent in structured/both channels, narrative tools stay content-only

## Test plan
- `git diff --check`
- `.\scripts\check-runtime.ps1 -Full`
  - Python: 266 passed, 2 skipped
  - TypeScript: 188 passed, 2 skipped
  - TypeScript typecheck: OK

## Notes
- Python production code is intentionally unchanged. Python-side edits are limited to tests that assert the Python builders match the shared parity fixtures used by TS.
- `prts_page` remains content-only; this PR only migrates `search_prts` in the PRTS tool group.