### PR TITLE
docs: prepare 2.0.0 release documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,13 @@ GAMEDATA_PATH=
 
 # Optional: override the default auto-synced story zip with your own zh_CN.zip.
 STORYJSON_PATH=
+
+# Optional: 2.0 output channel. Controls whether tools emit MCP-native
+# structuredContent in addition to (or instead of) the default markdown content.
+# Accepted: content (default) / structured / both.
+# - Python: read from this env var (one channel per stdio process).
+# - TypeScript: also settable per-request via ?output_channel= query string or
+#   x-prts-output-channel header.
+# Leave unset for the 1.x-compatible markdown-only behavior. Use "structured"
+# or "both" only with a client known to consume structuredContent.
+PRTS_OUTPUT_CHANNEL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ PRTS-MCP 是面向明日方舟同人创作的 MCP Server，包含 Python（stdio
 | 项目现状、版本状态、仓库结构 | [`STATUS.md`](STATUS.md) |
 | 代码规范、反模式、已知陷阱 | [`docs/dev/STYLE.md`](docs/dev/STYLE.md) |
 | 路线图与未来规划 | [`ROADMAP.md`](ROADMAP.md) |
+| 1.x → 2.0 迁移（破坏性变更） | [`docs/migration-1.x-to-2.0.md`](docs/migration-1.x-to-2.0.md) |
 | 1.7 LTS 维护规则 | [`docs/dev/LTS.md`](docs/dev/LTS.md) |
 | 外部贡献者指南 | [`python/CONTRIBUTING.md`](python/CONTRIBUTING.md) |
 | Python 实现 | [`python/`](python/) |
@@ -87,7 +88,7 @@ fix/*（最新稳定 hotfix）────────→ main ──→ dev（f
 
 例：
 - `feat/v2.0.0-tool-surface`
-- `refactor/v2.0.0-output-format`
+- `refactor/v2.0.0-output-channel`
 - `fix/v1.7.1-sync-schema`
 
 ## 单次迭代循环
@@ -219,6 +220,7 @@ EOF
 | `ts/CHANGELOG.md` | 新版本条目 |
 | `ts/package-lock.json` | npm lockfile 顶层版本 |
 | `ROADMAP.md` | 当前版本号 |
+| `ROADMAP.zh-CN.md` | 当前版本号（与 `ROADMAP.md` 成对同步，勿漏） |
 
 涉及用户可见行为变化时，顺手更新 `README.md`。
 
@@ -238,7 +240,7 @@ git push origin python/v1.3.1 ts/v1.3.1
 本项目 Python 和 TypeScript 是**独立实现**，不是翻译关系。规则：
 
 - 改了一个实现的工具行为，**必须检查**另一个实现是否有对应改动
-- 公共工具名、必填参数、输出格式在两套实现间必须一致（CI 有 tool surface 测试）
+- 公共工具名、必填参数、输出格式（含 `structuredContent` 载荷）在两套实现间必须一致（CI 有 tool surface / output-channel parity 测试）
 - 新工具建议先在一个实现中完成，验证后再移植到另一个
 - 两套实现各有独立的 CHANGELOG，版本号尽量同步
 

--- a/README.md
+++ b/README.md
@@ -23,20 +23,27 @@ This repository contains two independent implementations for different deploymen
 | [`python/`](python/) | Python 3.10+ | stdio | Local Claude Desktop / Claude Code, Docker |
 | [`ts/`](ts/) | TypeScript / Node.js | Streamable HTTP | Self-hosted server, remote HTTP access |
 
-### 1.x Compatibility Matrix
+### Release Lines
 
-1.7.0 is the last 1.x feature release and the LTS baseline. Future 1.7.x updates are limited to compatibility, security, data-sync, and critical bug fixes while 2.0 development focuses on tool-surface consolidation, structured output defaults, and Python/TypeScript transport parity.
+Two release lines ship in parallel:
 
-| Area | Python | TypeScript | 1.x policy |
-|------|--------|------------|------------|
-| Current line | `1.7.0` LTS | `1.7.0` LTS | 1.7.x is the final 1.x maintenance line |
-| MCP tools | Same 32 public tool names and required parameters | Same 32 public tool names and required parameters | Tool names, required parameters, and default markdown output stay stable through 1.7.x |
-| GameData | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | Custom paths disable auto-sync |
-| Level data | Auto-synced `zh_CN-levels.zip` beside GameData | Auto-synced `zh_CN-levels.zip` beside GameData | Custom GameData roots may provide their own `zh_CN/gamedata/levels` |
-| Story data | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | Custom zip paths disable auto-sync |
-| Bundled fallback data | Docker image only | Docker image and published npm package | PyPI remains data-light |
+| Line | Version | Tools | Status |
+|------|---------|-------|--------|
+| **2.0** (`dev`) | `2.0.0` (in development) | 23 | Tool-surface consolidation + output channel (structuredContent). Cross-transport parity deferred beyond 2.0. |
+| **1.7 LTS** (`main`) | `1.7.0` | 32 | Stable line. 1.7.x accepts only compatibility, security, data-sync, and critical bug fixes. |
 
-See [`docs/migration-0.x-to-1.0.md`](docs/migration-0.x-to-1.0.md) for the 0.x to 1.0 migration notes.
+| Area | Python | TypeScript |
+|------|--------|------------|
+| MCP tools | Same 23 public tool names and required parameters (2.0 `dev`) / 32 on 1.7 LTS | Same 23 (2.0 `dev`) / 32 on 1.7 LTS |
+| GameData | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` |
+| Level data | Auto-synced `zh_CN-levels.zip` beside GameData | Auto-synced `zh_CN-levels.zip` beside GameData |
+| Story data | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | `STORYJSON_PATH` or auto-synced `zh_CN.zip` |
+| Bundled fallback data | Docker image only | Docker image and published npm package (PyPI stays data-light) |
+
+See [`docs/migration-1.x-to-2.0.md`](docs/migration-1.x-to-2.0.md) for the 1.x → 2.0
+breaking changes (tool consolidation, `operator_name` → `name`, output channel),
+and [`docs/migration-0.x-to-1.0.md`](docs/migration-0.x-to-1.0.md) for the 0.x → 1.0
+transition.
 
 ### Tools
 
@@ -64,6 +71,24 @@ Both implementations expose the same tool set:
 | `get_stage_info(stage_id)` | Retrieve detailed stage information by stage ID |
 | `list_items(category?, limit?, offset?)` | List items/materials from `item_table.json` with optional category filtering |
 | `get_item_info(name)` | Retrieve item/material details, usage, obtain methods, drops, production, and shop links |
+| `get_operator_memoirs(name)` | Resolve an operator's memoir (干员密录) story keys for follow-up `read_story` calls |
+| `find_character_appearances(name, scope?, max_events?)` | Find chapters/events where a character speaks (dialog) or is mentioned (name substring) |
+| `find_speakers_in(event_id)` | List every speaker in an event with dialog line counts |
+
+### Output Channel
+
+Both implementations keep markdown as the default, human-readable output on
+MCP's `content` field. Deployments whose client consumes MCP-native
+`structuredContent` can opt in via a **connection-level** `output_channel` knob
+(`content` (default) / `structured` / `both`):
+
+- **Python** — `PRTS_OUTPUT_CHANNEL` environment variable.
+- **TypeScript** — `?output_channel=` query string, `x-prts-output-channel` header, or `PRTS_OUTPUT_CHANNEL` env.
+
+The default `content` requires no configuration and is unchanged from 1.x. See
+the [2.0 migration guide](docs/migration-1.x-to-2.0.md) for the per-tool
+mapping and the rationale for choosing a channel over a per-call format
+parameter.
 
 ### Quick Start
 
@@ -97,20 +122,26 @@ Published Docker images and the npm package include bundled fallback game/level/
 | [`python/`](python/) | Python 3.10+ | stdio | Claude Desktop / Claude Code 本地接入、Docker |
 | [`ts/`](ts/) | TypeScript / Node.js | Streamable HTTP | 个人服务器部署，供他人通过 HTTP 调用 |
 
-### 1.x 兼容矩阵
+### 版本线
 
-1.7.0 是最后一个 1.x 功能版本和 LTS 基线。后续 1.7.x 仅接受兼容性、安全性、数据同步和关键缺陷修复；2.0 开发线将集中处理工具面合并、结构化输出默认值和 Python/TypeScript 传输对齐。
+两个版本线并行维护：
 
-| 范围 | Python | TypeScript | 1.x 策略 |
-|------|--------|------------|----------|
-| 当前版本线 | `1.7.0` LTS | `1.7.0` LTS | 1.7.x 是最后的 1.x 维护线 |
-| MCP 工具 | 相同的 32 个工具名和必填参数 | 相同的 32 个工具名和必填参数 | 1.7.x 期间保持工具名、必填参数和默认 markdown 输出稳定 |
-| 干员数据 | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | 自定义路径会禁用自动同步 |
-| 关卡战斗数据 | 自动同步与 GameData 并列的 `zh_CN-levels.zip` | 自动同步与 GameData 并列的 `zh_CN-levels.zip` | 自定义 GameData 根目录可直接提供 `zh_CN/gamedata/levels` |
-| 剧情数据 | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | 自定义 zip 会禁用自动同步 |
-| bundled 兜底数据 | Docker 镜像 | Docker 镜像和正式 npm 包 | PyPI 继续保持轻量 |
+| 版本线 | 版本 | 工具数 | 状态 |
+|--------|------|--------|------|
+| **2.0**（`dev`） | `2.0.0`（开发中） | 23 | 工具面合并 + output channel（structuredContent）。双端协议同步后置到 2.0 之后。 |
+| **1.7 LTS**（`main`） | `1.7.0` | 32 | 稳定线。1.7.x 仅接受兼容性、安全性、数据同步和关键缺陷修复。 |
 
-0.x 到 1.0 的迁移说明见 [`docs/migration-0.x-to-1.0.md`](docs/migration-0.x-to-1.0.md)。
+| 范围 | Python | TypeScript |
+|------|--------|------------|
+| MCP 工具 | 相同的 23 个工具名和必填参数（2.0 `dev`）/ 1.7 LTS 为 32 个 | 相同的 23 个（2.0 `dev`）/ 1.7 LTS 为 32 个 |
+| 干员数据 | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` |
+| 关卡战斗数据 | 自动同步与 GameData 并列的 `zh_CN-levels.zip` | 自动同步与 GameData 并列的 `zh_CN-levels.zip` |
+| 剧情数据 | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` |
+| bundled 兜底数据 | Docker 镜像 | Docker 镜像和正式 npm 包（PyPI 保持轻量） |
+
+1.x → 2.0 的破坏性变更（工具面合并、`operator_name` → `name`、output channel）见
+[`docs/migration-1.x-to-2.0.md`](docs/migration-1.x-to-2.0.md)；0.x → 1.0 迁移见
+[`docs/migration-0.x-to-1.0.md`](docs/migration-0.x-to-1.0.md)。
 
 ### 工具集
 
@@ -138,6 +169,18 @@ Published Docker images and the npm package include bundled fallback game/level/
 | `get_stage_info(stage_id)` | 根据关卡 ID 获取关卡详细信息 |
 | `list_items(category?, limit?, offset?)` | 列出物品/材料，支持按类别过滤和分页 |
 | `get_item_info(name)` | 获取物品/材料详情、用途、获取方式、掉落、基建产出和商店关联 |
+| `get_operator_memoirs(name)` | 解析干员密录的 story_key，便于后续 `read_story` 调用 |
+| `find_character_appearances(name, scope?, max_events?)` | 查找角色在哪些章节/活动中开口（对话）或被提及（名字子串） |
+| `find_speakers_in(event_id)` | 列出指定活动中所有发言角色及其对话行数 |
+
+### 输出通道
+
+两个实现默认在 MCP 的 `content` 字段输出人类可读的 markdown。若部署环境使用的客户端能消费 MCP 原生的 `structuredContent`，可通过**连接级**的 `output_channel` 开关（`content`（默认）/ `structured` / `both`）启用：
+
+- **Python** — `PRTS_OUTPUT_CHANNEL` 环境变量。
+- **TypeScript** — `?output_channel=` 查询字符串、`x-prts-output-channel` 请求头，或 `PRTS_OUTPUT_CHANNEL` 环境变量。
+
+默认 `content` 无需任何配置，与 1.x 一致。各工具的通道映射，以及「为何选连接级通道而非 per-call 格式参数」的设计理由，见 [2.0 迁移指南](docs/migration-1.x-to-2.0.md)。
 
 ### 快速开始
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,17 +1,17 @@
 # PRTS-MCP Roadmap
 
-_Last updated: 2026-07-02_ · [中文版](ROADMAP.zh-CN.md)
+_Last updated: 2026-07-03_ · [中文版](ROADMAP.zh-CN.md)
 
 PRTS-MCP is past 1.0. Version 1.7.0 is the final 1.x feature release and the 1.7 LTS baseline. This document tracks **what comes next** — not what has shipped. For shipped features, see the Python and TypeScript CHANGELOGs.
 
 ## Current Release
 
-- Python: `1.7.0` LTS
-- TypeScript: `1.7.0` LTS
-- `dev` branch current target after the LTS release: `2.0.0-dev`
-- 32 public MCP tools, frozen in the 1.7 LTS line (CI-enforced).
-- See [migration guide](docs/migration-0.x-to-1.0.md) for the
-  0.x → 1.0 transition.
+- Python: `1.7.0` LTS _(stable line)_
+- TypeScript: `1.7.0` LTS _(stable line)_
+- `dev` branch: **2.0 development** — tool-surface consolidation (32 → 23 tools) and the output channel (structuredContent) are implemented on `dev`; cross-transport parity is deferred beyond 2.0.
+- 32 public MCP tools frozen in the 1.7 LTS line (CI-enforced); 23 public MCP tools on the 2.0 `dev` line.
+- See [migration guide 0.x → 1.0](docs/migration-0.x-to-1.0.md) and
+  [migration guide 1.x → 2.0](docs/migration-1.x-to-2.0.md).
 
 ## 1.x Compatibility Contract
 
@@ -118,25 +118,27 @@ Three structural shifts that warrant a major bump.
 
 ### Tool surface consolidation (context budget)
 
-The 1.x tool surface reached 32 tools by the 1.7.0 LTS release. For long-context flagship models this is fine; for 128K-class models, every additional tool schema eats into the prompt budget and hurts tool-selection accuracy.
+The 1.x tool surface reached 32 tools by the 1.7.0 LTS release. For long-context flagship models this is fine; for 128K-class models, every additional tool schema eats into the prompt budget and hurts tool-selection accuracy. 2.0 consolidates server-side by *schema shape* — merging tools that share parameter structure and output shape, keeping tools whose semantics genuinely differ — and drops the 32 → **23 tools** without losing capability.
 
 **Background**: MCP currently has no protocol-level support for deferred tool loading. Closed proposals: lazy hydration (#1978), lazyRegistration (#2376). Open drafts: tool-search query (#1821), token-bloat mitigations (#1576). Claude Code's ToolSearch is an Anthropic-API-level feature (`tool_reference` blocks), not portable to Cursor/Cline/Chatbox.
 
-**Approach**: server-side consolidation by *schema shape*, not by data domain. Merge tools that share parameter structure and output shape; keep tools whose semantics genuinely differ. Estimated reduction: 24 → ~16 tools (about a third) without losing capability.
+**Delivered in 2.0**:
 
-**Phase 1 (2.0 migration design)**:
-
-- `search(scope, pattern, ...)` consolidates `search_data`,
-  `search_stories`, `search_enemies`, `list_search_scopes`. Same
-  parameter shape across all four; differs only in `scope`.
+- `search(scope, pattern, max_results)` consolidates `search_data`,
+  `search_enemies`, `search_stages`, `search_items`, and `list_search_scopes`
+  into one tool keyed on a `scope` enum (`operators` / `enemies` / `stages` /
+  `items`). Story dialogue search remains the separate `search_stories` tool,
+  because its filters (character, line type, context lines) differ in shape.
 - `prts_page(page_title, action, ...)` consolidates `read_prts_page`,
-  `list_prts_sections`, `get_prts_categories`, `get_prts_links`,
-  `get_prts_template`. Single primary key; action selects the
-  sub-operation.
+  `list_prts_sections`, `get_prts_categories`, `get_prts_links`, and
+  `get_prts_template` into one tool keyed on an `action` enum.
+- `list_stories(event_id, include_summaries=true)` now prepends the event-level
+  LLM overview, absorbing the former `get_event_summary`. The single-chapter
+  deep summary tool `get_story_summary` is unchanged.
+- The deprecated legacy aliases behind these three consolidations are dropped
+  from the 2.0 tool surface. The 1.7 LTS line keeps the existing 32-tool surface.
 
-**Phase 2 (2.0)**: drop or hide the deprecated legacy aliases according to the final 2.0 migration plan. The 1.7 LTS line keeps the existing 32-tool surface.
-
-**What we explicitly will NOT consolidate**:
+**What was explicitly NOT consolidated**:
 
 - Operator triplet (`get_operator_archives` / `voicelines` /
   `basic_info`): outputs differ in shape and length; merging hurts
@@ -148,26 +150,46 @@ The 1.x tool surface reached 32 tools by the 1.7.0 LTS release. For long-context
 
 The bar for consolidation: same parameter shape, similar output length and structure, an LLM choosing between them today is choosing between near-synonyms.
 
-### Output format becomes selectable
+### Output channel (structuredContent)
 
-- Add an optional `output_format=markdown|json` parameter (default
-  `markdown` in 1.x — additive, no break).
-- JSON mode returns structured objects suitable for downstream
-  automation.
-- 2.0 flips the **default** to `json`, making this the breaking change.
-- Markdown remains supported under explicit opt-in.
+2.0 adds structured output via MCP's native `structuredContent` field. The
+control plane is a single **connection-level** `output_channel` knob
+(`content` (default) / `structured` / `both`), set via the
+`PRTS_OUTPUT_CHANNEL` env var on Python and via query string / header / env on
+TypeScript. Structural tools (17) carry real structured payloads with chainable
+IDs and raw/label field pairs; narrative tools (6) stay content-only. The
+default `content` channel preserves the 1.x human-readable markdown output, so
+incapable clients (e.g. Chatbox) are unaffected without configuration.
 
-The original staged plan expected 1.x opt-in. With 1.7 now serving as the LTS line, the exact migration path belongs to the 2.0 design phase and must be documented before the first 2.0 prerelease.
+**Design choice — channel, not a per-call format parameter.** The original
+roadmap proposed a per-call `output_format=markdown|json` parameter with 2.0
+flipping the default to `json`. **That shape was rejected during design.** The
+primary consumer is an LLM agent, and JSON inflates prompt tokens ~15–30%
+versus markdown — which would negate the context-budget savings the
+tool-surface consolidation was built to deliver. Instead, markdown stays the
+always-on `content` text and structured data rides a separate channel; the two
+axes are orthogonal. The default is **not** flipped to JSON.
+
+See [the 2.0 migration guide](docs/migration-1.x-to-2.0.md) for the per-tool
+channel mapping and client configuration.
 
 ### Implementation parity (Python ↔ TypeScript)
 
-Today the implementations have de-facto roles: Python is recommended for Docker / stdio, TypeScript for `npm install -g` / HTTP. 2.0 removes this asymmetry:
+2.0 narrows, but does not remove, the de-facto role split between the two
+implementations. Delivered in 2.0:
 
-- Both implementations support stdio **and** Streamable HTTP.
-- npm and PyPI packages have equivalent capability surface.
-- Environment variable names and defaults are unified.
-- Recommended deployment scenarios collapse into "use whichever runtime
-  fits your stack".
+- npm and PyPI packages have an equivalent **capability surface** — the same
+  23 tool names, parameters, structuredContent payloads, and parity fixtures
+  shared across both implementations.
+- Environment variable names and defaults are unified (`PRTS_OUTPUT_CHANNEL`,
+  `GAMEDATA_PATH`, `STORYJSON_PATH`, `GITHUB_TOKEN`, `GITHUB_MIRRORS`).
+
+**Deferred beyond 2.0 — cross-transport parity.** The original goal that both
+implementations support stdio **and** Streamable HTTP (Python gaining HTTP,
+TypeScript gaining stdio) is postponed to a later release. 2.0 ships with the
+same transport split as 1.x: Python = stdio (FastMCP), TypeScript =
+Streamable HTTP (Express). Recommended deployment scenarios therefore stay
+"Python for Docker / local stdio, TypeScript for `npm install -g` / HTTP."
 
 ### Cleanup
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -143,8 +143,9 @@ The 1.x tool surface reached 32 tools by the 1.7.0 LTS release. For long-context
 - Operator triplet (`get_operator_archives` / `voicelines` /
   `basic_info`): outputs differ in shape and length; merging hurts
   LLM selection accuracy more than it saves context.
-- Enemy triplet (`list_enemies` / `get_enemy_info` / `search_enemies`):
-  same reason.
+- Enemy pair (`list_enemies` / `get_enemy_info`): same reason. (The enemy
+  search tool `search_enemies` was folded into the cross-domain
+  `search(scope="enemies")` as described above.)
 - Story tools (`read_story` / `read_activity` / `get_story_summary`):
   genuinely distinct actions on related-but-different data.
 

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -1,16 +1,16 @@
 # PRTS-MCP 路线图
 
-_最近更新：2026-07-02_ · [English](ROADMAP.md)
+_最近更新：2026-07-03_ · [English](ROADMAP.md)
 
 PRTS-MCP 已进入 1.x 稳定期。1.7.0 是最后一个 1.x 功能版本和 1.7 LTS 基线。本文档记录**接下来要做什么**——已发布的内容请查看 Python 和 TypeScript 各自的 CHANGELOG。
 
 ## 当前发布
 
-- Python：`1.7.0` LTS
-- TypeScript：`1.7.0` LTS
-- LTS 发布后 `dev` 分支当前目标版本：`2.0.0-dev`
-- 1.7 LTS 线冻结 32 个公共 MCP 工具（CI 强制检查）。
-- 0.x → 1.0 迁移说明见 [迁移指南](docs/migration-0.x-to-1.0.md)。
+- Python：`1.7.0` LTS _（稳定线）_
+- TypeScript：`1.7.0` LTS _（稳定线）_
+- `dev` 分支：**2.0 开发**——工具面合并（32 → 23）与 output channel（structuredContent）已在 `dev` 落地；双端协议同步后置到 2.0 之后。
+- 1.7 LTS 线冻结 32 个公共 MCP 工具（CI 强制检查）；2.0 `dev` 线为 23 个公共 MCP 工具。
+- 迁移说明：[0.x → 1.0](docs/migration-0.x-to-1.0.md)、[1.x → 2.0](docs/migration-1.x-to-2.0.md)。
 
 ## 1.x 兼容合约
 
@@ -113,22 +113,22 @@ PRTS-MCP 已进入 1.x 稳定期。1.7.0 是最后一个 1.x 功能版本和 1.7
 
 ### 工具面合并（上下文预算）
 
-1.x 工具面在 1.7.0 LTS 时已达到 32 个。旗舰长上下文模型不在乎；但对 128K 级别模型，每个工具 schema 都吃 prompt 预算并降低工具选择准确率。
+1.x 工具面在 1.7.0 LTS 时已达到 32 个。旗舰长上下文模型不在乎；但对 128K 级别模型，每个工具 schema 都吃 prompt 预算并降低工具选择准确率。2.0 按 *schema 形态* 在服务端合并——合并参数结构和输出形态相似的工具，保留语义真正不同的工具——把工具面降到 **23 个**，不损失能力。
 
-**背景**：MCP 协议层目前无原生 deferred tool loading 支持。已关闭 提案：lazy hydration（#1978）、lazyRegistration（#2376）。开放草案： tool-search query（#1821）、token-bloat 缓解（#1576）。Claude Code 的 ToolSearch 是 Anthropic API 层特性（`tool_reference` blocks）， 不能移植到 Cursor / Cline / Chatbox。
+**背景**：MCP 协议层目前无原生 deferred tool loading 支持。已关闭提案：lazy hydration（#1978）、lazyRegistration（#2376）。开放草案：tool-search query（#1821）、token-bloat 缓解（#1576）。Claude Code 的 ToolSearch 是 Anthropic API 层特性（`tool_reference` blocks），不能移植到 Cursor / Cline / Chatbox。
 
-**方法**：服务端按 *schema 形态* 合并，而非按数据域合并。合并参数 结构和输出形态相似的工具，保留语义真正不同的工具。预估缩减： 24 → ~16 个工具（约 1/3），不损失能力。
+**已在 2.0 交付**：
 
-**阶段一（2.0 迁移设计）**：
-
-- `search(scope, pattern, ...)` 合并 `search_data` / `search_stories` /
-  `search_enemies` / `list_search_scopes`。四者参数形态完全相同，
-  仅 `scope` 不同。
-- `prts_page(page_title, action, ...)` 合并 `read_prts_page` /
-  `list_prts_sections` / `get_prts_categories` / `get_prts_links` /
-  `get_prts_template`。共享主键 `page_title`，`action` 选择子操作。
-
-**阶段二（2.0）**：按最终 2.0 迁移方案移除或隐藏 deprecated 旧别名。 1.7 LTS 线保留现有 32 工具面。
+- `search(scope, pattern, max_results)` 把 `search_data` / `search_enemies` /
+  `search_stages` / `search_items` / `list_search_scopes` 合并为一个以 `scope`
+  enum（`operators` / `enemies` / `stages` / `items`）为键的工具。剧情台词搜索仍为
+  独立的 `search_stories`，因其过滤器（角色、台词类型、上下文行）形态不同。
+- `prts_page(page_title, action, ...)` 把 `read_prts_page` / `list_prts_sections` /
+  `get_prts_categories` / `get_prts_links` / `get_prts_template` 合并为一个以
+  `action` enum 为键的工具。
+- `list_stories(event_id, include_summaries=true)` 现前置活动级 LLM 概览，吸收了
+  原 `get_event_summary`。单章深摘要工具 `get_story_summary` 不变。
+- 这三次合并背后的 deprecated 旧别名从 2.0 工具面移除。1.7 LTS 线保留现有 32 工具面。
 
 **明确不合并的部分**：
 
@@ -139,26 +139,38 @@ PRTS-MCP 已进入 1.x 稳定期。1.7.0 是最后一个 1.x 功能版本和 1.7
 - 剧情工具（`read_story` / `read_activity` / `get_story_summary`）：
   在相关但不同的数据上做真正不同的动作。
 
-合并的门槛：参数形态相同、输出长度和结构相似、LLM 在它们之间 做选择本质上是在选近义词。
+合并的门槛：参数形态相同、输出长度和结构相似、LLM 在它们之间做选择本质上是在选近义词。
 
-### 输出格式可选
+### Output channel（structuredContent）
 
-- 新增可选 `output_format=markdown|json` 参数，1.x 默认
-  `markdown`（增量、不破坏）。
-- JSON 模式返回结构化对象，便于下游自动化。
-- 2.0 翻转**默认值**为 `json`，这才是 break point。
-- markdown 在 2.0 仍可显式选择，不删除。
+2.0 经 MCP 原生 `structuredContent` 字段新增结构化输出。控制面是单个**连接级**
+`output_channel` 开关（`content`（默认）/ `structured` / `both`），Python 经
+`PRTS_OUTPUT_CHANNEL` 环境变量设置，TypeScript 经查询字符串 / 请求头 / 环境变量设置。
+结构化工具（17 个）携带真实结构化载荷，含可链式调用的 ID 与 raw/label 字段对；
+叙事工具（6 个）仅 content。默认 `content` 通道保留 1.x 人类可读的 markdown 输出，
+故不支持的客户端（如 Chatbox）无需配置即不受影响。
 
-原计划希望 1.x 期间先提供 opt-in。现在 1.7 已成为 LTS 线，具体迁移 路径归入 2.0 设计阶段，并必须在首个 2.0 预发布前写清楚。
+**设计选择——用通道，而非 per-call 格式参数。** 原路线图提出 per-call 的
+`output_format=markdown|json` 参数，并在 2.0 把默认翻转为 `json`。**该形态在设计阶段被
+否决。** 主要消费者是 LLM agent，JSON 会令 prompt token 膨胀 ~15–30%——这将抵消工具面
+合并带来的上下文预算收益。因此 markdown 始终作为 `content` 文本，结构化数据走独立通道，
+两轴正交。**默认不**翻转为 JSON。
+
+各工具的通道映射与客户端配置见 [2.0 迁移指南](docs/migration-1.x-to-2.0.md)。
 
 ### 双实现等价化（Python ↔ TypeScript）
 
-目前两套实现存在事实上的角色分工：Python 主要面向 Docker / stdio， TypeScript 主要面向 `npm install -g` / HTTP。2.0 取消这种不对称：
+2.0 收窄但未取消两套实现之间事实上的角色分工。**已在 2.0 交付**：
 
-- 两套实现都同时支持 stdio **和** Streamable HTTP。
-- npm 包和 PyPI 包能力对等。
-- 环境变量名称和默认值统一。
-- 部署推荐折叠为"用你 stack 里顺手的那个 runtime 即可"。
+- npm 包和 PyPI 包的**能力面对等**——相同的 23 个工具名、参数、structuredContent 载荷，
+  以及跨实现共享的 parity fixture。
+- 环境变量名称和默认值统一（`PRTS_OUTPUT_CHANNEL`、`GAMEDATA_PATH`、`STORYJSON_PATH`、
+  `GITHUB_TOKEN`、`GITHUB_MIRRORS`）。
+
+**后置到 2.0 之后——跨传输协议同步。** 原目标「两套实现都同时支持 stdio **和**
+Streamable HTTP」（Python 上 HTTP、TypeScript 上 stdio）推迟到后续版本。2.0 仍按 1.x 的
+传输分工发布：Python = stdio（FastMCP），TypeScript = Streamable HTTP（Express）。因此
+部署推荐维持「Python 用于 Docker / 本地 stdio，TypeScript 用于 `npm install -g` / HTTP」。
 
 ### 清理
 

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -134,8 +134,8 @@ PRTS-MCP 已进入 1.x 稳定期。1.7.0 是最后一个 1.x 功能版本和 1.7
 
 - 干员三件套（`get_operator_archives` / `voicelines` / `basic_info`）：
   输出形态和长度差异大，合并反而降低 LLM 选择准确率，得不偿失。
-- 敌人三件套（`list_enemies` / `get_enemy_info` / `search_enemies`）：
-  同上。
+- 敌人成对工具（`list_enemies` / `get_enemy_info`）：同上。（敌人搜索工具
+  `search_enemies` 已并入跨域 `search(scope="enemies")`，见上方说明。）
 - 剧情工具（`read_story` / `read_activity` / `get_story_summary`）：
   在相关但不同的数据上做真正不同的动作。
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+## Supported Versions
+
+PRTS-MCP maintains security fixes for the latest stable release line and the
+1.7 LTS line.
+
+| Version line | Security support |
+|--------------|------------------|
+| 2.x | Supported once released as the latest stable line. |
+| 1.7.x | Supported as the LTS line for security, compatibility, data-sync, and critical fixes. |
+| < 1.7 | Not supported. Please upgrade before reporting. |
+| `dev` / prerelease builds | Best-effort fixes before release; not a production support line. |
+
+## Reporting a Vulnerability
+
+Please do not report security vulnerabilities through public GitHub issues.
+
+Use one of these private channels:
+
+1. Email `cccp1945@vip.qq.com` with the subject prefix
+   `[PRTS-MCP security]`.
+2. If GitHub Private Vulnerability Reporting is enabled for this repository,
+   you may use GitHub's private reporting flow instead.
+
+Reports in English or Chinese are welcome.
+
+Please include as much of the following as you can:
+
+- Affected package and version (`prts-mcp` Python package, `prts-mcp-ts` npm
+  package, Docker image, or source branch).
+- Runtime and transport (`Python stdio`, `TypeScript Streamable HTTP`, Docker,
+  local install, or another deployment shape).
+- A clear reproduction case or proof of concept.
+- Expected impact, such as arbitrary file access, unsafe archive extraction,
+  secret exposure, denial of service, or remote transport/session issues.
+- Relevant logs, configuration, and environment variables with secrets removed.
+
+## Scope
+
+Security reports are most useful when they affect PRTS-MCP itself, including:
+
+- MCP transport handling, session handling, or request parsing.
+- Archive download, extraction, cache, or data-sync validation.
+- Path traversal or unintended local file access.
+- Unsafe parsing of PRTS Wiki, GameData, StoryJson, or packaged fallback data.
+- Dependency vulnerabilities that are reachable through normal server use.
+- Accidental exposure of tokens, paths, or sensitive configuration in package,
+  Docker, CI, or example files.
+
+The following are generally out of scope:
+
+- Incorrect upstream game/wiki/story content.
+- Availability of GitHub, PRTS Wiki, mirrors, or other external services.
+- MCP client configuration mistakes outside this repository.
+- Vulnerabilities that only affect unsupported versions.
+- Automated scanning reports without a practical PRTS-MCP impact.
+
+## Coordinated Disclosure
+
+We aim to acknowledge valid reports within 7 days, then coordinate a fix and
+release plan based on severity and affected release lines. Security fixes may
+be released as patch versions on the latest stable line and, when applicable,
+the 1.7 LTS line.
+
+Please give the maintainer reasonable time to investigate and publish a fix
+before public disclosure. Credit can be included in release notes or advisories
+if you want to be acknowledged.
+
+This project does not currently offer a bug bounty program.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,18 +1,18 @@
 # PRTS-MCP 项目状态
 
-_Last updated: 2026-07-02_
+_Last updated: 2026-07-03_
 
 ## 当前版本
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 2.0.0.dev0 | Development |
-| TypeScript | 2.0.0-dev.0 | Development |
+| Python | 2.0.0.dev0 | Development（2.0 代码工作完成，文档发版准备中） |
+| TypeScript | 2.0.0-dev.0 | Development（2.0 代码工作完成，文档发版准备中） |
 
-- 当前 LTS 发布：32 个 MCP 工具（1.7.0，剧情角色追踪）
+- 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）
 - 当前稳定发布：1.7.0 LTS
-- 当前开发目标：2.0.0
-- 兼容性合约：1.7.x 期间既有工具名、必填参数、默认输出格式不变；仅接受兼容性、安全性、数据同步和关键缺陷修复
+- 当前开发目标：2.0.0 — 工具面合并（32 → 23）与 output channel（structuredContent）已在 `dev` 分支落地，双端代码与测试就绪；**双端协议同步（Python 上 HTTP / TS 上 stdio）已后置到 2.0 之后**。
+- 兼容性合约：1.7.x 期间既有 32 个工具名、必填参数、默认输出格式不变；仅接受兼容性、安全性、数据同步和关键缺陷修复
 
 ## 当前分支
 
@@ -93,7 +93,7 @@ PRTS-MCP/
 | [ArknightsStoryJson](https://github.com/3aKHP/ArknightsStoryJson) | 剧情台词 | GitHub Release `zh_CN.zip` |
 | [PRTS Wiki API](https://prts.wiki/api.php) | 世界观词条/阵营设定 | 实时 HTTP 请求 |
 
-## 工具清单 (23, current branch)
+## 工具清单 (23, 2.0 dev 分支)
 
 | # | 工具 | 数据源 | 版本 |
 |---|------|--------|------|
@@ -134,6 +134,28 @@ PRTS-MCP/
 > `list_stories(event_id, include_summaries=True)` 现附带活动级长摘要（吸收了
 > 1.x 的 `get_event_summary`）；单章深摘要仍为独立的 `get_story_summary`。
 
+## Output Channel（2.0 新增）
+
+2.0 在 MCP 原生 `structuredContent` 字段上新增结构化输出能力，由**连接级**的
+`output_channel` 开关控制（`content`（默认）/ `structured` / `both`）。Python 经
+`PRTS_OUTPUT_CHANNEL` 环境变量设置，TypeScript 经查询字符串 / 请求头 / 环境变量设置。
+默认 `content` 与 1.x 行为一致，无需配置。
+
+- **结构化工具（17 个）** 走 `structuredContent`，载荷含可链式调用的 ID 与
+  raw/label 字段对：`search_prts`、`get_operator_basic_info`、`list_enemies`、
+  `get_enemy_info`、`get_stage_enemies`、`get_enemy_appearances`、`list_stages`、
+  `get_stage_info`、`list_items`、`get_item_info`、`search`、`list_story_events`、
+  `list_stories`、`search_stories`、`get_operator_memoirs`、`find_character_appearances`、
+  `find_speakers_in`。
+- **叙事工具（6 个）** 仅 `content`（markdown），无结构化形态：`prts_page`（所有
+  action）、`get_operator_archives`、`get_operator_voicelines`、`get_story_summary`、
+  `read_story`、`read_activity`。
+
+> 设计选择：采用连接级通道而非 per-call 的 `output_format=markdown|json` 参数，且
+> **不**翻转默认到 JSON——主要消费者是 LLM agent，JSON 会令 prompt token 膨胀
+> 15–30%，抵消工具面合并带来的上下文预算收益。详见
+> [`docs/migration-1.x-to-2.0.md`](docs/migration-1.x-to-2.0.md)。
+
 ## 遗留 TODO
 
 - [ ] PRTS 搜索结果中 redirect 页面自动解析（MediaWiki API 限制）
@@ -143,6 +165,7 @@ PRTS-MCP/
 
 | 版本 | 日期 | 亮点 |
 |------|------|------|
+| 2.0.0 _(dev，未正式发版)_ | 进行中 | 工具面合并 32 → 23 + output channel（structuredContent）；双端协议同步后置 |
 | 1.7.0 | 2026-07-02 | 1.7 LTS：剧情角色追踪 + 模块拆分（32 工具） |
 | 1.6.1 | 2026-06-03 | 干员密录发现 + 搜索缓存优化（30 工具） |
 | 1.6.0 | 2026-05-28 | 关卡敌人融合 + 物品/材料域（29 工具） |

--- a/docs/dev/LTS.md
+++ b/docs/dev/LTS.md
@@ -58,6 +58,14 @@ If `main` still points to the 1.7 line when the fix ships, merge `lts/1.7` back 
 2.0 work may break the 1.x compatibility contract. The 2.0 branch must provide migration notes before prerelease for:
 
 - Final tool-surface consolidation.
-- Markdown/JSON output-format behavior.
-- Python and TypeScript transport parity.
+- Output channel (`structuredContent`) behavior — note 2.0 keeps markdown as
+  the default `content` and does **not** flip to a JSON default; the originally
+  proposed per-call `output_format=markdown|json` parameter was rejected during
+  design.
 - Removed or hidden legacy tool aliases.
+
+Cross-transport parity (Python gaining HTTP, TypeScript gaining stdio) was an
+original 2.0 boundary goal but is **deferred beyond 2.0**; 2.0 ships with the
+same transport split as 1.x (Python = stdio, TypeScript = Streamable HTTP).
+See [`docs/migration-1.x-to-2.0.md`](../migration-1.x-to-2.0.md) for the
+delivered 2.0 changes.

--- a/docs/migration-1.x-to-2.0.md
+++ b/docs/migration-1.x-to-2.0.md
@@ -1,0 +1,197 @@
+# Migration Guide: 1.x to 2.0
+
+_Status: 2.0.0 (development)_
+
+PRTS-MCP 2.0 consolidates the 1.x tool surface (32 tools in 1.7.0 LTS) down to
+**23 tools**, normalizes a parameter name, and adds an optional structured-output
+channel. These are breaking changes for clients that hard-coded the old tool
+names or the `operator_name` parameter.
+
+## TL;DR
+
+- Tool surface: **32 → 23** (net reduction of 9). Eleven legacy tool names are
+  removed/folded into three unified entry points; nothing is lost.
+- One required parameter is renamed: `operator_name` → `name` on four operator
+  tools.
+- Output stays markdown by default. A new **connection-level** output channel
+  can additionally emit MCP-native `structuredContent`; it is **not** a per-call
+  `output_format` parameter and does **not** flip the default to JSON.
+- Transport roles are unchanged in 2.0: Python = stdio, TypeScript = Streamable
+  HTTP. Cross-transport parity (Python HTTP / TS stdio) is deferred beyond 2.0.
+
+## Breaking Changes
+
+### 1. Unified search tool — `search(scope, pattern, max_results)`
+
+The four 1.x search tools and the scope catalogue are replaced by one tool:
+
+| 1.x tool | 2.0 replacement |
+|----------|-----------------|
+| `search_data(pattern, scope, max_results)` | `search(scope="operators", pattern, max_results)` |
+| `search_enemies(pattern, max_results)` | `search(scope="enemies", pattern, max_results)` |
+| `search_stages(pattern, max_results)` | `search(scope="stages", pattern, max_results)` |
+| `search_items(pattern, max_results)` | `search(scope="items", pattern, max_results)` |
+| `list_search_scopes()` | _(removed)_ — the scope catalogue is now the `search` tool description |
+
+`scope` is a required enum (`operators` / `enemies` / `stages` / `items`).
+Story dialogue search remains the separate `search_stories` tool, because its
+filters (character, line type, context lines) differ in shape.
+
+### 2. Unified PRTS page tool — `prts_page(page_title, action, ...)`
+
+The five 1.x PRTS page tools are replaced by one tool keyed on `action`:
+
+| 1.x tool | 2.0 replacement |
+|----------|-----------------|
+| `read_prts_page(page_title, section_index?)` | `prts_page(page_title, action="read", section_index?)` |
+| `list_prts_sections(page_title)` | `prts_page(page_title, action="sections")` |
+| `get_prts_categories(page_title)` | `prts_page(page_title, action="categories")` |
+| `get_prts_links(page_title, direction?, limit?)` | `prts_page(page_title, action="links", direction?, limit?)` |
+| `get_prts_template(page_title)` | `prts_page(page_title, action="template")` |
+
+`action` is a required enum (`read` / `sections` / `categories` / `links` /
+`template`). Wiki keyword search remains the separate `search_prts` tool.
+
+### 3. Event summary folded into `list_stories`
+
+`get_event_summary(event_id)` is removed. Its content — the event-level LLM
+overview from `event_summaries.json` — is now prepended by:
+
+```python
+list_stories(event_id, include_summaries=True)
+```
+
+which returns the event overview **plus** the per-chapter one-liners it already
+returned in 1.x. The single-chapter deep summary tool `get_story_summary` is
+unchanged.
+
+### 4. Parameter rename — `operator_name` → `name`
+
+The four operator tools now take `name`, matching the convention already used
+by the enemy/stage/item/character tools:
+
+| Tool | 1.x parameter | 2.0 parameter |
+|------|---------------|---------------|
+| `get_operator_archives` | `operator_name` | `name` |
+| `get_operator_voicelines` | `operator_name` | `name` |
+| `get_operator_basic_info` | `operator_name` | `name` |
+| `get_operator_memoirs` | `operator_name` | `name` |
+
+### Removed tool aliases (summary)
+
+The following tool names no longer exist on the 2.0 tool surface:
+
+```
+search_data, search_enemies, search_stages, search_items, list_search_scopes,
+read_prts_page, list_prts_sections, get_prts_categories, get_prts_links,
+get_prts_template, get_event_summary
+```
+
+All eleven are reachable via the unified `search`, `prts_page`, and
+`list_stories` tools described above.
+
+## New Capability — Output Channel
+
+2.0 adds an optional, **connection-level** output channel that carries
+structured data on MCP's native `structuredContent` field, alongside the
+human-readable markdown `content`.
+
+### Design choice: channel, not a per-call format parameter
+
+The original roadmap proposed a per-call `output_format=markdown|json`
+parameter with 2.0 flipping the default to JSON. **This shape was rejected
+during design.** The primary consumer of these tools is an LLM agent, and
+JSON inflates prompt tokens ~15–30% versus markdown — which would negate the
+context-budget savings the tool-surface consolidation was designed to deliver.
+
+Instead, 2.0 keeps markdown as the always-on `content` text and carries
+structured data on a separate channel. The two axes are orthogonal:
+
+- **`content`** — always the human-readable markdown rendering (unchanged from 1.x).
+- **`structuredContent`** — a structured dict for downstream automation, on the
+  MCP-native field of the same name.
+
+### Control
+
+A single connection-level knob selects the channel:
+
+| Implementation | How to set |
+|----------------|------------|
+| **Python** (stdio) | `PRTS_OUTPUT_CHANNEL` environment variable |
+| **TypeScript** (HTTP) | query string `?output_channel=`, `x-prts-output-channel` header, or `PRTS_OUTPUT_CHANNEL` env |
+
+Accepted values:
+
+| Value | Behavior |
+|-------|----------|
+| `content` _(default)_ | markdown `content` only — identical to 1.x output |
+| `structured` | `structuredContent` only; `content` carries a one-line summary |
+| `both` | both `content` (markdown) and `structuredContent` |
+
+The channel is connection-level rather than per-call because its correct value
+depends on which client owns the connection — something the calling LLM cannot
+know. An unrecognized value logs a warning and falls back to `content`; a
+misconfigured channel never breaks tool calls.
+
+### Which tools emit structuredContent
+
+- **Structural tools (17)** carry real structured payloads: `search_prts`,
+  `get_operator_basic_info`, `list_enemies`, `get_enemy_info`,
+  `get_stage_enemies`, `get_enemy_appearances`, `list_stages`, `get_stage_info`,
+  `list_items`, `get_item_info`, `search`, `list_story_events`, `list_stories`,
+  `search_stories`, `get_operator_memoirs`, `find_character_appearances`,
+  `find_speakers_in`. Structured payloads carry chainable IDs plus raw enums
+  and rendered labels (e.g. `type="ACTIVITY"` + `type_label="活动"`).
+- **Narrative tools (6)** are content-only: `prts_page` (all actions),
+  `get_operator_archives`, `get_operator_voicelines`, `get_story_summary`,
+  `read_story`, `read_activity`. Their prose output has no useful structured
+  form.
+
+### Note for incapable clients
+
+`structured` mode is intended for deployments known to use a
+`structuredContent`-capable client. A client that does not consume
+`structuredContent` (for example Chatbox) receives only a one-line summary when
+`structured` is selected — so **leave the default `content`** unless the client
+is confirmed capable. No configuration is needed for the common case.
+
+## What Stays Compatible
+
+These are unchanged from 1.x and require no migration:
+
+- **Markdown content text.** The default `content` output stays markdown, and
+  most tools preserve their 1.7.x rendering. The notable exception is
+  `list_stories(include_summaries=true)`, which now prepends the event-level
+  overview (see breaking change #3 above); tools reached via the new unified
+  entry points (`search`, `prts_page`) render the same cards as their 1.x
+  counterparts. The TS story empty-result wording was aligned to Python.
+- **Environment variable semantics.** `GAMEDATA_PATH`, `STORYJSON_PATH`,
+  `GITHUB_TOKEN`, `GITHUB_MIRRORS`, and the auto-sync behavior are unchanged.
+- **Data sources and sync.** The three Release archives (`zh_CN-excel.zip`,
+  `zh_CN-levels.zip`, story `zh_CN.zip`) and the PRTS Wiki API are unchanged.
+- **Transport roles.** Python remains stdio (FastMCP); TypeScript remains
+  Streamable HTTP (Express). Docker and `npm install -g` deployment paths are
+  unchanged.
+
+## Upgrade Notes
+
+1. Upgrade the Python package (`pip install -U prts-mcp`) or TypeScript
+   package (`npm install -g prts-mcp-ts`) as usual.
+2. If your client or prompt hard-codes any of the removed tool names, switch to
+   the unified `search` / `prts_page` / `list_stories` calls above.
+3. If you call operator tools with `operator_name`, rename the argument to
+   `name`.
+4. No environment variable changes are required. To opt into structured output,
+   set `PRTS_OUTPUT_CHANNEL=structured` (or `both`) only if your client is
+   confirmed to consume `structuredContent`.
+5. For Docker deployments, no volume or compose changes are needed.
+
+## Deferred Beyond 2.0
+
+- **Cross-transport parity.** Both implementations supporting both stdio and
+  Streamable HTTP (Python gaining HTTP, TypeScript gaining stdio) was an
+  original 2.0 boundary goal but is deferred to a later release. 2.0 ships with
+  the same de-facto transport split as 1.x.
+
+For the 0.x → 1.0 transition, see
+[`migration-0.x-to-1.0.md`](migration-0.x-to-1.0.md).

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **Output channel design replaces the per-call `output_format` parameter
+  (2.0 design decision).** The original roadmap proposed an optional
+  `output_format=markdown|json` parameter with 2.0 flipping the default to
+  `json`. **That shape was rejected during design.** The primary consumer is an
+  LLM agent, and JSON inflates prompt tokens ~15–30% versus markdown — which
+  would negate the context-budget savings the tool-surface consolidation
+  delivers. 2.0 instead keeps markdown as the always-on `content` text and
+  carries structured data on MCP's native `structuredContent` field, selected
+  by a **connection-level** `output_channel` knob (`content` (default) /
+  `structured` / `both`) via the `PRTS_OUTPUT_CHANNEL` env var. The default is
+  **not** flipped to JSON. See [`docs/migration-1.x-to-2.0.md`](../docs/migration-1.x-to-2.0.md)
+  for the per-tool channel mapping and client configuration.
 - **Output channel (2.0).** Optional structured-content delivery via MCP's
   native `structuredContent` channel, controlled by a connection-level
   `PRTS_OUTPUT_CHANNEL` env var (`content` (default) / `structured` / `both`).

--- a/python/README.md
+++ b/python/README.md
@@ -2,7 +2,9 @@
 
 明日方舟同人创作辅助 MCP Server，Python 版本。通过 **stdio 传输**接入 MCP 客户端（Claude Desktop、Claude Code、Chatbox 等），支持 Docker 部署。
 
-提供 32 个 MCP 工具：PRTS 词条检索与页面结构、干员档案/语音/基础信息、剧情活动与台词、角色出场追踪、全文搜索、敌人图鉴、关卡查询、关卡敌人融合，以及物品/材料查询。完整清单见仓库根目录 [`README.md`](../README.md)。
+提供 23 个 MCP 工具（2.0）：PRTS 词条检索与页面结构、干员档案/语音/基础信息、剧情活动与台词、角色出场追踪、全文搜索、敌人图鉴、关卡查询、关卡敌人融合，以及物品/材料查询。完整清单见仓库根目录 [`README.md`](../README.md)。
+
+> **2.0 变更**：工具面由 1.x 的 32 个合并为 23 个（详见 [1.x → 2.0 迁移指南](../docs/migration-1.x-to-2.0.md)）；新增可选的 output channel（`PRTS_OUTPUT_CHANNEL` 环境变量，默认 `content`，与 1.x 行为一致）。
 
 ---
 

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -8,6 +8,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- **Output channel design replaces the per-call `output_format` parameter
+  (2.0 design decision).** The original roadmap proposed an optional
+  `output_format=markdown|json` parameter with 2.0 flipping the default to
+  `json`. **That shape was rejected during design.** The primary consumer is an
+  LLM agent, and JSON inflates prompt tokens ~15–30% versus markdown — which
+  would negate the context-budget savings the tool-surface consolidation
+  delivers. 2.0 instead keeps markdown as the always-on `content` text and
+  carries structured data on MCP's native `structuredContent` field, selected
+  by a **connection-level** `output_channel` knob (`content` (default) /
+  `structured` / `both`) via query string / `x-prts-output-channel` header /
+  `PRTS_OUTPUT_CHANNEL` env. The default is **not** flipped to JSON. See
+  [`docs/migration-1.x-to-2.0.md`](../docs/migration-1.x-to-2.0.md) for the
+  per-tool channel mapping and client configuration. _(The Python implementation
+  additionally documents a "narrative-tool wire slimming" entry for dropping
+  FastMCP's automatic `outputSchema={result:string}` wrapper; the TS transport
+  has no equivalent auto-wrapper, so narrative tools are simply part of the
+  content-only delivery path here.)_
 - **Output channel pilot (2.0).** Streamable HTTP sessions can opt into
   `output_channel=structured` or `output_channel=both` via query string,
   `x-prts-output-channel` header, or `PRTS_OUTPUT_CHANNEL`. This first TS

--- a/ts/README.md
+++ b/ts/README.md
@@ -2,7 +2,9 @@
 
 明日方舟同人创作辅助 MCP Server，TypeScript 版本。通过 **Streamable HTTP 传输**（单端点 `/mcp`）对外提供服务，适合部署在个人服务器或云环境，供他人通过 HTTP 接入。
 
-提供 32 个 MCP 工具：PRTS 词条检索与页面结构、干员档案/语音/基础信息、剧情活动与台词、角色出场追踪、全文搜索、敌人图鉴、关卡查询、关卡敌人融合，以及物品/材料查询。完整清单见仓库根目录 [`README.md`](../README.md)。
+提供 23 个 MCP 工具（2.0）：PRTS 词条检索与页面结构、干员档案/语音/基础信息、剧情活动与台词、角色出场追踪、全文搜索、敌人图鉴、关卡查询、关卡敌人融合，以及物品/材料查询。完整清单见仓库根目录 [`README.md`](../README.md)。
+
+> **2.0 变更**：工具面由 1.x 的 32 个合并为 23 个（详见 [1.x → 2.0 迁移指南](../docs/migration-1.x-to-2.0.md)）；新增可选的 output channel（查询字符串 `?output_channel=` / 请求头 `x-prts-output-channel` / `PRTS_OUTPUT_CHANNEL` 环境变量，默认 `content`，与 1.x 行为一致）。
 
 ---
 
@@ -74,6 +76,7 @@ npm start         # 运行编译后的版本
 | `STORYJSON_PATH` | 未设置 | 设置后指向本地 `zh_CN.zip`，**剧情 auto-sync 被禁用** |
 | `GITHUB_TOKEN` | 空 | 用于提高 GitHub API 限额，降低限流风险 |
 | `GITHUB_MIRRORS` | 空 | 逗号分隔的 ghproxy 风格代理前缀列表（如 `https://ghproxy.net`），依次在直连失败后尝试 |
+| `PRTS_OUTPUT_CHANNEL` | `content` | 2.0 输出通道：`content`（默认，仅 markdown，与 1.x 一致）/ `structured`（仅 structuredContent）/ `both`。也可经查询字符串 `?output_channel=` 或请求头 `x-prts-output-channel` 按请求覆盖。仅在客户端确认支持 `structuredContent` 时才用非默认值 |
 
 ---
 


### PR DESCRIPTION
Brings all Git-tracked docs and the package READMEs in line with the 2.0 deliverables (tool-surface consolidation 32 → 23 and the output channel / `structuredContent` design), and adds the missing `SECURITY.md`.

This is a **documentation-only** change set — no source, test, version-string, or CI changes. The `2.0.0.dev0` / `2.0.0-dev.0` suffixes are preserved per the dev-branch convention; flipping to clean `2.0.0` is left to the release step.

## Why
2.0 code work on `dev` is complete (23 tools, full Python/TS parity, green tests), but the docs still described the pre-deferral design. Two independent audits agreed the docs were the only blocker to release-prep. Decision principle #4 (breaking changes must be documented before prerelease) is now satisfied.

## Changes

**Root docs (EN + CN)**
- `ROADMAP.md` / `ROADMAP.zh-CN.md` — rewrite the tool-consolidation section as delivered facts (drop the `24 → ~16` estimate and Phase 1/2 design-stage framing; correct `search_stories` as a kept-separate tool); replace the rejected `output_format=markdown|json` default-flip with the connection-level `output_channel` design; move cross-transport parity to deferred-beyond-2.0.
- `README.md` — reframe around 2.0 with 1.7 LTS as the parallel maintenance line; fix the tool table to all 23 tools; add an Output Channel section; link the new migration guide.
- `STATUS.md` — 2.0 readiness framing, new Output Channel section, transport-parity deferral note, 2.0 dev row in the release history.

**New and aligned guides**
- `docs/migration-1.x-to-2.0.md` *(new)* — breaking changes (unified `search`/`prts_page`, `get_event_summary` fold, `operator_name` → `name`), output-channel semantics, and compatibility notes.
- `docs/dev/LTS.md` — 2.0 Boundary now lists output channel (not Markdown/JSON) and defers transport parity.
- `python/CHANGELOG.md`, `ts/CHANGELOG.md` — add the output-channel design-decision note to `[Unreleased]`.

**Package READMEs and config (CD publishes these verbatim)**
- `python/README.md`, `ts/README.md` — 32 → 23 tools, 2.0 framing, migration link; TS env table gains `PRTS_OUTPUT_CHANNEL`.
- `.env.example` — add `PRTS_OUTPUT_CHANNEL`.

**New**
- `SECURITY.md` — private reporting policy and supported version lines.

## Key facts locked across all files
- Tool surface: 32 → **23** (net −9; 11 legacy aliases folded into `search`/`prts_page`/`list_stories`).
- Output channel: connection-level `output_channel` (`content` default / `structured` / `both`); default is **not** flipped to JSON; the per-call `output_format=markdown|json` parameter was rejected during design.
- Structured/narrative split: **17 / 6** tools (matches the `ts/tests/toolSurface.test.ts` invariant).
- Cross-transport parity (Python HTTP / TS stdio) is **deferred beyond 2.0**.

## Verification
- Cross-file consistency grep: 23-tool count, 17/6 split, output-channel defaults, and transport-parity deferral are coherent across all 12 files.
- `git diff --name-only` confirms only `.md` + `.env.example` changed — no `.py`/`.ts`/`.js`.
- Existing test suites were not re-run (no source changes); CI will run them on this PR.