### PR TITLE
feat(sync): switch data source to arknights-data-pipeline factory repo

### DIFF
--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -130,7 +130,7 @@ jobs:
         run: |
           mkdir -p ts/data/storyjson
           gh release download \
-            --repo 3aKHP/ArknightsStoryJson \
+            --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
             --dir ts/data/storyjson/ \
             --clobber
@@ -189,7 +189,7 @@ jobs:
         run: |
           mkdir -p ts/data/storyjson
           gh release download \
-            --repo 3aKHP/ArknightsStoryJson \
+            --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
             --dir ts/data/storyjson/ \
             --clobber

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           mkdir -p .ci-data/storyjson
           gh release download \
-            --repo 3aKHP/ArknightsStoryJson \
+            --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
             --dir .ci-data/storyjson/ \
             --clobber
@@ -114,7 +114,7 @@ jobs:
         run: |
           mkdir -p data/storyjson
           gh release download \
-            --repo 3aKHP/ArknightsStoryJson \
+            --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
             --dir data/storyjson/ \
             --clobber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           mkdir -p .ci-data/storyjson
           gh release download \
-            --repo 3aKHP/ArknightsStoryJson \
+            --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
             --dir .ci-data/storyjson/ \
             --clobber
@@ -122,7 +122,7 @@ jobs:
         run: |
           mkdir -p data/storyjson
           gh release download \
-            --repo 3aKHP/ArknightsStoryJson \
+            --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
             --dir data/storyjson/ \
             --clobber
@@ -361,7 +361,7 @@ jobs:
         run: |
           mkdir -p data/storyjson
           gh release download \
-            --repo 3aKHP/ArknightsStoryJson \
+            --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
             --dir data/storyjson/ \
             --clobber
@@ -426,7 +426,7 @@ jobs:
         run: |
           mkdir -p data/storyjson
           gh release download \
-            --repo 3aKHP/ArknightsStoryJson \
+            --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
             --dir data/storyjson/ \
             --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,8 @@ data/gamedata-levels/archives/
 data/gamedata-levels/**/*.zip
 data/gamedata-levels/**/*.7z
 .release.lock/
+
+# Runtime sync artifacts
+data/*/.releases/
+data/*/release_meta.json
+data/*/zh_CN*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ data/gamedata/**/*.7z
 data/gamedata-levels/archives/
 data/gamedata-levels/**/*.zip
 data/gamedata-levels/**/*.7z
+.release.lock/

--- a/README.md
+++ b/README.md
@@ -111,8 +111,7 @@ runtime-agnostic).
 ### Data Sources
 
 - **PRTS Wiki API** (`https://prts.wiki/api.php`) — lore articles, faction info, world-building entries
-- **ArknightsGameData** ([`3aKHP/ArknightsGameData`](https://github.com/3aKHP/ArknightsGameData)) — Release archive mirror of [`Kengxxiao/ArknightsGameData`](https://github.com/Kengxxiao/ArknightsGameData), used for operator archives, voice lines, base stats, enemies, stages, items, and level combat data (`zh_CN-excel.zip` + `zh_CN-levels.zip`)
-- **ArknightsStoryJson** ([`3aKHP/ArknightsStoryJson`](https://github.com/3aKHP/ArknightsStoryJson)) — parsed story dialogue, auto-synced from GitHub Releases (`zh_CN.zip`)
+- **arknights-data-pipeline** ([`3aKHP/arknights-data-pipeline`](https://github.com/3aKHP/arknights-data-pipeline)) — self-hosted data factory producing game data tables (`zh_CN-excel.zip`), level combat data (`zh_CN-levels.zip`), and parsed story dialogue with LLM summaries (`zh_CN.zip`) from a single GitHub Release
 
 Game data lives in the `gamedata` volume. Level combat data lives in the `gamedata-levels` volume. Story data lives in the `storyjson` volume. After the server starts listening, all three are checked in the background immediately and then every hour without restarting the process. Set `PRTS_AUTO_SYNC_INTERVAL_SECONDS` to `60..604800` to change the interval, or `0` to keep startup sync only.
 
@@ -219,8 +218,7 @@ TypeScript 实现支持 Bun 与 Node.js。自 2.2.0 起 **Bun 是默认生产运
 
 - **PRTS Wiki API** (`https://prts.wiki/api.php`) — 世界观词条、阵营设定
 - **ArknightsGameData** ([`3aKHP/ArknightsGameData`](https://github.com/3aKHP/ArknightsGameData)) — [`Kengxxiao/ArknightsGameData`](https://github.com/Kengxxiao/ArknightsGameData) 的 Release 压缩包镜像，用于干员档案、语音记录、基础信息、敌人、关卡、物品和关卡战斗数据（`zh_CN-excel.zip` + `zh_CN-levels.zip`）
-- **ArknightsStoryJson** ([`3aKHP/ArknightsStoryJson`](https://github.com/3aKHP/ArknightsStoryJson)) — 剧情台词解析数据，从 GitHub Releases 自动同步（`zh_CN.zip`）
-
+- **arknights-data-pipeline** ([`3aKHP/arknights-data-pipeline`](https://github.com/3aKHP/arknights-data-pipeline)) — 自建数据工厂，从单一 GitHub Release 产出游戏数据表（`zh_CN-excel.zip`）、关卡战斗数据（`zh_CN-levels.zip`）和剧情台词解析+LLM 摘要（`zh_CN.zip`）
 干员/表格数据存放在 `gamedata` volume，关卡战斗数据存放在 `gamedata-levels` volume，剧情数据存放在 `storyjson` volume。服务器开始监听后会立即在后台检查，此后默认每小时检查一次，无需重启进程。可用 `PRTS_AUTO_SYNC_INTERVAL_SECONDS=60..604800` 调整周期，或设为 `0` 仅保留启动同步。
 
 正式发布的 Docker 镜像和 npm 包会由 CI 预置 bundled 兜底数据；PyPI 包保持轻量，不内置这些数据文件，依赖启动时 auto-sync 或用户自行提供数据路径。

--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ TypeScript 实现支持 Bun 与 Node.js。自 2.2.0 起 **Bun 是默认生产运
 ### 数据源
 
 - **PRTS Wiki API** (`https://prts.wiki/api.php`) — 世界观词条、阵营设定
-- **ArknightsGameData** ([`3aKHP/ArknightsGameData`](https://github.com/3aKHP/ArknightsGameData)) — [`Kengxxiao/ArknightsGameData`](https://github.com/Kengxxiao/ArknightsGameData) 的 Release 压缩包镜像，用于干员档案、语音记录、基础信息、敌人、关卡、物品和关卡战斗数据（`zh_CN-excel.zip` + `zh_CN-levels.zip`）
 - **arknights-data-pipeline** ([`3aKHP/arknights-data-pipeline`](https://github.com/3aKHP/arknights-data-pipeline)) — 自建数据工厂，从单一 GitHub Release 产出游戏数据表（`zh_CN-excel.zip`）、关卡战斗数据（`zh_CN-levels.zip`）和剧情台词解析+LLM 摘要（`zh_CN.zip`）
+
 干员/表格数据存放在 `gamedata` volume，关卡战斗数据存放在 `gamedata-levels` volume，剧情数据存放在 `storyjson` volume。服务器开始监听后会立即在后台检查，此后默认每小时检查一次，无需重启进程。可用 `PRTS_AUTO_SYNC_INTERVAL_SECONDS=60..604800` 调整周期，或设为 `0` 仅保留启动同步。
 
 正式发布的 Docker 镜像和 npm 包会由 CI 预置 bundled 兜底数据；PyPI 包保持轻量，不内置这些数据文件，依赖启动时 auto-sync 或用户自行提供数据路径。

--- a/STATUS.md
+++ b/STATUS.md
@@ -122,9 +122,9 @@ PRTS-MCP/
 
 | 数据源 | 用途 | 同步方式 |
 |--------|------|----------|
-| [ArknightsGameData](https://github.com/3aKHP/ArknightsGameData) | 干员/敌人/关卡/物品表格 | GitHub Release `zh_CN-excel.zip` |
-| [ArknightsGameData](https://github.com/3aKHP/ArknightsGameData) | 关卡实际出怪与关卡级敌人数值 | GitHub Release `zh_CN-levels.zip` |
-| [ArknightsStoryJson](https://github.com/3aKHP/ArknightsStoryJson) | 剧情台词 | GitHub Release `zh_CN.zip` |
+| [arknights-data-pipeline](https://github.com/3aKHP/arknights-data-pipeline) | 干员/敌人/关卡/物品表格 | GitHub Release `zh_CN-excel.zip` |
+| [arknights-data-pipeline](https://github.com/3aKHP/arknights-data-pipeline) | 关卡实际出怪与关卡级敌人数值 | GitHub Release `zh_CN-levels.zip` |
+| [arknights-data-pipeline](https://github.com/3aKHP/arknights-data-pipeline) | 剧情台词 + LLM 摘要 | GitHub Release `zh_CN.zip` |
 | [PRTS Wiki API](https://prts.wiki/api.php) | 世界观词条/阵营设定 | 实时 HTTP 请求 |
 
 ## 工具清单 (23, 2.0 发布线)

--- a/python/README.md
+++ b/python/README.md
@@ -61,9 +61,9 @@ GAMEDATA_PATH=/path/to/ArknightsGameData prts-mcp
 
 服务器启动时会立即在后台同步三类数据，此后默认每小时检查一次新 Release，无需重启进程：
 
-- **游戏表格数据**（`gamedata` volume）：从 [3aKHP/ArknightsGameData](https://github.com/3aKHP/ArknightsGameData) Release 下载 `zh_CN-excel.zip`，其内容同步自 [Kengxxiao/ArknightsGameData](https://github.com/Kengxxiao/ArknightsGameData)
+- **游戏表格数据**（`gamedata` volume）：从 [3aKHP/arknights-data-pipeline](https://github.com/3aKHP/arknights-data-pipeline) Release 下载 `zh_CN-excel.zip` 和 `zh_CN-levels.zip`
 - **关卡战斗数据**（`gamedata-levels` volume）：从同一 Release 下载 `zh_CN-levels.zip`，用于关卡实际出怪和关卡级敌人数值
-- **剧情数据**（`storyjson` volume）：从 [ArknightsStoryJson](https://github.com/3aKHP/ArknightsStoryJson) Releases 下载 `zh_CN.zip`
+- **剧情数据**（`storyjson` volume）：从同一 Release 下载 `zh_CN.zip`（含剧情 JSON 和 LLM 摘要）
 
 镜像内置 bundled 数据作为网络不可用时的离线保底。
 

--- a/python/docs/deployment.md
+++ b/python/docs/deployment.md
@@ -30,7 +30,7 @@ docker build -t prts-mcp .
 docker run -i --rm -v prts-mcp-data:/data/gamedata -v prts-mcp-levels:/data/gamedata-levels -v prts-mcp-storyjson:/data/storyjson prts-mcp
 ```
 
-Named volume 由 Docker 自动管理，无需关心宿主机路径，**在所有平台和所有 MCP 客户端配置里都能直接使用**。首次运行时 auto-sync 自动下载 `3aKHP/ArknightsGameData` 的 `zh_CN-excel.zip` 到 `/data/gamedata`、`zh_CN-levels.zip` 到 `/data/gamedata-levels`，以及剧情 `zh_CN.zip` 到 `/data/storyjson`；此后默认每小时检查一次 Release tag，有更新才重新下载、解压并清除进程内数据缓存，无需重启服务。
+Named volume 由 Docker 自动管理，无需关心宿主机路径，**在所有平台和所有 MCP 客户端配置里都能直接使用**。首次运行时 auto-sync 自动从 `3aKHP/arknights-data-pipeline` 下载 `zh_CN-excel.zip` 到 `/data/gamedata`、`zh_CN-levels.zip` 到 `/data/gamedata-levels`，以及剧情 `zh_CN.zip` 到 `/data/storyjson`；此后默认每小时检查一次 Release tag，有更新才重新下载、解压并清除进程内数据缓存，无需重启服务。
 
 > 如需降低 GitHub 匿名 API 限流风险，可追加 `-e GITHUB_TOKEN=ghp_xxx`。
 

--- a/python/docs/deployment.md
+++ b/python/docs/deployment.md
@@ -220,7 +220,7 @@ npx @modelcontextprotocol/inspector docker run -i --rm -v prts-mcp-data:/data/ga
 pip install -e .
 python scripts/fetch_gamedata.py
 mkdir -p ../data/storyjson
-gh release download --repo 3aKHP/ArknightsStoryJson --pattern "zh_CN.zip" --dir ../data/storyjson/ --clobber
+gh release download --repo 3aKHP/arknights-data-pipeline --pattern "zh_CN.zip" --dir ../data/storyjson/ --clobber
 docker build -t prts-mcp .
 ```
 

--- a/python/scripts/fetch_gamedata.py
+++ b/python/scripts/fetch_gamedata.py
@@ -40,7 +40,7 @@ _logger = logging.getLogger(__name__)
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Fetch the latest ArknightsGameData excel and levels archives from GitHub Releases."
+        description="Fetch the latest game data excel and levels archives from GitHub Releases."
     )
     parser.add_argument(
         "--force",

--- a/python/src/prts_mcp/data/datasets.py
+++ b/python/src/prts_mcp/data/datasets.py
@@ -88,7 +88,7 @@ def validate_storyjson_zip(zf: ZipFile) -> list[str]:
 GAMEDATA_EXCEL = ReleaseDatasetSpec(
     dataset_id="gamedata.excel",
     owner="3aKHP",
-    repo="ArknightsGameData",
+    repo="arknights-data-pipeline",
     asset_name="zh_CN-excel.zip",
     required_files=GAMEDATA_FILES,
 )
@@ -96,7 +96,7 @@ GAMEDATA_EXCEL = ReleaseDatasetSpec(
 STORY_ZH_CN = ReleaseDatasetSpec(
     dataset_id="story.zh_CN",
     owner="3aKHP",
-    repo="ArknightsStoryJson",
+    repo="arknights-data-pipeline",
     asset_name="zh_CN.zip",
     required_files=STORYJSON_REQUIRED_FILES,
 )
@@ -104,7 +104,7 @@ STORY_ZH_CN = ReleaseDatasetSpec(
 GAMEDATA_LEVELS = ReleaseDatasetSpec(
     dataset_id="gamedata.levels",
     owner="3aKHP",
-    repo="ArknightsGameData",
+    repo="arknights-data-pipeline",
     asset_name="zh_CN-levels.zip",
     required_files=LEVELS_REQUIRED_FILES,
 )

--- a/python/src/prts_mcp/data/operator.py
+++ b/python/src/prts_mcp/data/operator.py
@@ -50,7 +50,7 @@ def _load_json(filename: str) -> dict[str, Any]:
     if not store.exists(filename):
         raise FileNotFoundError(
             f"干员数据文件不存在：{store.root / filename}。"
-            "数据目录可能为空，或挂载路径有误（GAMEDATA_PATH 应指向 ArknightsGameData 仓库根目录）。"
+            "数据目录可能为空，或挂载路径有误（GAMEDATA_PATH 应指向游戏数据根目录）。"
         )
     return store.read_json(filename)
 

--- a/python/src/prts_mcp/data/sync.py
+++ b/python/src/prts_mcp/data/sync.py
@@ -269,7 +269,7 @@ def download_release_asset(spec: ReleaseSpec, tag: str, url: str, timeout: float
                 raise ValueError("Downloaded release asset is invalid: " + "; ".join(missing[:10]))
         tmp.replace(spec.local_zip)
 
-        # Extract upstream SHA from tag (format: "upstream-<sha>")
+        # Extract version identifier from tag (format: "data-<versionId>")
         commit_sha = tag[len(_TAG_PREFIX):] if tag.startswith(_TAG_PREFIX) else tag
         CacheMeta(
             repo=f"{spec.owner}/{spec.repo}",

--- a/python/src/prts_mcp/data/sync.py
+++ b/python/src/prts_mcp/data/sync.py
@@ -202,7 +202,7 @@ def _cache_is_fresh(cache: CacheMeta) -> bool:
 # ---------------------------------------------------------------------------
 
 _GITHUB_RELEASES_LATEST_URL = "https://api.github.com/repos/{owner}/{repo}/releases/latest"
-_TAG_PREFIX = "upstream-"
+_TAG_PREFIX = "data-"
 
 
 @dataclass(frozen=True)

--- a/python/tests/test_sync_release.py
+++ b/python/tests/test_sync_release.py
@@ -33,7 +33,7 @@ from prts_mcp.data.sync import (
 def _make_spec(tmp_path: Path) -> ReleaseSpec:
     return ReleaseSpec(
         owner="3aKHP",
-        repo="ArknightsStoryJson",
+        repo="arknights-data-pipeline",
         asset_name="zh_CN.zip",
         local_zip=tmp_path / "storyjson" / "zh_CN.zip",
     )
@@ -76,7 +76,7 @@ def _active_archive_root(spec: ReleaseArchiveSpec) -> Path:
 class TestCheckLatestRelease:
     def test_returns_tag_and_url(self, tmp_path):
         spec = _make_spec(tmp_path)
-        tag = "upstream-abc123"
+        tag = "data-abc123"
         url = "https://github.com/example/release/zh_CN.zip"
 
         with patch("httpx.get", return_value=_mock_release_response(tag, "zh_CN.zip", url)):
@@ -86,7 +86,7 @@ class TestCheckLatestRelease:
 
     def test_asset_not_found_returns_none(self, tmp_path):
         spec = _make_spec(tmp_path)
-        with patch("httpx.get", return_value=_mock_release_response("upstream-abc", "other.zip", "http://x")):
+        with patch("httpx.get", return_value=_mock_release_response("data-abc", "other.zip", "http://x")):
             result = check_latest_release(spec)
         assert result is None
 
@@ -139,7 +139,7 @@ class TestSyncRelease:
         _write_zip(spec.local_zip)
         (spec.local_zip.parent / "release_meta.json").write_text(
             json.dumps({
-                "repo": "3aKHP/ArknightsStoryJson",
+                "repo": "3aKHP/arknights-data-pipeline",
                 "branch": "releases",
                 "commitSha": "same-sha",
                 "fetchedAt": "2099-01-01T00:00:00.000Z",
@@ -172,7 +172,7 @@ class TestSyncRelease:
         _write_zip(spec.local_zip)
         (spec.local_zip.parent / "release_meta.json").write_text(
             json.dumps({
-                "repo": "3aKHP/ArknightsStoryJson",
+                "repo": "3aKHP/arknights-data-pipeline",
                 "branch": "releases",
                 "commit_sha": commit_sha,
                 "fetched_at": fetched_at,
@@ -193,7 +193,7 @@ class TestSyncRelease:
 
     def test_updated_when_new_tag(self, tmp_path):
         spec = _make_spec(tmp_path)
-        tag = "upstream-newsha1234"
+        tag = "data-newsha1234"
         asset_url = "https://example.com/zh_CN.zip"
 
         with (
@@ -210,14 +210,14 @@ class TestSyncRelease:
     def test_up_to_date_when_sha_matches(self, tmp_path):
         spec = _make_spec(tmp_path)
         sha = "abc123def456"
-        tag = f"upstream-{sha}"
+        tag = f"data-{sha}"
         _write_zip(spec.local_zip)
 
         # Write a cache meta that matches
         from prts_mcp.data.sync import CacheMeta
         from datetime import datetime, timezone
         CacheMeta(
-            repo="3aKHP/ArknightsStoryJson",
+            repo="3aKHP/arknights-data-pipeline",
             branch="releases",
             commit_sha=sha,
             fetched_at=datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -267,7 +267,7 @@ class TestSyncRelease:
     def test_tag_prefix_stripped_for_sha(self, tmp_path):
         spec = _make_spec(tmp_path)
         sha = "c785d88f552fce9bbe2ce9122bd0e9f516810e20"
-        tag = f"upstream-{sha}"
+        tag = f"data-{sha}"
 
         with (
             patch("prts_mcp.data.sync.check_latest_release", return_value=(tag, "http://x")),
@@ -285,7 +285,7 @@ class TestSyncRelease:
         from prts_mcp.data.sync import CacheMeta
         from datetime import datetime, timezone
         CacheMeta(
-            repo="3aKHP/ArknightsStoryJson",
+            repo="3aKHP/arknights-data-pipeline",
             branch="releases",
             commit_sha=sha,
             fetched_at=datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -306,7 +306,7 @@ class TestSyncRelease:
         from prts_mcp.data.sync import CacheMeta
         from datetime import datetime, timezone
         CacheMeta(
-            repo="3aKHP/ArknightsStoryJson",
+            repo="3aKHP/arknights-data-pipeline",
             branch="releases",
             commit_sha=sha,
             fetched_at=datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
@@ -315,7 +315,7 @@ class TestSyncRelease:
 
         with patch(
             "prts_mcp.data.sync.check_latest_release",
-            return_value=(f"upstream-{sha}", "http://x"),
+            return_value=(f"data-{sha}", "http://x"),
         ) as mock_check:
             result = sync_release(spec, force_check=True)
 
@@ -334,7 +334,7 @@ class TestSyncReleaseArchive:
         archive_dir.mkdir()
         spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name="zh_CN-excel.zip",
             local_zip=archive_dir / "zh_CN-excel.zip",
             local_root=tmp_path / "gamedata",
@@ -355,7 +355,7 @@ class TestSyncReleaseArchive:
         archive_dir.mkdir()
         spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name="zh_CN-excel.zip",
             local_zip=archive_dir / "zh_CN-excel.zip",
             local_root=tmp_path / "gamedata",
@@ -381,7 +381,7 @@ class TestSyncReleaseArchive:
         archive_dir.mkdir()
         spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name="zh_CN-excel.zip",
             local_zip=archive_dir / "zh_CN-excel.zip",
             local_root=tmp_path / "gamedata",
@@ -421,7 +421,7 @@ class TestSyncReleaseArchive:
 
         spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name="zh_CN-excel.zip",
             local_zip=zip_path,
             local_root=tmp_path / "gamedata",
@@ -464,7 +464,7 @@ class TestSyncReleaseArchive:
 
         spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name="zh_CN-excel.zip",
             local_zip=zip_path,
             local_root=tmp_path / "gamedata",
@@ -502,7 +502,7 @@ class TestSyncReleaseArchive:
 
         spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name="zh_CN-excel.zip",
             local_zip=zip_path,
             local_root=tmp_path / "gamedata",
@@ -555,7 +555,7 @@ class TestSyncReleaseArchive:
             zf.writestr(required, '{"version":"new"}')
         spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name="zh_CN-excel.zip",
             local_zip=zip_path,
             local_root=tmp_path / "gamedata",
@@ -593,7 +593,7 @@ class TestSyncReleaseArchive:
 
         spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name="zh_CN-levels.zip",
             local_zip=zip_path,
             local_root=tmp_path / "gamedata-levels",
@@ -617,7 +617,7 @@ class TestSyncReleaseArchive:
 
         spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name="zh_CN-excel.zip",
             local_zip=zip_path,
             local_root=tmp_path / "gamedata",
@@ -656,7 +656,7 @@ class TestSyncReleaseArchive:
         (local_root / ".releases").symlink_to(outside, target_is_directory=True)
         spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name=zip_path.name,
             local_zip=zip_path,
             local_root=local_root,
@@ -684,7 +684,7 @@ class TestSyncReleaseArchive:
             zf.writestr(required, "{}")
         spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name=zip_path.name,
             local_zip=zip_path,
             local_root=tmp_path / "gamedata",
@@ -740,7 +740,7 @@ local_root = Path(sys.argv[2])
 required = sys.argv[3]
 spec = sync.ReleaseArchiveSpec(
     owner="3aKHP",
-    repo="ArknightsGameData",
+    repo="arknights-data-pipeline",
     asset_name=zip_path.name,
     local_zip=zip_path,
     local_root=local_root,
@@ -775,7 +775,7 @@ print(sync.sync_release_archive(spec).status)
         assert {stdout.strip() for stdout, _ in outputs} == {"updated", "up_to_date"}
         spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name=zip_path.name,
             local_zip=zip_path,
             local_root=local_root,
@@ -791,7 +791,7 @@ print(sync.sync_release_archive(spec).status)
             zf.writestr(required, "{}")
         spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name=zip_path.name,
             local_zip=zip_path,
             local_root=tmp_path / "gamedata",
@@ -838,7 +838,7 @@ print(sync.sync_release_archive(spec).status)
         levels_required = "zh_CN/gamedata/levels/enemydata/enemy_database.json"
         excel_spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name="zh_CN-excel.zip",
             local_zip=tmp_path / "gamedata" / "archives" / "zh_CN-excel.zip",
             local_root=tmp_path / "gamedata",
@@ -846,7 +846,7 @@ print(sync.sync_release_archive(spec).status)
         )
         levels_spec = ReleaseArchiveSpec(
             owner="3aKHP",
-            repo="ArknightsGameData",
+            repo="arknights-data-pipeline",
             asset_name="zh_CN-levels.zip",
             local_zip=tmp_path / "gamedata-levels" / "archives" / "zh_CN-levels.zip",
             local_root=tmp_path / "gamedata-levels",

--- a/scripts/test-shared-volume-sync.sh
+++ b/scripts/test-shared-volume-sync.sh
@@ -33,7 +33,7 @@ for archive_arg, required_file in ((sys.argv[1], sys.argv[3]), (sys.argv[2], sys
     (archive.parent / "release_meta.json").write_text(
         json.dumps(
             {
-                "repo": "3aKHP/ArknightsGameData",
+                "repo": "3aKHP/arknights-data-pipeline",
                 "branch": "releases",
                 "commit_sha": "shared-volume-test",
                 "fetched_at": "2099-01-01T00:00:00Z",
@@ -55,7 +55,7 @@ from prts_mcp.data.sync import ReleaseArchiveSpec, sync_release_archive_pair
 
 excel = ReleaseArchiveSpec(
     owner="3aKHP",
-    repo="ArknightsGameData",
+    repo="arknights-data-pipeline",
     asset_name=Path(sys.argv[3]).name,
     local_zip=Path(sys.argv[3]),
     local_root=Path(sys.argv[1]),
@@ -63,7 +63,7 @@ excel = ReleaseArchiveSpec(
 )
 levels = ReleaseArchiveSpec(
     owner="3aKHP",
-    repo="ArknightsGameData",
+    repo="arknights-data-pipeline",
     asset_name=Path(sys.argv[4]).name,
     local_zip=Path(sys.argv[4]),
     local_root=Path(sys.argv[2]),
@@ -89,7 +89,7 @@ const [, , excelRoot, levelsRoot, excelArchive, levelsArchive, excelRequired, le
 const results = await syncReleaseArchivePair(
   {
     owner: "3aKHP",
-    repo: "ArknightsGameData",
+    repo: "arknights-data-pipeline",
     assetName: basename(excelArchive),
     localZip: excelArchive,
     localRoot: excelRoot,
@@ -97,7 +97,7 @@ const results = await syncReleaseArchivePair(
   },
   {
     owner: "3aKHP",
-    repo: "ArknightsGameData",
+    repo: "arknights-data-pipeline",
     assetName: basename(levelsArchive),
     localZip: levelsArchive,
     localRoot: levelsRoot,

--- a/ts/README.md
+++ b/ts/README.md
@@ -141,9 +141,9 @@ docker run -d -p 3000:3000 -v prts-mcp-ts-data:/data/gamedata -v prts-mcp-ts-lev
 
 服务器开始监听后会立即在后台同步三类数据，此后默认每小时检查一次新 Release，无需重启进程：
 
-- **游戏表格数据**（`/data/gamedata` volume）：从 [3aKHP/ArknightsGameData](https://github.com/3aKHP/ArknightsGameData) Release 下载 `zh_CN-excel.zip`，其内容同步自 [Kengxxiao/ArknightsGameData](https://github.com/Kengxxiao/ArknightsGameData)
+- **游戏表格数据**（`/data/gamedata` volume）：从 [3aKHP/arknights-data-pipeline](https://github.com/3aKHP/arknights-data-pipeline) Release 下载 `zh_CN-excel.zip`
 - **关卡战斗数据**（`/data/gamedata-levels` volume）：从同一 Release 下载 `zh_CN-levels.zip`，用于关卡实际出怪和关卡级敌人数值
-- **剧情数据**（`/data/storyjson` volume）：从 [ArknightsStoryJson](https://github.com/3aKHP/ArknightsStoryJson) Releases 下载 `zh_CN.zip`
+- **剧情数据**（`/data/storyjson` volume）：从同一 Release 下载 `zh_CN.zip`（含剧情 JSON 和 LLM 摘要）
 
 镜像内置 bundled 数据作为网络不可用时的离线保底。
 
@@ -174,6 +174,6 @@ docker run -d -p 3000:3000 -v prts-mcp-ts-data:/data/gamedata -v prts-mcp-ts-lev
 uv sync --directory python --locked
 uv run --directory python --locked python scripts/fetch_gamedata.py --output ../ts/data/gamedata
 mkdir -p ts/data/storyjson
-gh release download --repo 3aKHP/ArknightsStoryJson --pattern "zh_CN.zip" --dir ts/data/storyjson/ --clobber
+gh release download --repo 3aKHP/arknights-data-pipeline --pattern "zh_CN.zip" --dir ts/data/storyjson/ --clobber
 docker build -f ts/Dockerfile -t prts-mcp-ts .
 ```

--- a/ts/src/data/datasets.ts
+++ b/ts/src/data/datasets.ts
@@ -24,7 +24,7 @@ export interface ReleaseDatasetSpec {
 export const GAMEDATA_EXCEL: ReleaseDatasetSpec = {
   datasetId: "gamedata.excel",
   owner: "3aKHP",
-  repo: "ArknightsGameData",
+  repo: "arknights-data-pipeline",
   assetName: "zh_CN-excel.zip",
   requiredFiles: GAMEDATA_FILES,
 };
@@ -32,7 +32,7 @@ export const GAMEDATA_EXCEL: ReleaseDatasetSpec = {
 export const STORY_ZH_CN: ReleaseDatasetSpec = {
   datasetId: "story.zh_CN",
   owner: "3aKHP",
-  repo: "ArknightsStoryJson",
+  repo: "arknights-data-pipeline",
   assetName: "zh_CN.zip",
   requiredFiles: STORYJSON_REQUIRED_FILES,
   validateZip: validateStoryjsonZip,
@@ -41,7 +41,7 @@ export const STORY_ZH_CN: ReleaseDatasetSpec = {
 export const GAMEDATA_LEVELS: ReleaseDatasetSpec = {
   datasetId: "gamedata.levels",
   owner: "3aKHP",
-  repo: "ArknightsGameData",
+  repo: "arknights-data-pipeline",
   assetName: "zh_CN-levels.zip",
   requiredFiles: LEVELS_REQUIRED_FILES,
 };

--- a/ts/src/data/operator.ts
+++ b/ts/src/data/operator.ts
@@ -142,7 +142,7 @@ function loadJson<T>(filePath: string): T {
   if (!store.exists(filePath)) {
     throw new Error(
       `干员数据文件不存在：${store.resolveForDiagnostics(filePath)}。` +
-        "数据目录可能为空，或挂载路径有误（GAMEDATA_PATH 应指向 ArknightsGameData 仓库根目录）。"
+        "数据目录可能为空，或挂载路径有误（GAMEDATA_PATH 应指向游戏数据根目录）。"
     );
   }
   return store.readJson<T>(filePath);

--- a/ts/src/data/sync.ts
+++ b/ts/src/data/sync.ts
@@ -185,7 +185,7 @@ function releaseZipError(spec: ReleaseSpec): string | null {
 
 const GITHUB_RELEASES_LATEST_URL =
   "https://api.github.com/repos/{owner}/{repo}/releases/latest";
-const TAG_PREFIX = "upstream-";
+const TAG_PREFIX = "data-";
 
 /** Describes a GitHub Release asset to download as a local zip. */
 export interface ReleaseSpec {
@@ -714,7 +714,7 @@ async function pruneReleaseTrees(
  * Download a GitHub Release zip asset and extract it into localRoot.
  *
  * This keeps the gamedata distribution path aligned with storyjson releases
- * while preserving the existing on-disk ArknightsGameData layout.
+ * while preserving the existing on-disk game data layout.
  */
 async function syncReleaseArchiveLocked(
   spec: ReleaseArchiveSpec,

--- a/ts/tests/sync.test.ts
+++ b/ts/tests/sync.test.ts
@@ -26,7 +26,7 @@ function tempSpec(): ReleaseSpec {
   const root = mkdtempSync(join(tmpdir(), "prts-sync-test-"));
   return {
     owner: "3aKHP",
-    repo: "ArknightsStoryJson",
+    repo: "arknights-data-pipeline",
     assetName: "zh_CN.zip",
     localZip: join(root, "storyjson", "zh_CN.zip"),
   };
@@ -36,7 +36,7 @@ function tempArchiveSpec(assetName = "zh_CN-levels.zip"): ReleaseArchiveSpec {
   const root = mkdtempSync(join(tmpdir(), "prts-sync-archive-test-"));
   return {
     owner: "3aKHP",
-    repo: "ArknightsGameData",
+    repo: "arknights-data-pipeline",
     assetName,
     localZip: join(root, "archives", assetName),
     localRoot: join(root, "gamedata-levels"),
@@ -97,7 +97,7 @@ test("syncRelease reads Python release metadata", async () => {
   writeFileSync(
     join(dirname(spec.localZip), "release_meta.json"),
     JSON.stringify({
-      repo: "3aKHP/ArknightsStoryJson",
+      repo: "3aKHP/arknights-data-pipeline",
       branch: "releases",
       commit_sha: "same-sha",
       fetched_at: "2099-01-01T00:00:00.000Z",
@@ -175,7 +175,7 @@ test("syncRelease validates zip before fresh-cache fast path", async () => {
   writeFileSync(
     join(dirname(spec.localZip), "release_meta.json"),
     JSON.stringify({
-      repo: "3aKHP/ArknightsStoryJson",
+      repo: "3aKHP/arknights-data-pipeline",
       branch: "releases",
       commitSha: "cached-sha",
       fetchedAt: new Date().toISOString(),
@@ -213,7 +213,7 @@ test("syncRelease rejects empty release metadata fields", async () => {
     writeFileSync(
       join(dirname(spec.localZip), "release_meta.json"),
       JSON.stringify({
-        repo: "3aKHP/ArknightsStoryJson",
+        repo: "3aKHP/arknights-data-pipeline",
         branch: "releases",
         ...metadata,
         files: ["zh_CN.zip"],
@@ -242,7 +242,7 @@ test("syncRelease forced check bypasses fresh-cache fast path", async () => {
   writeFileSync(
     join(dirname(spec.localZip), "release_meta.json"),
     JSON.stringify({
-      repo: "3aKHP/ArknightsStoryJson",
+      repo: "3aKHP/arknights-data-pipeline",
       branch: "releases",
       commitSha: "cached-sha",
       fetchedAt: new Date().toISOString(),
@@ -256,7 +256,7 @@ test("syncRelease forced check bypasses fresh-cache fast path", async () => {
     fetchCalls += 1;
     return new Response(
       JSON.stringify({
-        tag_name: "upstream-cached-sha",
+        tag_name: "data-cached-sha",
         assets: [{
           name: "zh_CN.zip",
           browser_download_url: "https://example.test/zh_CN.zip",
@@ -348,7 +348,7 @@ test("syncReleaseArchive retries activation after extraction failure", async () 
   writeFileSync(
     join(dirname(spec.localZip), "release_meta.json"),
     JSON.stringify({
-      repo: "3aKHP/ArknightsGameData",
+      repo: "3aKHP/arknights-data-pipeline",
       branch: "releases",
       commitSha: "abc123",
       fetchedAt: new Date().toISOString(),
@@ -387,7 +387,7 @@ test("syncReleaseArchive reports updated after offline activation recovery", asy
   writeFileSync(
     join(dirname(spec.localZip), "release_meta.json"),
     JSON.stringify({
-      repo: "3aKHP/ArknightsGameData",
+      repo: "3aKHP/arknights-data-pipeline",
       branch: "releases",
       commitSha: "abc123",
       fetchedAt: "2000-01-01T00:00:00.000Z",
@@ -487,7 +487,7 @@ test("pair manifest switches only after both archives share one SHA", async () =
   const levelsRequired = "zh_CN/gamedata/levels/enemydata/enemy_database.json";
   const excelSpec: ReleaseArchiveSpec = {
     owner: "3aKHP",
-    repo: "ArknightsGameData",
+    repo: "arknights-data-pipeline",
     assetName: "zh_CN-excel.zip",
     localZip: join(root, "gamedata", "archives", "zh_CN-excel.zip"),
     localRoot: join(root, "gamedata"),
@@ -495,7 +495,7 @@ test("pair manifest switches only after both archives share one SHA", async () =
   };
   const levelsSpec: ReleaseArchiveSpec = {
     owner: "3aKHP",
-    repo: "ArknightsGameData",
+    repo: "arknights-data-pipeline",
     assetName: "zh_CN-levels.zip",
     localZip: join(root, "gamedata-levels", "archives", "zh_CN-levels.zip"),
     localRoot: join(root, "gamedata-levels"),
@@ -512,7 +512,7 @@ test("pair manifest switches only after both archives share one SHA", async () =
     writeFileSync(
       join(dirname(spec.localZip), "release_meta.json"),
       JSON.stringify({
-        repo: "3aKHP/ArknightsGameData",
+        repo: "3aKHP/arknights-data-pipeline",
         branch: "releases",
         commit_sha: "new",
         fetched_at: "2099-01-01T00:00:00Z",


### PR DESCRIPTION
## Summary

将 PRTS-MCP 的数据下载源从两个旧 fork 仓库切换到自建数据工厂 `3aKHP/arknights-data-pipeline`。

- **datasets.py/ts**: 三个数据集 spec 的 owner/repo 统一指向 `3aKHP/arknights-data-pipeline`（同一 Release、三个 asset）
- **sync.py/ts**: tag 前缀 `upstream-` → `data-`（匹配工厂 `data-*` Release tag）
- **CI workflows**: `gh release download --repo` 目标同步更新
- **docs**: README、STATUS、deployment guide 中数据源描述更新

on-disk 数据布局、asset 文件名、sync 决策树不变——只有 repo URL 和 tag 格式不同。旧缓存首次遇到新 tag 时会触发一次性重下载。

关联：3aKHP/prts-mcp#86、工厂仓库 <https://github.com/3aKHP/arknights-data-pipeline>

## Test plan

- [x] Python: `uv run --directory python --locked python -m pytest tests -q` → 286 passed, 23 skipped
- [x] TypeScript: `npm run build && npm run typecheck && npm test` → 222 passed, 2 skipped
- [x] 无残留旧引用（`grep -rn "ArknightsGameData\|ArknightsStoryJson" python/src/ ts/src/` → 0 hits）
- [ ] CI: 等待 GitHub Actions 验证（首次会从工厂仓库 `data-*` Release 下载数据）

## 未尽事宜

- 旧 fork 仓库（`3aKHP/ArknightsGameData`、`3aKHP/ArknightsStoryJson`）待生产切换确认后 archive
- 历史文档（docs/dev/plans/、CHANGELOG）中的旧仓库名保留为历史记录，不改