### PR TITLE
chore(release): retarget develop to 2.1.0

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,13 +6,14 @@ _Last updated: 2026-07-07_
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 2.0.3.dev0 | Development |
-| TypeScript | 2.0.3-dev.0 | Development |
+| Python | 2.1.0.dev0 | Development |
+| TypeScript | 2.1.0-dev.0 | Development |
 
 - 当前稳定发布：2.0.2（23 个 MCP 工具）
 - 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）
-- 当前开发目标：2.0.3（2.0.x 补丁线）
-- 当前补丁线：2.0.x
+- 当前开发目标：2.1.0（正式支持 Bun 的 minor 版本）
+- 当前稳定补丁线：2.0.x
+- 当前开发线：2.1.x
 - 2.0.2 补丁集：TS HTTP MCP smoke harness、TS Bun 候选运行路径、
   `search_prts` redirect/技术页面过滤修复。Bun 仍是可选候选路径；默认 TS
   本地开发、npm 全局安装、`npx prts-mcp-ts`、systemd 部署与 npm Trusted

--- a/STATUS.md
+++ b/STATUS.md
@@ -25,7 +25,7 @@ _Last updated: 2026-07-07_
 
 - `main`：2.0.2（最新稳定发布线）
 - `lts/1.7`：1.7.x LTS 维护线（从 1.7.0 发布提交创建）
-- `develop`：2.0 之后的开发集成线
+- `develop`：2.1 的开发集成线
 
 1.7.0 是最后一个 1.x 功能版本和 LTS 基线。它将 server.py/server.ts 和 story.py/story.ts 单体文件拆分为聚焦子模块，保留向后兼容垫片（shim），并新增剧情角色追踪工具：`find_character_appearances`、`find_speakers_in`。后续功能开发转向 2.0；1.7.x 仅做兼容性、安全性、数据同步和关键缺陷修复。
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.0.3.dev0"
+version = "2.1.0.dev0"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.0.3-dev.0",
+  "version": "2.1.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.0.3-dev.0",
+      "version": "2.1.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.0.3-dev.0",
+  "version": "2.1.0-dev.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP)",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
- bump Python and TypeScript development versions from 2.0.3 to 2.1.0
- update `STATUS.md` to make 2.1.0 the current development target for formally supported Bun runtime work
- keep 2.0.2 as the current stable release line

## Test plan
- `git diff --check`
- `.\scripts\check-runtime.ps1 -Full`

## 未尽事宜
- 无