### PR TITLE
fix(search): improve PRTS search result quality

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- `search_prts` now resolves redirect-like search results and filters technical
+  pages more precisely while preserving the upstream total-hit count.
+
 ## [1.7.0] - 2026-07-02
 
 1.7.0 is the final 1.x feature release and the 1.7 LTS baseline. Future 1.7.x updates are limited to compatibility, security, data-sync, and critical bug fixes.

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -76,8 +76,10 @@ def _is_redirect_like(snippet: str) -> bool:
     return bool(_REDIRECT_SNIPPET_RE.search(snippet))
 
 
-async def _resolve_redirect_title(title: str) -> str | None:
-    """Resolve a redirect page title, returning None if lookup fails or is unchanged."""
+async def _resolve_redirect_titles(titles: list[str]) -> dict[str, str]:
+    """Resolve redirect page titles in one request, returning known targets."""
+    if not titles:
+        return {}
     try:
         await _rate_limit()
         response = await _get_client().get(
@@ -85,18 +87,20 @@ async def _resolve_redirect_title(title: str) -> str | None:
             params={
                 "action": "query",
                 "redirects": "1",
-                "titles": title,
+                "titles": "|".join(titles),
                 "format": "json",
             },
         )
         response.raise_for_status()
         redirects = response.json().get("query", {}).get("redirects", [])
-        for item in redirects:
-            if item.get("from") == title and item.get("to"):
-                return item["to"]
+        return {
+            item["from"]: item["to"]
+            for item in redirects
+            if item.get("from") and item.get("to")
+        }
     except Exception as exc:
-        _logger.debug("Failed to resolve PRTS redirect title %r: %s", title, exc)
-    return None
+        _logger.debug("Failed to resolve PRTS redirect titles %r: %s", titles, exc)
+    return {}
 
 
 async def search_prts(
@@ -132,20 +136,23 @@ async def search_prts(
         return {"totalhits": 0, "results": []}
     data = resp.json()
     totalhits = data.get("query", {}).get("searchinfo", {}).get("totalhits", 0)
+    search_results = data.get("query", {}).get("search", [])
+    redirect_targets = await _resolve_redirect_titles([
+        item["title"]
+        for item in search_results
+        if not item.get("redirecttitle")
+        and _is_redirect_like(item.get("snippet", ""))
+    ])
     results: list[dict] = []
-    for item in data.get("query", {}).get("search", []):
-        title = item["title"]
-        raw_snippet = item.get("snippet", "")
-        if item.get("redirecttitle"):
-            title = item["redirecttitle"]
-        elif _is_redirect_like(raw_snippet):
-            target = await _resolve_redirect_title(title)
-            if target:
-                title = target
-        if filter_technical and _is_technical_page(title):
-            continue
+    for item in search_results:
         if len(results) >= limit:
             break
+        title = item["title"]
+        raw_snippet = item.get("snippet", "")
+        if not item.get("redirecttitle"):
+            title = redirect_targets.get(title, title)
+        if filter_technical and _is_technical_page(title):
+            continue
         snippet = strip_wikitext(raw_snippet)
         snippet = _html.unescape(snippet)
         snippet = _clean_snippet(snippet)

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -136,7 +136,9 @@ async def search_prts(
     for item in data.get("query", {}).get("search", []):
         title = item["title"]
         raw_snippet = item.get("snippet", "")
-        if not item.get("redirecttitle") and _is_redirect_like(raw_snippet):
+        if item.get("redirecttitle"):
+            title = item["redirecttitle"]
+        elif _is_redirect_like(raw_snippet):
             target = await _resolve_redirect_title(title)
             if target:
                 title = target

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import html as _html
+import logging
 import re
 
 import xml.etree.ElementTree as ET
@@ -13,6 +14,7 @@ from prts_mcp.utils.sanitizer import strip_wikitext
 
 # --- Shared httpx client (connection pooling) ---
 
+_logger = logging.getLogger(__name__)
 _client: httpx.AsyncClient | None = None
 
 
@@ -58,18 +60,43 @@ _HTML_ENTITY_RE = re.compile(r"&#?[a-zA-Z0-9]+;")
 
 
 _TECHNICAL_PAGE_PATTERNS = (
-    "/spine",
-    "/data",
-    "/db",
-    "/lua",
-    "/json",
-    "Widget:",
-    "Template:",
+    re.compile(r"/(?:spine|data|db|lua|json|module)(?:$|[/:._-])", re.IGNORECASE),
+    re.compile(r"\.(?:json|lua)$", re.IGNORECASE),
+    re.compile(r"^(?:Widget|Template|Module|MediaWiki|模块|模板):", re.IGNORECASE),
 )
+
+_REDIRECT_SNIPPET_RE = re.compile(r"#\s*(?:重定向|REDIRECT)", re.IGNORECASE)
 
 
 def _is_technical_page(title: str) -> bool:
-    return any(p in title for p in _TECHNICAL_PAGE_PATTERNS)
+    return any(p.search(title) for p in _TECHNICAL_PAGE_PATTERNS)
+
+
+def _is_redirect_like(snippet: str) -> bool:
+    return bool(_REDIRECT_SNIPPET_RE.search(snippet))
+
+
+async def _resolve_redirect_title(title: str) -> str | None:
+    """Resolve a redirect page title, returning None if lookup fails or is unchanged."""
+    try:
+        await _rate_limit()
+        response = await _get_client().get(
+            PRTS_API_ENDPOINT,
+            params={
+                "action": "query",
+                "redirects": "1",
+                "titles": title,
+                "format": "json",
+            },
+        )
+        response.raise_for_status()
+        redirects = response.json().get("query", {}).get("redirects", [])
+        for item in redirects:
+            if item.get("from") == title and item.get("to"):
+                return item["to"]
+    except Exception as exc:
+        _logger.debug("Failed to resolve PRTS redirect title %r: %s", title, exc)
+    return None
 
 
 async def search_prts(
@@ -93,6 +120,7 @@ async def search_prts(
         "srlimit": str(limit * 2 if filter_technical else limit),
         "srnamespace": "0",
         "srinfo": "totalhits",
+        "srprop": "snippet|redirecttitle",
         "format": "json",
     }
     if srwhat:
@@ -107,11 +135,16 @@ async def search_prts(
     results: list[dict] = []
     for item in data.get("query", {}).get("search", []):
         title = item["title"]
+        raw_snippet = item.get("snippet", "")
+        if not item.get("redirecttitle") and _is_redirect_like(raw_snippet):
+            target = await _resolve_redirect_title(title)
+            if target:
+                title = target
         if filter_technical and _is_technical_page(title):
             continue
         if len(results) >= limit:
             break
-        snippet = strip_wikitext(item.get("snippet", ""))
+        snippet = strip_wikitext(raw_snippet)
         snippet = _html.unescape(snippet)
         snippet = _clean_snippet(snippet)
         results.append({
@@ -371,7 +404,7 @@ def _clean_snippet(snippet: str) -> str:
     snippet = re.sub(r'\s*"[^"]*"\s*:\s*"[^"]*"\s*,?\s*', " ", snippet)
     # Remove isolated pipe-value artifacts with Chinese keys
     snippet = re.sub(r"\|[一-鿿\w]+\s*=[^\n]*", "", snippet)
-    snippet = re.sub(r"#重定向|#REDIRECT", "", snippet)
+    snippet = _REDIRECT_SNIPPET_RE.sub("", snippet)
     # Collapse whitespace
     snippet = re.sub(r"[ \t]+", " ", snippet)
     snippet = re.sub(r",{2,}", "", snippet)

--- a/python/tests/test_prts_search.py
+++ b/python/tests/test_prts_search.py
@@ -93,6 +93,34 @@ def test_search_prts_keeps_result_when_redirect_lookup_fails(
     }
 
 
+def test_search_prts_uses_native_redirect_title(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _patch_client(
+        monkeypatch,
+        [
+            {
+                "query": {
+                    "searchinfo": {"totalhits": 1},
+                    "search": [
+                        {
+                            "title": "阿米亚",
+                            "redirecttitle": "阿米娅",
+                            "snippet": "罗德岛领袖。",
+                        },
+                    ],
+                },
+            },
+        ],
+    )
+
+    assert asyncio.run(search_prts("阿米亚", limit=1)) == {
+        "totalhits": 1,
+        "results": [{"title": "阿米娅", "snippet": "罗德岛领袖。"}],
+    }
+    assert len(client.requests) == 1
+
+
 def test_search_prts_filters_technical_pages_and_keeps_totalhits(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/python/tests/test_prts_search.py
+++ b/python/tests/test_prts_search.py
@@ -104,8 +104,8 @@ def test_search_prts_uses_native_redirect_title(
                     "searchinfo": {"totalhits": 1},
                     "search": [
                         {
-                            "title": "阿米亚",
-                            "redirecttitle": "阿米娅",
+                            "title": "阿米娅",
+                            "redirecttitle": "阿米亚",
                             "snippet": "罗德岛领袖。",
                         },
                     ],

--- a/python/tests/test_prts_search.py
+++ b/python/tests/test_prts_search.py
@@ -93,6 +93,43 @@ def test_search_prts_keeps_result_when_redirect_lookup_fails(
     }
 
 
+def test_search_prts_batches_redirect_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _patch_client(
+        monkeypatch,
+        [
+            {
+                "query": {
+                    "searchinfo": {"totalhits": 2},
+                    "search": [
+                        {"title": "别名甲", "snippet": "# redirect [[目标甲]]"},
+                        {"title": "别名乙", "snippet": "# redirect [[目标乙]]"},
+                    ],
+                },
+            },
+            {
+                "query": {
+                    "redirects": [
+                        {"from": "别名甲", "to": "目标甲"},
+                        {"from": "别名乙", "to": "目标乙"},
+                    ],
+                },
+            },
+        ],
+    )
+
+    assert asyncio.run(search_prts("别名", limit=2)) == {
+        "totalhits": 2,
+        "results": [
+            {"title": "目标甲", "snippet": "目标甲"},
+            {"title": "目标乙", "snippet": "目标乙"},
+        ],
+    }
+    assert len(client.requests) == 2
+    assert client.requests[1]["titles"] == "别名甲|别名乙"
+
+
 def test_search_prts_uses_native_redirect_title(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/python/tests/test_prts_search.py
+++ b/python/tests/test_prts_search.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from prts_mcp.api.prts_wiki import search_prts
+
+
+class FakeResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._payload = payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class FakeClient:
+    def __init__(self, payloads: list[dict[str, Any] | Exception]) -> None:
+        self.payloads = payloads
+        self.requests: list[dict[str, Any]] = []
+
+    async def get(self, _url: str, params: dict[str, Any]) -> FakeResponse:
+        self.requests.append(params)
+        payload = self.payloads.pop(0)
+        if isinstance(payload, Exception):
+            raise payload
+        return FakeResponse(payload)
+
+
+async def _no_rate_limit() -> None:
+    return None
+
+
+def _patch_client(
+    monkeypatch: pytest.MonkeyPatch,
+    payloads: list[dict[str, Any] | Exception],
+) -> FakeClient:
+    client = FakeClient(payloads)
+    monkeypatch.setattr("prts_mcp.api.prts_wiki._get_client", lambda: client)
+    monkeypatch.setattr("prts_mcp.api.prts_wiki._rate_limit", _no_rate_limit)
+    return client
+
+
+def test_search_prts_resolves_redirect_like_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _patch_client(
+        monkeypatch,
+        [
+            {
+                "query": {
+                    "searchinfo": {"totalhits": 1},
+                    "search": [{"title": "阿米亚", "snippet": "# redirect [[阿米娅]]"}],
+                },
+            },
+            {"query": {"redirects": [{"from": "阿米亚", "to": "阿米娅"}]}},
+        ],
+    )
+
+    assert asyncio.run(search_prts("阿米亚", limit=1)) == {
+        "totalhits": 1,
+        "results": [{"title": "阿米娅", "snippet": "阿米娅"}],
+    }
+    assert client.requests[0]["srprop"] == "snippet|redirecttitle"
+    assert client.requests[1]["redirects"] == "1"
+    assert client.requests[1]["titles"] == "阿米亚"
+
+
+def test_search_prts_keeps_result_when_redirect_lookup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_client(
+        monkeypatch,
+        [
+            {
+                "query": {
+                    "searchinfo": {"totalhits": 1},
+                    "search": [{"title": "阿米亚", "snippet": "# redirect [[阿米娅]]"}],
+                },
+            },
+            RuntimeError("redirect lookup failed"),
+        ],
+    )
+
+    assert asyncio.run(search_prts("阿米亚", limit=1)) == {
+        "totalhits": 1,
+        "results": [{"title": "阿米亚", "snippet": "阿米娅"}],
+    }
+
+
+def test_search_prts_filters_technical_pages_and_keeps_totalhits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_client(
+        monkeypatch,
+        [
+            {
+                "query": {
+                    "searchinfo": {"totalhits": 2},
+                    "search": [
+                        {"title": "变格凯尔希(敌人)/module", "snippet": "技术数据"},
+                        {"title": "凯尔希", "snippet": "罗德岛医生。"},
+                    ],
+                },
+            },
+        ],
+    )
+
+    assert asyncio.run(search_prts("凯尔希", limit=2)) == {
+        "totalhits": 2,
+        "results": [{"title": "凯尔希", "snippet": "罗德岛医生。"}],
+    }
+
+
+def test_search_prts_can_keep_technical_pages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_client(
+        monkeypatch,
+        [
+            {
+                "query": {
+                    "searchinfo": {"totalhits": 1},
+                    "search": [{"title": "敌人数据/module", "snippet": "技术数据"}],
+                },
+            },
+        ],
+    )
+
+    assert asyncio.run(search_prts("敌人数据", limit=1, filter_technical=False)) == {
+        "totalhits": 1,
+        "results": [{"title": "敌人数据/module", "snippet": "技术数据"}],
+    }

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- `search_prts` now resolves redirect-like search results and filters technical
+  pages more precisely while preserving the upstream total-hit count.
+
 ## [1.7.0] - 2026-07-02
 
 1.7.0 is the final 1.x feature release and the 1.7 LTS baseline. Future 1.7.x updates are limited to compatibility, security, data-sync, and critical bug fixes.

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -107,23 +107,25 @@ function isRedirectLike(snippet: string): boolean {
   return REDIRECT_SNIPPET_RE.test(snippet);
 }
 
-async function resolveRedirectTitle(title: string): Promise<string | null> {
+async function resolveRedirectTitles(titles: string[]): Promise<Map<string, string>> {
+  if (titles.length === 0) return new Map();
   try {
     const data = (await prtsGet({
       action: "query",
       redirects: 1,
-      titles: title,
+      titles: titles.join("|"),
       format: "json",
     })) as {
       query?: { redirects?: Array<{ from?: string; to?: string }> };
     };
+    const targets = new Map<string, string>();
     for (const item of data.query?.redirects ?? []) {
-      if (item.from === title && item.to) return item.to;
+      if (item.from && item.to) targets.set(item.from, item.to);
     }
+    return targets;
   } catch {
-    return null;
+    return new Map();
   }
-  return null;
 }
 
 function stripHtml(text: string): string {
@@ -180,17 +182,19 @@ export async function searchPrts(
     };
   };
   const totalHits = data.query?.searchinfo?.totalhits ?? 0;
+  const searchResults = data.query?.search ?? [];
+  const redirectTargets = await resolveRedirectTitles(
+    searchResults
+      .filter((item) => !item.redirecttitle && isRedirectLike(item.snippet ?? ""))
+      .map((item) => item.title),
+  );
   const results: SearchResult[] = [];
-  for (const item of data.query?.search ?? []) {
+  for (const item of searchResults) {
+    if (results.length >= limit) break;
     let title = item.title;
     const rawSnippet = item.snippet ?? "";
-    if (item.redirecttitle) {
-      title = item.redirecttitle;
-    } else if (isRedirectLike(rawSnippet)) {
-      title = await resolveRedirectTitle(title) ?? title;
-    }
+    if (!item.redirecttitle) title = redirectTargets.get(title) ?? title;
     if (filterTechnical && isTechnicalPage(title)) continue;
-    if (results.length >= limit) break;
     let snippet = stripWikitext(rawSnippet);
     snippet = unescapeHTMLEntities(snippet);
     snippet = cleanSnippet(snippet);

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -58,6 +58,7 @@ const CSS_JS_RE =
   /@(font-face|keyframes|media|import|charset|namespace|supports|page)[^{]*\{[^}]*\}|\(window\.RLQ\s*\|\|\s*\[\]\)\.push\([^)]*\)|<style[^>]*>.*?<\/style>|<script[^>]*>.*?<\/script>/gis;
 
 const HTML_TAG_RE = /<[^>]+>/g;
+const REDIRECT_SNIPPET_RE = /#\s*(?:重定向|REDIRECT)/i;
 
 const NAMED_ENTITIES: Record<string, string> = {
   quot: '"', amp: "&", lt: "<", gt: ">", apos: "'", nbsp: " ",
@@ -80,7 +81,7 @@ function cleanSnippet(snippet: string): string {
   snippet = snippet.replace(/\s*"[^"]*"\s*:\s*"[^"]*"\s*,?\s*/g, " ");
   // Remove isolated pipe-value artifacts with Chinese keys
   snippet = snippet.replace(/\|[一-鿿\w]+\s*=[^\n]*/g, "");
-  snippet = snippet.replace(/#重定向|#REDIRECT/g, "");
+  snippet = snippet.replace(REDIRECT_SNIPPET_RE, "");
   // Collapse whitespace
   snippet = snippet.replace(/[ \t]+/g, " ");
   snippet = snippet.replace(/,{2,}/g, "");
@@ -93,17 +94,36 @@ function cleanSnippet(snippet: string): string {
 // ---------------------------------------------------------------------------
 
 const TECHNICAL_PAGE_PATTERNS = [
-  "/spine",
-  "/data",
-  "/db",
-  "/lua",
-  "/json",
-  "Widget:",
-  "Template:",
+  /\/(?:spine|data|db|lua|json|module)(?:$|[/:._-])/i,
+  /\.(?:json|lua)$/i,
+  /^(?:Widget|Template|Module|MediaWiki|模块|模板):/i,
 ];
 
 function isTechnicalPage(title: string): boolean {
-  return TECHNICAL_PAGE_PATTERNS.some((p) => title.includes(p));
+  return TECHNICAL_PAGE_PATTERNS.some((pattern) => pattern.test(title));
+}
+
+function isRedirectLike(snippet: string): boolean {
+  return REDIRECT_SNIPPET_RE.test(snippet);
+}
+
+async function resolveRedirectTitle(title: string): Promise<string | null> {
+  try {
+    const data = (await prtsGet({
+      action: "query",
+      redirects: 1,
+      titles: title,
+      format: "json",
+    })) as {
+      query?: { redirects?: Array<{ from?: string; to?: string }> };
+    };
+    for (const item of data.query?.redirects ?? []) {
+      if (item.from === title && item.to) return item.to;
+    }
+  } catch {
+    return null;
+  }
+  return null;
 }
 
 function stripHtml(text: string): string {
@@ -147,6 +167,7 @@ export async function searchPrts(
     srlimit: fetchLimit,
     srnamespace: 0,
     srinfo: "totalhits",
+    srprop: "snippet|redirecttitle",
     format: "json",
   };
   if (searchMode === "title") {
@@ -155,18 +176,23 @@ export async function searchPrts(
   const data = (await prtsGet(params)) as {
     query?: {
       searchinfo?: { totalhits: number };
-      search?: Array<{ title: string; snippet: string }>;
+      search?: Array<{ title: string; snippet: string; redirecttitle?: string }>;
     };
   };
   const totalHits = data.query?.searchinfo?.totalhits ?? 0;
   const results: SearchResult[] = [];
   for (const item of data.query?.search ?? []) {
-    if (filterTechnical && isTechnicalPage(item.title)) continue;
+    let title = item.title;
+    const rawSnippet = item.snippet ?? "";
+    if (!item.redirecttitle && isRedirectLike(rawSnippet)) {
+      title = await resolveRedirectTitle(title) ?? title;
+    }
+    if (filterTechnical && isTechnicalPage(title)) continue;
     if (results.length >= limit) break;
-    let snippet = stripWikitext(item.snippet ?? "");
+    let snippet = stripWikitext(rawSnippet);
     snippet = unescapeHTMLEntities(snippet);
     snippet = cleanSnippet(snippet);
-    results.push({ title: item.title, snippet });
+    results.push({ title, snippet });
   }
   return { totalHits, results };
 }

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -184,7 +184,9 @@ export async function searchPrts(
   for (const item of data.query?.search ?? []) {
     let title = item.title;
     const rawSnippet = item.snippet ?? "";
-    if (!item.redirecttitle && isRedirectLike(rawSnippet)) {
+    if (item.redirecttitle) {
+      title = item.redirecttitle;
+    } else if (isRedirectLike(rawSnippet)) {
       title = await resolveRedirectTitle(title) ?? title;
     }
     if (filterTechnical && isTechnicalPage(title)) continue;

--- a/ts/tests/prtsWiki.test.ts
+++ b/ts/tests/prtsWiki.test.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { searchPrts } from "../src/api/prtsWiki.js";
+
+function mockFetch(payloads: unknown[], requests: string[] = []): () => void {
+  const original = globalThis.fetch;
+  globalThis.fetch = (async (input) => {
+    requests.push(String(input));
+    const payload = payloads.shift();
+    if (payload instanceof Error) throw payload;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    };
+  }) as typeof fetch;
+  return () => {
+    globalThis.fetch = original;
+  };
+}
+
+test("searchPrts resolves redirect-like results", async () => {
+  const requests: string[] = [];
+  const restore = mockFetch([
+    {
+      query: {
+        searchinfo: { totalhits: 1 },
+        search: [{ title: "阿米亚", snippet: "# redirect [[阿米娅]]" }],
+      },
+    },
+    { query: { redirects: [{ from: "阿米亚", to: "阿米娅" }] } },
+  ], requests);
+  try {
+    assert.deepEqual(await searchPrts("阿米亚", 1), {
+      totalHits: 1,
+      results: [{ title: "阿米娅", snippet: "阿米娅" }],
+    });
+    assert.equal(new URL(requests[0]).searchParams.get("srprop"), "snippet|redirecttitle");
+    assert.equal(new URL(requests[1]).searchParams.get("redirects"), "1");
+  } finally {
+    restore();
+  }
+});
+
+test("searchPrts keeps results when redirect lookup fails", async () => {
+  const restore = mockFetch([
+    {
+      query: {
+        searchinfo: { totalhits: 1 },
+        search: [{ title: "阿米亚", snippet: "# redirect [[阿米娅]]" }],
+      },
+    },
+    new Error("redirect lookup failed"),
+  ]);
+  try {
+    assert.deepEqual(await searchPrts("阿米亚", 1), {
+      totalHits: 1,
+      results: [{ title: "阿米亚", snippet: "阿米娅" }],
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("searchPrts filters technical pages without changing totalHits", async () => {
+  const restore = mockFetch([
+    {
+      query: {
+        searchinfo: { totalhits: 2 },
+        search: [
+          { title: "变格凯尔希(敌人)/module", snippet: "技术数据" },
+          { title: "凯尔希", snippet: "罗德岛医生。" },
+        ],
+      },
+    },
+  ]);
+  try {
+    assert.deepEqual(await searchPrts("凯尔希", 2), {
+      totalHits: 2,
+      results: [{ title: "凯尔希", snippet: "罗德岛医生。" }],
+    });
+  } finally {
+    restore();
+  }
+});
+
+test("searchPrts can keep technical pages when requested", async () => {
+  const restore = mockFetch([
+    {
+      query: {
+        searchinfo: { totalhits: 1 },
+        search: [{ title: "敌人数据/module", snippet: "技术数据" }],
+      },
+    },
+  ]);
+  try {
+    assert.deepEqual(await searchPrts("敌人数据", 1, "text", false), {
+      totalHits: 1,
+      results: [{ title: "敌人数据/module", snippet: "技术数据" }],
+    });
+  } finally {
+    restore();
+  }
+});

--- a/ts/tests/prtsWiki.test.ts
+++ b/ts/tests/prtsWiki.test.ts
@@ -72,8 +72,8 @@ test("searchPrts uses native redirecttitle without another request", async () =>
       query: {
         searchinfo: { totalhits: 1 },
         search: [{
-          title: "阿米亚",
-          redirecttitle: "阿米娅",
+          title: "阿米娅",
+          redirecttitle: "阿米亚",
           snippet: "罗德岛领袖。",
         }],
       },

--- a/ts/tests/prtsWiki.test.ts
+++ b/ts/tests/prtsWiki.test.ts
@@ -3,10 +3,11 @@ import test from "node:test";
 
 import { searchPrts } from "../src/api/prtsWiki.js";
 
-function mockFetch(payloads: unknown[], requests: string[] = []): () => void {
+function mockFetch(payloads: unknown[], requests?: string[]): () => void {
   const original = globalThis.fetch;
+  const recordedRequests = requests ?? [];
   globalThis.fetch = (async (input) => {
-    requests.push(String(input));
+    recordedRequests.push(String(input));
     const payload = payloads.shift();
     if (payload instanceof Error) throw payload;
     return {
@@ -38,6 +39,7 @@ test("searchPrts resolves redirect-like results", async () => {
     });
     assert.equal(new URL(requests[0]).searchParams.get("srprop"), "snippet|redirecttitle");
     assert.equal(new URL(requests[1]).searchParams.get("redirects"), "1");
+    assert.equal(new URL(requests[1]).searchParams.get("titles"), "阿米亚");
   } finally {
     restore();
   }
@@ -58,6 +60,31 @@ test("searchPrts keeps results when redirect lookup fails", async () => {
       totalHits: 1,
       results: [{ title: "阿米亚", snippet: "阿米娅" }],
     });
+  } finally {
+    restore();
+  }
+});
+
+test("searchPrts uses native redirecttitle without another request", async () => {
+  const requests: string[] = [];
+  const restore = mockFetch([
+    {
+      query: {
+        searchinfo: { totalhits: 1 },
+        search: [{
+          title: "阿米亚",
+          redirecttitle: "阿米娅",
+          snippet: "罗德岛领袖。",
+        }],
+      },
+    },
+  ], requests);
+  try {
+    assert.deepEqual(await searchPrts("阿米亚", 1), {
+      totalHits: 1,
+      results: [{ title: "阿米娅", snippet: "罗德岛领袖。" }],
+    });
+    assert.equal(requests.length, 1);
   } finally {
     restore();
   }

--- a/ts/tests/prtsWiki.test.ts
+++ b/ts/tests/prtsWiki.test.ts
@@ -1,12 +1,15 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { type TestContext } from "node:test";
 
 import { searchPrts } from "../src/api/prtsWiki.js";
 
-function mockFetch(payloads: unknown[], requests?: string[]): () => void {
-  const original = globalThis.fetch;
+function mockFetch(
+  t: TestContext,
+  payloads: unknown[],
+  requests?: string[],
+): void {
   const recordedRequests = requests ?? [];
-  globalThis.fetch = (async (input) => {
+  t.mock.method(globalThis, "fetch", async (input) => {
     recordedRequests.push(String(input));
     const payload = payloads.shift();
     if (payload instanceof Error) throw payload;
@@ -15,15 +18,20 @@ function mockFetch(payloads: unknown[], requests?: string[]): () => void {
       status: 200,
       json: async () => payload,
     };
-  }) as typeof fetch;
-  return () => {
-    globalThis.fetch = original;
-  };
+  });
+  t.mock.method(
+    globalThis,
+    "setTimeout",
+    ((callback: () => void) => {
+      callback();
+      return 0;
+    }) as typeof setTimeout,
+  );
 }
 
-test("searchPrts resolves redirect-like results", async () => {
+test("searchPrts resolves redirect-like results", async (t) => {
   const requests: string[] = [];
-  const restore = mockFetch([
+  mockFetch(t, [
     {
       query: {
         searchinfo: { totalhits: 1 },
@@ -32,21 +40,17 @@ test("searchPrts resolves redirect-like results", async () => {
     },
     { query: { redirects: [{ from: "阿米亚", to: "阿米娅" }] } },
   ], requests);
-  try {
-    assert.deepEqual(await searchPrts("阿米亚", 1), {
-      totalHits: 1,
-      results: [{ title: "阿米娅", snippet: "阿米娅" }],
-    });
-    assert.equal(new URL(requests[0]).searchParams.get("srprop"), "snippet|redirecttitle");
-    assert.equal(new URL(requests[1]).searchParams.get("redirects"), "1");
-    assert.equal(new URL(requests[1]).searchParams.get("titles"), "阿米亚");
-  } finally {
-    restore();
-  }
+  assert.deepEqual(await searchPrts("阿米亚", 1), {
+    totalHits: 1,
+    results: [{ title: "阿米娅", snippet: "阿米娅" }],
+  });
+  assert.equal(new URL(requests[0]).searchParams.get("srprop"), "snippet|redirecttitle");
+  assert.equal(new URL(requests[1]).searchParams.get("redirects"), "1");
+  assert.equal(new URL(requests[1]).searchParams.get("titles"), "阿米亚");
 });
 
-test("searchPrts keeps results when redirect lookup fails", async () => {
-  const restore = mockFetch([
+test("searchPrts keeps results when redirect lookup fails", async (t) => {
+  mockFetch(t, [
     {
       query: {
         searchinfo: { totalhits: 1 },
@@ -55,19 +59,15 @@ test("searchPrts keeps results when redirect lookup fails", async () => {
     },
     new Error("redirect lookup failed"),
   ]);
-  try {
-    assert.deepEqual(await searchPrts("阿米亚", 1), {
-      totalHits: 1,
-      results: [{ title: "阿米亚", snippet: "阿米娅" }],
-    });
-  } finally {
-    restore();
-  }
+  assert.deepEqual(await searchPrts("阿米亚", 1), {
+    totalHits: 1,
+    results: [{ title: "阿米亚", snippet: "阿米娅" }],
+  });
 });
 
-test("searchPrts batches redirect resolution", async () => {
+test("searchPrts batches redirect resolution", async (t) => {
   const requests: string[] = [];
-  const restore = mockFetch([
+  mockFetch(t, [
     {
       query: {
         searchinfo: { totalhits: 2 },
@@ -86,24 +86,20 @@ test("searchPrts batches redirect resolution", async () => {
       },
     },
   ], requests);
-  try {
-    assert.deepEqual(await searchPrts("别名", 2), {
-      totalHits: 2,
-      results: [
-        { title: "目标甲", snippet: "目标甲" },
-        { title: "目标乙", snippet: "目标乙" },
-      ],
-    });
-    assert.equal(requests.length, 2);
-    assert.equal(new URL(requests[1]).searchParams.get("titles"), "别名甲|别名乙");
-  } finally {
-    restore();
-  }
+  assert.deepEqual(await searchPrts("别名", 2), {
+    totalHits: 2,
+    results: [
+      { title: "目标甲", snippet: "目标甲" },
+      { title: "目标乙", snippet: "目标乙" },
+    ],
+  });
+  assert.equal(requests.length, 2);
+  assert.equal(new URL(requests[1]).searchParams.get("titles"), "别名甲|别名乙");
 });
 
-test("searchPrts uses native redirecttitle without another request", async () => {
+test("searchPrts uses native redirecttitle without another request", async (t) => {
   const requests: string[] = [];
-  const restore = mockFetch([
+  mockFetch(t, [
     {
       query: {
         searchinfo: { totalhits: 1 },
@@ -115,19 +111,15 @@ test("searchPrts uses native redirecttitle without another request", async () =>
       },
     },
   ], requests);
-  try {
-    assert.deepEqual(await searchPrts("阿米亚", 1), {
-      totalHits: 1,
-      results: [{ title: "阿米娅", snippet: "罗德岛领袖。" }],
-    });
-    assert.equal(requests.length, 1);
-  } finally {
-    restore();
-  }
+  assert.deepEqual(await searchPrts("阿米亚", 1), {
+    totalHits: 1,
+    results: [{ title: "阿米娅", snippet: "罗德岛领袖。" }],
+  });
+  assert.equal(requests.length, 1);
 });
 
-test("searchPrts filters technical pages without changing totalHits", async () => {
-  const restore = mockFetch([
+test("searchPrts filters technical pages without changing totalHits", async (t) => {
+  mockFetch(t, [
     {
       query: {
         searchinfo: { totalhits: 2 },
@@ -138,18 +130,14 @@ test("searchPrts filters technical pages without changing totalHits", async () =
       },
     },
   ]);
-  try {
-    assert.deepEqual(await searchPrts("凯尔希", 2), {
-      totalHits: 2,
-      results: [{ title: "凯尔希", snippet: "罗德岛医生。" }],
-    });
-  } finally {
-    restore();
-  }
+  assert.deepEqual(await searchPrts("凯尔希", 2), {
+    totalHits: 2,
+    results: [{ title: "凯尔希", snippet: "罗德岛医生。" }],
+  });
 });
 
-test("searchPrts can keep technical pages when requested", async () => {
-  const restore = mockFetch([
+test("searchPrts can keep technical pages when requested", async (t) => {
+  mockFetch(t, [
     {
       query: {
         searchinfo: { totalhits: 1 },
@@ -157,12 +145,8 @@ test("searchPrts can keep technical pages when requested", async () => {
       },
     },
   ]);
-  try {
-    assert.deepEqual(await searchPrts("敌人数据", 1, "text", false), {
-      totalHits: 1,
-      results: [{ title: "敌人数据/module", snippet: "技术数据" }],
-    });
-  } finally {
-    restore();
-  }
+  assert.deepEqual(await searchPrts("敌人数据", 1, "text", false), {
+    totalHits: 1,
+    results: [{ title: "敌人数据/module", snippet: "技术数据" }],
+  });
 });

--- a/ts/tests/prtsWiki.test.ts
+++ b/ts/tests/prtsWiki.test.ts
@@ -65,6 +65,42 @@ test("searchPrts keeps results when redirect lookup fails", async () => {
   }
 });
 
+test("searchPrts batches redirect resolution", async () => {
+  const requests: string[] = [];
+  const restore = mockFetch([
+    {
+      query: {
+        searchinfo: { totalhits: 2 },
+        search: [
+          { title: "别名甲", snippet: "# redirect [[目标甲]]" },
+          { title: "别名乙", snippet: "# redirect [[目标乙]]" },
+        ],
+      },
+    },
+    {
+      query: {
+        redirects: [
+          { from: "别名甲", to: "目标甲" },
+          { from: "别名乙", to: "目标乙" },
+        ],
+      },
+    },
+  ], requests);
+  try {
+    assert.deepEqual(await searchPrts("别名", 2), {
+      totalHits: 2,
+      results: [
+        { title: "目标甲", snippet: "目标甲" },
+        { title: "目标乙", snippet: "目标乙" },
+      ],
+    });
+    assert.equal(requests.length, 2);
+    assert.equal(new URL(requests[1]).searchParams.get("titles"), "别名甲|别名乙");
+  } finally {
+    restore();
+  }
+});
+
 test("searchPrts uses native redirecttitle without another request", async () => {
   const requests: string[] = [];
   const restore = mockFetch([


### PR DESCRIPTION
## Summary

- Resolve redirect-like PRTS search hits to their target page, with a graceful fallback when lookup fails.
- Filter technical result pages more precisely without changing upstream total-hit counts.
- Add direct Python and TypeScript API regression coverage without importing 2.x output-channel or tool-wrapper code.

## Test plan

- `npm ci --prefix ts`
- `npm --prefix ts run build`
- `node --import tsx --test tests/prtsWiki.test.ts` (4 passed)
- `npm --prefix ts test` (166 passed, 2 skipped)
- `npm --prefix ts run typecheck`
- `uv run --directory python --with pytest python -m pytest tests/test_prts_search.py -q` (4 passed)
- `uv run --directory python --with pytest python -m pytest tests -q` (196 passed, 28 skipped)

## Remaining work

- This is one of the independent 1.7.1 fixes. Version bump and tags will happen in the final LTS release PR after all approved fixes merge.