### PR TITLE
fix(v2.0.1): output-channel followups

### DIFF
--- a/.mcp.example.json
+++ b/.mcp.example.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "prts_wiki": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "-v", "prts-mcp-data:/data/gamedata", "-v", "prts-mcp-levels:/data/gamedata-levels", "-v", "prts-mcp-storyjson:/data/storyjson", "prts-mcp"],
-      "env": {
-        "PRTS_OUTPUT_CHANNEL": "content"
-      }
+      "args": ["run", "-i", "--rm", "-v", "prts-mcp-data:/data/gamedata", "-v", "prts-mcp-levels:/data/gamedata-levels", "-v", "prts-mcp-storyjson:/data/storyjson", "-e", "PRTS_OUTPUT_CHANNEL=content", "prts-mcp"]
     }
   }
 }

--- a/.mcp.example.json
+++ b/.mcp.example.json
@@ -4,7 +4,7 @@
       "command": "docker",
       "args": ["run", "-i", "--rm", "-v", "prts-mcp-data:/data/gamedata", "-v", "prts-mcp-levels:/data/gamedata-levels", "-v", "prts-mcp-storyjson:/data/storyjson", "prts-mcp"],
       "env": {
-        "PRTS_OUTPUT_CHANNEL": "both"
+        "PRTS_OUTPUT_CHANNEL": "content"
       }
     }
   }

--- a/.mcp.example.json
+++ b/.mcp.example.json
@@ -2,7 +2,10 @@
   "mcpServers": {
     "prts_wiki": {
       "command": "docker",
-      "args": ["run", "-i", "--rm", "-v", "prts-mcp-data:/data/gamedata", "-v", "prts-mcp-levels:/data/gamedata-levels", "-v", "prts-mcp-storyjson:/data/storyjson", "prts-mcp"]
+      "args": ["run", "-i", "--rm", "-v", "prts-mcp-data:/data/gamedata", "-v", "prts-mcp-levels:/data/gamedata-levels", "-v", "prts-mcp-storyjson:/data/storyjson", "prts-mcp"],
+      "env": {
+        "PRTS_OUTPUT_CHANNEL": "both"
+      }
     }
   }
 }

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -8,9 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
-- `list_story_events` now preserves explicit content-only `CallToolResult`
-  delivery when story data is missing, avoiding FastMCP's automatic string
-  result wrapper on that error path.
+- `list_story_events` no longer emits a spurious `structuredContent` wrapper
+  when story data is not yet available, matching the other eight story tools
+  (which already delivered the missing-data message as content-only text).
 
 ## [2.0.0] - 2026-07-03
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- `list_story_events` now preserves explicit content-only `CallToolResult`
+  delivery when story data is missing, avoiding FastMCP's automatic string
+  result wrapper on that error path.
+
 ## [2.0.0] - 2026-07-03
 
 ### Added

--- a/python/src/prts_mcp/data/enemy.py
+++ b/python/src/prts_mcp/data/enemy.py
@@ -170,8 +170,8 @@ def build_enemies_listing(
 ) -> dict | str:
     """Build the structured payload for an enemies listing.
 
-    Returns the dict payload on success, or a markdown error string on a
-    validation / missing-data / empty-result path.
+    Returns the dict payload on success, including legitimate empty listings,
+    or a markdown error string on a validation / missing-data path.
     """
     if not _has_enemy_data():
         return _missing_data_message()

--- a/python/src/prts_mcp/data/enemy.py
+++ b/python/src/prts_mcp/data/enemy.py
@@ -149,47 +149,6 @@ _IMMUNITY_LABELS: dict[str, str] = {
 }
 
 
-def _fmt_enemy(info: dict, include_id: bool = False) -> str:
-    lines: list[str] = []
-    name = info.get("name", "")
-    if name:
-        lines.append(f"# {name} - 敌人图鉴\n")
-        if include_id:
-            lines.append(f"- **ID**：{info.get('enemyId', '')}")
-
-    enemy_index = info.get("enemyIndex", "")
-    if enemy_index:
-        lines.append(f"- **编号**：{enemy_index}")
-
-    level = info.get("enemyLevel", "")
-    level_zh = _ENEMY_LEVEL_ZH.get(level, level)
-    if level_zh:
-        lines.append(f"- **威胁等级**：{level_zh}")
-
-    desc = info.get("description", "")
-    if desc:
-        lines.append(f"- **描述**：{desc}")
-
-    attack = info.get("attackType") or ""
-    if attack:
-        lines.append(f"- **攻击方式**：{attack}")
-
-    ability = info.get("ability") or ""
-    if ability:
-        lines.append(f"- **特殊能力**：{ability}")
-
-    damage_types: list[str] = info.get("damageType") or []
-    if damage_types:
-        dt_zh = "、".join(_DAMAGE_TYPE_ZH.get(dt, dt) for dt in damage_types)
-        lines.append(f"- **伤害类型**：{dt_zh}")
-
-    enemy_tags: list[str] = info.get("enemyTags") or []
-    if enemy_tags:
-        lines.append(f"- **标签**：{'、'.join(enemy_tags)}")
-
-    return "\n".join(lines)
-
-
 # NOTE: a _fmt_stats helper previously lived here, formatting combat stats
 # from enemy_database.json into markdown. It became dead code when
 # get_enemy_info migrated to _extract_enemy_stats (structured dict) +
@@ -248,9 +207,17 @@ def build_enemies_listing(
     entries.sort(key=lambda x: (x[1].get("sortId", 9999), x[0]))
     total = len(entries)
 
-    # Legitimate-but-empty: offset past end (total>0) is a normal structured
-    # payload, not an error (P2b plan §3.4). Filter-no-match (total==0) falls
-    # through to the standard empty-dict path below.
+    # Empty-result semantics (2.0 output-channel contract, intentional
+    # distinction — see test_filter_no_match_is_structured_no_empty_reason):
+    #   - offset_out_of_range: total > 0 but the requested page is past the
+    #     end, so we return a structured payload carrying empty_reason so a
+    #     paging client can tell "no more pages" from a genuine zero dataset.
+    #   - filter no-match: total is legitimately 0, so there is nothing to
+    #     distinguish — it falls through to the standard empty-listing payload
+    #     ({total:0, enemies:[]}) below without an empty_reason marker. Adding
+    #     empty_reason="no_match" here would touch the renderer, parity
+    #     fixtures, and the TS equivalent, and is out of scope for this
+    #     cleanup; raise it as a separate follow-up if a client ever needs it.
     filters_payload = {"threat_level": threat_level, "threat_level_filter": level_filter}
     if not full and offset >= total and total > 0:
         return {

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -47,7 +47,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         try:
             zip_path = _require_story_zip(cfg)
         except RuntimeError as e:
-            return str(e)
+            return text_result(str(e))
 
         try:
             data = _build_story_events_listing(zip_path, category=category)

--- a/python/tests/test_enemy.py
+++ b/python/tests/test_enemy.py
@@ -180,6 +180,23 @@ class TestListEnemies:
         r = render_result(data, list_enemies(offset=999), channel="structured")
         assert r.structuredContent == data
 
+    def test_filter_no_match_is_structured_no_empty_reason(self, gamedata):
+        # Locks the current filter-no-match payload shape. Distinct from the
+        # offset_out_of_range case: a filter that matches nothing has total=0,
+        # so there is no "page vs dataset" ambiguity to disambiguate and the
+        # payload carries NO empty_reason marker (just the normal empty
+        # listing). Documented, not changed — adding empty_reason="no_match"
+        # would be a wider contract change (renderer + parity + TS).
+        # Fixture exposes BOSS (霜星) + NORMAL (源石虫); "elite" matches none.
+        data = build_enemies_listing(threat_level="elite")
+        assert isinstance(data, dict)
+        assert data["total"] == 0
+        assert data["enemies"] == []
+        assert "empty_reason" not in data
+        assert list_enemies(threat_level="elite") == "# 敌人图鉴（共 0 个）"
+        r = render_result(data, list_enemies(threat_level="elite"), channel="structured")
+        assert r.structuredContent == data
+
     def test_threat_level_invalid_returns_error(self, gamedata):
         out = list_enemies(threat_level="INVALID")
         assert "无效的 threat_level" in out

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -478,3 +478,28 @@ def test_search_stories_missing_zip_is_content_only(
         "剧情数据未就绪。请设置 STORYJSON_PATH 环境变量指向 zh_CN.zip，"
         "或等待服务器自动从 GitHub Release 下载完成后重试。"
     )
+
+
+def test_list_story_events_missing_zip_is_content_only(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # Regression for #42: list_story_events returned a bare str on the
+    # missing-zip path, which FastMCP then wrapped into an automatic
+    # structuredContent={"result": ...}. The fix routes it through
+    # text_result(...) so the missing-data message stays content-only.
+    monkeypatch.setenv("STORYJSON_PATH", str(tmp_path / "missing.zip"))
+    app = FastMCP("story-test")
+    register_story_tools(app)
+
+    result = asyncio.run(
+        app._tool_manager.call_tool(
+            "list_story_events", {}, convert_result=True,
+        )
+    )
+
+    assert result.structuredContent is None
+    assert result.content[0].text == (
+        "剧情数据未就绪。请设置 STORYJSON_PATH 环境变量指向 zh_CN.zip，"
+        "或等待服务器自动从 GitHub Release 下载完成后重试。"
+    )

--- a/ts/src/tools/gamedataTools.ts
+++ b/ts/src/tools/gamedataTools.ts
@@ -52,7 +52,7 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
     { name: z.string().describe("干员的游戏内中文名，如「阿米娅」、「能天使」。") },
     ({ name }) => {
       const text = getOperatorArchives(name);
-      return { content: [{ type: "text", text }] };
+      return textResult(text);
     }
   );
 
@@ -66,7 +66,7 @@ export function registerGamedataTools(server: McpServer, channel: OutputChannel 
     { name: z.string().describe("干员的游戏内中文名，如「阿米娅」、「能天使」。") },
     ({ name }) => {
       const text = getOperatorVoicelines(name);
-      return { content: [{ type: "text", text }] };
+      return textResult(text);
     }
   );
 

--- a/ts/src/tools/storyTools.ts
+++ b/ts/src/tools/storyTools.ts
@@ -169,24 +169,17 @@ export function registerStoryTools(server: McpServer, channel: OutputChannel = "
       try {
         zipPath = requireStoryZip();
       } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+        return textResult(e instanceof Error ? e.message : String(e));
       }
       try {
         const chapter = _readStory(zipPath, story_key, include_narration);
-        return { content: [{ type: "text", text: formatChapter(chapter) }] };
+        return textResult(formatChapter(chapter));
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         if (msg.includes("not found") || msg.includes("Entry not found")) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `未找到剧情："${story_key}"。请通过 list_stories 确认章节 key。`,
-              },
-            ],
-          };
+          return textResult(`未找到剧情："${story_key}"。请通过 list_stories 确认章节 key。`);
         }
-        return { content: [{ type: "text", text: `读取剧情失败：${msg}` }] };
+        return textResult(`读取剧情失败：${msg}`);
       }
     }
   );
@@ -209,7 +202,7 @@ export function registerStoryTools(server: McpServer, channel: OutputChannel = "
       try {
         zipPath = requireStoryZip();
       } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+        return textResult(e instanceof Error ? e.message : String(e));
       }
       try {
         const result = _readActivity(
@@ -242,20 +235,13 @@ export function registerStoryTools(server: McpServer, channel: OutputChannel = "
             `\n[还有更多章节，请调用 read_activity(event_id="${event_id}", page=${nextPage})]`
           );
         }
-        return { content: [{ type: "text", text: parts.join("\n") }] };
+        return textResult(parts.join("\n"));
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         if (msg.includes("not found")) {
-          return {
-            content: [
-              {
-                type: "text",
-                text: `未找到活动："${event_id}"。请先调用 list_story_events 确认活动 ID。`,
-              },
-            ],
-          };
+          return textResult(`未找到活动："${event_id}"。请先调用 list_story_events 确认活动 ID。`);
         }
-        return { content: [{ type: "text", text: `读取活动剧情失败：${msg}` }] };
+        return textResult(`读取活动剧情失败：${msg}`);
       }
     }
   );
@@ -279,7 +265,7 @@ export function registerStoryTools(server: McpServer, channel: OutputChannel = "
       try {
         zipPath = requireStoryZip();
       } catch (e) {
-        return { content: [{ type: "text", text: e instanceof Error ? e.message : String(e) }] };
+        return textResult(e instanceof Error ? e.message : String(e));
       }
       try {
         const data = _buildStorySearch(

--- a/ts/tests/enemy.test.ts
+++ b/ts/tests/enemy.test.ts
@@ -135,6 +135,26 @@ test("list_enemies threat_level filters", async () => {
   assert.doesNotMatch(out, /源石虫/);
 });
 
+test("list_enemies filter no-match is structured without empty_reason", async () => {
+  const root = tempGamedataRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  writeFixtures(root);
+  const enemy = await loadEnemyModule();
+  const data = enemy.buildEnemiesListing("elite");
+  assert.equal(typeof data, "object");
+  assert.deepEqual(data, {
+    total: 0,
+    offset: 0,
+    limit: 50,
+    full: false,
+    filters: { threat_level: "elite", threat_level_filter: "ELITE" },
+    enemies: [],
+  });
+  assert.equal("empty_reason" in data, false);
+  assert.equal(enemy.renderEnemiesListing(data), "# 敌人图鉴（共 0 个）");
+}
+);
+
 test("list_enemies invalid threat_level returns error", async () => {
   const root = tempGamedataRoot();
   process.env["GAMEDATA_PATH"] = root;


### PR DESCRIPTION
Implements the concrete post-2.0.0 fixes from `dev/docs/followups/2.0.1-cumulative-fix-plan.md`. Five commits; no CI/CD, LTS, or branch-rename work folded in. Merge left for maintainer review.

## Summary

- **Python `list_story_events` missing-data result shape (closes #42).** The missing-story-zip branch returned a bare `str`, which FastMCP re-wrapped into an automatic `structuredContent={"result": ...}` envelope — the lone holdout among the nine story tools. Routed through `text_result(...)` to match its siblings; regression test mirrors the existing `search_stories` missing-zip test.
- **TS content-only results centralized through `textResult(...)` (closes #43).** Replaced the remaining inline `{ content: [{ type: "text", text }] }` constructions under `ts/src/tools/` (gamedata narrative tools + all `read_story` / `read_activity` / `search_stories` paths) with the shared `textResult(...)` helper. Behavior-preserving — the helper yields the same content-only `CallToolResult`. Also covers the `search_stories` missing-zip path that issue #43 omitted.
- **Dead enemy formatter removed + empty-list semantics documented.** `_fmt_enemy` (superseded by the build/render split, no callers) is deleted. The intentional `build_enemies_listing` empty-listing distinction (`offset_out_of_range` carries `empty_reason`; filter-no-match with `total==0` does not) is now documented in-code and locked by a structural test. No new `empty_reason="no_match"` value is introduced (renderer + parity + TS ripple is out of scope for this cleanup).
- **`.mcp.example.json` shows `PRTS_OUTPUT_CHANNEL` (partially addresses #44).** Added an `env` block with `PRTS_OUTPUT_CHANNEL` set to the default `content`, documenting that the 2.0 output-channel knob exists at the most common configuration entry point while keeping the example to one compact entry and incurring zero token overhead for users who copy it. (`"both"` remains documented in `docs/migration-1.x-to-2.0.md` for clients that want both channels.) — *Adjustment from review: the initial value was `"both"` per the plan, but the deployed Bot Review flagged that as the most token-expensive mode; maintainer chose `"content"` (the recommended default).*

## Test plan

Full verification run (`pwsh .\scripts\check-runtime.ps1 -Full`): **0 failures, 1 warning** (the pre-existing benign `python\.venv` lacks-mcp warning documented in AGENTS.md — unrelated to this PR).

- Python: **270 passed, 2 skipped**. Targeted: `pytest tests/test_story_output_channel.py tests/test_enemy.py tests/test_tool_surface.py -q` (incl. new `test_list_story_events_missing_zip_is_content_only` and `test_filter_no_match_is_structured_no_empty_reason`).
- TypeScript: **190 passed, 2 skipped**; `npm run typecheck` clean.
- Post-patch audits:
  - `grep "return str(e)" python/src/prts_mcp/tools_story.py` → no matches.
  - `grep -rn 'return { content' ts/src/tools/` → no matches.
  - `_fmt_enemy` has no references under `python/src` or `python/tests`.
  - `.mcp.example.json` is valid JSON and carries `PRTS_OUTPUT_CHANNEL`.

## Review trail

- Independent subagent CR: **Approve** — all 5 claims verified against the code, behavior provably preserved, no blocking/should-fix findings (one pre-existing cross-domain `empty_reason` nit, correctly out of scope).
- Deployed Bot Review (`khpilot[bot]`): 1 MEDIUM (`.mcp.example.json` `both` → token overhead) + 1 LOW (CHANGELOG phrasing). **Both addressed** in 60956b7 — example value switched to `content`, CHANGELOG rephrased to describe the user-visible behavior.

## Deferred

- **`glama.json` extra metadata (#44 remainder).** Its schema currently requires only `maintainers`; a `tools` metadata field is not verified as accepted by Glama. Left unchanged pending confirmation of supported schema fields.
- **CI/CD hardening** remains in `dev/docs/followups/2.0-ci-cd-patch-followups.md`.
- **LTS backports** remain in `dev/docs/followups/2.0-lts-cherry-pick-followups.md`.

## Issue closure notes

- Closes #42 (Python test + fix landed).
- Closes #43 (all TS inline text-only return objects replaced, including the `search_stories` missing-zip path the issue body omitted).
- Partially addresses #44 (`.mcp.example.json` half); the Glama half stays open/deferred.