### PR TITLE
chore(release): back-merge 2.3.0 release to develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Two release lines ship in parallel:
 
 | Line | Version | Tools | Status |
 |------|---------|-------|--------|
-| **2.2** (`main`) | `2.2.0` | 23 | Bun is the default TypeScript production runtime (default Dockerfile, CI, npm scripts); Node.js remains a supported legacy/optional path. Cross-transport parity deferred beyond 2.2. |
+| **2.3** (`main`) | `2.3.0` | 23 | Cross-transport parity: both implementations support both stdio and Streamable HTTP (Python gains HTTP, TypeScript gains stdio). Bun remains the default TS runtime. |
 | **1.7 LTS** (`lts/1.7`) | `1.7.0` | 32 | Stable maintenance line. 1.7.x accepts only compatibility, security, data-sync, and critical bug fixes. |
 
 | Area | Python | TypeScript |
@@ -141,7 +141,7 @@ Published Docker images and the npm package include bundled fallback game/level/
 
 | 版本线 | 版本 | 工具数 | 状态 |
 |--------|------|--------|------|
-| **2.2**（`main`） | `2.2.0` | 23 | Bun 是 TypeScript 默认生产运行时（默认 Dockerfile、CI、npm scripts）；Node.js 保留为受支持 legacy/可选路径。双端协议同步后置到 2.2 之后。 |
+| **2.3**（`main`） | `2.3.0` | 23 | Cross-transport parity：双端均支持 stdio + Streamable HTTP（Python 新增 HTTP，TypeScript 新增 stdio）。Bun 仍是 TS 默认运行时。 |
 | **1.7 LTS**（`lts/1.7`） | `1.7.0` | 32 | 稳定维护线。1.7.x 仅接受兼容性、安全性、数据同步和关键缺陷修复。 |
 
 | 范围 | Python | TypeScript |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,8 +6,8 @@ PRTS-MCP is past 1.0. Version 1.7.0 is the final 1.x feature release and the 1.7
 
 ## Current Release
 
-- Python: `2.2.0` _(latest stable)_
-- TypeScript: `2.2.0` _(latest stable)_
+- Python: `2.3.0` _(latest stable)_
+- TypeScript: `2.3.0` _(latest stable)_
 - `1.7.0` LTS remains the maintenance line — compatibility, security, data-sync, and critical fixes only.
 - 23 public MCP tools on the 2.x line (CI-enforced); 32 public MCP tools frozen on the 1.7 LTS line.
 - See [migration guide 0.x → 1.0](docs/migration-0.x-to-1.0.md) and
@@ -185,12 +185,12 @@ implementations. Delivered in 2.0:
 - Environment variable names and defaults are unified (`PRTS_OUTPUT_CHANNEL`,
   `GAMEDATA_PATH`, `STORYJSON_PATH`, `GITHUB_TOKEN`, `GITHUB_MIRRORS`).
 
-**Cross-transport parity — in progress for 2.3.0.** The original goal that
+**Cross-transport parity — delivered in 2.3.0.** The original goal that
 both implementations support stdio **and** Streamable HTTP (Python gaining
-HTTP, TypeScript gaining stdio) was deferred beyond 2.0 and is now being
-delivered in 2.3.0. Python selects transport via `PRTS_TRANSPORT`
+HTTP, TypeScript gaining stdio) was deferred beyond 2.0 and shipped in
+2.3.0. Python selects transport via `PRTS_TRANSPORT`
 (stdio default | http); TypeScript selects via bin (`prts-mcp-ts`[-bun] = HTTP,
-`prts-mcp-ts-stdio` = stdio). After 2.3.0 the deployment guidance becomes
+`prts-mcp-ts-stdio` = stdio). Since 2.3.0 the deployment guidance is
 "choose by use case, not by language."
 
 ### Cleanup

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -6,8 +6,8 @@ PRTS-MCP 已进入 1.x 稳定期。1.7.0 是最后一个 1.x 功能版本和 1.7
 
 ## 当前发布
 
-- Python：`2.2.0` _（最新稳定版）_
-- TypeScript：`2.2.0` _（最新稳定版）_
+- Python：`2.3.0` _（最新稳定版）_
+- TypeScript：`2.3.0` _（最新稳定版）_
 - `1.7.0` LTS 仍为维护线——仅兼容性、安全性、数据同步和关键缺陷修复。
 - 2.x 线为 23 个公共 MCP 工具（CI 强制检查）；1.7 LTS 线冻结 32 个公共 MCP 工具。
 - 迁移说明：[0.x → 1.0](docs/migration-0.x-to-1.0.md)、[1.x → 2.0](docs/migration-1.x-to-2.0.md)。
@@ -167,10 +167,10 @@ PRTS-MCP 已进入 1.x 稳定期。1.7.0 是最后一个 1.x 功能版本和 1.7
 - 环境变量名称和默认值统一（`PRTS_OUTPUT_CHANNEL`、`GAMEDATA_PATH`、`STORYJSON_PATH`、
   `GITHUB_TOKEN`、`GITHUB_MIRRORS`）。
 
-**跨传输协议同步——2.3.0 开发中。** 原目标「两套实现都同时支持 stdio **和**
-Streamable HTTP」（Python 上 HTTP、TypeScript 上 stdio）曾后置到 2.0 之后，现于 2.3.0
+**跨传输协议同步——已于 2.3.0 交付。** 原目标「两套实现都同时支持 stdio **和**
+Streamable HTTP」（Python 上 HTTP、TypeScript 上 stdio）曾后置到 2.0 之后，已在 2.3.0
 交付。Python 经 `PRTS_TRANSPORT` 选择传输（stdio 默认 | http）；TypeScript 经 bin 选择
-（`prts-mcp-ts`[-bun] = HTTP，`prts-mcp-ts-stdio` = stdio）。2.3.0 后部署推荐改为「按场景
+（`prts-mcp-ts`[-bun] = HTTP，`prts-mcp-ts-stdio` = stdio）。自 2.3.0 起部署推荐为「按场景
 选择，而非按语言」。
 
 ### 清理

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,15 +6,18 @@ _Last updated: 2026-07-08_
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 2.3.0.dev0 | Development |
-| TypeScript | 2.3.0-dev.0 | Development |
+| Python | 2.3.0 | Stable |
+| TypeScript | 2.3.0 | Stable |
 
-- 当前稳定发布：2.2.0（23 个 MCP 工具）
+- 当前稳定发布：2.3.0（23 个 MCP 工具）
 - 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）
-- 当前开发目标：2.3.0（cross-transport parity：Python 新增 Streamable HTTP、
-  TS 新增 stdio，双端双 transport）
-- 当前稳定补丁线：2.2.x
-- 当前开发线：2.3.x
+- 当前开发目标：2.4.0（待规划）
+- 当前稳定补丁线：2.3.x
+- 当前开发线：2.4.x
+- 2.3.0 发布内容：Cross-transport parity——Python 新增 Streamable HTTP
+  （`PRTS_TRANSPORT=http`），TypeScript 新增 stdio（`prts-mcp-ts-stdio` bin），
+  双端双 transport。Python HTTP 的 output_channel 为 process-level（env-only，
+  FastMCP session 模型限制），TS HTTP 支持 per-request。
 - 2.2.0 发布内容：TypeScript 默认生产运行时由 Node.js 翻转为 Bun（默认
   `ts/Dockerfile`、CI 主链 `verify-ts`、npm scripts 切 Bun，验证版本 Bun
   `1.3.14`）。Node.js 降级为受支持 legacy/可选路径（`prts-mcp-ts` npm bin、
@@ -30,9 +33,9 @@ _Last updated: 2026-07-08_
 
 ## 当前分支
 
-- `main`：2.2.0（最新稳定发布线）
+- `main`：2.3.0（最新稳定发布线）
 - `lts/1.7`：1.7.x LTS 维护线（从 1.7.0 发布提交创建）
-- `develop`：2.3 的开发集成线
+- `develop`：2.4 的开发集成线
 
 1.7.0 是最后一个 1.x 功能版本和 LTS 基线。它将 server.py/server.ts 和 story.py/story.ts 单体文件拆分为聚焦子模块，保留向后兼容垫片（shim），并新增剧情角色追踪工具：`find_character_appearances`、`find_speakers_in`。后续功能开发转向 2.0；1.7.x 仅做兼容性、安全性、数据同步和关键缺陷修复。
 
@@ -170,7 +173,7 @@ PRTS-MCP/
 > 15–30%，抵消工具面合并带来的上下文预算收益。详见
 > [`docs/migration-1.x-to-2.0.md`](docs/migration-1.x-to-2.0.md)。
 
-## 2.3.0 开发中（develop）
+## 2.3.0 发布内容
 
 - [x] Python 新增 Streamable HTTP transport（`PRTS_TRANSPORT=http`，Starlette +
   uvicorn，`/mcp` 端点 + `/health` 探针）。stdio 保持默认（向后兼容）。
@@ -219,6 +222,7 @@ PRTS-MCP/
 
 | 版本 | 日期 | 亮点 |
 |------|------|------|
+| 2.3.0 | 2026-07-08 | Cross-transport parity：Python 新增 Streamable HTTP，TypeScript 新增 stdio，双端双 transport；部署改为按场景选择 |
 | 2.2.0 | 2026-07-08 | TypeScript 默认生产运行时翻转为 Bun（默认 Dockerfile/CI/scripts）；Node 降级为 legacy 可选路径；npm bin 与发布路径不变 |
 | 2.1.0 | 2026-07-07 | TypeScript 正式支持 Bun 可选运行时；新增 `prts-mcp-ts-bun`；Bun Dockerfile 提升为受支持替代构建路径 |
 | 2.0.2 | 2026-07-07 | TS HTTP MCP smoke harness；Bun 候选运行路径；`search_prts` redirect 解析与技术页面过滤修复 |

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,7 +4,29 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.3.0] - 2026-07-08
+
+### Added
+
+- Added Streamable HTTP transport: `PRTS_TRANSPORT=http` starts a Starlette
+  + uvicorn server with `/mcp` endpoint, `/health` probe, and `HOST`/`PORT`
+  env control (defaults `0.0.0.0:3000`). `stdio` remains the default.
+  Breaks the 2.0 transport split — the Python implementation now supports
+  both stdio and Streamable HTTP.
+- Added `test_e2e_http.py` covering HTTP health, initialize + tools/list,
+  and env-only output_channel behavior.
+- Declared `starlette>=0.27` and `uvicorn>=0.31` as explicit dependencies
+  (previously transitive via `mcp[cli]`).
+
+### Changed
+
+- Refactored `OUTPUT_CHANNEL` from a module-level constant to a
+  `contextvars.ContextVar`, paving the way for transport-level overrides.
+  Tool code is unchanged; `render_result` resolves the channel via
+  `get_output_channel()` at call time. **Note**: Python HTTP
+  output_channel is currently process-level (env-only) — FastMCP's session
+  model makes per-request contextvars invisible to tool code. The
+  TypeScript HTTP transport supports per-request resolution.
 
 ## [2.2.0] - 2026-07-08
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.3.0.dev0"
+version = "2.3.0"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -105,7 +105,12 @@ def main() -> None:
         import uvicorn
 
         host = os.environ.get("HOST", "0.0.0.0")
-        port = int(os.environ.get("PORT", "3000"))
+        port_raw = os.environ.get("PORT", "3000")
+        try:
+            port = int(port_raw)
+        except ValueError:
+            _logger.error("PORT must be numeric, got %r. Exiting.", port_raw)
+            sys.exit(1)
         app = _build_http_app()
         _logger.info("PRTS-MCP Streamable HTTP listening on %s:%s (/mcp)", host, port)
         uvicorn.run(app, host=host, port=port, log_level="info")

--- a/python/tests/test_e2e_http.py
+++ b/python/tests/test_e2e_http.py
@@ -113,8 +113,8 @@ def _start_server(extra_env: dict | None = None) -> dict:
 
     proc = subprocess.Popen(
         [sys.executable, "-m", "prts_mcp.server"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
         env=env,
     )
     _wait_for_health(origin)
@@ -197,12 +197,12 @@ def test_output_channel_env_governs_not_query():
     """Python HTTP output_channel is process-level (env), not per-request.
 
     Starts a server with PRTS_OUTPUT_CHANNEL=structured, then calls a
-    structured tool (list_enemies) with ?output_channel=content in the
-    query string. If query-string resolution worked, the response would
-    be content-only (structuredContent null). Because the env governs and
+    structured tool (search) with ?output_channel=content in the query
+    string. If query-string resolution worked, the response would be
+    content-only (structuredContent null). Because the env governs and
     the query is ignored, structuredContent stays non-null — proving
-    env-only behavior. Uses list_enemies which needs GameData excel
-    tables; skips if that data is absent.
+    env-only behavior. Uses search(operators) which needs the
+    character_table; skips if that data is absent or returns no results.
     """
     char_table = GAMEDATA_PATH / "zh_CN" / "gamedata" / "excel" / "character_table.json"
     if not char_table.is_file():
@@ -251,6 +251,17 @@ def test_output_channel_env_governs_not_query():
         assert status == 200
         assert payload is not None
         result = payload.get("result", {})
+        # Guard against the data-unavailable error path: if search hit the
+        # error/missing-data branch, structuredContent is null regardless of
+        # channel (text_result is used), which would make the channel
+        # assertion below meaningless. Verify data was actually returned first.
+        content_text = ""
+        if result.get("content"):
+            content_text = result["content"][0].get("text", "")
+        assert "暂不可用" not in content_text and "未就绪" not in content_text, (
+            f"search returned a data-unavailable path; cannot verify channel "
+            f"behavior. Response: {content_text[:120]}"
+        )
         assert result.get("structuredContent") is not None, (
             "env PRTS_OUTPUT_CHANNEL=structured should govern; "
             "query ?output_channel=content must be ignored. "

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,7 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.3.0] - 2026-07-08
+
+### Added
+
+- Added stdio transport support: new `prts-mcp-ts-stdio` npm bin and
+  `ts/src/server-stdio.ts` entry point. Reuses the existing
+  `createMcpServer` factory and `runStartupSync`; connects an
+  `StdioServerTransport` for single-session local MCP clients (Claude
+  Desktop, Claude Code, Cursor). Breaks the 2.0 transport split — the
+  TypeScript implementation now supports both Streamable HTTP (existing
+  `prts-mcp-ts` / `prts-mcp-ts-bun` bins) and stdio.
+- Added `start:stdio` / `start:stdio:bun` npm scripts.
+- Added `e2eStdio.test.ts` covering stdio initialize handshake, tools/list,
+  and graceful error handling.
+- Extended `smoke-package-bun.mjs` to assert the `prts-mcp-ts-stdio` bin
+  shim is installed and non-empty after `npm pack` + `bun add`.
+
+### Changed
+
+- `server.ts` now exports `createMcpServer`, `SERVER_VERSION`, and `log`
+  (previously module-private) so the stdio entry point can reuse them
+  without duplicating tool registration logic.
 
 ## [2.2.0] - 2026-07-08
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.3.0-dev.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.3.0-dev.0",
+      "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.3.0-dev.0",
+  "version": "2.3.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP + stdio)",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Back-merges the 2.3.0 release (now on `main` as of PR #64) back to `develop`. Path D step 10. `--no-ff` to preserve release-merge semantics.

The version bump to `2.3.0` (no `-dev`) is temporary — the follow-up `chore/v2.4.0-open-development` PR will bump develop back to `2.4.0.dev0` / `2.4.0-dev.0`.

## Test plan

- [ ] CI green (changes already validated on main via PR #64).