### PR TITLE
fix(ci): validate activated package data

### DIFF
--- a/python/scripts/check_package_data.py
+++ b/python/scripts/check_package_data.py
@@ -11,7 +11,11 @@ _SRC_DIR = _PYTHON_DIR / "src"
 if str(_SRC_DIR) not in sys.path:
     sys.path.insert(0, str(_SRC_DIR))
 
+from prts_mcp.config import Config  # noqa: E402
 from prts_mcp.data.datasets import GAMEDATA_EXCEL, GAMEDATA_LEVELS, STORY_ZH_CN  # noqa: E402
+
+
+_EXCEL_ROOT = Path("zh_CN/gamedata/excel")
 
 
 def parse_args() -> argparse.Namespace:
@@ -31,19 +35,40 @@ def main() -> int:
     gamedata_root = data_root / "gamedata"
     levels_root = data_root / "gamedata-levels"
     story_zip = data_root / "storyjson" / STORY_ZH_CN.asset_name
+    config = Config(
+        gamedata_path=gamedata_root,
+        storyjson_zip=story_zip,
+        is_custom_gamedata=True,
+    )
 
-    missing = [path for path in GAMEDATA_EXCEL.required_files if not (gamedata_root / path).is_file()]
+    active_excel = config.effective_excel_path
+    if active_excel is None or not active_excel.is_relative_to(gamedata_root):
+        missing = [gamedata_root / path for path in GAMEDATA_EXCEL.required_files]
+    else:
+        missing = [
+            active_excel / Path(path).relative_to(_EXCEL_ROOT)
+            for path in GAMEDATA_EXCEL.required_files
+            if not (active_excel / Path(path).relative_to(_EXCEL_ROOT)).is_file()
+        ]
     if missing:
         print("Missing bundled gamedata files:", file=sys.stderr)
         for path in missing:
-            print(f" - {gamedata_root / path}", file=sys.stderr)
+            print(f" - {path}", file=sys.stderr)
         return 1
 
-    missing_levels = [path for path in GAMEDATA_LEVELS.required_files if not (levels_root / path).is_file()]
+    active_levels = config.effective_levels_path
+    if active_levels is None or not active_levels.is_relative_to(levels_root):
+        missing_levels = [levels_root / path for path in GAMEDATA_LEVELS.required_files]
+    else:
+        missing_levels = [
+            active_levels / path
+            for path in GAMEDATA_LEVELS.required_files
+            if not (active_levels / path).is_file()
+        ]
     if missing_levels:
         print("Missing bundled level data files:", file=sys.stderr)
         for path in missing_levels:
-            print(f" - {levels_root / path}", file=sys.stderr)
+            print(f" - {path}", file=sys.stderr)
         return 1
 
     if not story_zip.is_file():

--- a/python/scripts/check_package_data.py
+++ b/python/scripts/check_package_data.py
@@ -35,6 +35,13 @@ def main() -> int:
     gamedata_root = data_root / "gamedata"
     levels_root = data_root / "gamedata-levels"
     story_zip = data_root / "storyjson" / STORY_ZH_CN.asset_name
+    for label, root in (
+        ("Bundled gamedata", gamedata_root),
+        ("Bundled level data", levels_root),
+    ):
+        if not root.resolve().is_relative_to(data_root):
+            print(f"{label} resolves outside package root: {root}", file=sys.stderr)
+            return 1
     config = Config(
         gamedata_path=gamedata_root,
         storyjson_zip=story_zip,

--- a/python/scripts/check_package_data.py
+++ b/python/scripts/check_package_data.py
@@ -42,8 +42,14 @@ def main() -> int:
     )
 
     active_excel = config.effective_excel_path
-    if active_excel is None or not active_excel.is_relative_to(gamedata_root):
+    if active_excel is None:
         missing = [gamedata_root / path for path in GAMEDATA_EXCEL.required_files]
+    elif not active_excel.resolve().is_relative_to(gamedata_root.resolve()):
+        print(
+            f"Bundled gamedata resolves outside package root: {active_excel}",
+            file=sys.stderr,
+        )
+        return 1
     else:
         missing = [
             active_excel / Path(path).relative_to(_EXCEL_ROOT)
@@ -57,8 +63,14 @@ def main() -> int:
         return 1
 
     active_levels = config.effective_levels_path
-    if active_levels is None or not active_levels.is_relative_to(levels_root):
+    if active_levels is None:
         missing_levels = [levels_root / path for path in GAMEDATA_LEVELS.required_files]
+    elif not active_levels.resolve().is_relative_to(levels_root.resolve()):
+        print(
+            f"Bundled level data resolves outside package root: {active_levels}",
+            file=sys.stderr,
+        )
+        return 1
     else:
         missing_levels = [
             active_levels / path

--- a/python/src/prts_mcp/config.py
+++ b/python/src/prts_mcp/config.py
@@ -273,10 +273,24 @@ class Config:
         )
         active_ep = _excel_path(active_gamedata_root)
 
-        bep = _excel_path(_BUNDLED_GAMEDATA_PATH)
+        bundled_pair = _activated_pair(
+            _BUNDLED_GAMEDATA_PATH,
+            _BUNDLED_LEVELS_PATH,
+        )
+        bundled_gamedata_root = (
+            bundled_pair[0]
+            if bundled_pair is not None
+            else _activated_root(_BUNDLED_GAMEDATA_PATH)
+        )
+        bundled_levels_root = (
+            bundled_pair[1]
+            if bundled_pair is not None
+            else _activated_root(_BUNDLED_LEVELS_PATH)
+        )
+        bep = _excel_path(bundled_gamedata_root)
         object.__setattr__(self, "bundled_excel_path", bep)
 
-        blp = _BUNDLED_LEVELS_PATH
+        blp = bundled_levels_root
         object.__setattr__(self, "bundled_levels_path", blp)
 
         # effective_excel_path: the path operator.py should actually read from.

--- a/python/tests/test_check_package_data.py
+++ b/python/tests/test_check_package_data.py
@@ -9,6 +9,24 @@ from zipfile import ZipFile
 from prts_mcp.data.datasets import GAMEDATA_EXCEL, GAMEDATA_LEVELS
 
 
+def _write_story_zip(data_root: Path) -> None:
+    story_zip = data_root / "storyjson" / "zh_CN.zip"
+    story_zip.parent.mkdir()
+    with ZipFile(story_zip, "w") as archive:
+        archive.writestr("zh_CN/gamedata/excel/story_review_table.json", "{}")
+        archive.writestr("zh_CN/storyinfo.json", "{}")
+
+
+def _run_package_check(data_root: Path) -> subprocess.CompletedProcess[str]:
+    script = Path(__file__).resolve().parents[1] / "scripts" / "check_package_data.py"
+    return subprocess.run(
+        [sys.executable, str(script), "--data-root", str(data_root)],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
 def test_package_check_follows_active_gamedata_generations(tmp_path: Path) -> None:
     excel_root = tmp_path / "gamedata"
     levels_root = tmp_path / "gamedata-levels"
@@ -35,19 +53,35 @@ def test_package_check_follows_active_gamedata_generations(tmp_path: Path) -> No
             encoding="utf-8",
         )
 
-    story_zip = tmp_path / "storyjson" / "zh_CN.zip"
-    story_zip.parent.mkdir()
-    with ZipFile(story_zip, "w") as archive:
-        archive.writestr("zh_CN/gamedata/excel/story_review_table.json", "{}")
-        archive.writestr("zh_CN/storyinfo.json", "{}")
-
-    script = Path(__file__).resolve().parents[1] / "scripts" / "check_package_data.py"
-    result = subprocess.run(
-        [sys.executable, str(script), "--data-root", str(tmp_path)],
-        capture_output=True,
-        check=False,
-        text=True,
-    )
+    _write_story_zip(tmp_path)
+    result = _run_package_check(tmp_path)
 
     assert result.returncode == 0, result.stderr
     assert "Package data check passed" in result.stdout
+
+
+def test_package_check_rejects_symlinked_external_data(tmp_path: Path) -> None:
+    external = tmp_path / "external"
+    external_excel = external / "excel"
+    external_levels = external / "levels"
+    external_excel.mkdir(parents=True)
+    for relative_path in GAMEDATA_EXCEL.required_files:
+        (external_excel / Path(relative_path).name).write_text("{}", encoding="utf-8")
+    for relative_path in GAMEDATA_LEVELS.required_files:
+        path = external_levels / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}", encoding="utf-8")
+
+    data_root = tmp_path / "package"
+    excel_link = data_root / "gamedata" / "zh_CN" / "gamedata" / "excel"
+    excel_link.parent.mkdir(parents=True)
+    excel_link.symlink_to(external_excel, target_is_directory=True)
+    levels_link = data_root / "gamedata-levels"
+    levels_link.parent.mkdir(parents=True, exist_ok=True)
+    levels_link.symlink_to(external_levels, target_is_directory=True)
+    _write_story_zip(data_root)
+
+    result = _run_package_check(data_root)
+
+    assert result.returncode == 1
+    assert "resolves outside package root" in result.stderr

--- a/python/tests/test_check_package_data.py
+++ b/python/tests/test_check_package_data.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from zipfile import ZipFile
 
+import pytest
+
 from prts_mcp.data.datasets import GAMEDATA_EXCEL, GAMEDATA_LEVELS
 
 
@@ -60,25 +62,36 @@ def test_package_check_follows_active_gamedata_generations(tmp_path: Path) -> No
     assert "Package data check passed" in result.stdout
 
 
-def test_package_check_rejects_symlinked_external_data(tmp_path: Path) -> None:
-    external = tmp_path / "external"
-    external_excel = external / "excel"
-    external_levels = external / "levels"
-    external_excel.mkdir(parents=True)
+def _write_gamedata(gamedata_root: Path, levels_root: Path) -> None:
     for relative_path in GAMEDATA_EXCEL.required_files:
-        (external_excel / Path(relative_path).name).write_text("{}", encoding="utf-8")
+        path = gamedata_root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}", encoding="utf-8")
     for relative_path in GAMEDATA_LEVELS.required_files:
-        path = external_levels / relative_path
+        path = levels_root / relative_path
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("{}", encoding="utf-8")
 
+
+@pytest.mark.parametrize("escaped_root", ["gamedata", "gamedata-levels"])
+def test_package_check_rejects_symlinked_external_data(
+    tmp_path: Path,
+    escaped_root: str,
+) -> None:
     data_root = tmp_path / "package"
-    excel_link = data_root / "gamedata" / "zh_CN" / "gamedata" / "excel"
-    excel_link.parent.mkdir(parents=True)
-    excel_link.symlink_to(external_excel, target_is_directory=True)
-    levels_link = data_root / "gamedata-levels"
-    levels_link.parent.mkdir(parents=True, exist_ok=True)
-    levels_link.symlink_to(external_levels, target_is_directory=True)
+    external_root = tmp_path / "external" / escaped_root
+    gamedata_root = (
+        external_root if escaped_root == "gamedata" else data_root / "gamedata"
+    )
+    levels_root = (
+        external_root
+        if escaped_root == "gamedata-levels"
+        else data_root / "gamedata-levels"
+    )
+    _write_gamedata(gamedata_root, levels_root)
+    linked_root = data_root / escaped_root
+    linked_root.parent.mkdir(parents=True, exist_ok=True)
+    linked_root.symlink_to(external_root, target_is_directory=True)
     _write_story_zip(data_root)
 
     result = _run_package_check(data_root)

--- a/python/tests/test_check_package_data.py
+++ b/python/tests/test_check_package_data.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from zipfile import ZipFile
+
+from prts_mcp.data.datasets import GAMEDATA_EXCEL, GAMEDATA_LEVELS
+
+
+def test_package_check_follows_active_gamedata_generations(tmp_path: Path) -> None:
+    excel_root = tmp_path / "gamedata"
+    levels_root = tmp_path / "gamedata-levels"
+    excel_generation = excel_root / ".releases" / "excel-generation"
+    levels_generation = levels_root / ".releases" / "levels-generation"
+
+    for relative_path in GAMEDATA_EXCEL.required_files:
+        path = excel_generation / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}", encoding="utf-8")
+    for relative_path in GAMEDATA_LEVELS.required_files:
+        path = levels_generation / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{}", encoding="utf-8")
+
+    for root, data_root in (
+        (excel_root, ".releases/excel-generation"),
+        (levels_root, ".releases/levels-generation"),
+    ):
+        archives = root / "archives"
+        archives.mkdir(parents=True)
+        (archives / "extract_meta.json").write_text(
+            json.dumps({"commit_sha": "test-sha", "data_root": data_root}),
+            encoding="utf-8",
+        )
+
+    story_zip = tmp_path / "storyjson" / "zh_CN.zip"
+    story_zip.parent.mkdir()
+    with ZipFile(story_zip, "w") as archive:
+        archive.writestr("zh_CN/gamedata/excel/story_review_table.json", "{}")
+        archive.writestr("zh_CN/storyinfo.json", "{}")
+
+    script = Path(__file__).resolve().parents[1] / "scripts" / "check_package_data.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--data-root", str(tmp_path)],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Package data check passed" in result.stdout

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -99,6 +99,57 @@ class TestActivatedDataRoot:
         assert cfg.excel_path == root / "zh_CN" / "gamedata" / "excel"
         assert cfg.effective_excel_path == excel
 
+    def test_bundled_fallback_uses_activated_release(self, tmp_path):
+        runtime_root = tmp_path / "runtime" / "gamedata"
+        bundled_gamedata = tmp_path / "bundle" / "gamedata"
+        bundled_levels = tmp_path / "bundle" / "gamedata-levels"
+        excel_generation = bundled_gamedata / ".releases" / "bundled"
+        levels_generation = bundled_levels / ".releases" / "bundled"
+        excel = excel_generation / "zh_CN" / "gamedata" / "excel"
+        excel.mkdir(parents=True)
+        for name in config_module._REQUIRED_OPERATOR_FILES:
+            (excel / name).write_text("{}", encoding="utf-8")
+        enemy_db = (
+            levels_generation
+            / "zh_CN"
+            / "gamedata"
+            / "levels"
+            / "enemydata"
+            / "enemy_database.json"
+        )
+        enemy_db.parent.mkdir(parents=True)
+        enemy_db.write_text("{}", encoding="utf-8")
+        for root in (bundled_gamedata, bundled_levels):
+            archives = root / "archives"
+            archives.mkdir()
+            (archives / "extract_meta.json").write_text(
+                json.dumps({
+                    "commit_sha": "bundled",
+                    "data_root": ".releases/bundled",
+                }),
+                encoding="utf-8",
+            )
+
+        with (
+            patch.dict(os.environ, {"GAMEDATA_PATH": str(runtime_root)}),
+            patch.object(
+                config_module,
+                "_BUNDLED_GAMEDATA_PATH",
+                bundled_gamedata,
+            ),
+            patch.object(
+                config_module,
+                "_BUNDLED_LEVELS_PATH",
+                bundled_levels,
+            ),
+        ):
+            cfg = Config.load()
+
+        assert cfg.bundled_excel_path == excel
+        assert cfg.bundled_levels_path == levels_generation
+        assert cfg.effective_excel_path == excel
+        assert cfg.effective_levels_path == levels_generation
+
     def test_pair_manifest_hides_partially_activated_generation(self, tmp_path):
         gamedata = tmp_path / "gamedata"
         levels = tmp_path / "gamedata-levels"

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -285,8 +285,10 @@ export function loadConfig(): Config {
   const lp = resolveLevelsPath(gamedataPath);
   const pair = activatedPair(gamedataPath, lp);
   const activeEp = excelPath(pair?.[0] ?? activatedRoot(gamedataPath));
-  const bep = excelPath(BUNDLED_GAMEDATA_PATH);
-  const blp = BUNDLED_LEVELS_PATH;
+  const bundledPair = activatedPair(BUNDLED_GAMEDATA_PATH, BUNDLED_LEVELS_PATH);
+  const bundledGamedataRoot = bundledPair?.[0] ?? activatedRoot(BUNDLED_GAMEDATA_PATH);
+  const bep = excelPath(bundledGamedataRoot);
+  const blp = bundledPair?.[1] ?? activatedRoot(BUNDLED_LEVELS_PATH);
 
   let effectiveExcelPath: string | null = null;
   if (filesComplete(activeEp)) effectiveExcelPath = activeEp;

--- a/ts/tests/config.test.ts
+++ b/ts/tests/config.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  copyFileSync,
   mkdirSync,
   mkdtempSync,
   renameSync,
@@ -9,6 +10,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 async function loadConfigModule(): Promise<typeof import("../src/config.js")> {
   return import(`../src/config.ts?cacheBust=${Date.now()}-${Math.random()}`);
@@ -87,6 +89,58 @@ test("effective excel path uses the activated release tree", async () => {
 
     assert.equal(cfg.excelPath, join(custom, "zh_CN", "gamedata", "excel"));
     assert.equal(cfg.effectiveExcelPath, excel);
+  } finally {
+    delete process.env["GAMEDATA_PATH"];
+  }
+});
+
+test("bundled fallback uses activated release trees", async () => {
+  const packageRoot = tempRoot();
+  const copiedSource = join(packageRoot, "src", "config.ts");
+  mkdirSync(join(packageRoot, "src"), { recursive: true });
+  copyFileSync(fileURLToPath(new URL("../src/config.ts", import.meta.url)), copiedSource);
+
+  const bundledGamedata = join(packageRoot, "data", "gamedata");
+  const bundledLevels = join(packageRoot, "data", "gamedata-levels");
+  const excelGeneration = join(bundledGamedata, ".releases", "bundled");
+  const levelsGeneration = join(bundledLevels, ".releases", "bundled");
+  const excel = join(excelGeneration, "zh_CN", "gamedata", "excel");
+  mkdirSync(excel, { recursive: true });
+  for (const name of [
+    "character_table.json",
+    "handbook_info_table.json",
+    "charword_table.json",
+    "story_review_table.json",
+  ]) writeFileSync(join(excel, name), "{}", "utf-8");
+  const enemyDir = join(
+    levelsGeneration,
+    "zh_CN",
+    "gamedata",
+    "levels",
+    "enemydata",
+  );
+  mkdirSync(enemyDir, { recursive: true });
+  writeFileSync(join(enemyDir, "enemy_database.json"), "{}", "utf-8");
+  for (const root of [bundledGamedata, bundledLevels]) {
+    const archives = join(root, "archives");
+    mkdirSync(archives);
+    writeFileSync(join(archives, "extract_meta.json"), JSON.stringify({
+      commit_sha: "bundled",
+      data_root: ".releases/bundled",
+    }), "utf-8");
+  }
+
+  process.env["GAMEDATA_PATH"] = join(packageRoot, "runtime", "gamedata");
+  try {
+    const copiedModule = await import(
+      `${pathToFileURL(copiedSource).href}?cacheBust=${Date.now()}-${Math.random()}`
+    ) as typeof import("../src/config.js");
+    const cfg = copiedModule.loadConfig();
+
+    assert.equal(cfg.bundledExcelPath, excel);
+    assert.equal(cfg.bundledLevelsPath, levelsGeneration);
+    assert.equal(cfg.effectiveExcelPath, excel);
+    assert.equal(cfg.effectiveLevelsPath, levelsGeneration);
   } finally {
     delete process.env["GAMEDATA_PATH"];
   }


### PR DESCRIPTION
## Summary

- make the release package-data gate resolve Auto-Sync's active GameData generations
- reject fallback data outside the package root so missing release data cannot pass accidentally
- cover generation-backed Excel and levels package validation

## Test plan

- `uv run --directory python --locked python -m pytest tests/test_check_package_data.py -q`
- fresh-fetch `zh_CN-excel.zip` and `zh_CN-levels.zip` into an empty temporary data root, then run `check_package_data.py`
- `./scripts/check-runtime.sh --full`
  - Python: 283 passed, 23 skipped
  - TypeScript: 221 passed, 2 skipped
  - TypeScript build/typecheck, shared-volume sync, and Bun HTTP smoke passed
- `git diff --check`

## Release recovery

The first `python/v2.4.0` and `ts/v2.4.0` CD runs stopped before publishing any package, image, or GitHub Release. After this PR merges, both unpublished tags will be repointed to the new `main` merge commit and the tag-driven CD runs will be verified end to end.
