### PR TITLE
chore(release): open 2.0.3 development

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,12 +6,12 @@ _Last updated: 2026-07-07_
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 2.0.2 | Stable |
-| TypeScript | 2.0.2 | Stable |
+| Python | 2.0.3.dev0 | Development |
+| TypeScript | 2.0.3-dev.0 | Development |
 
 - 当前稳定发布：2.0.2（23 个 MCP 工具）
 - 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）
-- 下一开发目标：待 2.0.2 release 回合并后在 `develop` 重新打开
+- 当前开发目标：2.0.3（2.0.x 补丁线）
 - 当前补丁线：2.0.x
 - 2.0.2 补丁集：TS HTTP MCP smoke harness、TS Bun 候选运行路径、
   `search_prts` redirect/技术页面过滤修复。Bun 仍是可选候选路径；默认 TS

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.0.2] - 2026-07-07
 
 ### Fixed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.0.2"
+version = "2.0.3.dev0"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.0.2] - 2026-07-07
 
 ### Added

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.0.2",
+  "version": "2.0.3-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.0.2",
+      "version": "2.0.3-dev.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.0.2",
+  "version": "2.0.3-dev.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP)",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
- bump Python and TypeScript development versions to 2.0.3 dev suffixes
- reopen empty `[Unreleased]` sections in both changelogs
- update `STATUS.md` to show 2.0.2 as stable and 2.0.3 as the current development target

## Test plan
- `git diff --check`
- `.\scripts\check-runtime.ps1 -Full`

## 未尽事宜
- 无