### PR TITLE
fix(docker): retain bundled fallback data

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,3 +23,11 @@ local_repo.jsonc
 *.tar
 *.zip
 *.7z
+
+# Exceptions: bundled fallback data must reach the Docker image even though
+# it ships as .zip archives. Without these, .dockerignore's *.zip rule above
+# strips the CI-pre-fetched storyjson/gamedata bundles from COPY data/ data/,
+# leaving the container without offline fallback data.
+!data/storyjson/zh_CN.zip
+!data/gamedata/archives/zh_CN-excel.zip
+!data/gamedata-levels/archives/zh_CN-levels.zip

--- a/.dockerignore
+++ b/.dockerignore
@@ -27,7 +27,7 @@ local_repo.jsonc
 # Exceptions: bundled fallback data must reach the Docker image even though
 # it ships as .zip archives. Without these, .dockerignore's *.zip rule above
 # strips the CI-pre-fetched storyjson/gamedata bundles from COPY data/ data/,
-# leaving the container without offline fallback data.
+# leaving the image without StoryJSON and packaged GameData archive fallbacks.
 !data/storyjson/zh_CN.zip
 !data/gamedata/archives/zh_CN-excel.zip
 !data/gamedata-levels/archives/zh_CN-levels.zip

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - `search_prts` now resolves redirect-like search results and filters technical
   pages more precisely while preserving the upstream total-hit count.
+- Docker builds retain bundled game and story data archives for offline fallback.
 
 ## [1.7.0] - 2026-07-02
 

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - `search_prts` now resolves redirect-like search results and filters technical
   pages more precisely while preserving the upstream total-hit count.
+- Docker builds retain bundled game and story data archives for offline fallback.
 
 ## [1.7.0] - 2026-07-02
 


### PR DESCRIPTION
## Summary

- Keep the CI-pre-fetched storyjson and gamedata zip archives in the Docker build context.
- Restore offline fallback data copied by the LTS Dockerfiles without changing the 1.7 transport or release workflow.

## Test plan

- Verified the LTS Dockerfiles copy `data/` to `/app/data/` and CI/release workflows prefetch the three archive paths.
- Built a disposable Docker context using the repository `.dockerignore`, all three archive fixtures, and the locally available Node runtime image. Its `COPY data/ data/` layer and in-image assertions verified all three archive paths are present.
- The equivalent official `node:24-alpine` build was also attempted, but the local registry proxy returned HTTP 429 before context processing.
- Python and TypeScript CI jobs pass.

## Remaining work

- This is one of the independent 1.7.1 fixes. The version bump and tags will happen in the final LTS release PR.