### PR TITLE
fix(python): cap incompatible mcp sdk major

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- Capped the MCP Python SDK below 2.0 so Docker and other unlocked `pip`
+  installs retain the compatible `mcp.server.fastmcp` API.
+
 ### Added
 
 - Added process-lifetime auto-sync: after the startup check, GameData excel,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "mcp[cli]",
+    "mcp[cli]>=1.28,<2",
     "httpx",
     "pydantic",
     # HTTP transport (PRTS_TRANSPORT=http). These are also transitively

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -442,7 +442,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx" },
-    { name = "mcp", extras = ["cli"] },
+    { name = "mcp", extras = ["cli"], specifier = ">=1.28,<2" },
     { name = "pydantic" },
     { name = "starlette", specifier = ">=0.27" },
     { name = "uvicorn", specifier = ">=0.31" },


### PR DESCRIPTION
## Summary

- constrain the Python MCP SDK to the compatible 1.x API used by `mcp.server.fastmcp`
- keep unlocked Docker and `pip install` environments from resolving the breaking MCP SDK 2.0 release
- refresh the uv lock metadata and document the compatibility fix

## Test plan

- `./scripts/check-runtime.sh --full`
  - Python: 282 passed, 23 skipped
  - TypeScript: 221 passed, 2 skipped
  - build, typecheck, shared-volume sync, and Bun HTTP smoke passed
- rebuilt `python/Dockerfile` without dependency locks; pip resolved `mcp 1.29.0`
- exercised MCP initialize and tools/list against the rebuilt container; all 23 tools were present
- `git diff --check`

## Unfinished work

- MCP SDK 2.x migration is intentionally out of scope for the 2.4.0 release blocker fix.
