### PR TITLE
feat(ts): add supported Bun runtime entrypoint

### DIFF
--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -226,7 +226,8 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.value }}
         run: |
-          printf '\n---\n\n**Install**\n```bash\n# Run directly (Streamable HTTP on :3000)\nnpx prts-mcp-ts\n\n# Or install globally\nnpm install -g prts-mcp-ts@%s\n```\n\nMCP endpoint: `http://localhost:3000/mcp`\n' \
+          printf '\n---\n\n**Install**\n```bash\n# Run directly with the default Node.js entrypoint (Streamable HTTP on :3000)\nnpx prts-mcp-ts\n\n# Or install globally\nnpm install -g prts-mcp-ts@%s\n\n# Optional Bun runtime\nbunx --bun -p prts-mcp-ts@%s prts-mcp-ts-bun\n```\n\nMCP endpoint: `http://localhost:3000/mcp`\n' \
+            "$VERSION" \
             "$VERSION" >> release_notes.txt
 
       - name: Create GitHub Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,10 +230,14 @@ jobs:
         working-directory: ts
 
       # The full unit suite uses Node's node:test runner and stays covered by
-      # verify-ts. Bun candidate coverage is intentionally black-box runtime
-      # smoke until a dedicated bun:test migration is planned.
+      # verify-ts. Bun coverage is intentionally black-box runtime smoke until
+      # a dedicated bun:test migration is planned.
       - name: Smoke test Bun runtime
         run: bun run smoke:bun
+        working-directory: ts
+
+      - name: Smoke test packed Bun bin
+        run: bun run smoke:bun:package
         working-directory: ts
 
   build-image-ts:
@@ -302,9 +306,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: verify-ts-bun
     if: github.event_name == 'pull_request' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
-    # Candidate Bun Docker build: run on PRs as well as develop/main to collect
-    # compatibility data before any default-runtime switch. The job does not
-    # save gamedata caches, so PR branches do not publish cache entries.
+    # Supported optional Bun Docker build: run on PRs as well as develop/main
+    # to keep the alternative runtime path verified. The job does not save
+    # gamedata caches, so PR branches do not publish cache entries.
 
     steps:
       - name: Checkout repository
@@ -346,11 +350,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Bun candidate Docker image
-        run: docker build -f ts/Dockerfile.bun -t prts-mcp-ts-bun:candidate .
+      - name: Build Bun Docker image
+        run: docker build -f ts/Dockerfile.bun -t prts-mcp-ts-bun:supported .
 
-      - name: Smoke test Bun candidate Docker image (HTTP MCP protocol)
+      - name: Smoke test Bun Docker image (HTTP MCP protocol)
         run: |
-          docker run -d --name prts-mcp-ts-bun-ci -p 3000:3000 prts-mcp-ts-bun:candidate
+          docker run -d --name prts-mcp-ts-bun-ci -p 3000:3000 prts-mcp-ts-bun:supported
           trap 'docker rm -f prts-mcp-ts-bun-ci' EXIT
           bun ts/scripts/smoke-http.mjs --origin http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This repository contains two independent implementations for different deploymen
 | Directory | Language | Transport | Use case |
 |-----------|----------|-----------|----------|
 | [`python/`](python/) | Python 3.10+ | stdio | Local Claude Desktop / Claude Code, Docker |
-| [`ts/`](ts/) | TypeScript / Node.js | Streamable HTTP | Self-hosted server, remote HTTP access |
+| [`ts/`](ts/) | TypeScript / Node.js + Bun | Streamable HTTP | Self-hosted server, remote HTTP access |
 
 ### Release Lines
 
@@ -95,6 +95,12 @@ parameter.
 - **Local stdio (Python / Docker)** → see [`python/`](python/)
 - **HTTP server (TypeScript / Docker)** → see [`ts/`](ts/)
 
+The TypeScript implementation supports Node.js and Bun. Node.js remains the
+default for `npx prts-mcp-ts`, npm global installs, systemd deployments, the
+default Dockerfile, and npm Trusted Publishing. Bun is available as an explicit
+optional runtime via `bunx --bun -p prts-mcp-ts prts-mcp-ts-bun` or the
+supported `ts/Dockerfile.bun` build path.
+
 ### Data Sources
 
 - **PRTS Wiki API** (`https://prts.wiki/api.php`) — lore articles, faction info, world-building entries
@@ -120,7 +126,7 @@ Published Docker images and the npm package include bundled fallback game/level/
 | 目录 | 语言 | 传输方式 | 适用场景 |
 |------|------|----------|----------|
 | [`python/`](python/) | Python 3.10+ | stdio | Claude Desktop / Claude Code 本地接入、Docker |
-| [`ts/`](ts/) | TypeScript / Node.js | Streamable HTTP | 个人服务器部署，供他人通过 HTTP 调用 |
+| [`ts/`](ts/) | TypeScript / Node.js + Bun | Streamable HTTP | 个人服务器部署，供他人通过 HTTP 调用 |
 
 ### 版本线
 
@@ -186,6 +192,11 @@ Published Docker images and the npm package include bundled fallback game/level/
 
 - **本地 stdio 接入（Python / Docker）** → 见 [`python/`](python/)
 - **HTTP 服务部署（TypeScript / Docker）** → 见 [`ts/`](ts/)
+
+TypeScript 实现支持 Node.js 与 Bun。Node.js 仍是 `npx prts-mcp-ts`、npm 全局安装、
+systemd 部署、默认 Dockerfile 和 npm Trusted Publishing 的默认路径；Bun 作为显式可选
+运行时，可通过 `bunx --bun -p prts-mcp-ts prts-mcp-ts-bun` 或受支持的
+`ts/Dockerfile.bun` 构建路径使用。
 
 ### 数据源
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -14,10 +14,11 @@ _Last updated: 2026-07-07_
 - 当前开发目标：2.1.0（正式支持 Bun 的 minor 版本）
 - 当前稳定补丁线：2.0.x
 - 当前开发线：2.1.x
+- 2.1.0 开发目标：将 TS Bun 从候选路径提升为受支持可选运行时，新增
+  `prts-mcp-ts-bun` npm bin，并保留 Node/npm 作为默认入口、默认 Dockerfile 和
+  npm Trusted Publishing 路径。Bun 最低验证版本为 1.3.14。
 - 2.0.2 补丁集：TS HTTP MCP smoke harness、TS Bun 候选运行路径、
-  `search_prts` redirect/技术页面过滤修复。Bun 仍是可选候选路径；默认 TS
-  本地开发、npm 全局安装、`npx prts-mcp-ts`、systemd 部署与 npm Trusted
-  Publishing 继续走 Node/npm。
+  `search_prts` redirect/技术页面过滤修复。Bun 在 2.0.2 仍是可选候选路径。
 - 2.0 交付内容：工具面合并（32 → 23）+ output channel（structuredContent）；**双端协议同步（Python 上 HTTP / TS 上 stdio）已后置到 2.0 之后**。
 - 兼容性合约：1.7.x LTS 线既有 32 个工具名、必填参数、默认输出格式不变；仅接受兼容性、安全性、数据同步和关键缺陷修复
 
@@ -163,9 +164,18 @@ PRTS-MCP/
 > 15–30%，抵消工具面合并带来的上下文预算收益。详见
 > [`docs/migration-1.x-to-2.0.md`](docs/migration-1.x-to-2.0.md)。
 
+## 2.1.0 开发内容
+
+- [x] TS Bun 从候选路径提升为受支持可选运行时；`prts-mcp-ts` 继续走
+  Node.js，新增 `prts-mcp-ts-bun` 作为显式 Bun 入口。
+- [x] Bun package smoke 覆盖 `npm pack`、临时项目 `bun add`、安装后
+  `prts-mcp-ts-bun` 启动和 HTTP MCP 黑盒 smoke。
+- [x] `ts/Dockerfile.bun` 作为受支持的 Bun 替代构建路径保留；默认
+  `ts/Dockerfile` 不切换。
+
 ## 2.0.2 发布内容
 
-- [x] TS HTTP MCP smoke harness 已加入 Node/Bun/Docker 候选验证路径。
+- [x] TS HTTP MCP smoke harness 已加入 Node/Bun/Docker 验证路径。
 - [x] TS Bun 候选运行路径已加入；不改变 Node/npm 默认运行与发布合同。
 - [x] PRTS 搜索结果中 redirect 页面自动解析已实现，follow-up lookup 失败时
   保留原始搜索结果。

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- Added the `prts-mcp-ts-bun` public bin as the supported optional Bun runtime
+  entry point. The default `prts-mcp-ts` bin remains Node.js-based.
+- Added a packed-package Bun smoke test that runs `npm pack`, installs the
+  tarball with Bun in a temporary project, starts `prts-mcp-ts-bun`, and reuses
+  the HTTP MCP smoke harness.
+
+### Changed
+
+- Promoted the Bun runtime and `ts/Dockerfile.bun` from candidate coverage to a
+  supported optional TypeScript runtime path, verified against Bun `1.3.14`.
+  Node/npm remains the default runtime, Dockerfile, and Trusted Publishing path.
+
 ## [2.0.2] - 2026-07-07
 
 ### Added

--- a/ts/Dockerfile.bun
+++ b/ts/Dockerfile.bun
@@ -2,7 +2,7 @@ FROM oven/bun:1.3.14-alpine AS builder
 
 WORKDIR /build
 
-# Install dependencies first (layer cache). Bun is optional for this project;
+# Install dependencies first (layer cache). Bun is a supported optional runtime;
 # npm remains the default package manager and publishing path.
 COPY ts/package.json ts/bun.lock ./
 RUN bun install --frozen-lockfile
@@ -39,4 +39,4 @@ RUN mkdir -p /data/gamedata /data/gamedata-levels /data/storyjson
 
 EXPOSE 3000
 
-ENTRYPOINT ["bun", "dist/server.js"]
+ENTRYPOINT ["bun", "dist/server-bun.js"]

--- a/ts/README.md
+++ b/ts/README.md
@@ -4,6 +4,11 @@
 
 提供 23 个 MCP 工具（2.0）：PRTS 词条检索与页面结构、干员档案/语音/基础信息、剧情活动与台词、角色出场追踪、全文搜索、敌人图鉴、关卡查询、关卡敌人融合，以及物品/材料查询。完整清单见仓库根目录 [`README.md`](../README.md)。
 
+TypeScript 实现正式支持 Node.js 与 Bun 双运行时。默认 `prts-mcp-ts`、`npx`、
+npm 全局安装、systemd 部署、默认 Dockerfile 与 npm Trusted Publishing 仍走
+Node.js；Bun 作为显式可选运行时提供 `prts-mcp-ts-bun` 入口和
+`ts/Dockerfile.bun` 构建路径。
+
 > **2.0 变更**：工具面由 1.x 的 32 个合并为 23 个（详见 [1.x → 2.0 迁移指南](../docs/migration-1.x-to-2.0.md)）；新增可选的 output channel（查询字符串 `?output_channel=` / 请求头 `x-prts-output-channel` / `PRTS_OUTPUT_CHANNEL` 环境变量，默认 `content`，与 1.x 行为一致）。
 
 ---
@@ -50,26 +55,43 @@ npm run build     # 编译到 dist/
 npm start         # 运行编译后的版本
 ```
 
-### 可选 Bun 候选运行路径
+### 可选 Bun 运行路径
 
-Bun 目前是 TypeScript 实现的候选运行路径，用于收集兼容性和性能数据。
+Bun 是 TypeScript 实现的受支持可选运行时，最低验证版本为 Bun `1.3.14`。
 默认开发、npm 全局安装、`npx prts-mcp-ts`、systemd 部署和 npm Trusted Publishing
-仍然走 Node/npm。
+仍然走 Node/npm；需要 Bun 时请显式调用 Bun 入口。
+
+无需克隆仓库的一次性运行：
+
+```bash
+bunx --bun -p prts-mcp-ts prts-mcp-ts-bun
+```
+
+全局安装后运行：
+
+```bash
+bun add -g prts-mcp-ts
+prts-mcp-ts-bun
+```
+
+本地开发验证：
 
 ```bash
 cd ts
 bun install --frozen-lockfile
 bun run build:bun
 bun run smoke:bun    # 使用临时 fixture 数据启动 Bun server 并跑 HTTP MCP smoke
-bun run start:bun    # 运行 dist/server.js
+bun run smoke:bun:package  # npm pack 后用 Bun 安装并验证 prts-mcp-ts-bun
+bun run start:bun    # 运行 dist/server-bun.js
 ```
 
-现阶段 TypeScript 单元测试仍由 Node 的 `node:test` 路径覆盖；Bun 候选路径使用
-`bun run typecheck`、`bun run build:bun` 和黑盒 HTTP MCP smoke 验证运行时兼容性。
+现阶段 TypeScript 单元测试仍由 Node 的 `node:test` 路径覆盖；Bun 路径使用
+`bun run typecheck`、`bun run build:bun`、源码级 HTTP MCP smoke 和安装后 package smoke
+验证运行时兼容性。
 如调整 `package.json` 或 `package-lock.json` 依赖，请同步运行 `bun install --lockfile-only`
 刷新 `bun.lock`。
 
-候选 Bun Docker 镜像可从仓库根目录构建：
+受支持的 Bun Docker 替代镜像可从仓库根目录构建：
 
 ```bash
 docker build -f ts/Dockerfile.bun -t prts-mcp-ts-bun .

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -14,7 +14,8 @@
         "express": "^5.2.1"
       },
       "bin": {
-        "prts-mcp-ts": "dist/server.js"
+        "prts-mcp-ts": "dist/server.js",
+        "prts-mcp-ts-bun": "dist/server-bun.js"
       },
       "devDependencies": {
         "@types/adm-zip": "^0.5.7",

--- a/ts/package.json
+++ b/ts/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "main": "dist/server.js",
   "bin": {
-    "prts-mcp-ts": "./dist/server.js"
+    "prts-mcp-ts": "./dist/server.js",
+    "prts-mcp-ts-bun": "./dist/server-bun.js"
   },
   "files": [
     "dist/",
@@ -19,10 +20,11 @@
     "build:bun": "bun run build",
     "dev": "tsx src/server.ts",
     "start": "node dist/server.js",
-    "start:bun": "bun dist/server.js",
+    "start:bun": "bun dist/server-bun.js",
     "smoke:http": "node scripts/smoke-http.mjs -- node dist/server.js",
     "smoke:http:fixture": "node scripts/smoke-http.mjs --fixture-data -- node dist/server.js",
-    "smoke:bun": "bun scripts/smoke-http.mjs --fixture-data -- bun dist/server.js",
+    "smoke:bun": "bun scripts/smoke-http.mjs --fixture-data -- bun dist/server-bun.js",
+    "smoke:bun:package": "bun scripts/smoke-package-bun.mjs",
     "test": "node --import tsx --test \"tests/**/*.test.ts\"",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "tsc"

--- a/ts/scripts/smoke-package-bun.mjs
+++ b/ts/scripts/smoke-package-bun.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Pack the npm package, install it with Bun in a temporary project, then run
+ * the published Bun bin through the shared HTTP MCP smoke harness.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(scriptDir, "..");
+const tempRoot = mkdtempSync(join(tmpdir(), "prts-bun-package-smoke-"));
+const isWindows = process.platform === "win32";
+
+function npmCommand() {
+  return isWindows ? "npm.cmd" : "npm";
+}
+
+function bunCommand() {
+  if (process.versions.bun) return process.execPath;
+  return isWindows ? "bun.exe" : "bun";
+}
+
+function pathKey(env) {
+  return Object.keys(env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+}
+
+function run(command, args, options = {}) {
+  return new Promise((resolveRun, reject) => {
+    const usesCmdWrapper = isWindows && /\.(?:cmd|bat)$/i.test(command);
+    const spawnCommand = usesCmdWrapper ? process.env.ComSpec ?? "cmd.exe" : command;
+    const spawnArgs = usesCmdWrapper ? ["/d", "/s", "/c", command, ...args] : args;
+    const child = spawn(spawnCommand, spawnArgs, {
+      cwd: options.cwd ?? packageRoot,
+      env: options.env ?? process.env,
+      stdio: options.capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    });
+
+    let stdout = "";
+    let stderr = "";
+    if (options.capture) {
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => { stdout += chunk; });
+      child.stderr.on("data", (chunk) => { stderr += chunk; });
+    }
+
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0) {
+        resolveRun({ stdout, stderr });
+        return;
+      }
+      const detail = options.capture && stderr ? `\n${stderr}` : "";
+      reject(new Error(`${command} ${args.join(" ")} failed with ${signal ?? `exit code ${code}`}${detail}`));
+    });
+  });
+}
+
+function parsePackOutput(stdout) {
+  const entries = JSON.parse(stdout);
+  if (!Array.isArray(entries) || entries.length === 0 || typeof entries[0].filename !== "string") {
+    throw new Error(`Unexpected npm pack output: ${stdout}`);
+  }
+  return entries[0].filename;
+}
+
+function installedBinPath() {
+  return join(tempRoot, "node_modules", ".bin", isWindows ? "prts-mcp-ts-bun.exe" : "prts-mcp-ts-bun");
+}
+
+function smokeServerCommand() {
+  if (!isWindows) return ["prts-mcp-ts-bun"];
+
+  // Bun's Windows .exe shim starts the right server, but it can leave the
+  // grandchild Bun process attached after the smoke harness kills the shim.
+  // CI runs the real package bin on Linux; local Windows smoke verifies the
+  // installed bin exists and starts the installed Bun entry file directly.
+  return [bunCommand(), join(tempRoot, "node_modules", "prts-mcp-ts", "dist", "server-bun.js")];
+}
+
+async function main() {
+  try {
+    for (const file of ["dist/server.js", "dist/server-bun.js"]) {
+      const path = join(packageRoot, file);
+      if (!existsSync(path)) {
+        throw new Error(`${file} is missing. Run bun run build:bun before package smoke.`);
+      }
+    }
+
+    console.log("Packing prts-mcp-ts ...");
+    const pack = await run(npmCommand(), ["pack", "--pack-destination", tempRoot, "--json"], {
+      capture: true,
+    });
+    const tarball = join(tempRoot, parsePackOutput(pack.stdout));
+
+    console.log("Installing packed tarball with Bun ...");
+    await run(bunCommand(), ["add", tarball], { cwd: tempRoot });
+
+    const bin = installedBinPath();
+    if (!existsSync(bin)) {
+      throw new Error(`Installed Bun bin is missing: ${bin}`);
+    }
+
+    const env = { ...process.env };
+    const key = pathKey(env);
+    env[key] = `${join(tempRoot, "node_modules", ".bin")}${delimiter}${env[key] ?? ""}`;
+    const serverCommand = smokeServerCommand();
+
+    console.log("Running installed Bun package entrypoint through HTTP MCP smoke ...");
+    await run(
+      bunCommand(),
+      [join(packageRoot, "scripts", "smoke-http.mjs"), "--fixture-data", "--", ...serverCommand],
+      { cwd: tempRoot, env },
+    );
+  } finally {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`Bun package smoke failed: ${message}`);
+  process.exit(1);
+});

--- a/ts/scripts/smoke-package-bun.mjs
+++ b/ts/scripts/smoke-package-bun.mjs
@@ -5,7 +5,7 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -72,6 +72,16 @@ function installedBinPath() {
   return join(tempRoot, "node_modules", ".bin", isWindows ? "prts-mcp-ts-bun.exe" : "prts-mcp-ts-bun");
 }
 
+function assertInstalledBin() {
+  const bin = installedBinPath();
+  if (!existsSync(bin)) {
+    throw new Error(`Installed Bun bin is missing: ${bin}`);
+  }
+  if (statSync(bin).size <= 0) {
+    throw new Error(`Installed Bun bin is empty: ${bin}`);
+  }
+}
+
 function smokeServerCommand() {
   if (!isWindows) return ["prts-mcp-ts-bun"];
 
@@ -100,10 +110,7 @@ async function main() {
     console.log("Installing packed tarball with Bun ...");
     await run(bunCommand(), ["add", tarball], { cwd: tempRoot });
 
-    const bin = installedBinPath();
-    if (!existsSync(bin)) {
-      throw new Error(`Installed Bun bin is missing: ${bin}`);
-    }
+    assertInstalledBin();
 
     const env = { ...process.env };
     const key = pathKey(env);
@@ -117,7 +124,11 @@ async function main() {
       { cwd: tempRoot, env },
     );
   } finally {
-    rmSync(tempRoot, { recursive: true, force: true });
+    try {
+      rmSync(tempRoot, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup: preserve the original smoke failure.
+    }
   }
 }
 

--- a/ts/src/server-bun.ts
+++ b/ts/src/server-bun.ts
@@ -12,4 +12,10 @@ if (!("Bun" in globalThis)) {
   process.exit(1);
 }
 
-await import("./server.js");
+try {
+  await import("./server.js");
+} catch (err) {
+  const message = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`prts-mcp-ts-bun failed to load server: ${message}\n`);
+  process.exit(1);
+}

--- a/ts/src/server-bun.ts
+++ b/ts/src/server-bun.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env bun
+/**
+ * Bun package entry point.
+ *
+ * The actual server stays in server.ts so Node and Bun share the same
+ * Express/MCP implementation. This wrapper only verifies the runtime selected
+ * by the public bin before loading the server.
+ */
+
+if (!("Bun" in globalThis)) {
+  process.stderr.write("prts-mcp-ts-bun must be run with Bun.\n");
+  process.exit(1);
+}
+
+await import("./server.js");


### PR DESCRIPTION
## Summary
- add `prts-mcp-ts-bun` as the supported optional Bun package entrypoint while keeping `prts-mcp-ts` on Node.js
- add packed-package Bun smoke coverage (`npm pack` -> temporary `bun add` -> HTTP MCP smoke)
- promote `ts/Dockerfile.bun` and docs/CI wording from candidate to supported optional Bun runtime without changing default Node/npm publishing paths

## Test plan
- `npm.cmd run typecheck`
- `npm.cmd run build`
- `npm.cmd test`
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run build:bun`
- `bun run smoke:bun`
- `bun run smoke:bun:package`
- `npm.cmd run smoke:http:fixture`
- `./scripts/check-runtime.ps1 -Full`
- `docker build -f ts/Dockerfile.bun -t prts-mcp-ts-bun:local .`
- Bun Docker `/health` probe
- `docker build -f ts/Dockerfile -t prts-mcp-ts:local .`
- Node Docker `/health` probe

## Notes
- Local Bun was upgraded from 1.3.11 to 1.3.14 to match the CI pin.
- Full Docker MCP story smoke was not run locally because the local `data/storyjson/zh_CN.zip` fixture is not present; CI downloads bundled story data before Docker smoke.