### PR TITLE
chore(release): merge 2.1.0 back to develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Two release lines ship in parallel:
 
 | Line | Version | Tools | Status |
 |------|---------|-------|--------|
-| **2.0** (`main`) | `2.0.2` | 23 | Tool-surface consolidation + output channel (structuredContent). Cross-transport parity deferred beyond 2.0. |
+| **2.1** (`main`) | `2.1.0` | 23 | TypeScript supports Node.js plus Bun as a supported optional runtime. Cross-transport parity deferred beyond 2.1. |
 | **1.7 LTS** (`lts/1.7`) | `1.7.0` | 32 | Stable maintenance line. 1.7.x accepts only compatibility, security, data-sync, and critical bug fixes. |
 
 | Area | Python | TypeScript |
@@ -134,7 +134,7 @@ Published Docker images and the npm package include bundled fallback game/level/
 
 | 版本线 | 版本 | 工具数 | 状态 |
 |--------|------|--------|------|
-| **2.0**（`main`） | `2.0.2` | 23 | 工具面合并 + output channel（structuredContent）。双端协议同步后置到 2.0 之后。 |
+| **2.1**（`main`） | `2.1.0` | 23 | TypeScript 支持 Node.js + Bun 受支持可选运行时。双端协议同步后置到 2.1 之后。 |
 | **1.7 LTS**（`lts/1.7`） | `1.7.0` | 32 | 稳定维护线。1.7.x 仅接受兼容性、安全性、数据同步和关键缺陷修复。 |
 
 | 范围 | Python | TypeScript |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,15 +1,15 @@
 # PRTS-MCP Roadmap
 
-_Last updated: 2026-07-03_ · [中文版](ROADMAP.zh-CN.md)
+_Last updated: 2026-07-07_ · [中文版](ROADMAP.zh-CN.md)
 
 PRTS-MCP is past 1.0. Version 1.7.0 is the final 1.x feature release and the 1.7 LTS baseline. This document tracks **what comes next** — not what has shipped. For shipped features, see the Python and TypeScript CHANGELOGs.
 
 ## Current Release
 
-- Python: `2.0.2` _(latest stable)_
-- TypeScript: `2.0.2` _(latest stable)_
+- Python: `2.1.0` _(latest stable)_
+- TypeScript: `2.1.0` _(latest stable)_
 - `1.7.0` LTS remains the maintenance line — compatibility, security, data-sync, and critical fixes only.
-- 23 public MCP tools on the 2.0 line (CI-enforced); 32 public MCP tools frozen on the 1.7 LTS line.
+- 23 public MCP tools on the 2.x line (CI-enforced); 32 public MCP tools frozen on the 1.7 LTS line.
 - See [migration guide 0.x → 1.0](docs/migration-0.x-to-1.0.md) and
   [migration guide 1.x → 2.0](docs/migration-1.x-to-2.0.md).
 

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -1,15 +1,15 @@
 # PRTS-MCP 路线图
 
-_最近更新：2026-07-03_ · [English](ROADMAP.md)
+_最近更新：2026-07-07_ · [English](ROADMAP.md)
 
 PRTS-MCP 已进入 1.x 稳定期。1.7.0 是最后一个 1.x 功能版本和 1.7 LTS 基线。本文档记录**接下来要做什么**——已发布的内容请查看 Python 和 TypeScript 各自的 CHANGELOG。
 
 ## 当前发布
 
-- Python：`2.0.2` _（最新稳定版）_
-- TypeScript：`2.0.2` _（最新稳定版）_
+- Python：`2.1.0` _（最新稳定版）_
+- TypeScript：`2.1.0` _（最新稳定版）_
 - `1.7.0` LTS 仍为维护线——仅兼容性、安全性、数据同步和关键缺陷修复。
-- 2.0 线为 23 个公共 MCP 工具（CI 强制检查）；1.7 LTS 线冻结 32 个公共 MCP 工具。
+- 2.x 线为 23 个公共 MCP 工具（CI 强制检查）；1.7 LTS 线冻结 32 个公共 MCP 工具。
 - 迁移说明：[0.x → 1.0](docs/migration-0.x-to-1.0.md)、[1.x → 2.0](docs/migration-1.x-to-2.0.md)。
 
 ## 1.x 兼容合约

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,15 +6,13 @@ _Last updated: 2026-07-07_
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 2.1.0.dev0 | Development |
-| TypeScript | 2.1.0-dev.0 | Development |
+| Python | 2.1.0 | Stable |
+| TypeScript | 2.1.0 | Stable |
 
-- 当前稳定发布：2.0.2（23 个 MCP 工具）
+- 当前稳定发布：2.1.0（23 个 MCP 工具）
 - 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）
-- 当前开发目标：2.1.0（正式支持 Bun 的 minor 版本）
-- 当前稳定补丁线：2.0.x
-- 当前开发线：2.1.x
-- 2.1.0 开发目标：将 TS Bun 从候选路径提升为受支持可选运行时，新增
+- 当前稳定补丁线：2.1.x
+- 2.1.0 发布内容：将 TS Bun 从候选路径提升为受支持可选运行时，新增
   `prts-mcp-ts-bun` npm bin，并保留 Node/npm 作为默认入口、默认 Dockerfile 和
   npm Trusted Publishing 路径。Bun 最低验证版本为 1.3.14。
 - 2.0.2 补丁集：TS HTTP MCP smoke harness、TS Bun 候选运行路径、
@@ -24,9 +22,9 @@ _Last updated: 2026-07-07_
 
 ## 当前分支
 
-- `main`：2.0.2（最新稳定发布线）
+- `main`：2.1.0（最新稳定发布线）
 - `lts/1.7`：1.7.x LTS 维护线（从 1.7.0 发布提交创建）
-- `develop`：2.1 的开发集成线
+- `develop`：后续版本开发集成线
 
 1.7.0 是最后一个 1.x 功能版本和 LTS 基线。它将 server.py/server.ts 和 story.py/story.ts 单体文件拆分为聚焦子模块，保留向后兼容垫片（shim），并新增剧情角色追踪工具：`find_character_appearances`、`find_speakers_in`。后续功能开发转向 2.0；1.7.x 仅做兼容性、安全性、数据同步和关键缺陷修复。
 
@@ -164,7 +162,7 @@ PRTS-MCP/
 > 15–30%，抵消工具面合并带来的上下文预算收益。详见
 > [`docs/migration-1.x-to-2.0.md`](docs/migration-1.x-to-2.0.md)。
 
-## 2.1.0 开发内容
+## 2.1.0 发布内容
 
 - [x] TS Bun 从候选路径提升为受支持可选运行时；`prts-mcp-ts` 继续走
   Node.js，新增 `prts-mcp-ts-bun` 作为显式 Bun 入口。
@@ -186,6 +184,7 @@ PRTS-MCP/
 
 | 版本 | 日期 | 亮点 |
 |------|------|------|
+| 2.1.0 | 2026-07-07 | TypeScript 正式支持 Bun 可选运行时；新增 `prts-mcp-ts-bun`；Bun Dockerfile 提升为受支持替代构建路径 |
 | 2.0.2 | 2026-07-07 | TS HTTP MCP smoke harness；Bun 候选运行路径；`search_prts` redirect 解析与技术页面过滤修复 |
 | 2.0.1 | 2026-07-03 | 修复 `list_story_events` 缺失剧情数据时的 output-channel 包装；统一 TS 文本结果 helper；补充 MCP 示例配置 |
 | 2.0.0 | 2026-07-03 | 工具面合并 32 → 23 + output channel（structuredContent）；双端协议同步后置 |

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.1.0] - 2026-07-07
+
+### Changed
+
+- No user-facing Python changes. This release keeps the Python package version
+  aligned with the 2.1.0 repository release.
 
 ## [2.0.2] - 2026-07-07
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.1.0.dev0"
+version = "2.1.0"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.1.0] - 2026-07-07
 
 ### Added
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.1.0-dev.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.1.0-dev.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.1.0-dev.0",
+  "version": "2.1.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP)",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary
- merge the 2.1.0 release branch back into develop
- keep release metadata, changelogs, README, STATUS, and ROADMAP aligned after the main release

## Test plan
- Already validated on the release branch before merging to main:
  - `./scripts/check-runtime.ps1 -Full`
  - `bun run smoke:bun`
  - `bun run smoke:bun:package`
- Release tag workflows completed:
  - `ts/v2.1.0` CD passed
  - `python/v2.1.0` CD passed after rerunning a transient PyPI OIDC failure