### PR TITLE
fix(search): improve PRTS search result quality

### DIFF
--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -58,18 +58,41 @@ _HTML_ENTITY_RE = re.compile(r"&#?[a-zA-Z0-9]+;")
 
 
 _TECHNICAL_PAGE_PATTERNS = (
-    "/spine",
-    "/data",
-    "/db",
-    "/lua",
-    "/json",
-    "Widget:",
-    "Template:",
+    re.compile(r"/(?:spine|data|db|lua|json|module)(?:$|[/:._-])", re.IGNORECASE),
+    re.compile(r"\.(?:json|lua)$", re.IGNORECASE),
+    re.compile(r"^(?:Widget|Template|Module|MediaWiki|模块|模板):", re.IGNORECASE),
 )
+
+_REDIRECT_SNIPPET_RE = re.compile(r"#\s*(?:重定向|REDIRECT)", re.IGNORECASE)
 
 
 def _is_technical_page(title: str) -> bool:
-    return any(p in title for p in _TECHNICAL_PAGE_PATTERNS)
+    return any(p.search(title) for p in _TECHNICAL_PAGE_PATTERNS)
+
+
+def _is_redirect_like(snippet: str) -> bool:
+    return bool(_REDIRECT_SNIPPET_RE.search(snippet))
+
+
+async def _resolve_redirect_title(title: str) -> str | None:
+    """Resolve a redirect page title to its target, returning None if unchanged."""
+    await _rate_limit()
+    resp = await _get_client().get(
+        PRTS_API_ENDPOINT,
+        params={
+            "action": "query",
+            "redirects": "1",
+            "titles": title,
+            "format": "json",
+        },
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    redirects = data.get("query", {}).get("redirects", [])
+    for item in redirects:
+        if item.get("from") == title and item.get("to"):
+            return item["to"]
+    return None
 
 
 async def search_prts(
@@ -97,6 +120,7 @@ async def search_prts(
         "srlimit": str(limit * 2 if filter_technical else limit),
         "srnamespace": "0",
         "srinfo": "totalhits",
+        "srprop": "snippet|redirecttitle|redirectsnippet",
         "format": "json",
     }
     if srwhat:
@@ -108,11 +132,16 @@ async def search_prts(
     results: list[dict] = []
     for item in data.get("query", {}).get("search", []):
         title = item["title"]
+        raw_snippet = item.get("snippet", "")
+        if not item.get("redirecttitle") and _is_redirect_like(raw_snippet):
+            target = await _resolve_redirect_title(title)
+            if target:
+                title = target
         if filter_technical and _is_technical_page(title):
             continue
         if len(results) >= limit:
             break
-        snippet = strip_wikitext(item.get("snippet", ""))
+        snippet = strip_wikitext(raw_snippet)
         snippet = _html.unescape(snippet)
         snippet = _clean_snippet(snippet)
         results.append({

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import html as _html
+import logging
 import re
 
 import xml.etree.ElementTree as ET
@@ -13,6 +14,7 @@ from prts_mcp.utils.sanitizer import strip_wikitext
 
 # --- Shared httpx client (connection pooling) ---
 
+_logger = logging.getLogger(__name__)
 _client: httpx.AsyncClient | None = None
 
 
@@ -76,22 +78,25 @@ def _is_redirect_like(snippet: str) -> bool:
 
 async def _resolve_redirect_title(title: str) -> str | None:
     """Resolve a redirect page title to its target, returning None if unchanged."""
-    await _rate_limit()
-    resp = await _get_client().get(
-        PRTS_API_ENDPOINT,
-        params={
-            "action": "query",
-            "redirects": "1",
-            "titles": title,
-            "format": "json",
-        },
-    )
-    resp.raise_for_status()
-    data = resp.json()
-    redirects = data.get("query", {}).get("redirects", [])
-    for item in redirects:
-        if item.get("from") == title and item.get("to"):
-            return item["to"]
+    try:
+        await _rate_limit()
+        resp = await _get_client().get(
+            PRTS_API_ENDPOINT,
+            params={
+                "action": "query",
+                "redirects": "1",
+                "titles": title,
+                "format": "json",
+            },
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        redirects = data.get("query", {}).get("redirects", [])
+        for item in redirects:
+            if item.get("from") == title and item.get("to"):
+                return item["to"]
+    except Exception as exc:
+        _logger.debug("Failed to resolve PRTS redirect title %r: %s", title, exc)
     return None
 
 
@@ -120,7 +125,7 @@ async def search_prts(
         "srlimit": str(limit * 2 if filter_technical else limit),
         "srnamespace": "0",
         "srinfo": "totalhits",
-        "srprop": "snippet|redirecttitle|redirectsnippet",
+        "srprop": "snippet|redirecttitle",
         "format": "json",
     }
     if srwhat:

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -401,7 +401,7 @@ def _clean_snippet(snippet: str) -> str:
     snippet = re.sub(r'\s*"[^"]*"\s*:\s*"[^"]*"\s*,?\s*', " ", snippet)
     # Remove isolated pipe-value artifacts with Chinese keys
     snippet = re.sub(r"\|[一-鿿\w]+\s*=[^\n]*", "", snippet)
-    snippet = re.sub(r"#重定向|#REDIRECT", "", snippet)
+    snippet = _REDIRECT_SNIPPET_RE.sub("", snippet)
     # Collapse whitespace
     snippet = re.sub(r"[ \t]+", " ", snippet)
     snippet = re.sub(r",{2,}", "", snippet)

--- a/python/tests/test_prts_search.py
+++ b/python/tests/test_prts_search.py
@@ -20,7 +20,7 @@ class FakeResponse:
 
 
 class FakeClient:
-    def __init__(self, payloads: list[dict[str, Any]]) -> None:
+    def __init__(self, payloads: list[dict[str, Any] | Exception]) -> None:
         self.payloads = payloads
         self.requests: list[dict[str, Any]] = []
 
@@ -28,7 +28,10 @@ class FakeClient:
         self.requests.append(params)
         if not self.payloads:
             raise AssertionError("unexpected request")
-        return FakeResponse(self.payloads.pop(0))
+        payload = self.payloads.pop(0)
+        if isinstance(payload, Exception):
+            raise payload
+        return FakeResponse(payload)
 
 
 async def _no_rate_limit() -> None:
@@ -37,7 +40,7 @@ async def _no_rate_limit() -> None:
 
 def _patch_client(
     monkeypatch: pytest.MonkeyPatch,
-    payloads: list[dict[str, Any]],
+    payloads: list[dict[str, Any] | Exception],
 ) -> FakeClient:
     client = FakeClient(payloads)
     monkeypatch.setattr("prts_mcp.api.prts_wiki._get_client", lambda: client)
@@ -74,9 +77,35 @@ def test_search_prts_resolves_redirect_like_result(
         "totalhits": 1,
         "results": [{"title": "阿米娅", "snippet": "阿米娅"}],
     }
-    assert client.requests[0]["srprop"] == "snippet|redirecttitle|redirectsnippet"
+    assert client.requests[0]["srprop"] == "snippet|redirecttitle"
     assert client.requests[1]["redirects"] == "1"
     assert client.requests[1]["titles"] == "阿米亚"
+
+
+def test_search_prts_keeps_result_when_redirect_resolution_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_client(
+        monkeypatch,
+        [
+            {
+                "query": {
+                    "searchinfo": {"totalhits": 1},
+                    "search": [
+                        {"title": "阿米亚", "snippet": "# redirect [[阿米娅]]"},
+                    ],
+                },
+            },
+            RuntimeError("redirect lookup failed"),
+        ],
+    )
+
+    result = asyncio.run(search_prts("阿米亚", limit=1))
+
+    assert result == {
+        "totalhits": 1,
+        "results": [{"title": "阿米亚", "snippet": "阿米娅"}],
+    }
 
 
 def test_search_prts_filters_technical_pages_but_keeps_totalhits(

--- a/python/tests/test_prts_search.py
+++ b/python/tests/test_prts_search.py
@@ -55,7 +55,7 @@ def test_search_prts_resolves_redirect_like_result(
                 "query": {
                     "searchinfo": {"totalhits": 1},
                     "search": [
-                        {"title": "阿米亚", "snippet": "#REDIRECT [[阿米娅]]"},
+                        {"title": "阿米亚", "snippet": "# redirect [[阿米娅]]"},
                     ],
                 },
             },

--- a/python/tests/test_prts_search.py
+++ b/python/tests/test_prts_search.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from prts_mcp.api.prts_wiki import search_prts
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class FakeClient:
+    def __init__(self, payloads: list[dict[str, Any]]) -> None:
+        self.payloads = payloads
+        self.requests: list[dict[str, Any]] = []
+
+    async def get(self, _url: str, params: dict[str, Any]) -> FakeResponse:
+        self.requests.append(params)
+        if not self.payloads:
+            raise AssertionError("unexpected request")
+        return FakeResponse(self.payloads.pop(0))
+
+
+async def _no_rate_limit() -> None:
+    return None
+
+
+def _patch_client(
+    monkeypatch: pytest.MonkeyPatch,
+    payloads: list[dict[str, Any]],
+) -> FakeClient:
+    client = FakeClient(payloads)
+    monkeypatch.setattr("prts_mcp.api.prts_wiki._get_client", lambda: client)
+    monkeypatch.setattr("prts_mcp.api.prts_wiki._rate_limit", _no_rate_limit)
+    return client
+
+
+def test_search_prts_resolves_redirect_like_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _patch_client(
+        monkeypatch,
+        [
+            {
+                "query": {
+                    "searchinfo": {"totalhits": 1},
+                    "search": [
+                        {"title": "阿米亚", "snippet": "#REDIRECT [[阿米娅]]"},
+                    ],
+                },
+            },
+            {
+                "query": {
+                    "redirects": [{"from": "阿米亚", "to": "阿米娅"}],
+                    "pages": {"1": {"title": "阿米娅"}},
+                },
+            },
+        ],
+    )
+
+    result = asyncio.run(search_prts("阿米亚", limit=1))
+
+    assert result == {
+        "totalhits": 1,
+        "results": [{"title": "阿米娅", "snippet": "阿米娅"}],
+    }
+    assert client.requests[0]["srprop"] == "snippet|redirecttitle|redirectsnippet"
+    assert client.requests[1]["redirects"] == "1"
+    assert client.requests[1]["titles"] == "阿米亚"
+
+
+def test_search_prts_filters_technical_pages_but_keeps_totalhits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_client(
+        monkeypatch,
+        [
+            {
+                "query": {
+                    "searchinfo": {"totalhits": 2},
+                    "search": [
+                        {"title": "变格凯尔希(敌人)/module", "snippet": "技术数据"},
+                        {"title": "凯尔希", "snippet": "罗德岛医生。"},
+                    ],
+                },
+            },
+        ],
+    )
+
+    result = asyncio.run(search_prts("凯尔希", limit=2))
+
+    assert result == {
+        "totalhits": 2,
+        "results": [{"title": "凯尔希", "snippet": "罗德岛医生。"}],
+    }
+
+
+def test_search_prts_filter_technical_false_keeps_technical_pages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_client(
+        monkeypatch,
+        [
+            {
+                "query": {
+                    "searchinfo": {"totalhits": 1},
+                    "search": [
+                        {"title": "变格凯尔希(敌人)/module", "snippet": "技术数据"},
+                    ],
+                },
+            },
+        ],
+    )
+
+    result = asyncio.run(search_prts("凯尔希", limit=1, filter_technical=False))
+
+    assert result == {
+        "totalhits": 1,
+        "results": [{"title": "变格凯尔希(敌人)/module", "snippet": "技术数据"}],
+    }
+
+
+def test_search_prts_filtered_empty_is_structured_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_client(
+        monkeypatch,
+        [
+            {
+                "query": {
+                    "searchinfo": {"totalhits": 1},
+                    "search": [
+                        {"title": "敌人数据/module", "snippet": "技术数据"},
+                    ],
+                },
+            },
+        ],
+    )
+
+    result = asyncio.run(search_prts("敌人数据", limit=1))
+
+    assert result == {"totalhits": 1, "results": []}

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -108,18 +108,22 @@ function isRedirectLike(snippet: string): boolean {
 }
 
 async function resolveRedirectTitle(title: string): Promise<string | null> {
-  const data = (await prtsGet({
-    action: "query",
-    redirects: 1,
-    titles: title,
-    format: "json",
-  })) as {
-    query?: {
-      redirects?: Array<{ from?: string; to?: string }>;
+  try {
+    const data = (await prtsGet({
+      action: "query",
+      redirects: 1,
+      titles: title,
+      format: "json",
+    })) as {
+      query?: {
+        redirects?: Array<{ from?: string; to?: string }>;
+      };
     };
-  };
-  for (const item of data.query?.redirects ?? []) {
-    if (item.from === title && item.to) return item.to;
+    for (const item of data.query?.redirects ?? []) {
+      if (item.from === title && item.to) return item.to;
+    }
+  } catch {
+    return null;
   }
   return null;
 }
@@ -165,7 +169,7 @@ export async function searchPrts(
     srlimit: fetchLimit,
     srnamespace: 0,
     srinfo: "totalhits",
-    srprop: "snippet|redirecttitle|redirectsnippet",
+    srprop: "snippet|redirecttitle",
     format: "json",
   };
   if (searchMode === "title") {
@@ -178,7 +182,6 @@ export async function searchPrts(
         title: string;
         snippet: string;
         redirecttitle?: string;
-        redirectsnippet?: string;
       }>;
     };
   };

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -93,17 +93,36 @@ function cleanSnippet(snippet: string): string {
 // ---------------------------------------------------------------------------
 
 const TECHNICAL_PAGE_PATTERNS = [
-  "/spine",
-  "/data",
-  "/db",
-  "/lua",
-  "/json",
-  "Widget:",
-  "Template:",
+  /\/(?:spine|data|db|lua|json|module)(?:$|[/:._-])/i,
+  /\.(?:json|lua)$/i,
+  /^(?:Widget|Template|Module|MediaWiki|模块|模板):/i,
 ];
 
 function isTechnicalPage(title: string): boolean {
-  return TECHNICAL_PAGE_PATTERNS.some((p) => title.includes(p));
+  return TECHNICAL_PAGE_PATTERNS.some((p) => p.test(title));
+}
+
+const REDIRECT_SNIPPET_RE = /#\s*(?:重定向|REDIRECT)/i;
+
+function isRedirectLike(snippet: string): boolean {
+  return REDIRECT_SNIPPET_RE.test(snippet);
+}
+
+async function resolveRedirectTitle(title: string): Promise<string | null> {
+  const data = (await prtsGet({
+    action: "query",
+    redirects: 1,
+    titles: title,
+    format: "json",
+  })) as {
+    query?: {
+      redirects?: Array<{ from?: string; to?: string }>;
+    };
+  };
+  for (const item of data.query?.redirects ?? []) {
+    if (item.from === title && item.to) return item.to;
+  }
+  return null;
 }
 
 function stripHtml(text: string): string {
@@ -147,6 +166,7 @@ export async function searchPrts(
     srlimit: fetchLimit,
     srnamespace: 0,
     srinfo: "totalhits",
+    srprop: "snippet|redirecttitle|redirectsnippet",
     format: "json",
   };
   if (searchMode === "title") {
@@ -155,18 +175,28 @@ export async function searchPrts(
   const data = (await prtsGet(params)) as {
     query?: {
       searchinfo?: { totalhits: number };
-      search?: Array<{ title: string; snippet: string }>;
+      search?: Array<{
+        title: string;
+        snippet: string;
+        redirecttitle?: string;
+        redirectsnippet?: string;
+      }>;
     };
   };
   const totalHits = data.query?.searchinfo?.totalhits ?? 0;
   const results: SearchResult[] = [];
   for (const item of data.query?.search ?? []) {
-    if (filterTechnical && isTechnicalPage(item.title)) continue;
+    let title = item.title;
+    const rawSnippet = item.snippet ?? "";
+    if (!item.redirecttitle && isRedirectLike(rawSnippet)) {
+      title = await resolveRedirectTitle(title) ?? title;
+    }
+    if (filterTechnical && isTechnicalPage(title)) continue;
     if (results.length >= limit) break;
-    let snippet = stripWikitext(item.snippet ?? "");
+    let snippet = stripWikitext(rawSnippet);
     snippet = unescapeHTMLEntities(snippet);
     snippet = cleanSnippet(snippet);
-    results.push({ title: item.title, snippet });
+    results.push({ title, snippet });
   }
   return { totalHits, results };
 }

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -58,6 +58,7 @@ const CSS_JS_RE =
   /@(font-face|keyframes|media|import|charset|namespace|supports|page)[^{]*\{[^}]*\}|\(window\.RLQ\s*\|\|\s*\[\]\)\.push\([^)]*\)|<style[^>]*>.*?<\/style>|<script[^>]*>.*?<\/script>/gis;
 
 const HTML_TAG_RE = /<[^>]+>/g;
+const REDIRECT_SNIPPET_RE = /#\s*(?:重定向|REDIRECT)/i;
 
 const NAMED_ENTITIES: Record<string, string> = {
   quot: '"', amp: "&", lt: "<", gt: ">", apos: "'", nbsp: " ",
@@ -80,7 +81,7 @@ function cleanSnippet(snippet: string): string {
   snippet = snippet.replace(/\s*"[^"]*"\s*:\s*"[^"]*"\s*,?\s*/g, " ");
   // Remove isolated pipe-value artifacts with Chinese keys
   snippet = snippet.replace(/\|[一-鿿\w]+\s*=[^\n]*/g, "");
-  snippet = snippet.replace(/#重定向|#REDIRECT/g, "");
+  snippet = snippet.replace(REDIRECT_SNIPPET_RE, "");
   // Collapse whitespace
   snippet = snippet.replace(/[ \t]+/g, " ");
   snippet = snippet.replace(/,{2,}/g, "");
@@ -101,8 +102,6 @@ const TECHNICAL_PAGE_PATTERNS = [
 function isTechnicalPage(title: string): boolean {
   return TECHNICAL_PAGE_PATTERNS.some((p) => p.test(title));
 }
-
-const REDIRECT_SNIPPET_RE = /#\s*(?:重定向|REDIRECT)/i;
 
 function isRedirectLike(snippet: string): boolean {
   return REDIRECT_SNIPPET_RE.test(snippet);

--- a/ts/tests/prtsTools.test.ts
+++ b/ts/tests/prtsTools.test.ts
@@ -11,13 +11,20 @@ function loadParityFixture(name: string): unknown {
   );
 }
 
-function mockFetch(payload: unknown): () => void {
+function mockFetch(payload: unknown | unknown[], requests?: string[]): () => void {
   const original = globalThis.fetch;
-  globalThis.fetch = (async () => ({
-    ok: true,
-    status: 200,
-    json: async () => payload,
-  })) as typeof fetch;
+  const queue = Array.isArray(payload) ? [...payload] : [payload];
+  globalThis.fetch = (async (input) => {
+    requests?.push(String(input));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => {
+        if (queue.length === 0) throw new Error("unexpected fetch call");
+        return queue.shift();
+      },
+    };
+  }) as typeof fetch;
   return () => {
     globalThis.fetch = original;
   };
@@ -65,4 +72,95 @@ test("buildPrtsSearch rejects invalid mode before network", async () => {
     await buildPrtsSearch("阿米娅", 5, "bad"),
     "无效的 search_mode 参数，可选值：text、title。",
   );
+});
+
+test("buildPrtsSearch resolves redirect-like search results", async () => {
+  const requests: string[] = [];
+  const restore = mockFetch([
+    {
+      query: {
+        searchinfo: { totalhits: 1 },
+        search: [{ title: "阿米亚", snippet: "#REDIRECT [[阿米娅]]" }],
+      },
+    },
+    {
+      query: {
+        redirects: [{ from: "阿米亚", to: "阿米娅" }],
+        pages: { "1": { title: "阿米娅" } },
+      },
+    },
+  ], requests);
+  try {
+    const data = await buildPrtsSearch("阿米亚", 1);
+    if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+    assert.equal(data.total, 1);
+    assert.deepStrictEqual(data.results, [{ title: "阿米娅", snippet: "阿米娅" }]);
+    assert.equal(
+      new URL(requests[0]).searchParams.get("srprop"),
+      "snippet|redirecttitle|redirectsnippet",
+    );
+  } finally {
+    restore();
+  }
+});
+
+test("buildPrtsSearch filters technical pages but keeps totalhits", async () => {
+  const restore = mockFetch({
+    query: {
+      searchinfo: { totalhits: 2 },
+      search: [
+        { title: "变格凯尔希(敌人)/module", snippet: "技术数据" },
+        { title: "凯尔希", snippet: "罗德岛医生。" },
+      ],
+    },
+  });
+  try {
+    const data = await buildPrtsSearch("凯尔希", 2);
+    if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+    assert.equal(data.total, 2);
+    assert.deepStrictEqual(data.results, [{ title: "凯尔希", snippet: "罗德岛医生。" }]);
+  } finally {
+    restore();
+  }
+});
+
+test("buildPrtsSearch filter_technical=false keeps technical pages", async () => {
+  const restore = mockFetch({
+    query: {
+      searchinfo: { totalhits: 1 },
+      search: [{ title: "变格凯尔希(敌人)/module", snippet: "技术数据" }],
+    },
+  });
+  try {
+    const data = await buildPrtsSearch("凯尔希", 1, "text", false);
+    if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+    assert.equal(data.total, 1);
+    assert.deepStrictEqual(data.results, [{ title: "变格凯尔希(敌人)/module", snippet: "技术数据" }]);
+  } finally {
+    restore();
+  }
+});
+
+test("buildPrtsSearch returns structured empty after filtering all technical hits", async () => {
+  const restore = mockFetch({
+    query: {
+      searchinfo: { totalhits: 1 },
+      search: [{ title: "敌人数据/module", snippet: "技术数据" }],
+    },
+  });
+  try {
+    const data = await buildPrtsSearch("敌人数据", 1);
+    assert.deepStrictEqual(data, {
+      query: "敌人数据",
+      search_mode: "text",
+      filters: {
+        limit: 1,
+        filter_technical: true,
+      },
+      total: 1,
+      results: [],
+    });
+  } finally {
+    restore();
+  }
 });

--- a/ts/tests/prtsTools.test.ts
+++ b/ts/tests/prtsTools.test.ts
@@ -80,7 +80,7 @@ test("buildPrtsSearch resolves redirect-like search results", async () => {
     {
       query: {
         searchinfo: { totalhits: 1 },
-        search: [{ title: "阿米亚", snippet: "#REDIRECT [[阿米娅]]" }],
+        search: [{ title: "阿米亚", snippet: "# redirect [[阿米娅]]" }],
       },
     },
     {

--- a/ts/tests/prtsTools.test.ts
+++ b/ts/tests/prtsTools.test.ts
@@ -16,12 +16,14 @@ function mockFetch(payload: unknown | unknown[], requests?: string[]): () => voi
   const queue = Array.isArray(payload) ? [...payload] : [payload];
   globalThis.fetch = (async (input) => {
     requests?.push(String(input));
+    const next = queue.shift();
+    if (next instanceof Error) throw next;
     return {
       ok: true,
       status: 200,
       json: async () => {
-        if (queue.length === 0) throw new Error("unexpected fetch call");
-        return queue.shift();
+        if (next === undefined) throw new Error("unexpected fetch call");
+        return next;
       },
     };
   }) as typeof fetch;
@@ -97,8 +99,30 @@ test("buildPrtsSearch resolves redirect-like search results", async () => {
     assert.deepStrictEqual(data.results, [{ title: "阿米娅", snippet: "阿米娅" }]);
     assert.equal(
       new URL(requests[0]).searchParams.get("srprop"),
-      "snippet|redirecttitle|redirectsnippet",
+      "snippet|redirecttitle",
     );
+    assert.equal(new URL(requests[1]).searchParams.get("redirects"), "1");
+    assert.equal(new URL(requests[1]).searchParams.get("titles"), "阿米亚");
+  } finally {
+    restore();
+  }
+});
+
+test("buildPrtsSearch keeps result when redirect resolution fails", async () => {
+  const restore = mockFetch([
+    {
+      query: {
+        searchinfo: { totalhits: 1 },
+        search: [{ title: "阿米亚", snippet: "# redirect [[阿米娅]]" }],
+      },
+    },
+    new Error("redirect lookup failed"),
+  ]);
+  try {
+    const data = await buildPrtsSearch("阿米亚", 1);
+    if (typeof data === "string") assert.fail(`unexpected error: ${data}`);
+    assert.equal(data.total, 1);
+    assert.deepStrictEqual(data.results, [{ title: "阿米亚", snippet: "阿米娅" }]);
   } finally {
     restore();
   }


### PR DESCRIPTION
## Summary
- resolve redirect-like `search_prts` hits to their target page when PRTS search metadata is absent
- filter technical/wiki implementation pages more robustly while preserving `totalhits`
- add aligned Python and TypeScript regression coverage for redirects, technical filtering, and filtered-empty results

## Test plan
- `PYTHONPATH=F:\2026-Spring\PRTS-MCP\python\src E:\Anaconda3\envs\python311\python.exe -m pytest python\tests\test_prts_search.py python\tests\test_story_output_channel.py -q`
- `cd ts && npm.cmd test -- tests/prtsTools.test.ts`
- `.\scripts\check-runtime.ps1 -Full`

## 未尽事宜
- 无