### PR TITLE
fix(sync): verify self-hosted data releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Two release lines ship in parallel:
 | **2.4** (`main`) | `2.4.0` | 23 | Process-lifetime Auto-Sync keeps GameData and StoryJson current without service restarts; GameData excel and levels activate atomically. |
 | **1.7 LTS** (`lts/1.7`) | `1.7.0` | 32 | Stable maintenance line. 1.7.x accepts only compatibility, security, data-sync, and critical bug fixes. |
 
+The `develop` line (targeting 2.5.0) uses the self-built `arknights-data-pipeline`
+Release exclusively for default Auto-Sync. The 2.4/main and 1.7 LTS lines retain
+their legacy upstream compatibility until a separate, backwards-compatible migration;
+changes to the new factory path must not be backported to LTS as an implicit source switch.
+
 | Area | Python | TypeScript |
 |------|--------|------------|
 | MCP tools | Same 23 public tool names and required parameters (2.0) / 32 on 1.7 LTS | Same 23 (2.0) / 32 on 1.7 LTS |
@@ -39,6 +44,19 @@ Two release lines ship in parallel:
 | Level data | Auto-synced `zh_CN-levels.zip` beside GameData | Auto-synced `zh_CN-levels.zip` beside GameData |
 | Story data | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | `STORYJSON_PATH` or auto-synced `zh_CN.zip` |
 | Bundled fallback data | Docker image only | Docker image and published npm package (PyPI stays data-light) |
+
+### Auto-Sync data contract
+
+Both implementations consume the self-built [`arknights-data-pipeline`](https://github.com/3aKHP/arknights-data-pipeline)
+Release. New releases carry a `manifest.json` with the `prts-mcp-data/v1` contract,
+source `versionId`, and SHA-256/size for each archive; a mismatch is rejected before
+activation, while pre-manifest releases remain readable during the transition. The
+last activated generation stays in place on download, schema, or manifest failure.
+
+`GITHUB_MIRRORS` is an explicit fallback for GitHub URL access. In Node deployments,
+standard `HTTP_PROXY`/`HTTPS_PROXY` (including lowercase spellings) are honored via
+Undici; Bun keeps its native `fetch` path. Proxy support does not weaken manifest or
+ZIP validation.
 
 See [`docs/migration-1.x-to-2.0.md`](docs/migration-1.x-to-2.0.md) for the 1.x → 2.0
 breaking changes (tool consolidation, `operator_name` → `name`, output channel),
@@ -156,6 +174,17 @@ and macOS development setup.
 | 关卡战斗数据 | 自动同步与 GameData 并列的 `zh_CN-levels.zip` | 自动同步与 GameData 并列的 `zh_CN-levels.zip` |
 | 剧情数据 | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` |
 | bundled 兜底数据 | Docker 镜像 | Docker 镜像和正式 npm 包（PyPI 保持轻量） |
+
+### Auto-Sync 数据契约
+
+两套实现都消费自建 [`arknights-data-pipeline`](https://github.com/3aKHP/arknights-data-pipeline)
+Release。新 Release 附带 `manifest.json`，声明 `prts-mcp-data/v1` 契约、源
+`versionId` 以及每个压缩包的大小/SHA-256；不匹配会在激活前拒绝，迁移期间仍兼容没有
+manifest 的旧 Release。下载、结构或 manifest 校验失败时，服务继续使用上一代已激活数据。
+
+`GITHUB_MIRRORS` 是显式的 GitHub 访问备用路径；Node 部署会通过 Undici 使用标准
+`HTTP_PROXY`/`HTTPS_PROXY`（也识别小写变量），Bun 保持原生 `fetch` 路径。代理不会
+绕过 manifest 或 ZIP 校验。
 
 1.x → 2.0 的破坏性变更（工具面合并、`operator_name` → `name`、output channel）见
 [`docs/migration-1.x-to-2.0.md`](docs/migration-1.x-to-2.0.md)；0.x → 1.0 迁移见

--- a/STATUS.md
+++ b/STATUS.md
@@ -120,6 +120,11 @@ PRTS-MCP/
 
 ## 数据源
 
+2.5.0 开发线（`develop`）的默认 Auto-Sync 只消费自建
+`3aKHP/arknights-data-pipeline` Release；旧版两个上游仓库不再是新版本的数据依赖。
+`main` 的 2.4.x 与 `lts/1.7` 暂保留旧上游兼容路径，供 LTS 维护使用，后续另行设计迁移，
+不在本轮跨线切换。
+
 | 数据源 | 用途 | 同步方式 |
 |--------|------|----------|
 | [arknights-data-pipeline](https://github.com/3aKHP/arknights-data-pipeline) | 干员/敌人/关卡/物品表格 | GitHub Release `zh_CN-excel.zip` |

--- a/python/README.md
+++ b/python/README.md
@@ -67,6 +67,9 @@ GAMEDATA_PATH=/path/to/ArknightsGameData prts-mcp
 
 镜像内置 bundled 数据作为网络不可用时的离线保底。
 
+自建数据工厂的新 Release 附带 manifest（`prts-mcp-data/v1`、源 versionId、包大小和
+SHA-256）；Python 实现会在原子激活前校验它。没有 manifest 的历史 Release 仍兼容读取。
+
 周期可通过 `PRTS_AUTO_SYNC_INTERVAL_SECONDS` 调整（`60..604800` 秒）；设为 `0` 时只执行启动同步。
 
 > PyPI 包本身不内置 bundled 数据；直接 `pip install prts-mcp` 时会在启动时自动同步，或使用 `GAMEDATA_PATH` / `STORYJSON_PATH` 指向你自己的本地数据。若 `GAMEDATA_PATH` 指向完整 ArknightsGameData 仓库根目录，内含的 `zh_CN/gamedata/levels` 会直接用于关卡战斗数据；否则默认在其相邻目录维护 `gamedata-levels`。正式 Docker 镜像会由 CI 预置兜底数据。

--- a/python/src/prts_mcp/data/datasets.py
+++ b/python/src/prts_mcp/data/datasets.py
@@ -25,6 +25,7 @@ class ReleaseDatasetSpec:
     repo: str
     asset_name: str
     required_files: tuple[str, ...]
+    verify_manifest: bool = True
 
     def release_spec(self, local_zip: Path) -> ReleaseSpec:
         return ReleaseSpec(
@@ -33,6 +34,7 @@ class ReleaseDatasetSpec:
             asset_name=self.asset_name,
             local_zip=local_zip,
             validate_zip=self.validate_zip,
+            verify_manifest=self.verify_manifest,
         )
 
     def archive_spec(self, *, local_zip: Path, local_root: Path) -> ReleaseArchiveSpec:
@@ -43,6 +45,7 @@ class ReleaseDatasetSpec:
             local_zip=local_zip,
             local_root=local_root,
             required_files=self.required_files,
+            verify_manifest=self.verify_manifest,
         )
 
     def validate_zip(self, zip_path: Path) -> list[str]:

--- a/python/src/prts_mcp/data/sync.py
+++ b/python/src/prts_mcp/data/sync.py
@@ -302,9 +302,14 @@ def _verify_release_manifest(
     Older releases predate the manifest asset and remain readable during the
     transition; once a release publishes one, mismatches fail closed.
     """
-    manifest_url = (
-        f"https://github.com/{spec.owner}/{spec.repo}/releases/download/{tag}/manifest.json"
-    )
+    if tag == "unknown":
+        manifest_url = (
+            f"https://github.com/{spec.owner}/{spec.repo}/releases/latest/download/manifest.json"
+        )
+    else:
+        manifest_url = (
+            f"https://github.com/{spec.owner}/{spec.repo}/releases/download/{tag}/manifest.json"
+        )
     try:
         response = _get_cascading(
             manifest_url, timeout=timeout, headers=_github_headers(), follow_redirects=True,

--- a/python/src/prts_mcp/data/sync.py
+++ b/python/src/prts_mcp/data/sync.py
@@ -40,6 +40,10 @@ GAMEDATA_FILES: tuple[str, ...] = (
     "zh_CN/gamedata/excel/item_table.json",
 )
 
+# Must match the factory manifest contract. Older releases without a manifest
+# remain readable during the migration to the self-built pipeline.
+DATA_CONTRACT_VERSION = "prts-mcp-data/v1"
+
 _GITHUB_UA = "PRTS-MCP-Bot/0.1 (Arknights fan-creation helper)"
 
 
@@ -214,6 +218,7 @@ class ReleaseSpec:
     asset_name: str   # e.g. "zh_CN.zip"
     local_zip: Path   # destination path on disk
     validate_zip: Callable[[Path], list[str]] | None = None
+    verify_manifest: bool = False
 
 
 @dataclass(frozen=True)
@@ -226,6 +231,7 @@ class ReleaseArchiveSpec:
     local_zip: Path
     local_root: Path
     required_files: tuple[str, ...]
+    verify_manifest: bool = False
 
 
 def _release_cache_path(spec: ReleaseSpec) -> Path:
@@ -267,6 +273,8 @@ def download_release_asset(spec: ReleaseSpec, tag: str, url: str, timeout: float
             missing = spec.validate_zip(tmp)
             if missing:
                 raise ValueError("Downloaded release asset is invalid: " + "; ".join(missing[:10]))
+        if spec.verify_manifest:
+            _verify_release_manifest(spec, tag, tmp, timeout=timeout)
         tmp.replace(spec.local_zip)
 
         # Extract version identifier from tag (format: "data-<versionId>")
@@ -284,6 +292,54 @@ def download_release_asset(spec: ReleaseSpec, tag: str, url: str, timeout: float
         except OSError:
             pass
         raise
+
+
+def _verify_release_manifest(
+    spec: ReleaseSpec, tag: str, asset_path: Path, *, timeout: float,
+) -> None:
+    """Verify an asset against the optional factory manifest asset.
+
+    Older releases predate the manifest asset and remain readable during the
+    transition; once a release publishes one, mismatches fail closed.
+    """
+    manifest_url = (
+        f"https://github.com/{spec.owner}/{spec.repo}/releases/download/{tag}/manifest.json"
+    )
+    try:
+        response = _get_cascading(
+            manifest_url, timeout=timeout, headers=_github_headers(), follow_redirects=True,
+        )
+    except Exception as exc:
+        if "404" in str(exc):
+            return
+        raise ValueError(f"manifest unavailable for {tag}: {exc}") from exc
+    try:
+        manifest = response.json()
+        if not isinstance(manifest, dict):
+            raise ValueError("manifest root must be an object")
+        if manifest.get("contractVersion") != DATA_CONTRACT_VERSION:
+            raise ValueError(
+                f"unsupported contractVersion {manifest.get('contractVersion')!r}"
+            )
+        expected = manifest["assets"][spec.asset_name]
+        expected_size = int(expected["size"])
+        expected_sha = str(expected["sha256"])
+        expected_version = tag.removeprefix("data-")
+        source = manifest.get("source", {})
+        if not isinstance(source, dict):
+            raise ValueError("manifest source must be an object")
+        source_version = source.get("versionId")
+        if tag.startswith("data-") and source_version != expected_version:
+            raise ValueError("manifest source version does not match release tag")
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise ValueError(f"manifest for {tag} is invalid: {exc}") from exc
+    actual_sha = hashlib.sha256(asset_path.read_bytes()).hexdigest()
+    if expected_size != asset_path.stat().st_size or expected_sha != actual_sha:
+        raise ValueError(
+            f"manifest mismatch for {spec.asset_name}: "
+            f"expected {expected_size}/{expected_sha}, "
+            f"got {asset_path.stat().st_size}/{actual_sha}"
+        )
 
 
 def _sync_release_locked(spec: ReleaseSpec, *, force_check: bool = False) -> SyncResult:
@@ -656,6 +712,7 @@ def _sync_release_archive_locked(
             asset_name=spec.asset_name,
             local_zip=spec.local_zip,
             validate_zip=lambda path: _validate_archive_zip(path, spec.required_files),
+            verify_manifest=spec.verify_manifest,
         ),
         force_check=force_check,
     )

--- a/python/tests/test_e2e.py
+++ b/python/tests/test_e2e.py
@@ -217,7 +217,7 @@ def test_search(server: subprocess.Popen) -> None:
 
 def test_list_enemies_graceful(server: subprocess.Popen) -> None:
     text = _call_result_text(server, "list_enemies", {"limit": 5}, 8)
-    assert "敌方图鉴" in text or _data_unavailable(text), f"unexpected: {text[:120]}"
+    assert "敌人图鉴" in text or _data_unavailable(text), f"unexpected: {text[:120]}"
 
 
 def test_list_story_events_graceful(server: subprocess.Popen) -> None:

--- a/python/tests/test_sync_release.py
+++ b/python/tests/test_sync_release.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import hashlib
 import os
 import subprocess
 import sys
@@ -102,6 +103,104 @@ class TestCheckLatestRelease:
 # ---------------------------------------------------------------------------
 
 class TestSyncRelease:
+    def test_manifest_digest_is_verified_before_activation(self, tmp_path):
+        spec = ReleaseSpec(
+            owner="3aKHP",
+            repo="arknights-data-pipeline",
+            asset_name="zh_CN.zip",
+            local_zip=tmp_path / "storyjson" / "zh_CN.zip",
+            verify_manifest=True,
+        )
+        content = b"verified"
+        release = _mock_release_response("data-new", "zh_CN.zip", "https://example/asset")
+        asset = _mock_asset_response(content)
+        manifest = _mock_asset_response()
+        manifest.json.return_value = {
+            "contractVersion": "prts-mcp-data/v1",
+            "source": {"versionId": "new"},
+            "assets": {
+                "zh_CN.zip": {
+                    "size": len(content),
+                    "sha256": hashlib.sha256(content).hexdigest(),
+                },
+            },
+        }
+        with patch(
+            "prts_mcp.data.sync._get_cascading",
+            side_effect=[release, asset, manifest],
+        ):
+            result = sync_release(spec, force_check=True)
+        assert result.status == "updated"
+        assert spec.local_zip.read_bytes() == content
+
+    def test_manifest_digest_mismatch_keeps_previous_zip(self, tmp_path):
+        spec = ReleaseSpec(
+            owner="3aKHP",
+            repo="arknights-data-pipeline",
+            asset_name="zh_CN.zip",
+            local_zip=tmp_path / "storyjson" / "zh_CN.zip",
+            verify_manifest=True,
+        )
+        spec.local_zip.parent.mkdir(parents=True)
+        spec.local_zip.write_bytes(b"old")
+        release = _mock_release_response("data-new", "zh_CN.zip", "https://example/asset")
+        asset = _mock_asset_response(b"new")
+        manifest = _mock_asset_response()
+        manifest.json.return_value = {
+            "contractVersion": "prts-mcp-data/v1",
+            "source": {"versionId": "new"},
+            "assets": {"zh_CN.zip": {"size": 3, "sha256": "bad"}},
+        }
+        with patch(
+            "prts_mcp.data.sync._get_cascading",
+            side_effect=[release, asset, manifest],
+        ):
+            result = sync_release(spec, force_check=True)
+        assert result.status == "offline_fallback"
+        assert spec.local_zip.read_bytes() == b"old"
+
+    def test_missing_manifest_keeps_legacy_release_compatible(self, tmp_path):
+        spec = ReleaseSpec(
+            owner="3aKHP",
+            repo="arknights-data-pipeline",
+            asset_name="zh_CN.zip",
+            local_zip=tmp_path / "storyjson" / "zh_CN.zip",
+            verify_manifest=True,
+        )
+        release = _mock_release_response("data-legacy", "zh_CN.zip", "https://example/asset")
+        asset = _mock_asset_response(b"legacy")
+        with patch(
+            "prts_mcp.data.sync._get_cascading",
+            side_effect=[release, asset, Exception("HTTP 404")],
+        ):
+            result = sync_release(spec, force_check=True)
+        assert result.status == "updated"
+        assert spec.local_zip.read_bytes() == b"legacy"
+
+    def test_unsupported_manifest_contract_keeps_previous_zip(self, tmp_path):
+        spec = ReleaseSpec(
+            owner="3aKHP",
+            repo="arknights-data-pipeline",
+            asset_name="zh_CN.zip",
+            local_zip=tmp_path / "storyjson" / "zh_CN.zip",
+            verify_manifest=True,
+        )
+        spec.local_zip.parent.mkdir(parents=True)
+        spec.local_zip.write_bytes(b"old")
+        manifest = _mock_asset_response()
+        manifest.json.return_value = {"contractVersion": "unknown", "assets": {}}
+        with patch(
+            "prts_mcp.data.sync._get_cascading",
+            side_effect=[
+                _mock_release_response("data-new", "zh_CN.zip", "https://example/asset"),
+                _mock_asset_response(b"new"),
+                manifest,
+            ],
+        ):
+            result = sync_release(spec, force_check=True)
+        assert result.status == "offline_fallback"
+        assert spec.local_zip.read_bytes() == b"old"
+
     def test_concurrent_release_checks_are_serialized(self, tmp_path):
         spec = _make_spec(tmp_path)
         _write_zip(spec.local_zip)

--- a/ts/README.md
+++ b/ts/README.md
@@ -147,6 +147,9 @@ docker run -d -p 3000:3000 -v prts-mcp-ts-data:/data/gamedata -v prts-mcp-ts-lev
 
 镜像内置 bundled 数据作为网络不可用时的离线保底。
 
+自建数据工厂的新 Release 附带 manifest（`prts-mcp-data/v1`、源 versionId、包大小和
+SHA-256）；TypeScript 实现会在原子激活前校验它。没有 manifest 的历史 Release 仍兼容读取。
+
 周期可通过 `PRTS_AUTO_SYNC_INTERVAL_SECONDS` 调整（`60..604800` 秒）；设为 `0` 时只执行启动同步。
 
 > 正式发布到 npm 的包会由 CI 预置 bundled 数据；本地 `npm pack` 或手动发布前需先运行下方预置步骤，否则包内只会包含空目录占位。

--- a/ts/bun.lock
+++ b/ts/bun.lock
@@ -8,6 +8,7 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
         "adm-zip": "^0.5.16",
         "express": "^5.2.1",
+        "undici": "^8.10.0",
       },
       "devDependencies": {
         "@types/adm-zip": "^0.5.7",
@@ -272,6 +273,8 @@
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "adm-zip": "^0.5.16",
-        "express": "^5.2.1"
+        "express": "^5.2.1",
+        "undici": "^8.10.0"
       },
       "bin": {
         "prts-mcp-ts": "dist/server.js",
@@ -1767,6 +1768,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -64,7 +64,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "adm-zip": "^0.5.16",
-    "express": "^5.2.1"
+    "express": "^5.2.1",
+    "undici": "^8.10.0"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.5.7",

--- a/ts/src/data/datasets.ts
+++ b/ts/src/data/datasets.ts
@@ -19,6 +19,7 @@ export interface ReleaseDatasetSpec {
   assetName: string;
   requiredFiles: readonly string[];
   validateZip?: (zipPath: string) => string[];
+  verifyManifest?: boolean;
 }
 
 export const GAMEDATA_EXCEL: ReleaseDatasetSpec = {
@@ -27,6 +28,7 @@ export const GAMEDATA_EXCEL: ReleaseDatasetSpec = {
   repo: "arknights-data-pipeline",
   assetName: "zh_CN-excel.zip",
   requiredFiles: GAMEDATA_FILES,
+  verifyManifest: true,
 };
 
 export const STORY_ZH_CN: ReleaseDatasetSpec = {
@@ -36,6 +38,7 @@ export const STORY_ZH_CN: ReleaseDatasetSpec = {
   assetName: "zh_CN.zip",
   requiredFiles: STORYJSON_REQUIRED_FILES,
   validateZip: validateStoryjsonZip,
+  verifyManifest: true,
 };
 
 export const GAMEDATA_LEVELS: ReleaseDatasetSpec = {
@@ -44,6 +47,7 @@ export const GAMEDATA_LEVELS: ReleaseDatasetSpec = {
   repo: "arknights-data-pipeline",
   assetName: "zh_CN-levels.zip",
   requiredFiles: LEVELS_REQUIRED_FILES,
+  verifyManifest: true,
 };
 
 export function releaseSpecForDataset(
@@ -56,6 +60,7 @@ export function releaseSpecForDataset(
     assetName: dataset.assetName,
     localZip,
     validateZip: dataset.validateZip,
+    verifyManifest: dataset.verifyManifest,
   };
 }
 
@@ -71,6 +76,7 @@ export function archiveSpecForDataset(
     localZip,
     localRoot,
     requiredFiles: dataset.requiredFiles,
+    verifyManifest: dataset.verifyManifest,
   };
 }
 

--- a/ts/src/data/sync.ts
+++ b/ts/src/data/sync.ts
@@ -30,6 +30,14 @@ import type { Dispatcher } from "undici";
 const NATIVE_FETCH = globalThis.fetch;
 let envProxyAgent: Dispatcher | undefined;
 
+/** The response surface shared by the global and Undici fetch runtimes. */
+interface FetchResponse {
+  readonly ok: boolean;
+  readonly status: number;
+  json(): Promise<unknown>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
 /** Versioned contract shared with the arknights-data-pipeline manifest. */
 export const DATA_CONTRACT_VERSION = "prts-mcp-data/v1";
 
@@ -133,7 +141,7 @@ async function fetchWithRuntimeProxy(
   url: string,
   options: Omit<RequestInit, "signal">,
   signal: AbortSignal,
-): Promise<Response> {
+): Promise<FetchResponse> {
   // Preserve test/in-process fetch overrides and Bun's native proxy support.
   if (
     globalThis.fetch !== NATIVE_FETCH
@@ -152,7 +160,7 @@ async function fetchWithRuntimeProxy(
     signal,
     dispatcher: envProxyAgent,
   } as Parameters<typeof undiciFetch>[1]);
-  return response as unknown as Response;
+  return response;
 }
 
 /**
@@ -168,7 +176,7 @@ async function fetchCascading(
   url: string,
   options: Omit<RequestInit, "signal">,
   timeoutMs: number,
-): Promise<Response> {
+): Promise<FetchResponse> {
   const candidates = urlCandidates(url);
   let lastErr: unknown = new Error("All URL candidates failed");
   for (let i = 0; i < candidates.length; i++) {
@@ -379,8 +387,10 @@ async function verifyReleaseManifest(
   assetPath: string,
   timeoutMs: number,
 ): Promise<void> {
-  const manifestUrl = `https://github.com/${spec.owner}/${spec.repo}/releases/download/${tag}/manifest.json`;
-  let response: Response;
+  const manifestUrl = tag === "unknown"
+    ? `https://github.com/${spec.owner}/${spec.repo}/releases/latest/download/manifest.json`
+    : `https://github.com/${spec.owner}/${spec.repo}/releases/download/${tag}/manifest.json`;
+  let response: FetchResponse;
   try {
     response = await fetchCascading(
       manifestUrl, { headers: githubHeaders(), redirect: "follow" }, timeoutMs,
@@ -389,13 +399,17 @@ async function verifyReleaseManifest(
     if (errorMessage(err).includes("HTTP 404")) return;
     throw new Error(`manifest unavailable for ${tag}: ${errorMessage(err)}`);
   }
-  let manifest: { assets?: Record<string, { size?: number; sha256?: string }> };
+  let manifest: unknown;
   try {
-    manifest = await response.json() as typeof manifest;
+    manifest = await response.json();
   } catch (err) {
     throw new Error(`manifest for ${tag} is invalid: ${errorMessage(err)}`);
   }
-  const typedManifest = manifest as typeof manifest & {
+  if (typeof manifest !== "object" || manifest === null || Array.isArray(manifest)) {
+    throw new Error(`manifest for ${tag} is invalid: manifest root must be an object`);
+  }
+  const typedManifest = manifest as {
+    assets?: Record<string, { size?: number; sha256?: string }>;
     contractVersion?: unknown;
     source?: { versionId?: unknown };
   };
@@ -408,7 +422,7 @@ async function verifyReleaseManifest(
   ) {
     throw new Error(`manifest source version does not match release tag ${tag}`);
   }
-  const expected = manifest.assets?.[spec.assetName];
+  const expected = typedManifest.assets?.[spec.assetName];
   if (typeof expected?.size !== "number" || typeof expected.sha256 !== "string") {
     throw new Error(`manifest for ${tag} has no valid entry for ${spec.assetName}`);
   }
@@ -813,6 +827,7 @@ async function syncReleaseArchiveLocked(
     assetName: spec.assetName,
     localZip: spec.localZip,
     validateZip: (zipPath) => validateArchiveZip(zipPath, spec.requiredFiles),
+    verifyManifest: spec.verifyManifest,
   }, forceCheck);
 
   const dummySpec: RepoSpec = {

--- a/ts/src/data/sync.ts
+++ b/ts/src/data/sync.ts
@@ -25,6 +25,13 @@ import {
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import AdmZip from "adm-zip";
+import type { Dispatcher } from "undici";
+
+const NATIVE_FETCH = globalThis.fetch;
+let envProxyAgent: Dispatcher | undefined;
+
+/** Versioned contract shared with the arknights-data-pipeline manifest. */
+export const DATA_CONTRACT_VERSION = "prts-mcp-data/v1";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -122,6 +129,32 @@ function urlCandidates(url: string): string[] {
   return [url, ...parseMirrors().map((m) => `${m}/${url}`)];
 }
 
+async function fetchWithRuntimeProxy(
+  url: string,
+  options: Omit<RequestInit, "signal">,
+  signal: AbortSignal,
+): Promise<Response> {
+  // Preserve test/in-process fetch overrides and Bun's native proxy support.
+  if (
+    globalThis.fetch !== NATIVE_FETCH
+    || process.versions.bun
+    || !(
+      process.env["HTTP_PROXY"] || process.env["HTTPS_PROXY"]
+      || process.env["http_proxy"] || process.env["https_proxy"]
+    )
+  ) {
+    return globalThis.fetch(url, { ...options, signal });
+  }
+  const { EnvHttpProxyAgent, fetch: undiciFetch } = await import("undici");
+  if (envProxyAgent === undefined) envProxyAgent = new EnvHttpProxyAgent();
+  const response = await undiciFetch(url, {
+    ...options,
+    signal,
+    dispatcher: envProxyAgent,
+  } as Parameters<typeof undiciFetch>[1]);
+  return response as unknown as Response;
+}
+
 /**
  * fetch() wrapper that cascades through URL candidates on failure.
  *
@@ -140,10 +173,9 @@ async function fetchCascading(
   let lastErr: unknown = new Error("All URL candidates failed");
   for (let i = 0; i < candidates.length; i++) {
     try {
-      const res = await fetch(candidates[i], {
-        ...options,
-        signal: AbortSignal.timeout(timeoutMs),
-      });
+      const res = await fetchWithRuntimeProxy(
+        candidates[i], options, AbortSignal.timeout(timeoutMs),
+      );
       if (res.ok) return res;
       lastErr = new Error(`HTTP ${res.status}`);
       // Direct 4xx → the resource does not exist; mirrors cannot help.
@@ -197,6 +229,8 @@ export interface ReleaseSpec {
   localZip: string;
   /** Optional validator returning missing or invalid zip entries. */
   validateZip?: (zipPath: string) => string[];
+  /** Verify the optional factory manifest when the release provides it. */
+  verifyManifest?: boolean;
 }
 
 /** Describes a GitHub Release zip asset that should be extracted locally. */
@@ -207,6 +241,7 @@ export interface ReleaseArchiveSpec {
   localZip: string;
   localRoot: string;
   requiredFiles: readonly string[];
+  verifyManifest?: boolean;
 }
 
 function releaseCachePath(spec: ReleaseSpec): string {
@@ -319,6 +354,9 @@ export async function downloadReleaseAsset(
     if (missing.length > 0) {
       throw new Error(`Downloaded ${spec.assetName} is missing required entries: ${missing.join(", ")}`);
     }
+    if (spec.verifyManifest) {
+      await verifyReleaseManifest(spec, tag, tmp, timeoutMs);
+    }
     await rename(tmp, spec.localZip);
 
     const commitSha = tag.startsWith(TAG_PREFIX) ? tag.slice(TAG_PREFIX.length) : tag;
@@ -332,6 +370,55 @@ export async function downloadReleaseAsset(
   } catch (err) {
     try { await unlink(tmp); } catch { /* best-effort */ }
     throw err;
+  }
+}
+
+async function verifyReleaseManifest(
+  spec: ReleaseSpec,
+  tag: string,
+  assetPath: string,
+  timeoutMs: number,
+): Promise<void> {
+  const manifestUrl = `https://github.com/${spec.owner}/${spec.repo}/releases/download/${tag}/manifest.json`;
+  let response: Response;
+  try {
+    response = await fetchCascading(
+      manifestUrl, { headers: githubHeaders(), redirect: "follow" }, timeoutMs,
+    );
+  } catch (err) {
+    if (errorMessage(err).includes("HTTP 404")) return;
+    throw new Error(`manifest unavailable for ${tag}: ${errorMessage(err)}`);
+  }
+  let manifest: { assets?: Record<string, { size?: number; sha256?: string }> };
+  try {
+    manifest = await response.json() as typeof manifest;
+  } catch (err) {
+    throw new Error(`manifest for ${tag} is invalid: ${errorMessage(err)}`);
+  }
+  const typedManifest = manifest as typeof manifest & {
+    contractVersion?: unknown;
+    source?: { versionId?: unknown };
+  };
+  if (typedManifest.contractVersion !== DATA_CONTRACT_VERSION) {
+    throw new Error(`manifest for ${tag} has unsupported contractVersion`);
+  }
+  if (
+    tag.startsWith("data-")
+    && typedManifest.source?.versionId !== tag.slice("data-".length)
+  ) {
+    throw new Error(`manifest source version does not match release tag ${tag}`);
+  }
+  const expected = manifest.assets?.[spec.assetName];
+  if (typeof expected?.size !== "number" || typeof expected.sha256 !== "string") {
+    throw new Error(`manifest for ${tag} has no valid entry for ${spec.assetName}`);
+  }
+  const bytes = await readFile(assetPath);
+  const actualSha = createHash("sha256").update(bytes).digest("hex");
+  if (expected.size !== bytes.byteLength || expected.sha256 !== actualSha) {
+    throw new Error(
+      `manifest mismatch for ${spec.assetName}: expected `
+      + `${expected.size}/${expected.sha256}, got ${bytes.byteLength}/${actualSha}`,
+    );
   }
 }
 

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -237,7 +237,7 @@ test("E2E", async (t) => {
     const r = await mcpPost(origin, tc("list_enemies", { limit: 5 }, 8), sessionId);
     assert.equal(r.status, 200);
     const text = toolResultText(r);
-    assert.ok(text.includes("敌方图鉴") || dataUnavailable(text), `unexpected: ${text.slice(0, 100)}`);
+    assert.ok(text.includes("敌人图鉴") || dataUnavailable(text), `unexpected: ${text.slice(0, 100)}`);
   });
 
   await t.test("list_story_events — data or graceful error", async () => {

--- a/ts/tests/sync.test.ts
+++ b/ts/tests/sync.test.ts
@@ -12,15 +12,92 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { createHash } from "node:crypto";
 import AdmZip from "adm-zip";
 import {
   syncRelease,
+  downloadReleaseAsset,
   syncReleaseArchive,
   syncReleaseArchivePair,
   withArchiveActivationLock,
   type ReleaseArchiveSpec,
   type ReleaseSpec,
 } from "../src/data/sync.ts";
+
+test("downloadReleaseAsset verifies the optional factory manifest", async () => {
+  const spec = { ...tempSpec(), verifyManifest: true };
+  const content = Buffer.from("verified", "utf-8");
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  let call = 0;
+  await withFetchMock((async (input: RequestInfo | URL) => {
+    call += 1;
+    if (call === 1) return new Response(content);
+    assert.match(String(input), /manifest\.json$/);
+    return new Response(JSON.stringify({
+      contractVersion: "prts-mcp-data/v1",
+      source: { versionId: "test" },
+      assets: { "zh_CN.zip": { size: content.byteLength, sha256 } },
+    }), { headers: { "content-type": "application/json" } });
+  }) as typeof fetch, async () => {
+    await downloadReleaseAsset(spec, "data-test", "https://example/asset");
+  });
+  assert.deepEqual(readFileSync(spec.localZip), content);
+});
+
+test("downloadReleaseAsset keeps the old zip on manifest mismatch", async () => {
+  const spec = { ...tempSpec(), verifyManifest: true };
+  mkdirSync(dirname(spec.localZip), { recursive: true });
+  writeFileSync(spec.localZip, "old", "utf-8");
+  const content = Buffer.from("new", "utf-8");
+  let call = 0;
+  await withFetchMock((async (input: RequestInfo | URL) => {
+    call += 1;
+    if (call === 1) return new Response(content);
+    assert.match(String(input), /manifest\.json$/);
+    return new Response(JSON.stringify({
+      contractVersion: "prts-mcp-data/v1",
+      source: { versionId: "test" },
+      assets: { "zh_CN.zip": { size: content.byteLength, sha256: "bad" } },
+    }));
+  }) as typeof fetch, async () => {
+    await assert.rejects(
+      downloadReleaseAsset(spec, "data-test", "https://example/asset"),
+      /manifest mismatch/,
+    );
+  });
+  assert.equal(readFileSync(spec.localZip, "utf-8"), "old");
+});
+
+test("downloadReleaseAsset keeps legacy releases without a manifest", async () => {
+  const spec = { ...tempSpec(), verifyManifest: true };
+  const content = Buffer.from("legacy", "utf-8");
+  let call = 0;
+  await withFetchMock((async (input: RequestInfo | URL) => {
+    call += 1;
+    if (call === 1) return new Response(content);
+    assert.match(String(input), /manifest\.json$/);
+    return new Response("missing", { status: 404 });
+  }) as typeof fetch, async () => {
+    await downloadReleaseAsset(spec, "data-test", "https://example/asset");
+  });
+  assert.deepEqual(readFileSync(spec.localZip), content);
+});
+
+test("downloadReleaseAsset rejects an unsupported manifest contract", async () => {
+  const spec = { ...tempSpec(), verifyManifest: true };
+  let call = 0;
+  await withFetchMock((async () => {
+    call += 1;
+    if (call === 1) return new Response("new");
+    return new Response(JSON.stringify({ contractVersion: "unknown", assets: {} }));
+  }) as typeof fetch, async () => {
+    await assert.rejects(
+      downloadReleaseAsset(spec, "data-test", "https://example/asset"),
+      /unsupported contractVersion/,
+    );
+  });
+  assert.equal(existsSync(spec.localZip), false);
+});
 
 function tempSpec(): ReleaseSpec {
   const root = mkdtempSync(join(tmpdir(), "prts-sync-test-"));

--- a/ts/tests/sync.test.ts
+++ b/ts/tests/sync.test.ts
@@ -99,6 +99,22 @@ test("downloadReleaseAsset rejects an unsupported manifest contract", async () =
   assert.equal(existsSync(spec.localZip), false);
 });
 
+test("downloadReleaseAsset rejects a non-object manifest", async () => {
+  const spec = { ...tempSpec(), verifyManifest: true };
+  let call = 0;
+  await withFetchMock((async () => {
+    call += 1;
+    if (call === 1) return new Response("new");
+    return new Response("null", { headers: { "content-type": "application/json" } });
+  }) as typeof fetch, async () => {
+    await assert.rejects(
+      downloadReleaseAsset(spec, "data-test", "https://example/asset"),
+      /manifest for data-test is invalid: manifest root must be an object/,
+    );
+  });
+  assert.equal(existsSync(spec.localZip), false);
+});
+
 function tempSpec(): ReleaseSpec {
   const root = mkdtempSync(join(tmpdir(), "prts-sync-test-"));
   return {
@@ -398,6 +414,43 @@ test("syncReleaseArchive extracts updated archive", async () => {
     assert.equal(result.status, "updated");
     assert.match(result.commitSha ?? "", /^local-/);
   });
+});
+
+test("syncReleaseArchive verifies the factory manifest before activation", async () => {
+  const spec = { ...tempArchiveSpec(), verifyManifest: true };
+  const required = spec.requiredFiles[0];
+  const assetPath = join(dirname(spec.localZip), "asset.zip");
+  writeZip(assetPath, { [required]: "new" });
+  const asset = readFileSync(assetPath);
+  let call = 0;
+
+  await withFetchMock((async (input: RequestInfo | URL) => {
+    call += 1;
+    const url = String(input);
+    if (call === 1) {
+      assert.match(url, /api\.github\.com\/repos\/3aKHP\/arknights-data-pipeline\/releases\/latest$/);
+      return new Response(JSON.stringify({
+        tag_name: "data-new",
+        assets: [{ name: spec.assetName, browser_download_url: "https://example/asset" }],
+      }), { headers: { "content-type": "application/json" } });
+    }
+    if (call === 2) {
+      assert.equal(url, "https://example/asset");
+      return new Response(asset);
+    }
+    assert.match(url, /releases\/download\/data-new\/manifest\.json$/);
+    return new Response(JSON.stringify({
+      contractVersion: "prts-mcp-data/v1",
+      source: { versionId: "new" },
+      assets: { [spec.assetName]: { size: asset.byteLength, sha256: "bad" } },
+    }), { headers: { "content-type": "application/json" } });
+  }) as typeof fetch, async () => {
+    const result = await syncReleaseArchive(spec, true);
+    assert.equal(result.status, "no_data");
+    assert.match(result.error ?? "", /manifest mismatch/);
+  });
+  assert.equal(existsSync(spec.localZip), false);
+  assert.equal(existsSync(join(spec.localRoot, required)), false);
 });
 
 test("syncReleaseArchive returns no_data when zip misses required entries", async () => {


### PR DESCRIPTION
## Summary

- switch 2.5.0/default Auto-Sync consumption to the self-built factory manifest contract
- verify contract version, source version, archive size, and SHA-256 before activation in Python and TypeScript
- preserve legacy Releases without manifest during transition and keep atomic previous-generation fallback
- add Node proxy-aware fetch via Undici while preserving Bun native fetch
- document the develop/2.5.0 versus main/LTS data-source boundary

## Test plan

- `./scripts/check-runtime.sh --full`
- Python: 311 passed, 2 skipped
- TypeScript: build, typecheck, 226 passed, 2 skipped; Bun HTTP smoke passed
- live Python, Node, and Bun download of current factory Release asset
- `git diff --check`

## Delivery boundary

This is the 2.5.0/develop path. `lts/1.7` retains legacy source compatibility and is not modified by this PR. Production activation and Release publication remain separate follow-up checks.
