### PR TITLE
chore(release): open 2.3.0 development

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,8 +6,8 @@ _Last updated: 2026-07-08_
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 2.2.0 | Stable |
-| TypeScript | 2.2.0 | Stable |
+| Python | 2.3.0.dev0 | Development |
+| TypeScript | 2.3.0-dev.0 | Development |
 
 - 当前稳定发布：2.2.0（23 个 MCP 工具）
 - 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.2.0] - 2026-07-08
 
 ### Changed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.2.0"
+version = "2.3.0.dev0"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.2.0] - 2026-07-08
 
 ### Added

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.2.0",
+  "version": "2.3.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.2.0",
+      "version": "2.3.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.2.0",
+  "version": "2.3.0-dev.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP)",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Reopens development for the next minor (2.3.0) after the 2.2.0 release. Path D step 11-12.

- Bump version to `2.3.0.dev0` / `2.3.0-dev.0` (pyproject, package.json, package-lock top-level + packages[""]).
- Reopen empty `[Unreleased]` in both CHANGELOGs.
- STATUS version table back to Development; current stable (2.2.0), patch line (2.2.x), dev target (2.3.0 TBD) already correct from the release.

## Test plan

- [x] `npm install --package-lock-only` — lockfile consistent.
- [x] `npm test` — 198 tests, 0 fail.
- [x] typecheck — pass.
- [ ] CI green on this PR.