### PR TITLE
fix(ci): publish LTS npm releases to dedicated tag

### DIFF
--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -141,7 +141,9 @@ jobs:
             PRERELEASE="${VERSION#*-}"
             echo "value=${PRERELEASE%%.*}" >> $GITHUB_OUTPUT
           else
-            echo "value=latest" >> $GITHUB_OUTPUT
+            # Keep the 1.7 maintenance line separate from the current stable
+            # release line. The latter alone owns npm's `latest` dist-tag.
+            echo "value=lts-1.7" >> $GITHUB_OUTPUT
           fi
 
       - name: Publish to npm (Trusted Publishing)

--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -138,8 +138,8 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#ts/v}"
           if [[ "${VERSION}" == *-* ]]; then
-            PRERELEASE="${VERSION#*-}"
-            echo "value=${PRERELEASE%%.*}" >> $GITHUB_OUTPUT
+            echo "::error::LTS releases must use stable version tags; alpha and beta are reserved for the current release line"
+            exit 1
           else
             # Keep the 1.7 maintenance line separate from the current stable
             # release line. The latter alone owns npm's `latest` dist-tag.

--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -140,6 +140,9 @@ jobs:
           if [[ "${VERSION}" == *-* ]]; then
             echo "::error::LTS releases must use stable version tags; alpha and beta are reserved for the current release line"
             exit 1
+          elif [[ ! "${VERSION}" =~ ^1\.7\.[0-9]+$ ]]; then
+            echo "::error::LTS releases must use a 1.7.x version tag"
+            exit 1
           else
             # Keep the 1.7 maintenance line separate from the current stable
             # release line. The latter alone owns npm's `latest` dist-tag.
@@ -237,4 +240,5 @@ jobs:
           body_path: release_notes.txt
           files: ts/prts-mcp-ts-*.tgz
           prerelease: ${{ steps.version.outputs.prerelease }}
-          make_latest: ${{ steps.version.outputs.prerelease == 'true' && 'false' || 'true' }}
+          # An LTS release never supersedes the current GitHub release line.
+          make_latest: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,6 +46,14 @@ jobs:
           TAG_VERSION="${GITHUB_REF_NAME#python/v}"
           python -c "import importlib.metadata, re, sys; normalize=lambda v: re.sub(r'-(alpha|beta|rc|a|b)\.?', lambda m: {'alpha': 'a', 'beta': 'b'}.get(m.group(1), m.group(1)), v); tag=normalize(sys.argv[1]); pkg=normalize(importlib.metadata.version('prts-mcp')); print(f'Version check passed: {tag}') if tag == pkg else (print(f'::error::Tag version ({tag}) does not match package version ({pkg}) in pyproject.toml'), sys.exit(1))" "$TAG_VERSION"
 
+      - name: Validate LTS release tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#python/v}"
+          if [[ ! "${TAG_VERSION}" =~ ^1\.7\.[0-9]+$ ]]; then
+            echo "::error::LTS releases must use stable 1.7.x version tags"
+            exit 1
+          fi
+
       - name: Verify import and config fallback
         run: |
           mkdir -p .ci-empty/gamedata .ci-empty/storyjson
@@ -195,10 +203,6 @@ jobs:
           VERSION="${{ steps.version.outputs.value }}"
           docker tag prts-mcp:release "${IMAGE}:${VERSION}"
           docker push "${IMAGE}:${VERSION}"
-          if [[ "${{ steps.version.outputs.prerelease }}" != "true" ]]; then
-            docker tag prts-mcp:release "${IMAGE}:latest"
-            docker push "${IMAGE}:latest"
-          fi
 
   github-release:
     runs-on: ubuntu-latest
@@ -249,7 +253,8 @@ jobs:
           body_path: release_notes.txt
           files: python/dist/*
           prerelease: ${{ needs.build-and-push.outputs.prerelease }}
-          make_latest: ${{ needs.build-and-push.outputs.prerelease == 'true' && 'false' || 'true' }}
+          # An LTS release never supersedes the current GitHub release line.
+          make_latest: false
 
   publish-pypi:
     runs-on: ubuntu-latest

--- a/docs/dev/LTS.md
+++ b/docs/dev/LTS.md
@@ -60,7 +60,9 @@ Do not push directly to any long-lived branch. Use PRs.
 
 6. Cherry-pick or reimplement the fix on `dev` when it also applies to 2.0.
 
-If `main` still points to the 1.7 line when the fix ships, merge `lts/1.7` back to `main` or target `main` directly according to the maintainer's release decision. After 2.0 ships, `main` follows 2.0 and `lts/1.7` remains the only 1.7 maintenance branch.
+`main` follows the current stable 2.x release line. Do not merge `lts/1.7`
+back to `main`; cherry-pick or reimplement an applicable fix on the current
+development line instead.
 
 ## 2.0 Boundary
 

--- a/docs/dev/LTS.md
+++ b/docs/dev/LTS.md
@@ -49,6 +49,16 @@ Do not push directly to any long-lived branch. Use PRs.
    git push origin python/v1.7.x ts/v1.7.x
    ```
 
+   The TypeScript CD workflow on `lts/1.7` publishes stable npm releases under
+   the `lts-1.7` dist-tag. `latest` belongs exclusively to the current stable
+   release line on `main`; never move it as part of an LTS release. LTS
+   consumers should install `prts-mcp-ts@lts-1.7` (or a fully pinned version).
+   Before the next LTS release, seed the channel once with the current release:
+
+   ```bash
+   npm dist-tag add prts-mcp-ts@1.7.1 lts-1.7
+   ```
+
 6. Cherry-pick or reimplement the fix on `dev` when it also applies to 2.0.
 
 If `main` still points to the 1.7 line when the fix ships, merge `lts/1.7` back to `main` or target `main` directly according to the maintainer's release decision. After 2.0 ships, `main` follows 2.0 and `lts/1.7` remains the only 1.7 maintenance branch.

--- a/docs/dev/LTS.md
+++ b/docs/dev/LTS.md
@@ -29,9 +29,9 @@ Not allowed in `1.7.x`:
 
 | Branch | Purpose |
 |--------|---------|
-| `main` | Latest stable release line. It is `1.7.0` until 2.0 ships. |
+| `main` | Latest stable release line. Currently 2.x. |
 | `lts/1.7` | Long-term 1.7.x maintenance branch, created from the 1.7.0 release commit. |
-| `dev` | Active 2.0 development after the 1.7.0 LTS release. |
+| `develop` | Active development integration after the 1.7.0 LTS release. |
 
 Do not push directly to any long-lived branch. Use PRs.
 
@@ -58,7 +58,8 @@ Do not push directly to any long-lived branch. Use PRs.
    LTS prerelease tags are not supported: `alpha` and `beta` are reserved for
    the current release line.
 
-6. Cherry-pick or reimplement the fix on `dev` when it also applies to 2.0.
+6. Cherry-pick or reimplement the fix on `develop` when it also applies to the
+   current development line.
 
 `main` follows the current stable 2.x release line. Do not merge `lts/1.7`
 back to `main`; cherry-pick or reimplement an applicable fix on the current

--- a/docs/dev/LTS.md
+++ b/docs/dev/LTS.md
@@ -50,14 +50,13 @@ Do not push directly to any long-lived branch. Use PRs.
    ```
 
    The TypeScript CD workflow on `lts/1.7` publishes stable npm releases under
-   the `lts-1.7` dist-tag. `latest` belongs exclusively to the current stable
-   release line on `main`; never move it as part of an LTS release. LTS
-   consumers should install `prts-mcp-ts@lts-1.7` (or a fully pinned version).
-   Before the next LTS release, seed the channel once with the current release:
-
-   ```bash
-   npm dist-tag add prts-mcp-ts@1.7.1 lts-1.7
-   ```
+   the `lts-1.7` dist-tag. npm's `latest` belongs exclusively to the current
+   stable release line on `main`; never move it as part of an LTS release.
+   LTS consumers should install `prts-mcp-ts@lts-1.7` (or a fully pinned
+   version). The channel is initialized at `1.7.1`; do not move it manually,
+   because each subsequent stable LTS release updates it automatically.
+   LTS prerelease tags are not supported: `alpha` and `beta` are reserved for
+   the current release line.
 
 6. Cherry-pick or reimplement the fix on `dev` when it also applies to 2.0.
 


### PR DESCRIPTION
## Summary
- publish stable 1.7.x TypeScript releases under the dedicated `lts-1.7` npm dist-tag
- reject LTS prerelease and non-1.7 tags so they cannot overwrite Main npm channels
- prevent LTS TypeScript and Python releases from replacing the GitHub latest release or Docker `latest` image
- document the current LTS/Main branch policy and that `lts-1.7` is already initialized

## Test plan
- `git diff --check`
- exercised the TypeScript guard: `1.7.2 -> lts-1.7`; prerelease and non-1.7 tags are rejected
- exercised the Python guard: only stable `1.7.x` tags are accepted
- verified the LTS Python workflow no longer pushes the Docker `latest` tag
- verified npm registry tags: `latest=2.3.1`, `lts-1.7=1.7.1`

## Outstanding
- no release tag is created by this PR; the next real stable 1.7.x release will exercise the new CD route
- one-time external-state repair remains: restore GitHub Releases latest and `ghcr.io/3akhp/prts-mcp:latest` to the current Main 2.3.1 artifact