### PR TITLE
chore(release): forward-merge cd-ts hotfix to develop

### DIFF
--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -34,12 +34,12 @@ jobs:
         run: npx tsc --noEmit
         working-directory: ts
 
-      - name: Run tests
-        run: npm test
-        working-directory: ts
-
       - name: Build
         run: npx tsc
+        working-directory: ts
+
+      - name: Run tests
+        run: npm test
         working-directory: ts
 
       - name: Check tag matches package version


### PR DESCRIPTION
## Summary

Forward-merges the cd-ts.yml build-order hotfix (PR #67, on `main`) to `develop` so both long-lived branches carry the fix. Path C step 6.

The hotfix moved the `Build` step before `Run tests` in cd-ts.yml's verify job — the 2.3.0 TS release failed because e2eStdio tests spawn `dist/server-stdio.js` which didn't exist yet.

Mechanical merge, no conflicts. Already validated by the successful 2.3.0 re-release on main.

## Test plan

- [ ] CI green.