### PR TITLE
feat: cross-transport parity (2.3.0) — Python HTTP + TS stdio

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,9 @@ STORYJSON_PATH=
 # Optional: 2.0 output channel. Controls whether tools emit MCP-native
 # structuredContent in addition to (or instead of) the default markdown content.
 # Accepted: content (default) / structured / both.
-# - Python stdio: read from this env var (one channel per process).
-# - Python HTTP (2.3+): also settable per-request via ?output_channel= query
-#   string or x-prts-output-channel header (overrides env).
+# - Python (stdio and HTTP): read from this env var (one channel per process).
+#   Note: per-request query/header resolution is NOT supported on Python HTTP
+#   due to FastMCP's session model; use env or separate processes per channel.
 # - TypeScript: also settable per-request via ?output_channel= query string or
 #   x-prts-output-channel header.
 # Leave unset for the 1.x-compatible markdown-only behavior. Use "structured"

--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,20 @@ STORYJSON_PATH=
 # Optional: 2.0 output channel. Controls whether tools emit MCP-native
 # structuredContent in addition to (or instead of) the default markdown content.
 # Accepted: content (default) / structured / both.
-# - Python: read from this env var (one channel per stdio process).
+# - Python stdio: read from this env var (one channel per process).
+# - Python HTTP (2.3+): also settable per-request via ?output_channel= query
+#   string or x-prts-output-channel header (overrides env).
 # - TypeScript: also settable per-request via ?output_channel= query string or
 #   x-prts-output-channel header.
 # Leave unset for the 1.x-compatible markdown-only behavior. Use "structured"
 # or "both" only with a client known to consume structuredContent.
 PRTS_OUTPUT_CHANNEL=
+
+# Optional (Python only, 2.3+): transport selection.
+# Accepted: stdio (default) / http.
+# - stdio: local MCP client (Claude Desktop / Code). The 2.x default.
+# - http: Streamable HTTP server (Starlette + uvicorn), for self-hosted remote
+#   access. Uses HOST and PORT env vars (defaults 0.0.0.0:3000).
+# TypeScript selects transport by bin: prts-mcp-ts[-bun] = HTTP,
+# prts-mcp-ts-stdio = stdio.
+PRTS_TRANSPORT=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,10 @@ jobs:
         run: npm ci
         working-directory: ts
 
+      - name: Build (for e2e tests that spawn dist/server-stdio.js)
+        run: npm run build
+        working-directory: ts
+
       - name: Run tests
         run: npm test
         working-directory: ts

--- a/.mcp.example.json
+++ b/.mcp.example.json
@@ -1,8 +1,12 @@
 {
   "mcpServers": {
-    "prts_wiki": {
+    "prts_wiki_docker": {
       "command": "docker",
       "args": ["run", "-i", "--rm", "-v", "prts-mcp-data:/data/gamedata", "-v", "prts-mcp-levels:/data/gamedata-levels", "-v", "prts-mcp-storyjson:/data/storyjson", "-e", "PRTS_OUTPUT_CHANNEL=content", "prts-mcp"]
+    },
+    "prts_wiki_ts_stdio": {
+      "command": "npx",
+      "args": ["prts-mcp-ts-stdio"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ This repository contains two independent implementations for different deploymen
 
 | Directory | Language | Transport | Use case |
 |-----------|----------|-----------|----------|
-| [`python/`](python/) | Python 3.10+ | stdio | Local Claude Desktop / Claude Code, Docker |
-| [`ts/`](ts/) | TypeScript / Node.js + Bun | Streamable HTTP | Self-hosted server, remote HTTP access |
+| [`python/`](python/) | Python 3.10+ | stdio + Streamable HTTP | Local Claude Desktop / Claude Code (stdio), self-hosted HTTP server |
+| [`ts/`](ts/) | TypeScript / Node.js + Bun | Streamable HTTP + stdio | Self-hosted HTTP server, local stdio for Claude Desktop / Code |
 
 ### Release Lines
 
@@ -92,8 +92,12 @@ parameter.
 
 ### Quick Start
 
-- **Local stdio (Python / Docker)** → see [`python/`](python/)
-- **HTTP server (TypeScript / Docker)** → see [`ts/`](ts/)
+Since 2.3.0 both implementations support both transports — pick by use case,
+not by language:
+
+- **Local stdio** (Claude Desktop / Claude Code) → Python `prts-mcp` (stdio, default) or TypeScript `npx prts-mcp-ts-stdio`
+- **HTTP server** (self-hosted, remote access) → Python `PRTS_TRANSPORT=http prts-mcp` or TypeScript `npx prts-mcp-ts`
+- See [`python/`](python/) and [`ts/`](ts/) for per-implementation details
 
 The TypeScript implementation supports Bun and Node.js. Since 2.2.0 **Bun is
 the default production runtime**: the default `ts/Dockerfile`, the primary CI
@@ -128,8 +132,8 @@ Published Docker images and the npm package include bundled fallback game/level/
 
 | 目录 | 语言 | 传输方式 | 适用场景 |
 |------|------|----------|----------|
-| [`python/`](python/) | Python 3.10+ | stdio | Claude Desktop / Claude Code 本地接入、Docker |
-| [`ts/`](ts/) | TypeScript / Node.js + Bun | Streamable HTTP | 个人服务器部署，供他人通过 HTTP 调用 |
+| [`python/`](python/) | Python 3.10+ | stdio + Streamable HTTP | Claude Desktop / Claude Code 本地接入（stdio）、自建 HTTP 服务 |
+| [`ts/`](ts/) | TypeScript / Node.js + Bun | Streamable HTTP + stdio | 自建 HTTP 服务、Claude Desktop / Claude Code 本地接入（stdio） |
 
 ### 版本线
 
@@ -193,8 +197,11 @@ Published Docker images and the npm package include bundled fallback game/level/
 
 ### 快速开始
 
-- **本地 stdio 接入（Python / Docker）** → 见 [`python/`](python/)
-- **HTTP 服务部署（TypeScript / Docker）** → 见 [`ts/`](ts/)
+自 2.3.0 起两个实现都支持双传输——按场景选择，而非按语言：
+
+- **本地 stdio 接入**（Claude Desktop / Claude Code）→ Python `prts-mcp`（stdio，默认）或 TypeScript `npx prts-mcp-ts-stdio`
+- **HTTP 服务部署**（自建服务器，供他人调用）→ Python `PRTS_TRANSPORT=http prts-mcp` 或 TypeScript `npx prts-mcp-ts`
+- 详见 [`python/`](python/) 和 [`ts/`](ts/)
 
 TypeScript 实现支持 Bun 与 Node.js。自 2.2.0 起 **Bun 是默认生产运行时**：默认
 `ts/Dockerfile`、CI 主验证链与推荐 Docker 部署均在 Bun 下运行（最低验证版本 Bun

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -185,12 +185,13 @@ implementations. Delivered in 2.0:
 - Environment variable names and defaults are unified (`PRTS_OUTPUT_CHANNEL`,
   `GAMEDATA_PATH`, `STORYJSON_PATH`, `GITHUB_TOKEN`, `GITHUB_MIRRORS`).
 
-**Deferred beyond 2.0 — cross-transport parity.** The original goal that both
-implementations support stdio **and** Streamable HTTP (Python gaining HTTP,
-TypeScript gaining stdio) is postponed to a later release. 2.0 ships with the
-same transport split as 1.x: Python = stdio (FastMCP), TypeScript =
-Streamable HTTP (Express). Recommended deployment scenarios therefore stay
-"Python for Docker / local stdio, TypeScript for `npm install -g` / HTTP."
+**Cross-transport parity — in progress for 2.3.0.** The original goal that
+both implementations support stdio **and** Streamable HTTP (Python gaining
+HTTP, TypeScript gaining stdio) was deferred beyond 2.0 and is now being
+delivered in 2.3.0. Python selects transport via `PRTS_TRANSPORT`
+(stdio default | http); TypeScript selects via bin (`prts-mcp-ts`[-bun] = HTTP,
+`prts-mcp-ts-stdio` = stdio). After 2.3.0 the deployment guidance becomes
+"choose by use case, not by language."
 
 ### Cleanup
 

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -167,10 +167,11 @@ PRTS-MCP 已进入 1.x 稳定期。1.7.0 是最后一个 1.x 功能版本和 1.7
 - 环境变量名称和默认值统一（`PRTS_OUTPUT_CHANNEL`、`GAMEDATA_PATH`、`STORYJSON_PATH`、
   `GITHUB_TOKEN`、`GITHUB_MIRRORS`）。
 
-**后置到 2.0 之后——跨传输协议同步。** 原目标「两套实现都同时支持 stdio **和**
-Streamable HTTP」（Python 上 HTTP、TypeScript 上 stdio）推迟到后续版本。2.0 仍按 1.x 的
-传输分工发布：Python = stdio（FastMCP），TypeScript = Streamable HTTP（Express）。因此
-部署推荐维持「Python 用于 Docker / 本地 stdio，TypeScript 用于 `npm install -g` / HTTP」。
+**跨传输协议同步——2.3.0 开发中。** 原目标「两套实现都同时支持 stdio **和**
+Streamable HTTP」（Python 上 HTTP、TypeScript 上 stdio）曾后置到 2.0 之后，现于 2.3.0
+交付。Python 经 `PRTS_TRANSPORT` 选择传输（stdio 默认 | http）；TypeScript 经 bin 选择
+（`prts-mcp-ts`[-bun] = HTTP，`prts-mcp-ts-stdio` = stdio）。2.3.0 后部署推荐改为「按场景
+选择，而非按语言」。
 
 ### 清理
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -173,10 +173,11 @@ PRTS-MCP/
 ## 2.3.0 开发中（develop）
 
 - [x] Python 新增 Streamable HTTP transport（`PRTS_TRANSPORT=http`，Starlette +
-  uvicorn，`/mcp` 端点 + `/health` 探针 + per-request output_channel
-  middleware）。stdio 保持默认（向后兼容）。
+  uvicorn，`/mcp` 端点 + `/health` 探针）。stdio 保持默认（向后兼容）。
 - [x] Python `OUTPUT_CHANNEL` 从进程级常量重构为 `contextvars.ContextVar`，
-  支持 HTTP 下的 per-request 解析（query / header / env）。工具代码零改动。
+  为后续 transport 扩展铺路。**注意**：因 FastMCP Streamable HTTP 的 session
+  模型，Python HTTP 的 output_channel 当前是 process-level（env-only），不支持
+  per-request query/header 解析（TS HTTP 支持 per-request）。
 - [x] TypeScript 新增 stdio transport（`prts-mcp-ts-stdio` bin，
   `server-stdio.ts` 入口复用 `createMcpServer` + `runStartupSync`）。
 - [x] 跨 transport e2e 测试：Python HTTP（`test_e2e_http.py`）+ TS stdio

--- a/STATUS.md
+++ b/STATUS.md
@@ -11,7 +11,8 @@ _Last updated: 2026-07-08_
 
 - 当前稳定发布：2.2.0（23 个 MCP 工具）
 - 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）
-- 当前开发目标：2.3.0（待规划）
+- 当前开发目标：2.3.0（cross-transport parity：Python 新增 Streamable HTTP、
+  TS 新增 stdio，双端双 transport）
 - 当前稳定补丁线：2.2.x
 - 当前开发线：2.3.x
 - 2.2.0 发布内容：TypeScript 默认生产运行时由 Node.js 翻转为 Bun（默认
@@ -168,6 +169,19 @@ PRTS-MCP/
 > **不**翻转默认到 JSON——主要消费者是 LLM agent，JSON 会令 prompt token 膨胀
 > 15–30%，抵消工具面合并带来的上下文预算收益。详见
 > [`docs/migration-1.x-to-2.0.md`](docs/migration-1.x-to-2.0.md)。
+
+## 2.3.0 开发中（develop）
+
+- [x] Python 新增 Streamable HTTP transport（`PRTS_TRANSPORT=http`，Starlette +
+  uvicorn，`/mcp` 端点 + `/health` 探针 + per-request output_channel
+  middleware）。stdio 保持默认（向后兼容）。
+- [x] Python `OUTPUT_CHANNEL` 从进程级常量重构为 `contextvars.ContextVar`，
+  支持 HTTP 下的 per-request 解析（query / header / env）。工具代码零改动。
+- [x] TypeScript 新增 stdio transport（`prts-mcp-ts-stdio` bin，
+  `server-stdio.ts` 入口复用 `createMcpServer` + `runStartupSync`）。
+- [x] 跨 transport e2e 测试：Python HTTP（`test_e2e_http.py`）+ TS stdio
+  （`e2eStdio.test.ts`）。
+- [x] 文档同步：README transport 表/快速开始、`.mcp.example.json`、`.env.example`。
 
 ## 2.2.0 发布内容
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -42,6 +42,11 @@ dependencies = [
     "mcp[cli]",
     "httpx",
     "pydantic",
+    # HTTP transport (PRTS_TRANSPORT=http). These are also transitively
+    # required by mcp[cli], but we import uvicorn/starlette directly in
+    # server.py so declare them explicitly to survive upstream reshuffling.
+    "starlette>=0.27",
+    "uvicorn>=0.31",
 ]
 
 [project.urls]

--- a/python/src/prts_mcp/output.py
+++ b/python/src/prts_mcp/output.py
@@ -81,29 +81,15 @@ OUTPUT_CHANNEL: OutputChannel = _ENV_DEFAULT_CHANNEL
 
 
 def get_output_channel() -> OutputChannel:
-    """Return the effective output channel for the current connection context.
+    """Return the effective output channel for the current context.
 
-    On stdio this is the env-parsed default (one process, one connection).
-    On Streamable HTTP a per-request middleware calls
-    :func:`set_output_channel` to override it with the query/header-resolved
-    value, and this function reads that override.
+    Currently always the env-parsed default, since per-request overrides
+    are not effective under FastMCP's session model (see server.py
+    ``_build_http_app`` docstring). The ContextVar indirection is kept so
+    a future transport or SDK change can plug in per-connection overrides
+    without touching tool code.
     """
     return _channel_var.get()
-
-
-def set_output_channel(channel: OutputChannel) -> contextvars.Token[OutputChannel]:
-    """Set the output channel for the current connection context.
-
-    Returns the ContextVar token for later restoration via
-    :func:`reset_output_channel`. HTTP middleware should call this at the
-    start of each request.
-    """
-    return _channel_var.set(channel)
-
-
-def reset_output_channel(token: contextvars.Token[OutputChannel]) -> None:
-    """Restore the output channel to its previous value (undo ``set``)."""
-    _channel_var.reset(token)
 
 
 def render_result(

--- a/python/src/prts_mcp/output.py
+++ b/python/src/prts_mcp/output.py
@@ -56,14 +56,17 @@ def _parse_channel(raw: str | None) -> OutputChannel:
     return value  # type: ignore[return-value]
 
 
-#: Per-connection channel, backed by a ContextVar so each transport can set
-#: its own value per request/session without global mutation.
+#: Per-connection channel, backed by a ContextVar so future transports or
+#: SDK changes can plug in per-connection overrides without touching tool
+#: code.
 #:
-#: The default value is read once from the ``PRTS_OUTPUT_CHANNEL`` env var —
-#: on stdio a connection maps to one process, so the import-time default is
-#: the right scope. The Streamable HTTP transport overrides this per request
-#: via :func:`set_output_channel` (resolving query string / header / env),
-#: matching the TypeScript ``resolveOutputChannel`` precedence.
+#: The default value is read once from the ``PRTS_OUTPUT_CHANNEL`` env var
+#: and is currently the only effective source — both stdio and the
+#: Streamable HTTP transport read it at process scope. Per-request
+#: query/header resolution is NOT supported on the Python HTTP transport
+#: (FastMCP's session model makes per-request contextvars invisible to
+#: tool code; see server.py ``_build_http_app`` docstring). The TypeScript
+#: HTTP transport differs, resolving channel at session creation.
 #:
 #: The module-level identifier ``OUTPUT_CHANNEL`` is kept as a backward-compat
 #: alias for the parsed env default; the *environment variable* that populates
@@ -76,7 +79,8 @@ _channel_var: contextvars.ContextVar[OutputChannel] = contextvars.ContextVar(
 )
 
 #: Backward-compat alias for the env-parsed default. Tools should prefer
-#: :func:`get_output_channel` so per-connection overrides take effect.
+#: :func:`get_output_channel` (the ContextVar is currently env-only but kept
+#: for future transport extensibility).
 OUTPUT_CHANNEL: OutputChannel = _ENV_DEFAULT_CHANNEL
 
 

--- a/python/src/prts_mcp/output.py
+++ b/python/src/prts_mcp/output.py
@@ -109,9 +109,10 @@ def render_result(
     (or ``None`` when the call hit an error/missing-data path).
 
     ``channel`` resolves the effective channel via :func:`get_output_channel`
-    when left as ``None`` (the default), so per-connection overrides set by
-    the HTTP transport's middleware are honored. Pass an explicit value only
-    when overriding per-call (rare).
+    when left as ``None`` (the default). Today that value is the env-parsed
+    process default; the ContextVar indirection is reserved for future
+    per-connection transport support. Pass an explicit value only when
+    overriding per-call (rare).
 
     Channel behaviour:
 

--- a/python/src/prts_mcp/output.py
+++ b/python/src/prts_mcp/output.py
@@ -19,6 +19,7 @@ the ``tools_*`` registration modules.
 """
 from __future__ import annotations
 
+import contextvars
 import logging
 import os
 from typing import Any, Literal
@@ -55,21 +56,60 @@ def _parse_channel(raw: str | None) -> OutputChannel:
     return value  # type: ignore[return-value]
 
 
-#: Connection-level channel, read once at import time. On stdio a connection
-#: maps to one process, so a module-level constant is the right scope.
+#: Per-connection channel, backed by a ContextVar so each transport can set
+#: its own value per request/session without global mutation.
 #:
-#: The module-level identifier ``OUTPUT_CHANNEL`` is the parsed value's name;
-#: the *environment variable* that populates it is ``PRTS_OUTPUT_CHANNEL``
-#: (``PRTS_`` prefix to avoid collisions in shared Docker/CI environments).
-#: Other transports can map their own connection-level control names to the
-#: same parsed value.
-OUTPUT_CHANNEL: OutputChannel = _parse_channel(os.environ.get("PRTS_OUTPUT_CHANNEL"))
+#: The default value is read once from the ``PRTS_OUTPUT_CHANNEL`` env var —
+#: on stdio a connection maps to one process, so the import-time default is
+#: the right scope. The Streamable HTTP transport overrides this per request
+#: via :func:`set_output_channel` (resolving query string / header / env),
+#: matching the TypeScript ``resolveOutputChannel`` precedence.
+#:
+#: The module-level identifier ``OUTPUT_CHANNEL`` is kept as a backward-compat
+#: alias for the parsed env default; the *environment variable* that populates
+#: it is ``PRTS_OUTPUT_CHANNEL`` (``PRTS_`` prefix to avoid collisions in
+#: shared Docker/CI environments).
+_ENV_DEFAULT_CHANNEL: OutputChannel = _parse_channel(os.environ.get("PRTS_OUTPUT_CHANNEL"))
+
+_channel_var: contextvars.ContextVar[OutputChannel] = contextvars.ContextVar(
+    "prts_output_channel", default=_ENV_DEFAULT_CHANNEL
+)
+
+#: Backward-compat alias for the env-parsed default. Tools should prefer
+#: :func:`get_output_channel` so per-connection overrides take effect.
+OUTPUT_CHANNEL: OutputChannel = _ENV_DEFAULT_CHANNEL
+
+
+def get_output_channel() -> OutputChannel:
+    """Return the effective output channel for the current connection context.
+
+    On stdio this is the env-parsed default (one process, one connection).
+    On Streamable HTTP a per-request middleware calls
+    :func:`set_output_channel` to override it with the query/header-resolved
+    value, and this function reads that override.
+    """
+    return _channel_var.get()
+
+
+def set_output_channel(channel: OutputChannel) -> contextvars.Token[OutputChannel]:
+    """Set the output channel for the current connection context.
+
+    Returns the ContextVar token for later restoration via
+    :func:`reset_output_channel`. HTTP middleware should call this at the
+    start of each request.
+    """
+    return _channel_var.set(channel)
+
+
+def reset_output_channel(token: contextvars.Token[OutputChannel]) -> None:
+    """Restore the output channel to its previous value (undo ``set``)."""
+    _channel_var.reset(token)
 
 
 def render_result(
     data: dict[str, Any] | None,
     markdown: str,
-    channel: OutputChannel = OUTPUT_CHANNEL,
+    channel: OutputChannel | None = None,
     summary: str | None = None,
 ) -> CallToolResult:
     """Build a ``CallToolResult`` carrying markdown text and/or structured data.
@@ -77,6 +117,11 @@ def render_result(
     The two inputs are kept orthogonal: ``markdown`` is always the
     human-readable rendering, ``data`` is always the structured payload
     (or ``None`` when the call hit an error/missing-data path).
+
+    ``channel`` resolves the effective channel via :func:`get_output_channel`
+    when left as ``None`` (the default), so per-connection overrides set by
+    the HTTP transport's middleware are honored. Pass an explicit value only
+    when overriding per-call (rare).
 
     Channel behaviour:
 
@@ -101,6 +146,8 @@ def render_result(
     a content-only result carrying ``markdown`` — per the design doc, errors
     never travel in structuredContent.
     """
+    if channel is None:
+        channel = get_output_channel()
     if data is None:
         # Error / missing-data path: text only, regardless of channel.
         return CallToolResult(

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -94,12 +94,6 @@ def _build_http_app():
 
     return app
 
-    async def health(_request):
-        return JSONResponse({"status": "ok"})
-
-    # Prepend /health so it is matched before any catch-all.
-    app.router.routes.insert(0, Route("/health", health))
-
     return app
 
 

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -2,7 +2,15 @@
 
 Creates the FastMCP instance, delegates tool registration to focused
 modules (tools_prts / tools_gamedata / tools_story), and starts the
-background data-sync daemon before running the MCP stdio transport.
+background data-sync daemon before running the MCP transport.
+
+Supports two transports selected by the ``PRTS_TRANSPORT`` env var:
+
+- ``stdio`` (default) — FastMCP stdio, for local Claude Desktop / Code.
+- ``http`` — Streamable HTTP via Starlette + uvicorn, for self-hosted
+  remote access. Mirrors the TypeScript implementation's HTTP surface
+  (``/mcp`` endpoint, ``/health`` probe, per-request output_channel
+  resolution from query string / header / env).
 
 Sync orchestration lives in startup_sync; its symbols are re-exported here
 for backward compatibility with tests that access them via ``server.*``.
@@ -10,6 +18,7 @@ for backward compatibility with tests that access them via ``server.*``.
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import threading
 
@@ -51,10 +60,82 @@ def _register_tools() -> None:
 _register_tools()
 
 
+# ---------------------------------------------------------------------------
+# Transport selection
+# ---------------------------------------------------------------------------
+
+
+def _resolve_http_channel(query_val: str | None, header_val: str | None) -> str:
+    """Resolve output_channel for an HTTP request.
+
+    Precedence matches the TypeScript ``resolveOutputChannel``:
+    query string → header → env → default (content).
+    """
+    from prts_mcp.output import _parse_channel
+
+    if query_val:
+        return _parse_channel(query_val)
+    if header_val:
+        return _parse_channel(header_val)
+    return _parse_channel(os.environ.get("PRTS_OUTPUT_CHANNEL"))
+
+
+def _build_http_app():
+    """Build the Starlette app for the Streamable HTTP transport.
+
+    Wraps ``mcp.streamable_http_app()`` with:
+    - a per-request output_channel middleware (query / header / env)
+    - a ``/health`` JSON probe endpoint
+    """
+    from starlette.middleware.base import BaseHTTPMiddleware
+    from starlette.responses import JSONResponse
+    from starlette.routing import Route
+
+    from prts_mcp.output import set_output_channel, reset_output_channel
+
+    app = mcp.streamable_http_app()
+
+    class OutputChannelMiddleware(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            query_val = request.query_params.get("output_channel")
+            # Starlette headers are case-insensitive
+            header_val = request.headers.get("x-prts-output-channel")
+            channel = _resolve_http_channel(query_val, header_val)
+            token = set_output_channel(channel)
+            try:
+                response = await call_next(request)
+            finally:
+                reset_output_channel(token)
+            return response
+
+    app.add_middleware(OutputChannelMiddleware)
+
+    async def health(_request):
+        return JSONResponse({"status": "ok"})
+
+    # Prepend /health so it is matched before any catch-all.
+    app.router.routes.insert(0, Route("/health", health))
+
+    return app
+
+
 def main() -> None:
+    transport = os.environ.get("PRTS_TRANSPORT", "stdio").strip().lower()
+    # Start background data sync regardless of transport.
     t = threading.Thread(target=_run_startup_sync, daemon=True, name="prts-sync")
     t.start()
-    mcp.run()
+
+    if transport == "http":
+        import uvicorn
+
+        host = os.environ.get("HOST", "0.0.0.0")
+        port = int(os.environ.get("PORT", "3000"))
+        app = _build_http_app()
+        _logger.info("PRTS-MCP Streamable HTTP listening on %s:%s (/mcp)", host, port)
+        uvicorn.run(app, host=host, port=port, log_level="info")
+    else:
+        # stdio (default) — preserves 1.x/2.x behavior.
+        mcp.run()
 
 
 if __name__ == "__main__":

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -65,50 +65,34 @@ _register_tools()
 # ---------------------------------------------------------------------------
 
 
-def _resolve_http_channel(query_val: str | None, header_val: str | None) -> str:
-    """Resolve output_channel for an HTTP request.
-
-    Precedence matches the TypeScript ``resolveOutputChannel``:
-    query string → header → env → default (content).
-    """
-    from prts_mcp.output import _parse_channel
-
-    if query_val:
-        return _parse_channel(query_val)
-    if header_val:
-        return _parse_channel(header_val)
-    return _parse_channel(os.environ.get("PRTS_OUTPUT_CHANNEL"))
-
-
 def _build_http_app():
     """Build the Starlette app for the Streamable HTTP transport.
 
-    Wraps ``mcp.streamable_http_app()`` with:
-    - a per-request output_channel middleware (query / header / env)
-    - a ``/health`` JSON probe endpoint
+    Wraps ``mcp.streamable_http_app()`` with a ``/health`` JSON probe.
+
+    Note on output_channel: per-request resolution (query string / header)
+    is **not supported** on the Python HTTP transport. FastMCP's Streamable
+    HTTP uses a stateful session model — the session task is created at
+    ``initialize`` and tools execute inside that long-lived task, so a
+    per-request contextvar set in middleware is invisible to tool code.
+    The output channel is therefore process-level (read from
+    ``PRTS_OUTPUT_CHANNEL`` env) on Python HTTP, matching Python stdio.
+    The TypeScript HTTP transport does support per-request resolution
+    because it resolves the channel at session-creation time and injects
+    it into ``createMcpServer(channel)``.
     """
-    from starlette.middleware.base import BaseHTTPMiddleware
     from starlette.responses import JSONResponse
     from starlette.routing import Route
 
-    from prts_mcp.output import set_output_channel, reset_output_channel
-
     app = mcp.streamable_http_app()
 
-    class OutputChannelMiddleware(BaseHTTPMiddleware):
-        async def dispatch(self, request, call_next):
-            query_val = request.query_params.get("output_channel")
-            # Starlette headers are case-insensitive
-            header_val = request.headers.get("x-prts-output-channel")
-            channel = _resolve_http_channel(query_val, header_val)
-            token = set_output_channel(channel)
-            try:
-                response = await call_next(request)
-            finally:
-                reset_output_channel(token)
-            return response
+    async def health(_request):
+        return JSONResponse({"status": "ok"})
 
-    app.add_middleware(OutputChannelMiddleware)
+    # Prepend /health so it is matched before any catch-all.
+    app.router.routes.insert(0, Route("/health", health))
+
+    return app
 
     async def health(_request):
         return JSONResponse({"status": "ok"})

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -9,8 +9,8 @@ Supports two transports selected by the ``PRTS_TRANSPORT`` env var:
 - ``stdio`` (default) — FastMCP stdio, for local Claude Desktop / Code.
 - ``http`` — Streamable HTTP via Starlette + uvicorn, for self-hosted
   remote access. Mirrors the TypeScript implementation's HTTP surface
-  (``/mcp`` endpoint, ``/health`` probe, per-request output_channel
-  resolution from query string / header / env).
+  (``/mcp`` endpoint, ``/health`` probe). output_channel is process-level
+  (env-only) on Python HTTP; see ``_build_http_app`` for the limitation.
 
 Sync orchestration lives in startup_sync; its symbols are re-exported here
 for backward compatibility with tests that access them via ``server.*``.
@@ -91,8 +91,6 @@ def _build_http_app():
 
     # Prepend /health so it is matched before any catch-all.
     app.router.routes.insert(0, Route("/health", health))
-
-    return app
 
     return app
 

--- a/python/tests/test_e2e_http.py
+++ b/python/tests/test_e2e_http.py
@@ -183,10 +183,18 @@ def test_initialize_and_tools_list(server):
         assert required in names, f"missing tool {required}; got {sorted(names)[:10]}..."
 
 
-def test_output_channel_query_string(server):
-    """output_channel=? should be resolved per-request via the middleware."""
+def test_output_channel_env_only_on_http(server):
+    """Python HTTP output_channel is process-level (env-only), not per-request.
+
+    FastMCP's Streamable HTTP session model means tools execute in a
+    long-lived session task, so per-request query/header resolution is not
+    effective. This test documents that: a query-string output_channel
+    does NOT change the tool's output shape (the env default 'content'
+    governs). The TypeScript HTTP transport differs — it resolves channel
+    at session creation.
+    """
     origin = server["origin"]
-    _, init_payload, sid = _mcp_post(
+    _, _, sid = _mcp_post(
         origin,
         {
             "jsonrpc": "2.0",
@@ -206,18 +214,24 @@ def test_output_channel_query_string(server):
         session_id=sid,
     )
 
-    # Call a structured tool with output_channel=structured via query string.
+    # Call list_story_events (graceful error path, no data needed) with
+    # output_channel=structured in the query string. It should be IGNORED
+    # — the response is content-only (env default), confirming env-only.
     status, payload, _ = _mcp_post(
         origin,
         {
             "jsonrpc": "2.0",
             "method": "tools/call",
             "id": 11,
-            "params": {"name": "list_enemies", "arguments": {"limit": 1}},
+            "params": {"name": "list_story_events", "arguments": {}},
         },
         session_id=sid,
-        extra_headers={"output_channel": "structured"},
     )
-    # We can't easily inject a query string into _mcp_post; verify via header instead.
-    # The middleware accepts x-prts-output-channel header too.
     assert status == 200
+    assert payload is not None
+    result = payload.get("result", {})
+    # Content-only: structuredContent should be absent or null (error path
+    # is always content-only regardless, but the point is the query string
+    # had no effect).
+    assert "content" in result
+    assert result.get("structuredContent") is None

--- a/python/tests/test_e2e_http.py
+++ b/python/tests/test_e2e_http.py
@@ -90,12 +90,12 @@ def _mcp_post(
 
 
 # ---------------------------------------------------------------------------
-# Fixture: start the HTTP server once
+# Server factory + fixtures
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="module")
-def server():
+def _start_server(extra_env: dict | None = None) -> dict:
+    """Start an HTTP server with the given env overrides; return origin/proc."""
     port = _free_port()
     origin = f"http://127.0.0.1:{port}"
     env = os.environ.copy()
@@ -105,6 +105,8 @@ def server():
     env["GAMEDATA_PATH"] = str(GAMEDATA_PATH)
     env["GITHUB_MIRRORS"] = ""
     env.setdefault("STORYJSON_PATH", str(GAMEDATA_PATH / "does-not-exist.zip"))
+    if extra_env:
+        env.update(extra_env)
 
     python_src = Path(__file__).resolve().parents[1] / "src"
     env["PYTHONPATH"] = str(python_src)
@@ -115,15 +117,22 @@ def server():
         stderr=subprocess.PIPE,
         env=env,
     )
+    _wait_for_health(origin)
+    return {"origin": origin, "proc": proc}
+
+
+@pytest.fixture(scope="module")
+def server():
+    """Default server (env-default output_channel = content)."""
+    handle = _start_server()
     try:
-        _wait_for_health(origin)
-        yield {"origin": origin, "proc": proc}
+        yield handle
     finally:
-        proc.terminate()
+        handle["proc"].terminate()
         try:
-            proc.wait(timeout=5)
+            handle["proc"].wait(timeout=5)
         except subprocess.TimeoutExpired:
-            proc.kill()
+            handle["proc"].kill()
 
 
 # ---------------------------------------------------------------------------
@@ -184,58 +193,72 @@ def test_initialize_and_tools_list(server):
         assert required in names, f"missing tool {required}; got {sorted(names)[:10]}..."
 
 
-def test_output_channel_env_only_on_http(server):
-    """Python HTTP output_channel is process-level (env-only), not per-request.
+def test_output_channel_env_governs_not_query():
+    """Python HTTP output_channel is process-level (env), not per-request.
 
-    FastMCP's Streamable HTTP session model means tools execute in a
-    long-lived session task, so per-request query/header resolution is not
-    effective. This test verifies that explicitly: a query-string
-    ``output_channel=structured`` is passed but the response remains
-    content-only (env default governs). The TypeScript HTTP transport
-    differs — it resolves channel at session creation.
+    Starts a server with PRTS_OUTPUT_CHANNEL=structured, then calls a
+    structured tool (list_enemies) with ?output_channel=content in the
+    query string. If query-string resolution worked, the response would
+    be content-only (structuredContent null). Because the env governs and
+    the query is ignored, structuredContent stays non-null — proving
+    env-only behavior. Uses list_enemies which needs GameData excel
+    tables; skips if that data is absent.
     """
-    origin = server["origin"]
-    _, _, sid = _mcp_post(
-        origin,
-        {
-            "jsonrpc": "2.0",
-            "method": "initialize",
-            "id": 10,
-            "params": {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {"name": "pytest", "version": "0"},
-            },
-        },
-    )
-    assert sid is not None
-    _mcp_post(
-        origin,
-        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
-        session_id=sid,
-    )
+    char_table = GAMEDATA_PATH / "zh_CN" / "gamedata" / "excel" / "character_table.json"
+    if not char_table.is_file():
+        pytest.skip("GameData character_table not available; cannot test structured tool")
 
-    # Call list_story_events with output_channel=structured in the query
-    # string. Even though the server is env-default (content), we pass
-    # structured to prove it is IGNORED — structuredContent stays null.
-    status, payload, _ = _mcp_post(
-        origin,
-        {
-            "jsonrpc": "2.0",
-            "method": "tools/call",
-            "id": 11,
-            "params": {"name": "list_story_events", "arguments": {}},
-        },
-        session_id=sid,
-        query="output_channel=structured",
-    )
-    assert status == 200
-    assert payload is not None
-    result = payload.get("result", {})
-    # The query-string override had no effect: structuredContent is null
-    # (would be non-null if the override had taken effect on a structured
-    # tool). This confirms env-only behavior.
-    assert result.get("structuredContent") is None, (
-        "query-string output_channel=structured should be ignored on "
-        "Python HTTP; structuredContent must be null"
-    )
+    handle = _start_server(extra_env={"PRTS_OUTPUT_CHANNEL": "structured"})
+    try:
+        origin = handle["origin"]
+        _, _, sid = _mcp_post(
+            origin,
+            {
+                "jsonrpc": "2.0",
+                "method": "initialize",
+                "id": 1,
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "pytest", "version": "0"},
+                },
+            },
+        )
+        assert sid is not None
+        _mcp_post(
+            origin,
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+            session_id=sid,
+        )
+
+        # Call search (structured tool) with ?output_channel=content — the
+        # query should be IGNORED; env=structured governs, so structuredContent
+        # is non-null.
+        status, payload, _ = _mcp_post(
+            origin,
+            {
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "id": 2,
+                "params": {
+                    "name": "search",
+                    "arguments": {"scope": "operators", "pattern": "阿"},
+                },
+            },
+            session_id=sid,
+            query="output_channel=content",
+        )
+        assert status == 200
+        assert payload is not None
+        result = payload.get("result", {})
+        assert result.get("structuredContent") is not None, (
+            "env PRTS_OUTPUT_CHANNEL=structured should govern; "
+            "query ?output_channel=content must be ignored. "
+            "If structuredContent is null, the query override leaked."
+        )
+    finally:
+        handle["proc"].terminate()
+        try:
+            handle["proc"].wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            handle["proc"].kill()

--- a/python/tests/test_e2e_http.py
+++ b/python/tests/test_e2e_http.py
@@ -1,0 +1,223 @@
+"""
+E2E test for the Python MCP server (Streamable HTTP transport).
+
+Spawns ``PRTS_TRANSPORT=http python -m prts_mcp.server`` as a subprocess
+and communicates via HTTP POST to /mcp. Mirrors the TypeScript e2e.test.ts
+pattern. Tests that run without network or full data:
+
+  1. /health probe
+  2. MCP initialize handshake + session id
+  3. tools/list — all tools registered
+  4. output_channel per-request resolution (query string)
+"""
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+GAMEDATA_PATH = Path(__file__).resolve().parents[2] / "data" / "gamedata"
+GAMEDATA_PATH = GAMEDATA_PATH.resolve()
+
+_op_table = GAMEDATA_PATH / "zh_CN" / "gamedata" / "excel" / "character_table.json"
+_has_operator_data = _op_table.is_file()
+
+
+def _free_port() -> int:
+    """Return a free TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_health(origin: str, timeout: float = 20.0) -> None:
+    deadline = time.monotonic() + timeout
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            r = httpx.get(f"{origin}/health", timeout=1.0)
+            if r.status_code == 200 and r.json().get("status") == "ok":
+                return
+        except Exception as e:  # noqa: BLE001
+            last_err = e
+        time.sleep(0.2)
+    raise TimeoutError(f"server did not become healthy: {last_err}")
+
+
+def _parse_sse(text: str) -> dict:
+    """Extract the JSON payload from an SSE ``data:`` line."""
+    for line in text.splitlines():
+        if line.startswith("data: "):
+            return json.loads(line[6:])
+    raise ValueError(f"no data line in SSE response: {text[:200]}")
+
+
+def _mcp_post(
+    origin: str,
+    body: dict,
+    session_id: str | None = None,
+    extra_headers: dict | None = None,
+) -> tuple[int, dict | None, str | None]:
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    if session_id:
+        headers["mcp-session-id"] = session_id
+    if extra_headers:
+        headers.update(extra_headers)
+    r = httpx.post(f"{origin}/mcp", json=body, headers=headers, timeout=10.0)
+    sid = r.headers.get("mcp-session-id")
+    payload: dict | None = None
+    if r.text:
+        try:
+            payload = _parse_sse(r.text)
+        except (ValueError, json.JSONDecodeError):
+            payload = None
+    return r.status_code, payload, sid
+
+
+# ---------------------------------------------------------------------------
+# Fixture: start the HTTP server once
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def server():
+    port = _free_port()
+    origin = f"http://127.0.0.1:{port}"
+    env = os.environ.copy()
+    env["PRTS_TRANSPORT"] = "http"
+    env["PORT"] = str(port)
+    env["HOST"] = "127.0.0.1"
+    env["GAMEDATA_PATH"] = str(GAMEDATA_PATH)
+    env["GITHUB_MIRRORS"] = ""
+    env.setdefault("STORYJSON_PATH", str(GAMEDATA_PATH / "does-not-exist.zip"))
+
+    python_src = Path(__file__).resolve().parents[1] / "src"
+    env["PYTHONPATH"] = str(python_src)
+
+    proc = subprocess.Popen(
+        [sys.executable, "-m", "prts_mcp.server"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    try:
+        _wait_for_health(origin)
+        yield {"origin": origin, "proc": proc}
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_health(server):
+    r = httpx.get(f"{server['origin']}/health", timeout=5.0)
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+def test_initialize_and_tools_list(server):
+    origin = server["origin"]
+    status, payload, sid = _mcp_post(
+        origin,
+        {
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 1,
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest", "version": "0"},
+            },
+        },
+    )
+    assert status == 200
+    assert payload is not None
+    assert payload["result"]["serverInfo"]["name"] == "PRTS_Wiki_Assistant"
+    assert sid is not None
+
+    # Send initialized notification
+    _mcp_post(
+        origin,
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        session_id=sid,
+    )
+
+    # tools/list
+    status, payload, _ = _mcp_post(
+        origin,
+        {"jsonrpc": "2.0", "method": "tools/list", "id": 2, "params": {}},
+        session_id=sid,
+    )
+    assert status == 200
+    assert payload is not None
+    names = {t["name"] for t in payload["result"]["tools"]}
+    # Spot-check a few tools across domains.
+    for required in [
+        "search_prts",
+        "get_operator_archives",
+        "list_story_events",
+        "read_story",
+        "list_enemies",
+    ]:
+        assert required in names, f"missing tool {required}; got {sorted(names)[:10]}..."
+
+
+def test_output_channel_query_string(server):
+    """output_channel=? should be resolved per-request via the middleware."""
+    origin = server["origin"]
+    _, init_payload, sid = _mcp_post(
+        origin,
+        {
+            "jsonrpc": "2.0",
+            "method": "initialize",
+            "id": 10,
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "pytest", "version": "0"},
+            },
+        },
+    )
+    assert sid is not None
+    _mcp_post(
+        origin,
+        {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        session_id=sid,
+    )
+
+    # Call a structured tool with output_channel=structured via query string.
+    status, payload, _ = _mcp_post(
+        origin,
+        {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "id": 11,
+            "params": {"name": "list_enemies", "arguments": {"limit": 1}},
+        },
+        session_id=sid,
+        extra_headers={"output_channel": "structured"},
+    )
+    # We can't easily inject a query string into _mcp_post; verify via header instead.
+    # The middleware accepts x-prts-output-channel header too.
+    assert status == 200

--- a/python/tests/test_e2e_http.py
+++ b/python/tests/test_e2e_http.py
@@ -8,7 +8,7 @@ pattern. Tests that run without network or full data:
   1. /health probe
   2. MCP initialize handshake + session id
   3. tools/list — all tools registered
-  4. output_channel per-request resolution (query string)
+  4. output_channel env-only behavior (query string ignored)
 """
 from __future__ import annotations
 

--- a/python/tests/test_e2e_http.py
+++ b/python/tests/test_e2e_http.py
@@ -30,9 +30,6 @@ import pytest
 GAMEDATA_PATH = Path(__file__).resolve().parents[2] / "data" / "gamedata"
 GAMEDATA_PATH = GAMEDATA_PATH.resolve()
 
-_op_table = GAMEDATA_PATH / "zh_CN" / "gamedata" / "excel" / "character_table.json"
-_has_operator_data = _op_table.is_file()
-
 
 def _free_port() -> int:
     """Return a free TCP port on localhost."""
@@ -68,6 +65,7 @@ def _mcp_post(
     body: dict,
     session_id: str | None = None,
     extra_headers: dict | None = None,
+    query: str | None = None,
 ) -> tuple[int, dict | None, str | None]:
     headers = {
         "Content-Type": "application/json",
@@ -77,7 +75,10 @@ def _mcp_post(
         headers["mcp-session-id"] = session_id
     if extra_headers:
         headers.update(extra_headers)
-    r = httpx.post(f"{origin}/mcp", json=body, headers=headers, timeout=10.0)
+    url = f"{origin}/mcp"
+    if query:
+        url += f"?{query}"
+    r = httpx.post(url, json=body, headers=headers, timeout=10.0)
     sid = r.headers.get("mcp-session-id")
     payload: dict | None = None
     if r.text:
@@ -188,10 +189,10 @@ def test_output_channel_env_only_on_http(server):
 
     FastMCP's Streamable HTTP session model means tools execute in a
     long-lived session task, so per-request query/header resolution is not
-    effective. This test documents that: a query-string output_channel
-    does NOT change the tool's output shape (the env default 'content'
-    governs). The TypeScript HTTP transport differs — it resolves channel
-    at session creation.
+    effective. This test verifies that explicitly: a query-string
+    ``output_channel=structured`` is passed but the response remains
+    content-only (env default governs). The TypeScript HTTP transport
+    differs — it resolves channel at session creation.
     """
     origin = server["origin"]
     _, _, sid = _mcp_post(
@@ -214,9 +215,9 @@ def test_output_channel_env_only_on_http(server):
         session_id=sid,
     )
 
-    # Call list_story_events (graceful error path, no data needed) with
-    # output_channel=structured in the query string. It should be IGNORED
-    # — the response is content-only (env default), confirming env-only.
+    # Call list_story_events with output_channel=structured in the query
+    # string. Even though the server is env-default (content), we pass
+    # structured to prove it is IGNORED — structuredContent stays null.
     status, payload, _ = _mcp_post(
         origin,
         {
@@ -226,12 +227,15 @@ def test_output_channel_env_only_on_http(server):
             "params": {"name": "list_story_events", "arguments": {}},
         },
         session_id=sid,
+        query="output_channel=structured",
     )
     assert status == 200
     assert payload is not None
     result = payload.get("result", {})
-    # Content-only: structuredContent should be absent or null (error path
-    # is always content-only regardless, but the point is the query string
-    # had no effect).
-    assert "content" in result
-    assert result.get("structuredContent") is None
+    # The query-string override had no effect: structuredContent is null
+    # (would be non-null if the override had taken effect on a structured
+    # tool). This confirms env-only behavior.
+    assert result.get("structuredContent") is None, (
+        "query-string output_channel=structured should be ignored on "
+        "Python HTTP; structuredContent must be null"
+    )

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,12 +1,13 @@
 {
   "name": "prts-mcp-ts",
   "version": "2.3.0-dev.0",
-  "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP)",
+  "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP + stdio)",
   "type": "module",
   "main": "dist/server.js",
   "bin": {
     "prts-mcp-ts": "./dist/server.js",
-    "prts-mcp-ts-bun": "./dist/server-bun.js"
+    "prts-mcp-ts-bun": "./dist/server-bun.js",
+    "prts-mcp-ts-stdio": "./dist/server-stdio.js"
   },
   "files": [
     "dist/",
@@ -23,6 +24,8 @@
     "start": "bun dist/server-bun.js",
     "start:bun": "bun dist/server-bun.js",
     "start:node": "node dist/server.js",
+    "start:stdio": "node dist/server-stdio.js",
+    "start:stdio:bun": "bun dist/server-stdio.js",
     "smoke:http": "bun scripts/smoke-http.mjs -- bun dist/server-bun.js",
     "smoke:http:fixture": "bun scripts/smoke-http.mjs --fixture-data -- bun dist/server-bun.js",
     "smoke:http:node": "node scripts/smoke-http.mjs -- node dist/server.js",

--- a/ts/scripts/smoke-package-bun.mjs
+++ b/ts/scripts/smoke-package-bun.mjs
@@ -72,6 +72,10 @@ function installedBinPath() {
   return join(tempRoot, "node_modules", ".bin", isWindows ? "prts-mcp-ts-bun.exe" : "prts-mcp-ts-bun");
 }
 
+function stdioBinPath() {
+  return join(tempRoot, "node_modules", ".bin", isWindows ? "prts-mcp-ts-stdio.exe" : "prts-mcp-ts-stdio");
+}
+
 function assertInstalledBin() {
   const bin = installedBinPath();
   if (!existsSync(bin)) {
@@ -79,6 +83,14 @@ function assertInstalledBin() {
   }
   if (statSync(bin).size <= 0) {
     throw new Error(`Installed Bun bin is empty: ${bin}`);
+  }
+  // Verify the stdio bin shim is also installed (added in 2.3.0).
+  const stdioBin = stdioBinPath();
+  if (!existsSync(stdioBin)) {
+    throw new Error(`Installed stdio bin is missing: ${stdioBin}`);
+  }
+  if (statSync(stdioBin).size <= 0) {
+    throw new Error(`Installed stdio bin is empty: ${stdioBin}`);
   }
 }
 

--- a/ts/src/server-stdio.ts
+++ b/ts/src/server-stdio.ts
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+/**
+ * PRTS-MCP stdio entry point (TypeScript).
+ *
+ * The default HTTP server lives in server.ts; this file provides the stdio
+ * transport so the TypeScript implementation can be used from local MCP
+ * clients (Claude Desktop, Claude Code, Cursor, etc.) without running an
+ * HTTP listener. It reuses the same McpServer factory, tool registration,
+ * and startup sync as the HTTP path — only the transport differs.
+ *
+ * Output channel is resolved purely from the PRTS_OUTPUT_CHANNEL env var
+ * (stdio has no query string / headers); the default is "content".
+ */
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createMcpServer, log, SERVER_VERSION } from "./server.js";
+import { runStartupSync } from "./startupSync.js";
+import { parseChannel } from "./output.js";
+
+async function main(): Promise<void> {
+  const warn = (message: string) => log("WARN", message);
+  const channel = parseChannel(
+    process.env["PRTS_OUTPUT_CHANNEL"],
+    "PRTS_OUTPUT_CHANNEL",
+    warn,
+  );
+
+  const server = createMcpServer(channel);
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  log("INFO", `PRTS-MCP stdio server ${SERVER_VERSION} connected (channel=${channel})`);
+
+  // Background data sync — same as the HTTP path. On stdio the process is
+  // typically short-lived (client spawns per use), so retry timers use
+  // unref and incomplete sync is acceptable (resumes next launch).
+  void runStartupSync().catch((err) => {
+    log("ERROR", `startup sync failed: ${err instanceof Error ? err.message : String(err)}`);
+  });
+}
+
+main().catch((err) => {
+  log("ERROR", `stdio server failed to start: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+});

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -27,9 +27,9 @@ import { parseChannel, type OutputChannel } from "./output.js";
 
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json") as { version?: string };
-const SERVER_VERSION = packageJson.version ?? "0.0.0";
+export const SERVER_VERSION = packageJson.version ?? "0.0.0";
 
-function log(level: "INFO" | "WARN" | "ERROR", msg: string): void {
+export function log(level: "INFO" | "WARN" | "ERROR", msg: string): void {
   const ts = new Date().toISOString();
   process.stderr.write(`${ts} ${level} prts_mcp.server: ${msg}\n`);
 }
@@ -38,7 +38,7 @@ function log(level: "INFO" | "WARN" | "ERROR", msg: string): void {
 // MCP Server factory — one instance per session
 // ---------------------------------------------------------------------------
 
-function createMcpServer(channel: OutputChannel): McpServer {
+export function createMcpServer(channel: OutputChannel): McpServer {
   const server = new McpServer({
     name: "PRTS_Wiki_Assistant",
     version: SERVER_VERSION,

--- a/ts/tests/e2eStdio.test.ts
+++ b/ts/tests/e2eStdio.test.ts
@@ -1,0 +1,190 @@
+/**
+ * E2E test — starts the TS MCP stdio server and exercises core tools via
+ * stdin/stdout JSON-RPC. Mirrors the Python test_e2e.py pattern.
+ *
+ * Tests that run without network or full data:
+ *   1. MCP initialize handshake
+ *   2. tools/list — all tools registered
+ *   3. Graceful errors for unavailable data
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawn, ChildProcess } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..");
+const GAMEDATA_PATH = join(REPO_ROOT, "data", "gamedata");
+const OPERATOR_TABLE = join(
+  GAMEDATA_PATH,
+  "zh_CN",
+  "gamedata",
+  "excel",
+  "character_table.json",
+);
+const HAS_OPERATOR_DATA = existsSync(OPERATOR_TABLE);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface ServerHandle {
+  child: ChildProcess;
+}
+
+function startServer(): ServerHandle {
+  const distServer = join(REPO_ROOT, "ts", "dist", "server-stdio.js");
+  const env: Record<string, string> = {
+    ...process.env,
+    GAMEDATA_PATH: GAMEDATA_PATH,
+    GITHUB_MIRRORS: "",
+    STORYJSON_PATH: join(GAMEDATA_PATH, "does-not-exist.zip"),
+  } as Record<string, string>;
+
+  const child = spawn(process.execPath, [distServer], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env,
+  });
+  return { child };
+}
+
+async function send(child: ChildProcess, msg: unknown): Promise<void> {
+  const stdin = child.stdin;
+  if (!stdin) throw new Error("no stdin");
+  stdin.write(JSON.stringify(msg) + "\n");
+}
+
+async function recv(child: ChildProcess, timeoutMs = 10000): Promise<Record<string, unknown>> {
+  const stdout = child.stdout;
+  if (!stdout) throw new Error("no stdout");
+  const deadline = Date.now() + timeoutMs;
+  const chunks: Buffer[] = [];
+  return new Promise((resolveFn, reject) => {
+    const timer = setTimeout(() => {
+      stdout.off("data", onData);
+      reject(new Error("recv timeout"));
+    }, deadline - Date.now());
+
+    function onData(data: Buffer) {
+      chunks.push(data);
+      const text = Buffer.concat(chunks).toString("utf-8");
+      const lines = text.split("\n");
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const parsed = JSON.parse(trimmed);
+          clearTimeout(timer);
+          stdout.off("data", onData);
+          resolveFn(parsed);
+          return;
+        } catch {
+          // not a complete JSON line yet
+        }
+      }
+    }
+    stdout.on("data", onData);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("stdio: initialize handshake + tools/list", async () => {
+  const { child } = startServer();
+  try {
+    await send(child, {
+      jsonrpc: "2.0",
+      method: "initialize",
+      id: 1,
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "test", version: "0" },
+      },
+    });
+    const initResp = await recv(child);
+    assert.equal(initResp["id"], 1);
+    const result = initResp["result"] as Record<string, unknown>;
+    const serverInfo = result["serverInfo"] as Record<string, string>;
+    assert.equal(serverInfo["name"], "PRTS_Wiki_Assistant");
+
+    // notifications/initialized
+    await send(child, {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: {},
+    });
+
+    // tools/list
+    await send(child, {
+      jsonrpc: "2.0",
+      method: "tools/list",
+      id: 2,
+      params: {},
+    });
+    const listResp = await recv(child);
+    assert.equal(listResp["id"], 2);
+    const tools = (listResp["result"] as { tools: Array<{ name: string }> }).tools;
+    const names = new Set(tools.map((t) => t.name));
+    for (const required of [
+      "search_prts",
+      "get_operator_archives",
+      "list_story_events",
+      "read_story",
+      "list_enemies",
+    ]) {
+      assert.ok(names.has(required), `missing tool ${required}`);
+    }
+  } finally {
+    child.kill();
+  }
+});
+
+test("stdio: graceful error for unavailable data", async () => {
+  const { child } = startServer();
+  try {
+    await send(child, {
+      jsonrpc: "2.0",
+      method: "initialize",
+      id: 1,
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "test", version: "0" },
+      },
+    });
+    await recv(child);
+
+    await send(child, {
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+      params: {},
+    });
+
+    // list_story_events should gracefully report story data unavailable,
+    // not crash the server.
+    await send(child, {
+      jsonrpc: "2.0",
+      method: "tools/call",
+      id: 2,
+      params: { name: "list_story_events", arguments: {} },
+    });
+    const resp = await recv(child);
+    assert.equal(resp["id"], 2);
+    const result = resp["result"] as { content: Array<{ text: string }>; isError?: boolean };
+    assert.ok(!result.isError, "expected graceful text, not isError");
+    assert.ok(result.content.length > 0);
+    const text = result.content[0].text;
+    // Should mention unavailability, not crash.
+    assert.ok(
+      text.includes("暂不可用") || text.includes("未就绪") || text.includes("仍在进行中"),
+      `unexpected response: ${text.slice(0, 100)}`,
+    );
+  } finally {
+    child.kill();
+  }
+});

--- a/ts/tests/e2eStdio.test.ts
+++ b/ts/tests/e2eStdio.test.ts
@@ -10,21 +10,12 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawn, ChildProcess } from "node:child_process";
-import { existsSync } from "node:fs";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "..", "..");
 const GAMEDATA_PATH = join(REPO_ROOT, "data", "gamedata");
-const OPERATOR_TABLE = join(
-  GAMEDATA_PATH,
-  "zh_CN",
-  "gamedata",
-  "excel",
-  "character_table.json",
-);
-const HAS_OPERATOR_DATA = existsSync(OPERATOR_TABLE);
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Summary

Delivers the **2.3.0 minor theme**: cross-transport parity. Both implementations now support both stdio and Streamable HTTP, breaking the 2.0 transport split. Choose by use case, not by language.

### What's new

**Python gains Streamable HTTP** (`PRTS_TRANSPORT=http`):
- `server.py` main() reads `PRTS_TRANSPORT` env (stdio default | http).
- HTTP mode: `mcp.streamable_http_app()` (Starlette) + uvicorn, `/mcp` endpoint + `/health` probe.
- `output_channel` refactor: `OUTPUT_CHANNEL` → `contextvars.ContextVar` (commit 1), paving the way for transport-level overrides. Tool code unchanged.

**TypeScript gains stdio** (`prts-mcp-ts-stdio` bin):
- New `server-stdio.ts` (~40 lines) reuses `createMcpServer` + `runStartupSync` + `StdioServerTransport`. Single-session, no Express/session pool.
- `server.ts` exports `createMcpServer`/`SERVER_VERSION`/`log` for reuse.
- New npm bin + scripts (`start:stdio`, `start:stdio:bun`).

### Known limitation (honestly documented)

**Python HTTP output_channel is process-level (env-only)**, not per-request. FastMCP's Streamable HTTP session model creates a long-lived task at `initialize`; tools execute inside that task, so a per-request contextvar set in middleware is invisible to tool code (verified empirically, see CR B1). The middleware was removed; Python HTTP reads `PRTS_OUTPUT_CHANNEL` env only. TypeScript HTTP still supports per-request resolution (query/header) because it injects channel at session creation. This asymmetry is documented in `server.py`, `.env.example`, and `STATUS.md`.

### Commits
1. `refactor(python): make output_channel per-connection via contextvar`
2. `feat(python): add Streamable HTTP transport`
3. `feat(ts): add stdio transport`
4. `test: add cross-transport e2e coverage`
5. `docs: document dual-transport support`
6. `chore(release): update STATUS/ROADMAP`
7. `fix: address CR blocking findings (B1-B3) + S4`

## Test plan

- [x] `check-runtime.ps1 -Full` — 0 failures (Python 248 + TS 200 tests, typecheck).
- [x] Python HTTP manual: `PRTS_TRANSPORT=http` → `/health` ok, `/mcp` initialize + tools/list returns 23 tools.
- [x] TS stdio manual: stdin JSON-RPC initialize + tools/list returns 23 tools.
- [x] New e2e: `test_e2e_http.py` (3 tests) + `e2eStdio.test.ts` (2 tests).
- [x] Independent CR: **3 Blocking found and fixed** (B1 contextvar ineffectiveness, B2 bogus test, B3 CI missing build), S4 (explicit deps) fixed.
- [ ] CI on this PR.

## 未尽事宜 / Follow-ups

- **Per-request output_channel on Python HTTP**: requires either a FastMCP hook to inject channel at session creation, or upstream SDK support. Deferred.
- **Python HTTP Docker**: `python/Dockerfile` still defaults to stdio; HTTP Docker users set `PRTS_TRANSPORT=http -e PORT=3000 -p 3000:3000`. A dedicated HTTP Dockerfile is a follow-up if demand emerges.
- **session_idle_timeout parity**: TS HTTP has 24h idle eviction + LLM-actionable 404; Python HTTP relies on SDK defaults. Aligning is a follow-up.