### PR TITLE
fix(ci): build before tests in cd-ts verify job (2.3.0 CD blocker)

### DIFF
--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -34,12 +34,12 @@ jobs:
         run: npx tsc --noEmit
         working-directory: ts
 
-      - name: Run tests
-        run: npm test
-        working-directory: ts
-
       - name: Build
         run: npx tsc
+        working-directory: ts
+
+      - name: Run tests
+        run: npm test
         working-directory: ts
 
       - name: Check tag matches package version


### PR DESCRIPTION
## Summary

The 2.3.0 TS release (`ts/v2.3.0` tag) failed to publish because cd-ts.yml's verify job ran `npm test` before `npx tsc`. The stdio e2e tests (`e2eStdio.test.ts`) spawn `dist/server-stdio.js`, which didn't exist yet, causing both tests to time out (recv timeout 10s).

This is the same class of bug fixed in ci.yml's `test-ts` job during PR #63 (CR B3), but the cd-ts.yml verify job was missed.

**Fix:** move the `Build` step before `Run tests` in cd-ts.yml, matching ci.yml.

## Test plan

- [ ] CI green on this PR (the PR CI uses ci.yml which already has the build step).
- After merge: re-tag `ts/v2.3.0` on the new main HEAD to re-trigger CD.

## Post-merge plan

1. Delete the failed `ts/v2.3.0` tag (no package was published — npm CD aborted).
2. Re-tag `ts/v2.3.0` on the new main merge commit.
3. CD re-runs and publishes 2.3.0 to npm + Docker.
4. Forward-merge / cherry-pick to develop for consistency.