### PR TITLE
feat(artwork): operator_artwork LOCAL_IMAGE=true 主路径 (Py+TS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ changes to the new factory path must not be backported to LTS as an implicit sou
 | GameData | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` |
 | Level data | Auto-synced `zh_CN-levels.zip` beside GameData | Auto-synced `zh_CN-levels.zip` beside GameData |
 | Story data | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | `STORYJSON_PATH` or auto-synced `zh_CN.zip` |
+| Image artwork (2.5) | Opt-in via `IMAGES_ENABLED=true`; auto-synced AKDP image Release (local PNG assets) | Opt-in via `IMAGES_ENABLED=true`; auto-synced AKDP image Release (local PNG assets) |
 | Bundled fallback data | Docker image only | Docker image and published npm package (PyPI stays data-light) |
 
 ### Auto-Sync data contract
@@ -173,6 +174,7 @@ and macOS development setup.
 | 干员数据 | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` |
 | 关卡战斗数据 | 自动同步与 GameData 并列的 `zh_CN-levels.zip` | 自动同步与 GameData 并列的 `zh_CN-levels.zip` |
 | 剧情数据 | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` |
+| 立绘图片（2.5） | 需 `IMAGES_ENABLED=true` 开启；自动同步 AKDP 图片 Release（本地 PNG 资产） | 需 `IMAGES_ENABLED=true` 开启；自动同步 AKDP 图片 Release（本地 PNG 资产） |
 | bundled 兜底数据 | Docker 镜像 | Docker 镜像和正式 npm 包（PyPI 保持轻量） |
 
 ### Auto-Sync 数据契约

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- New `operator_artwork` tool (opt-in via `IMAGES_ENABLED=true`) serving
+  operator illustration and skin images from the AKDP image Release.
+  `action="list"` returns bounded metadata with semantic labels;
+  `action="get"` returns one image as base64 `ImageContent` (default `large`
+  variant, max 1024px). `LOCAL_IMAGE=true` (default) consumes synced local
+  assets via the existing auto-sync scheduler; `ORIGINAL_IMAGE=true` also
+  pulls full-resolution shards. Labels are joined from `skin_table.json`.
+
 ## [2.4.0] - 2026-07-29
 
 ### Fixed

--- a/python/scripts/check_package_data.py
+++ b/python/scripts/check_package_data.py
@@ -46,6 +46,10 @@ def main() -> int:
         gamedata_path=gamedata_root,
         storyjson_zip=story_zip,
         is_custom_gamedata=True,
+        images_enabled=False,
+        local_image=True,
+        original_image=False,
+        images_path=gamedata_root.parent / "images",
     )
 
     active_excel = config.effective_excel_path

--- a/python/src/prts_mcp/config.py
+++ b/python/src/prts_mcp/config.py
@@ -158,6 +158,17 @@ _DEFAULT_GAMEDATA_PATH = _resolve_default_gamedata_path()
 # storyjson zip alongside gamedata in the user data directory.
 _DEFAULT_STORYJSON_ZIP = _DEFAULT_GAMEDATA_PATH.parent / "storyjson" / "zh_CN.zip"
 
+# Image artwork assets (2.5.0) sit alongside gamedata under the data root.
+_DEFAULT_IMAGES_PATH = _DEFAULT_GAMEDATA_PATH.parent / "images"
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    """Parse a boolean env var (``1``/``true``/``yes``/``on``); unset → default."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
 
 def _excel_path(gamedata_root: Path) -> Path:
     return gamedata_root / "zh_CN" / "gamedata" / "excel"
@@ -246,6 +257,10 @@ class Config:
     gamedata_path: Path          # sync write target (volume or user dir)
     storyjson_zip: Path          # storyjson zip path (custom, volume, or default)
     is_custom_gamedata: bool     # True when GAMEDATA_PATH was set by the user
+    images_enabled: bool         # IMAGES_ENABLED; False → operator_artwork not registered
+    local_image: bool            # LOCAL_IMAGE; True = AKDP local assets, False = MediaWiki (future)
+    original_image: bool         # ORIGINAL_IMAGE; True = also sync original-variant shards
+    images_path: Path            # image asset sync target (PRTS_IMAGE_DIR or default)
 
     # Derived paths — set in __post_init__, never passed to __init__.
     excel_path: Path = field(init=False)
@@ -355,10 +370,19 @@ class Config:
             if "STORYJSON_PATH" in os.environ
             else _DEFAULT_STORYJSON_ZIP
         )
+        images_path = (
+            Path(os.environ["PRTS_IMAGE_DIR"])
+            if "PRTS_IMAGE_DIR" in os.environ
+            else _DEFAULT_IMAGES_PATH
+        )
         config = cls(
             gamedata_path=gamedata,
             storyjson_zip=storyjson_zip,
             is_custom_gamedata=custom,
+            images_enabled=_env_bool("IMAGES_ENABLED", False),
+            local_image=_env_bool("LOCAL_IMAGE", True),
+            original_image=_env_bool("ORIGINAL_IMAGE", False),
+            images_path=images_path,
         )
         return config
 

--- a/python/src/prts_mcp/data/images.py
+++ b/python/src/prts_mcp/data/images.py
@@ -1,0 +1,212 @@
+"""Image artwork index schema, data loading and label construction.
+
+Consumes the AKDP ``akdp-images/v1`` index.json (frozen schema in
+``arknights-data-pipeline/docs/image-index-schema.md``). Semantic labels
+are joined from ``skin_table.json`` at the consumer side; the index itself
+carries no display names, keeping the schema stable across game versions.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+from prts_mcp.config import (
+    Config,
+    activation_aware_cache,
+    register_activation_listener,
+)
+from prts_mcp.data.stores import DirectoryStore
+
+_logger = logging.getLogger(__name__)
+
+SCHEMA_VERSION = "akdp-images/v1"
+VARIANT_ORDER: tuple[str, ...] = ("original", "large", "preview")
+DEFAULT_VARIANT = "large"
+
+
+# ---------------------------------------------------------------------------
+# Index schema types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VariantMeta:
+    file: str
+    width: int
+    height: int
+    bytes: int
+    sha256: str
+
+
+@dataclass(frozen=True)
+class ArtworkEntry:
+    skin_id: str
+    kind: str            # "base" | "skin"
+    shard: str           # "chararts" | "skinpack"
+    since_version: str
+    variants: Mapping[str, VariantMeta]
+
+    def variant(self, name: str) -> VariantMeta | None:
+        """Return the named variant or None when absent."""
+        return self.variants.get(name)
+
+    def available_variants(self) -> tuple[str, ...]:
+        """Variants present for this artwork, in canonical order."""
+        return tuple(v for v in VARIANT_ORDER if v in self.variants)
+
+
+@dataclass(frozen=True)
+class ImagesIndex:
+    schema_version: str
+    baseline_version: str
+    current_version: str
+    shards: Mapping[str, str]
+    artworks: Mapping[str, ArtworkEntry]
+
+
+def _parse_variant(raw: Any) -> VariantMeta | None:
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return VariantMeta(
+            file=str(raw["file"]),
+            width=int(raw["w"]),
+            height=int(raw["h"]),
+            bytes=int(raw["bytes"]),
+            sha256=str(raw["sha256"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def parse_index(data: Mapping[str, Any]) -> ImagesIndex | None:
+    """Parse a raw index.json mapping. Returns None on schema mismatch.
+
+    The schema is frozen at ``akdp-images/v1``; an unfamiliar schemaVersion
+    is rejected so a future incompatible index does not silently misparse.
+    """
+    if data.get("schemaVersion") != SCHEMA_VERSION:
+        _logger.warning(
+            "images index schemaVersion mismatch: expected %r, got %r",
+            SCHEMA_VERSION,
+            data.get("schemaVersion"),
+        )
+        return None
+    artworks: dict[str, ArtworkEntry] = {}
+    raw_artworks = data.get("artworks")
+    if isinstance(raw_artworks, dict):
+        for skin_id, entry in raw_artworks.items():
+            if not isinstance(entry, dict):
+                continue
+            variants: dict[str, VariantMeta] = {}
+            for vname in VARIANT_ORDER:
+                parsed = _parse_variant(entry.get(vname))
+                if parsed is not None:
+                    variants[vname] = parsed
+            if not variants:
+                continue
+            artworks[str(skin_id)] = ArtworkEntry(
+                skin_id=str(skin_id),
+                kind=str(entry.get("kind", "base")),
+                shard=str(entry.get("shard", "")),
+                since_version=str(entry.get("sinceVersion", "")),
+                variants=variants,
+            )
+    raw_shards = data.get("shards")
+    shards = (
+        {str(k): str(v) for k, v in raw_shards.items()}
+        if isinstance(raw_shards, dict)
+        else {}
+    )
+    return ImagesIndex(
+        schema_version=SCHEMA_VERSION,
+        baseline_version=str(data.get("baselineVersion", "")),
+        current_version=str(data.get("currentVersion", "")),
+        shards=shards,
+        artworks=artworks,
+    )
+
+
+# ---------------------------------------------------------------------------
+# skin_table.json loading (charSkins mapping)
+# ---------------------------------------------------------------------------
+
+
+@activation_aware_cache(maxsize=1)
+def _load_char_skins() -> dict[str, Any]:
+    """Load the ``charSkins`` mapping from ``skin_table.json``.
+
+    Returns an empty mapping when excel data is unavailable or the file is
+    absent (the bundled fallback does not ship skin_table); callers fall
+    back to skinId-derived labels in that case.
+    """
+    cfg = Config.load()
+    excel = cfg.effective_excel_path
+    if excel is None:
+        return {}
+    store = DirectoryStore(excel)
+    if not store.exists("skin_table.json"):
+        return {}
+    try:
+        table = store.read_json("skin_table.json")
+    except (OSError, ValueError):
+        return {}
+    char_skins = table.get("charSkins")
+    return char_skins if isinstance(char_skins, dict) else {}
+
+
+def clear_image_caches() -> None:
+    """Clear image-related caches after synced game data changes on disk."""
+    _load_char_skins.cache_clear()
+
+
+register_activation_listener(clear_image_caches)
+
+
+# ---------------------------------------------------------------------------
+# Label construction
+# ---------------------------------------------------------------------------
+
+_BASE_ILLUST_LABELS: Mapping[str, str] = {"1": "精英零立绘", "2": "精英二立绘"}
+
+
+def build_artwork_label(
+    skin_id: str,
+    char_skins: Mapping[str, Any] | None = None,
+) -> str:
+    """Construct a human-readable label for an artwork ``skin_id``.
+
+    Priority:
+    - ``@`` fashion skins → ``displaySkin.skinName`` (e.g. "报童"); falls back
+      to a theme-derived placeholder when the skin name is unavailable.
+    - ``#N`` base illusts → programmatic label from the number suffix
+      (e.g. "精英二立绘"); a ``+`` suffix appends "（变体）".
+    - Unknown shapes → a tolerant fallback using the raw skin_id.
+
+    Labels intentionally omit the operator name: ``operator_artwork`` list
+    is already scoped to one operator, so the label only needs to
+    distinguish that operator's illusts/skins from each other.
+    """
+    skins = char_skins if char_skins is not None else _load_char_skins()
+    entry = skins.get(skin_id)
+
+    if "@" in skin_id:
+        if isinstance(entry, dict):
+            display = entry.get("displaySkin")
+            if isinstance(display, dict):
+                name = display.get("skinName")
+                if name:
+                    return str(name)
+        theme = skin_id.split("@", 1)[1].split("#", 1)[0]
+        return f"时装（{theme}）" if theme else "时装"
+
+    suffix = skin_id.rsplit("#", 1)[-1] if "#" in skin_id else ""
+    base_num = suffix.rstrip("+")
+    plus = "+" in suffix
+    label = _BASE_ILLUST_LABELS.get(base_num)
+    if label is None:
+        label = f"立绘 {base_num}" if base_num else "立绘"
+    if plus:
+        label += "（变体）"
+    return label

--- a/python/src/prts_mcp/data/images_sync.py
+++ b/python/src/prts_mcp/data/images_sync.py
@@ -1,0 +1,438 @@
+"""AKDP image asset sync for ``LOCAL_IMAGE=true`` mode.
+
+Discovers ``images-*`` GitHub Releases from the arknights-data-pipeline
+factory, downloads baseline shard zips + delta zips, and atomically
+activates a generation directory of PNG files indexed by ``index.json``.
+
+This module reuses the JSON sync's reliability primitives (cascading mirrors,
+atomic activation, cross-process locking, offline fallback) from
+:mod:`prts_mcp.data.sync`, but uses an images-specific discovery path:
+images Releases are tag-isolated from ``data-*`` Releases and cannot use the
+``/releases/latest`` endpoint (see
+``arknights-data-pipeline/docs/image-index-schema.md`` §6).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import shutil
+import time
+from pathlib import Path
+from uuid import uuid4
+
+import httpx
+
+from prts_mcp.data.images import SCHEMA_VERSION, parse_index
+from prts_mcp.data.sync import (
+    ReleaseSpec,
+    RepoSpec,
+    SyncResult,
+    _archive_activation_lock,
+    _get_cascading,
+    _github_headers,
+    _safe_extract_zip,
+    _url_candidates,
+)
+
+_logger = logging.getLogger(__name__)
+
+IMAGES_REPO_OWNER = "3aKHP"
+IMAGES_REPO = "arknights-data-pipeline"
+
+_DELTA_PREFIX = "images-"
+_BASELINE_PREFIX = "images-baseline-"
+_DELTA_ASSET_PREFIX = "images-delta-"
+
+# Default shard set: large + preview. original variants are added only when
+# ORIGINAL_IMAGE=true, to avoid pulling ~3.6 GB of full-res assets that most
+# deployments never read.
+_DEFAULT_SHARD_KEYS: tuple[str, ...] = (
+    "chararts-large",
+    "chararts-preview",
+    "skinpack-large",
+    "skinpack-preview",
+)
+_ORIGINAL_SHARD_KEYS: tuple[str, ...] = (
+    "chararts-original",
+    "skinpack-original",
+)
+_RETENTION_SECONDS = 24 * 60 * 60
+_IMAGES_META = ".images_meta.json"
+_IMAGES_LOCK = ".images.lock"
+
+
+def needed_shard_keys(include_original: bool) -> tuple[str, ...]:
+    """Return the shard keys to download given the original-variant flag."""
+    return _DEFAULT_SHARD_KEYS + (_ORIGINAL_SHARD_KEYS if include_original else ())
+
+
+# ---------------------------------------------------------------------------
+# Discovery (tag-prefix filtered; /releases/latest is not usable — schema §6)
+# ---------------------------------------------------------------------------
+
+
+def _list_releases(owner: str, repo: str, *, timeout: float = 10.0) -> list[dict] | None:
+    """List all non-draft releases. Returns None on any network/API failure."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/releases?per_page=100"
+    try:
+        response = _get_cascading(url, timeout=timeout, headers=_github_headers())
+        data = response.json()
+        return data if isinstance(data, list) else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _latest_release_by_prefix(
+    releases: list[dict],
+    prefix: str,
+    *,
+    exclude_prefix: str | None = None,
+) -> dict | None:
+    """Pick the newest release whose tag starts with ``prefix``.
+
+    Sorts by ``created_at`` (GitHub release creation timestamp) descending,
+    which is robust across baseline/delta tag formats.
+    """
+    candidates: list[dict] = []
+    for release in releases:
+        tag = release.get("tag_name")
+        if not isinstance(tag, str) or not tag.startswith(prefix):
+            continue
+        if exclude_prefix and tag.startswith(exclude_prefix):
+            continue
+        candidates.append(release)
+    if not candidates:
+        return None
+    candidates.sort(key=lambda r: str(r.get("created_at", "")), reverse=True)
+    return candidates[0]
+
+
+def _asset_url(release: dict, asset_name: str) -> str | None:
+    for asset in release.get("assets", []):
+        if isinstance(asset, dict) and asset.get("name") == asset_name:
+            url = asset.get("browser_download_url")
+            if isinstance(url, str):
+                return url
+    return None
+
+
+def _release_download_url(tag: str, asset_name: str) -> str:
+    """Construct a direct download URL (no API call; ghproxy-friendly)."""
+    return (
+        f"https://github.com/{IMAGES_REPO_OWNER}/{IMAGES_REPO}"
+        f"/releases/download/{tag}/{asset_name}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Downloads
+# ---------------------------------------------------------------------------
+
+
+def _download_small(url: str, *, timeout: float = 30.0) -> bytes | None:
+    """Download a small asset (index.json) into memory. None on failure."""
+    try:
+        response = _get_cascading(
+            url, timeout=timeout, headers=_github_headers(), follow_redirects=True,
+        )
+        return response.content
+    except Exception as exc:  # noqa: BLE001
+        _logger.debug("Failed to download %s: %s", url, exc)
+        return None
+
+
+def _download_large(url: str, dest: Path, *, timeout: float = 300.0) -> None:
+    """Stream-download a large asset (shard zip) to ``dest`` atomically.
+
+    Cascades through mirrors on failure, mirroring :func:`_get_cascading`
+    but with chunked writes so multi-hundred-MB shards do not stay resident.
+    Raises on total failure; the caller decides whether to fall back.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_name(f".{dest.name}.{uuid4().hex}.tmp")
+    last_exc: BaseException = RuntimeError(f"All URL candidates failed for {url}")
+    try:
+        for i, candidate in enumerate(_url_candidates(url)):
+            try:
+                with httpx.stream(
+                    "GET",
+                    candidate,
+                    timeout=timeout,
+                    headers=_github_headers(),
+                    follow_redirects=True,
+                ) as response:
+                    if not response.is_success:
+                        last_exc = RuntimeError(f"HTTP {response.status_code}")
+                        # Direct 4xx → resource genuinely missing; stop.
+                        if i == 0 and 400 <= response.status_code < 500:
+                            raise last_exc
+                        continue
+                    with tmp.open("wb") as dst:
+                        for chunk in response.iter_bytes(chunk_size=1024 * 1024):
+                            dst.write(chunk)
+                tmp.replace(dest)
+                return
+            except RuntimeError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+                continue
+        raise last_exc
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Generation state (.images_meta.json + .releases/<gen>/)
+# ---------------------------------------------------------------------------
+
+
+def _meta_path(root: Path) -> Path:
+    return root / _IMAGES_META
+
+
+def _load_meta(root: Path) -> dict | None:
+    try:
+        data = json.loads(_meta_path(root).read_text("utf-8"))
+        return data if isinstance(data, dict) else None
+    except (OSError, ValueError):
+        return None
+
+
+def _save_meta(root: Path, meta: dict) -> None:
+    path = _meta_path(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    tmp.write_text(json.dumps(meta, ensure_ascii=False, indent=2), "utf-8")
+    tmp.replace(path)
+
+
+def _active_generation(image_dir: Path) -> Path | None:
+    """Resolve the currently activated generation directory, or None."""
+    meta = _load_meta(image_dir)
+    if meta is None:
+        return None
+    rel = meta.get("generation_root")
+    if not isinstance(rel, str) or not rel:
+        return None
+    gen = (image_dir / rel).resolve()
+    try:
+        if not gen.is_relative_to(image_dir.resolve()):
+            return None
+    except ValueError:
+        return None
+    if not gen.is_dir() or not (gen / "index.json").is_file():
+        return None
+    return gen
+
+
+def _releases_dir(image_dir: Path) -> Path:
+    releases = image_dir / ".releases"
+    releases.mkdir(parents=True, exist_ok=True)
+    return releases
+
+
+def _version_hash(version: str) -> str:
+    return hashlib.sha256(version.encode("utf-8")).hexdigest()[:16]
+
+
+def _prune_generations(releases_dir: Path, keep: Path) -> None:
+    cutoff = time.time() - _RETENTION_SECONDS
+    for candidate in releases_dir.iterdir():
+        if candidate == keep or candidate.name.startswith("."):
+            continue
+        try:
+            if candidate.stat().st_mtime >= cutoff:
+                continue
+        except OSError:
+            continue
+        if candidate.is_dir():
+            shutil.rmtree(candidate, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Sync
+# ---------------------------------------------------------------------------
+
+
+def _dummy_spec(image_dir: Path) -> RepoSpec:
+    return RepoSpec(
+        owner=IMAGES_REPO_OWNER,
+        repo=IMAGES_REPO,
+        branch="releases",
+        files=("images",),
+        local_root=image_dir,
+    )
+
+
+def _offline_or_no_data(image_dir: Path, *, error: str) -> SyncResult:
+    """Return offline_fallback if cached images exist, else no_data."""
+    spec = _dummy_spec(image_dir)
+    if _active_generation(image_dir) is not None:
+        meta = _load_meta(image_dir)
+        ver = meta.get("current_version") if meta else None
+        return SyncResult(
+            spec,
+            "offline_fallback",
+            ver if isinstance(ver, str) else None,
+            error,
+        )
+    return SyncResult(spec, "no_data", None, error)
+
+
+def _sync_images_locked(
+    image_dir: Path,
+    shard_keys: tuple[str, ...],
+    *,
+    force_check: bool,
+) -> SyncResult:
+    spec = _dummy_spec(image_dir)
+
+    releases = _list_releases(IMAGES_REPO_OWNER, IMAGES_REPO)
+    if releases is None:
+        return _offline_or_no_data(image_dir, error="Network unavailable")
+
+    delta_release = _latest_release_by_prefix(
+        releases,
+        _DELTA_PREFIX,
+        exclude_prefix=_BASELINE_PREFIX,
+    )
+    if delta_release is None:
+        return _offline_or_no_data(image_dir, error="No images delta release found")
+
+    delta_tag = str(delta_release.get("tag_name", ""))
+    current_version = delta_tag[len(_DELTA_PREFIX):]
+
+    # index.json is a standalone asset on the delta Release (~1.1 MB).
+    index_url = _asset_url(delta_release, "index.json")
+    index_bytes = _download_small(index_url) if index_url else None
+    if index_bytes is None:
+        return _offline_or_no_data(image_dir, error="Failed to download index.json")
+
+    try:
+        index_data = json.loads(index_bytes.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        return SyncResult(spec, "no_data", None, "index.json is unreadable")
+
+    index = parse_index(index_data)
+    if index is None:
+        return SyncResult(spec, "no_data", None, "index.json schema mismatch")
+
+    baseline_version = index.baseline_version
+
+    meta = _load_meta(image_dir)
+    gen_dir = _active_generation(image_dir)
+    if (
+        not force_check
+        and meta is not None
+        and gen_dir is not None
+        and meta.get("current_version") == current_version
+        and meta.get("baseline_version") == baseline_version
+    ):
+        return SyncResult(spec, "up_to_date", current_version, None)
+
+    # --- Rebuild a new generation -----------------------------------------
+    releases_dir = _releases_dir(image_dir)
+    generation = f"{_version_hash(current_version)}-{uuid4().hex}"
+    staging = releases_dir / f".{generation}.tmp"
+    activated = releases_dir / generation
+    try:
+        staging.mkdir(parents=True, exist_ok=False)
+
+        baseline_unchanged = (
+            meta is not None
+            and gen_dir is not None
+            and meta.get("baseline_version") == baseline_version
+        )
+        if baseline_unchanged:
+            # Fast path: reuse prior PNGs, overlay only the new delta.
+            shutil.copytree(gen_dir, staging, dirs_exist_ok=True)
+            for stale in ("index.json", _IMAGES_META):
+                (staging / stale).unlink(missing_ok=True)
+        else:
+            baseline_tag = f"{_BASELINE_PREFIX}{baseline_version}"
+            for shard_key in shard_keys:
+                shard_file = index.shards.get(shard_key, "")
+                if not shard_file:
+                    continue
+                shard_zip = staging / f".{shard_key}.zip"
+                _download_large(
+                    _release_download_url(baseline_tag, shard_file),
+                    shard_zip,
+                )
+                _safe_extract_zip(shard_zip, staging)
+                shard_zip.unlink(missing_ok=True)
+
+        # Delta: overlay incremental PNGs (sentinel delta extracts nothing).
+        delta_asset = f"{_DELTA_ASSET_PREFIX}{current_version}.zip"
+        delta_url = _asset_url(delta_release, delta_asset)
+        if delta_url is not None:
+            delta_zip = staging / ".delta.zip"
+            try:
+                _download_large(delta_url, delta_zip)
+                _safe_extract_zip(delta_zip, staging)
+            except Exception as exc:  # noqa: BLE001
+                _logger.debug("Delta extract skipped: %s", exc)
+            finally:
+                delta_zip.unlink(missing_ok=True)
+
+        # Authoritative index.json + generation meta.
+        (staging / "index.json").write_bytes(index_bytes)
+        gen_meta = {
+            "schemaVersion": SCHEMA_VERSION,
+            "baselineVersion": baseline_version,
+            "currentVersion": current_version,
+        }
+        _save_meta(staging, gen_meta)
+
+        # Atomic activation.
+        if activated.exists():
+            shutil.rmtree(activated)
+        staging.replace(activated)
+        staging = None
+
+        # Top-level meta points at the active generation.
+        _save_meta(
+            image_dir,
+            {**gen_meta, "generation_root": str(activated.relative_to(image_dir))},
+        )
+        _prune_generations(releases_dir, activated)
+        _logger.info(
+            "Images synced: baseline=%s current=%s (%d artworks)",
+            baseline_version[:16],
+            current_version[:16],
+            len(index.artworks),
+        )
+        return SyncResult(spec, "updated", current_version, None)
+    except Exception as exc:  # noqa: BLE001
+        if staging is not None:
+            shutil.rmtree(staging, ignore_errors=True)
+        return _offline_or_no_data(image_dir, error=str(exc))
+
+
+def sync_images(
+    image_dir: Path | str,
+    *,
+    include_original: bool = False,
+    force_check: bool = False,
+) -> SyncResult:
+    """Discover, download and activate AKDP image assets under ``image_dir``.
+
+    Returns a :class:`SyncResult` compatible with the auto-sync scheduler.
+    The ``commit_sha`` field carries the images ``currentVersion``.
+    """
+    image_dir = Path(image_dir)
+    image_dir.mkdir(parents=True, exist_ok=True)
+    shard_keys = needed_shard_keys(include_original)
+    lock_spec = ReleaseSpec(
+        owner=IMAGES_REPO_OWNER,
+        repo=IMAGES_REPO,
+        asset_name="images-sync",
+        local_zip=image_dir / ".images-sync",
+    )
+    try:
+        with _archive_activation_lock(lock_spec, _IMAGES_LOCK):
+            return _sync_images_locked(image_dir, shard_keys, force_check=force_check)
+    except Exception as exc:  # noqa: BLE001
+        return _offline_or_no_data(image_dir, error=str(exc))

--- a/python/src/prts_mcp/data/images_sync.py
+++ b/python/src/prts_mcp/data/images_sync.py
@@ -304,7 +304,27 @@ def _sync_images_locked(
     delta_tag = str(delta_release.get("tag_name", ""))
     current_version = delta_tag[len(_DELTA_PREFIX):]
 
-    # index.json is a standalone asset on the delta Release (~1.1 MB).
+    meta = _load_meta(image_dir)
+    gen_dir = _active_generation(image_dir)
+    synced = meta.get("shardsSynced") if meta else None
+    same_shards = isinstance(synced, list) and set(synced) == set(shard_keys)
+
+    # Tag-level shortcut: if the release tag's currentVersion and the shard
+    # set already match the active generation, skip the ~1.1 MB index.json
+    # download. baselineVersion rides in index.json but cannot change without
+    # a new delta tag, so tag equality implies baseline equality. force_check
+    # still drives a real GitHub API call here; a TTL freshness skip like
+    # sync.py's _cache_is_fresh is deferred (the API call is cheap; only the
+    # index.json download is avoided when the tag is unchanged).
+    if (
+        meta is not None
+        and gen_dir is not None
+        and meta.get("currentVersion") == current_version
+        and same_shards
+    ):
+        return SyncResult(spec, "up_to_date", current_version, None)
+
+    # Tag differs (or first sync) → download index.json and rebuild.
     index_url = _asset_url(delta_release, "index.json")
     index_bytes = _download_small(index_url) if index_url else None
     if index_bytes is None:
@@ -320,19 +340,6 @@ def _sync_images_locked(
         return SyncResult(spec, "no_data", None, "index.json schema mismatch")
 
     baseline_version = index.baseline_version
-
-    meta = _load_meta(image_dir)
-    gen_dir = _active_generation(image_dir)
-    synced = meta.get("shardsSynced") if meta else None
-    same_shards = isinstance(synced, list) and set(synced) == set(shard_keys)
-    if (
-        meta is not None
-        and gen_dir is not None
-        and meta.get("currentVersion") == current_version
-        and meta.get("baselineVersion") == baseline_version
-        and same_shards
-    ):
-        return SyncResult(spec, "up_to_date", current_version, None)
 
     # --- Rebuild a new generation -----------------------------------------
     releases_dir = _releases_dir(image_dir)

--- a/python/src/prts_mcp/data/images_sync.py
+++ b/python/src/prts_mcp/data/images_sync.py
@@ -271,7 +271,7 @@ def _offline_or_no_data(image_dir: Path, *, error: str) -> SyncResult:
     spec = _dummy_spec(image_dir)
     if _active_generation(image_dir) is not None:
         meta = _load_meta(image_dir)
-        ver = meta.get("current_version") if meta else None
+        ver = meta.get("currentVersion") if meta else None
         return SyncResult(
             spec,
             "offline_fallback",
@@ -323,12 +323,14 @@ def _sync_images_locked(
 
     meta = _load_meta(image_dir)
     gen_dir = _active_generation(image_dir)
+    synced = meta.get("shardsSynced") if meta else None
+    same_shards = isinstance(synced, list) and set(synced) == set(shard_keys)
     if (
-        not force_check
-        and meta is not None
+        meta is not None
         and gen_dir is not None
-        and meta.get("current_version") == current_version
-        and meta.get("baseline_version") == baseline_version
+        and meta.get("currentVersion") == current_version
+        and meta.get("baselineVersion") == baseline_version
+        and same_shards
     ):
         return SyncResult(spec, "up_to_date", current_version, None)
 
@@ -343,7 +345,8 @@ def _sync_images_locked(
         baseline_unchanged = (
             meta is not None
             and gen_dir is not None
-            and meta.get("baseline_version") == baseline_version
+            and meta.get("baselineVersion") == baseline_version
+            and same_shards
         )
         if baseline_unchanged:
             # Fast path: reuse prior PNGs, overlay only the new delta.
@@ -364,18 +367,18 @@ def _sync_images_locked(
                 _safe_extract_zip(shard_zip, staging)
                 shard_zip.unlink(missing_ok=True)
 
-        # Delta: overlay incremental PNGs (sentinel delta extracts nothing).
+        # Delta: overlay incremental PNGs. A download/extract failure must
+        # propagate (not be swallowed) so a half-applied delta never activates
+        # — the authoritative index.json would otherwise reference PNGs that
+        # are absent. The sentinel delta (empty zip) downloads and extracts
+        # without raising, so it passes through cleanly.
         delta_asset = f"{_DELTA_ASSET_PREFIX}{current_version}.zip"
         delta_url = _asset_url(delta_release, delta_asset)
         if delta_url is not None:
             delta_zip = staging / ".delta.zip"
-            try:
-                _download_large(delta_url, delta_zip)
-                _safe_extract_zip(delta_zip, staging)
-            except Exception as exc:  # noqa: BLE001
-                _logger.debug("Delta extract skipped: %s", exc)
-            finally:
-                delta_zip.unlink(missing_ok=True)
+            _download_large(delta_url, delta_zip)
+            _safe_extract_zip(delta_zip, staging)
+            delta_zip.unlink(missing_ok=True)
 
         # Authoritative index.json + generation meta.
         (staging / "index.json").write_bytes(index_bytes)
@@ -383,6 +386,7 @@ def _sync_images_locked(
             "schemaVersion": SCHEMA_VERSION,
             "baselineVersion": baseline_version,
             "currentVersion": current_version,
+            "shardsSynced": list(shard_keys),
         }
         _save_meta(staging, gen_meta)
 

--- a/python/src/prts_mcp/output.py
+++ b/python/src/prts_mcp/output.py
@@ -24,7 +24,7 @@ import logging
 import os
 from typing import Any, Literal
 
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, ImageContent, TextContent
 
 _logger = logging.getLogger("prts_mcp.output")
 
@@ -206,5 +206,50 @@ def text_result(markdown: str) -> CallToolResult:
     return CallToolResult(
         content=[TextContent(type="text", text=markdown)],
         structuredContent=None,
+        isError=False,
+    )
+
+
+def render_image_result(
+    markdown: str,
+    image_data: str,
+    image_mimetype: str,
+    data: dict[str, Any] | None = None,
+    channel: OutputChannel | None = None,
+    summary: str | None = None,
+) -> CallToolResult:
+    """Build a ``CallToolResult`` carrying text + one image, shaped by the channel.
+
+    The image always rides in ``content`` as an ``ImageContent`` block — MCP
+    does not allow images inside ``structuredContent``. The ``data`` payload
+    (image metadata) travels in ``structuredContent`` per the same channel
+    rules as :func:`render_result`:
+
+    - ``content``   → markdown + image; no structuredContent.
+    - ``structured`` → summary text + image + structuredContent.
+    - ``both``      → markdown + image + structuredContent.
+
+    When ``data is None`` the image is still returned with the markdown text
+    and no structuredContent (rare; prefer passing metadata for ``get``).
+    """
+    if channel is None:
+        channel = get_output_channel()
+    image = ImageContent(type="image", data=image_data, mimeType=image_mimetype)
+    if data is None or channel == "content":
+        return CallToolResult(
+            content=[TextContent(type="text", text=markdown), image],
+            structuredContent=None,
+            isError=False,
+        )
+    if channel == "both":
+        return CallToolResult(
+            content=[TextContent(type="text", text=markdown), image],
+            structuredContent=data,
+            isError=False,
+        )
+    # structured: summary text + image, plus structured payload.
+    return CallToolResult(
+        content=[TextContent(type="text", text=_summarize(data, summary)), image],
+        structuredContent=data,
         isError=False,
     )

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -49,6 +49,7 @@ mcp = FastMCP("PRTS_Wiki_Assistant")
 
 def _register_tools() -> None:
     """Register MCP tools via the focused tool modules."""
+    from prts_mcp.config import Config
     from prts_mcp.tools_prts import register_prts_tools
     from prts_mcp.tools_gamedata import register_gamedata_tools
     from prts_mcp.tools_story import register_story_tools
@@ -56,6 +57,12 @@ def _register_tools() -> None:
     register_prts_tools(mcp)
     register_gamedata_tools(mcp)
     register_story_tools(mcp)
+
+    # operator_artwork is registered only when IMAGES_ENABLED=true.
+    if Config.load().images_enabled:
+        from prts_mcp.tools_artwork import register_artwork_tools
+
+        register_artwork_tools(mcp)
 
 
 _register_tools()

--- a/python/src/prts_mcp/startup_sync.py
+++ b/python/src/prts_mcp/startup_sync.py
@@ -197,6 +197,26 @@ def _run_startup_sync(*, force_check: bool = False) -> None:
         if needs_retry and not force_check:
             _schedule_sync_retry("Storyjson", _sync_storyjson)
 
+    # Images artwork sync (2.5.0) — LOCAL_IMAGE mode consumes AKDP assets.
+    if cfg.images_enabled and cfg.local_image:
+        from prts_mcp.data.images_sync import sync_images as _sync_images_release
+
+        def _sync_images() -> bool:
+            r = _sync_images_release(
+                cfg.images_path,
+                include_original=cfg.original_image,
+                force_check=force_check,
+            )
+            _log_sync_result(r)
+            return _sync_needs_retry(r.status)
+
+        needs_retry = _run_initial_sync(
+            "Images",
+            lambda: _single_flight_sync("Images", _sync_images) != "done",
+        )
+        if needs_retry and not force_check:
+            _schedule_sync_retry("Images", _sync_images)
+
 
 def _auto_sync_interval_seconds() -> int:
     raw = os.environ.get("PRTS_AUTO_SYNC_INTERVAL_SECONDS")

--- a/python/src/prts_mcp/tools_artwork.py
+++ b/python/src/prts_mcp/tools_artwork.py
@@ -63,7 +63,11 @@ def _data_not_ready() -> object:
 
 
 async def _do_list(operator_name: str) -> object:
-    char_id = _resolve_char_id(operator_name)
+    try:
+        char_id = _resolve_char_id(operator_name)
+    except (OSError, AssertionError):
+        # gamedata not synced yet (effective_excel_path None or table missing).
+        return _data_not_ready()
     if char_id is None:
         return text_result(
             f"找不到干员「{operator_name}」。建议先用 search_prts 确认准确的中文名称。"
@@ -143,8 +147,12 @@ async def _do_get(
         return text_result(
             f"artwork_id「{artwork_id}」不提供「{chosen}」变体（可用：{available}）。"
         )
-    png_path = gen_dir / variant_meta.file
-    if not png_path.is_file():
+    # The file field comes from the network-downloaded index; contain it to
+    # the generation dir so a malformed/compromised upstream cannot read an
+    # arbitrary host file and exfiltrate it base64-encoded.
+    gen_resolved = gen_dir.resolve()
+    png_path = (gen_dir / variant_meta.file).resolve()
+    if not png_path.is_relative_to(gen_resolved) or not png_path.is_file():
         return text_result(
             f"图片文件缺失：{variant_meta.file}。同步可能不完整，请稍后重试。"
         )

--- a/python/src/prts_mcp/tools_artwork.py
+++ b/python/src/prts_mcp/tools_artwork.py
@@ -13,7 +13,7 @@ from typing import Annotated, Literal
 
 from pydantic import Field
 
-from prts_mcp.config import Config
+from prts_mcp.config import Config, activation_snapshot
 from prts_mcp.data.images import (
     DEFAULT_VARIANT,
     _load_char_skins,
@@ -194,6 +194,7 @@ def register_artwork_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     """Register the ``operator_artwork`` tool on the given FastMCP instance."""
 
     @mcp.tool()
+    @activation_snapshot
     async def operator_artwork(
         operator_name: Annotated[str, Field(description="干员名称（中文），如「阿米娅」。")],
         action: Annotated[Literal["list", "get"], Field(description="操作（必填）：list=列出该干员所有立绘及 artwork_id；get=按 artwork_id 获取一张图片。")],

--- a/python/src/prts_mcp/tools_artwork.py
+++ b/python/src/prts_mcp/tools_artwork.py
@@ -1,0 +1,211 @@
+"""Operator artwork (立绘) tool — list illusts/skins and get image variants.
+
+Consumes AKDP image assets synced in ``LOCAL_IMAGE=true`` mode. Registered
+only when ``IMAGES_ENABLED=true`` (see server.py).
+"""
+from __future__ import annotations
+
+import base64
+import json
+import logging
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import Field
+
+from prts_mcp.config import Config
+from prts_mcp.data.images import (
+    DEFAULT_VARIANT,
+    _load_char_skins,
+    build_artwork_label,
+    parse_index,
+)
+from prts_mcp.data.images_sync import _active_generation
+from prts_mcp.data.operator import _resolve_char_id
+from prts_mcp.output import render_image_result, render_result, text_result
+
+_logger = logging.getLogger(__name__)
+
+
+def _images_generation() -> Path | None:
+    """Return the active images generation directory, or None when unavailable."""
+    cfg = Config.load()
+    if not cfg.images_enabled:
+        return None
+    return _active_generation(cfg.images_path)
+
+
+def _load_index(gen_dir: Path):
+    """Parse index.json from a generation dir; None on missing/unreadable."""
+    index_path = gen_dir / "index.json"
+    if not index_path.is_file():
+        return None
+    try:
+        return parse_index(json.loads(index_path.read_text("utf-8")))
+    except (OSError, ValueError):
+        return None
+
+
+def _char_id_of(skin_id: str) -> str:
+    """Extract the charId prefix from a skinId.
+
+    ``char_002_amiya#1+`` → ``char_002_amiya``;
+    ``char_002_amiya@epoque#4`` → ``char_002_amiya``.
+    """
+    return skin_id.split("#", 1)[0].split("@", 1)[0]
+
+
+def _data_not_ready() -> object:
+    return text_result(
+        "立绘数据未就绪。可能原因：IMAGES_ENABLED 未开启，或图片同步仍在进行中。"
+        "请稍后重试；若持续不可用，请检查网络或 GITHUB_TOKEN。"
+    )
+
+
+async def _do_list(operator_name: str) -> object:
+    char_id = _resolve_char_id(operator_name)
+    if char_id is None:
+        return text_result(
+            f"找不到干员「{operator_name}」。建议先用 search_prts 确认准确的中文名称。"
+        )
+    gen_dir = _images_generation()
+    if gen_dir is None:
+        return _data_not_ready()
+    index = _load_index(gen_dir)
+    if index is None:
+        return _data_not_ready()
+
+    matched = sorted(
+        (
+            (sid, entry)
+            for sid, entry in index.artworks.items()
+            if _char_id_of(sid) == char_id
+        ),
+        key=lambda item: item[0],
+    )
+    if not matched:
+        return text_result(f"未找到「{operator_name}」的立绘数据。")
+
+    char_skins = _load_char_skins()
+    artworks = [
+        {
+            "artwork_id": sid,
+            "label": build_artwork_label(sid, char_skins),
+            "kind": entry.kind,
+            "variants": {
+                v: {
+                    "width": entry.variants[v].width,
+                    "height": entry.variants[v].height,
+                    "bytes": entry.variants[v].bytes,
+                }
+                for v in entry.available_variants()
+            },
+        }
+        for sid, entry in matched
+    ]
+    data = {
+        "operator_name": operator_name,
+        "char_id": char_id,
+        "total": len(artworks),
+        "artworks": artworks,
+    }
+    markdown = _render_list(operator_name, artworks)
+    return render_result(
+        data,
+        markdown,
+        summary=f"「{operator_name}」共 {len(artworks)} 张立绘，详见 structuredContent",
+    )
+
+
+async def _do_get(
+    operator_name: str,
+    artwork_id: str | None,
+    variant: str | None,
+) -> object:
+    if not artwork_id:
+        return text_result("action=get 时必须提供 artwork_id。请先用 action=list 获取。")
+    chosen = variant or DEFAULT_VARIANT
+    gen_dir = _images_generation()
+    if gen_dir is None:
+        return _data_not_ready()
+    index = _load_index(gen_dir)
+    if index is None:
+        return _data_not_ready()
+
+    entry = index.artworks.get(artwork_id)
+    if entry is None:
+        return text_result(
+            f"找不到 artwork_id「{artwork_id}」。该 ID 不透明，请用 action=list 重新获取。"
+        )
+    variant_meta = entry.variant(chosen)
+    if variant_meta is None:
+        available = "、".join(entry.available_variants()) or "无"
+        return text_result(
+            f"artwork_id「{artwork_id}」不提供「{chosen}」变体（可用：{available}）。"
+        )
+    png_path = gen_dir / variant_meta.file
+    if not png_path.is_file():
+        return text_result(
+            f"图片文件缺失：{variant_meta.file}。同步可能不完整，请稍后重试。"
+        )
+    try:
+        image_bytes = png_path.read_bytes()
+    except OSError as exc:
+        return text_result(f"读取图片文件失败：{exc}")
+
+    image_b64 = base64.b64encode(image_bytes).decode("ascii")
+    char_skins = _load_char_skins()
+    label = build_artwork_label(artwork_id, char_skins)
+    markdown = (
+        f"**{label}**（{operator_name}）\n"
+        f"变体：{chosen}｜尺寸：{variant_meta.width}×{variant_meta.height}"
+        f"｜{variant_meta.bytes} bytes\n"
+        f"artwork_id：`{artwork_id}`"
+    )
+    data = {
+        "operator_name": operator_name,
+        "artwork_id": artwork_id,
+        "label": label,
+        "variant": chosen,
+        "width": variant_meta.width,
+        "height": variant_meta.height,
+        "bytes": variant_meta.bytes,
+        "sha256": variant_meta.sha256,
+    }
+    return render_image_result(
+        markdown,
+        image_b64,
+        "image/png",
+        data,
+        summary=f"{operator_name} 的「{label}」（{chosen}）",
+    )
+
+
+def _render_list(operator_name: str, artworks: list[dict]) -> str:
+    header = f"# 「{operator_name}」的立绘（共 {len(artworks)} 张）\n"
+    lines = []
+    for art in artworks:
+        variants = "/".join(art["variants"].keys())
+        lines.append(f"- **{art['label']}**｜`{art['artwork_id']}`｜变体：{variants}")
+    return header + "\n".join(lines)
+
+
+def register_artwork_tools(mcp) -> None:  # type: ignore[no-untyped-def]
+    """Register the ``operator_artwork`` tool on the given FastMCP instance."""
+
+    @mcp.tool()
+    async def operator_artwork(
+        operator_name: Annotated[str, Field(description="干员名称（中文），如「阿米娅」。")],
+        action: Annotated[Literal["list", "get"], Field(description="操作（必填）：list=列出该干员所有立绘及 artwork_id；get=按 artwork_id 获取一张图片。")],
+        artwork_id: Annotated[str | None, Field(default=None, description="仅 action=get 必填：list 返回的不透明 token，原样回传即可，不可自行构造。")] = None,
+        variant: Annotated[Literal["original", "large", "preview"] | None, Field(default=None, description="仅 action=get 生效：图片变体。large=max 1024px（默认），preview=max 256px，original=原图（需服务端开启 ORIGINAL_IMAGE 同步）。")] = None,
+    ) -> object:
+        """查询干员立绘（精英化立绘、时装等）并获取图片。
+
+        先用 action="list" 拿到该干员所有立绘的 artwork_id 与元数据（不返回图片），
+        再用 action="get" + artwork_id 获取一张图片（base64 编码，默认 large 变体）。
+        单次 get 最多返回一张图片。
+        """
+        if action == "list":
+            return await _do_list(operator_name)
+        return await _do_get(operator_name, artwork_id, variant)

--- a/python/tests/test_images.py
+++ b/python/tests/test_images.py
@@ -1,0 +1,212 @@
+"""Tests for image artwork index parsing, labels and the operator_artwork tool."""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+
+import pytest
+
+from prts_mcp.data.images import SCHEMA_VERSION, build_artwork_label, parse_index
+from prts_mcp.output import _channel_var
+from prts_mcp.tools_artwork import _do_get, _do_list
+
+# A 1x1 transparent PNG used as a stand-in image payload.
+_SAMPLE_PNG_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9aw"
+    "AAAABJRU5ErkJggg=="
+)
+
+
+def _sample_index() -> dict:
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "baselineVersion": "b1",
+        "currentVersion": "c1",
+        "shards": {"chararts-large": "chararts-large.zip"},
+        "artworks": {
+            "char_002_amiya#1": {
+                "kind": "base",
+                "shard": "chararts",
+                "large": {
+                    "file": "amiya_1.large.png",
+                    "w": 1024,
+                    "h": 1100,
+                    "bytes": 50,
+                    "sha256": "h1",
+                },
+                "preview": {
+                    "file": "amiya_1.preview.png",
+                    "w": 256,
+                    "h": 275,
+                    "bytes": 20,
+                    "sha256": "h2",
+                },
+            },
+            "char_002_amiya@winter#1": {
+                "kind": "skin",
+                "shard": "skinpack",
+                "large": {
+                    "file": "amiya_winter.large.png",
+                    "w": 1024,
+                    "h": 1024,
+                    "bytes": 60,
+                    "sha256": "h3",
+                },
+            },
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# parse_index
+# ---------------------------------------------------------------------------
+
+
+def test_parse_index_accepts_valid_schema():
+    idx = parse_index(_sample_index())
+    assert idx is not None
+    assert idx.baseline_version == "b1"
+    assert idx.current_version == "c1"
+    assert idx.shards == {"chararts-large": "chararts-large.zip"}
+    entry = idx.artworks["char_002_amiya#1"]
+    assert entry.kind == "base"
+    assert entry.shard == "chararts"
+    assert entry.variant("large").file == "amiya_1.large.png"
+    assert entry.variant("original") is None
+    assert entry.available_variants() == ("large", "preview")
+
+
+def test_parse_index_rejects_unknown_schema():
+    assert parse_index({"schemaVersion": "other"}) is None
+
+
+def test_parse_index_skips_artworks_without_variants():
+    raw = _sample_index()
+    raw["artworks"]["char_002_amiya#2"] = {"kind": "base", "shard": "chararts"}
+    idx = parse_index(raw)
+    assert idx is not None
+    assert "char_002_amiya#2" not in idx.artworks
+
+
+# ---------------------------------------------------------------------------
+# build_artwork_label
+# ---------------------------------------------------------------------------
+
+
+def test_build_artwork_labels():
+    char_skins = {
+        "char_002_amiya@winter#1": {"displaySkin": {"skinName": "报童"}},
+    }
+    assert build_artwork_label("char_002_amiya#1", char_skins) == "精英零立绘"
+    assert build_artwork_label("char_002_amiya#1+", char_skins) == "精英零立绘（变体）"
+    assert build_artwork_label("char_002_amiya#2", char_skins) == "精英二立绘"
+    assert build_artwork_label("char_002_amiya@winter#1", char_skins) == "报童"
+    # Unknown fashion theme falls back to a theme-derived placeholder.
+    assert build_artwork_label("char_002_amiya@unknown#1", char_skins) == "时装（unknown）"
+    # Unknown base illust number gets a tolerant label.
+    assert build_artwork_label("char_002_amiya#5", char_skins) == "立绘 5"
+
+
+# ---------------------------------------------------------------------------
+# operator_artwork list / get
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_images(monkeypatch, tmp_path):
+    """Stand up a fake active generation directory with index.json + PNGs."""
+    gen = tmp_path / "gen"
+    gen.mkdir()
+    (gen / "index.json").write_text(json.dumps(_sample_index()), "utf-8")
+    png = base64.b64decode(_SAMPLE_PNG_B64)
+    for name in ("amiya_1.large.png", "amiya_1.preview.png", "amiya_winter.large.png"):
+        (gen / name).write_bytes(png)
+
+    monkeypatch.setattr(
+        "prts_mcp.tools_artwork._images_generation", lambda: gen,
+    )
+    monkeypatch.setattr(
+        "prts_mcp.tools_artwork._resolve_char_id",
+        lambda name: "char_002_amiya" if name == "阿米娅" else None,
+    )
+    monkeypatch.setattr(
+        "prts_mcp.tools_artwork._load_char_skins",
+        lambda: {"char_002_amiya@winter#1": {"displaySkin": {"skinName": "报童"}}},
+    )
+    return gen
+
+
+def test_list_returns_markdown_with_labels(mock_images):
+    result = asyncio.run(_do_list("阿米娅"))
+    assert result.isError is False
+    assert result.structuredContent is None  # default channel = content
+    text_blocks = [c for c in result.content if c.type == "text"]
+    assert len(text_blocks) == 1
+    body = text_blocks[0].text
+    assert "阿米娅" in body
+    assert "精英零立绘" in body
+    assert "报童" in body
+    # No image content in list.
+    assert not any(c.type == "image" for c in result.content)
+
+
+def test_list_structured_channel(mock_images):
+    token = _channel_var.set("structured")
+    try:
+        result = asyncio.run(_do_list("阿米娅"))
+    finally:
+        _channel_var.reset(token)
+    data = result.structuredContent
+    assert data is not None
+    assert data["operator_name"] == "阿米娅"
+    assert data["char_id"] == "char_002_amiya"
+    assert data["total"] == 2
+    labels = {a["label"] for a in data["artworks"]}
+    assert "精英零立绘" in labels
+    assert "报童" in labels
+
+
+def test_list_unknown_operator(mock_images):
+    result = asyncio.run(_do_list("不存在"))
+    text = result.content[0].text
+    assert "找不到" in text
+
+
+def test_get_returns_image_content(mock_images):
+    result = asyncio.run(_do_get("阿米娅", "char_002_amiya#1", "large"))
+    assert result.isError is False
+    image_blocks = [c for c in result.content if c.type == "image"]
+    assert len(image_blocks) == 1
+    assert image_blocks[0].mimeType == "image/png"
+    # Pure base64 (no data: prefix) that decodes to the fixture PNG.
+    assert image_blocks[0].data == _SAMPLE_PNG_B64
+    text_blocks = [c for c in result.content if c.type == "text"]
+    assert any("精英零立绘" in t.text for t in text_blocks)
+
+
+def test_get_default_variant_is_large(mock_images):
+    result = asyncio.run(_do_get("阿米娅", "char_002_amiya#1", None))
+    image_blocks = [c for c in result.content if c.type == "image"]
+    assert len(image_blocks) == 1
+
+
+def test_get_missing_artwork_id(mock_images):
+    result = asyncio.run(_do_get("阿米娅", "char_999_nonexistent#1", "large"))
+    text = result.content[0].text
+    assert "找不到" in text
+    assert not any(c.type == "image" for c in result.content)
+
+
+def test_get_unavailable_variant(mock_images):
+    # char_002_amiya@winter#1 only has large, not preview.
+    result = asyncio.run(_do_get("阿米娅", "char_002_amiya@winter#1", "preview"))
+    text = result.content[0].text
+    assert "不提供" in text
+    assert not any(c.type == "image" for c in result.content)
+
+
+def test_get_without_artwork_id(mock_images):
+    result = asyncio.run(_do_get("阿米娅", None, "large"))
+    text = result.content[0].text
+    assert "artwork_id" in text

--- a/python/tests/test_images_sync.py
+++ b/python/tests/test_images_sync.py
@@ -1,0 +1,124 @@
+"""Tests for images_sync round-trip behavior (discovery mocked).
+
+These guard the meta read/write key consistency and the atomic-activation
+invariants that a single-shot E2E cannot exercise.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+
+from prts_mcp.data.images import SCHEMA_VERSION
+from prts_mcp.data.images_sync import _active_generation, needed_shard_keys, sync_images
+
+
+def _make_index(baseline: str = "b1", current: str = "c1") -> dict:
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "baselineVersion": baseline,
+        "currentVersion": current,
+        "shards": {f"{s}-{v}": f"images-baseline-{s}-{v}-{baseline}.zip"
+                   for s in ("chararts", "skinpack")
+                   for v in ("original", "large", "preview")},
+        "artworks": {},
+    }
+
+
+def _setup_mocks(monkeypatch, *, current: str = "c1", baseline: str = "b1",
+                 delta_fails: bool = False) -> dict:
+    """Mock discovery + downloads; return a call counter."""
+    calls = {"large": 0}
+    releases = [{
+        "tag_name": f"images-{current}",
+        "created_at": "2026-08-06T00:56:29Z",
+        "assets": [
+            {"name": "index.json",
+             "browser_download_url": f"https://ex/{current}/index.json"},
+            {"name": f"images-delta-{current}.zip",
+             "browser_download_url": f"https://ex/{current}/delta.zip"},
+        ],
+    }]
+
+    monkeypatch.setattr(
+        "prts_mcp.data.images_sync._list_releases",
+        lambda owner, repo, *, timeout=10.0: releases,
+    )
+    monkeypatch.setattr(
+        "prts_mcp.data.images_sync._download_small",
+        lambda url, *, timeout=30.0: json.dumps(_make_index(baseline, current)).encode("utf-8")
+        if "index.json" in url else None,
+    )
+
+    def mock_download_large(url: str, dest: Path, *, timeout: float = 300.0) -> None:
+        calls["large"] += 1
+        if delta_fails and "delta" in url:
+            raise RuntimeError("delta download failed")
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with ZipFile(dest, "w"):  # empty zip — extracts nothing
+            pass
+
+    monkeypatch.setattr("prts_mcp.data.images_sync._download_large", mock_download_large)
+    return calls
+
+
+def test_sync_first_updated_then_up_to_date(tmp_path, monkeypatch):
+    """Regression guard: meta read/write keys must match.
+
+    A key mismatch (write camelCase, read snake_case) would make the second
+    sync re-download everything instead of returning up_to_date.
+    """
+    image_dir = tmp_path / "images"
+    calls = _setup_mocks(monkeypatch)
+
+    r1 = sync_images(image_dir, include_original=False, force_check=True)
+    assert r1.status == "updated"
+    assert r1.commit_sha == "c1"
+    first = calls["large"]
+    assert first == len(needed_shard_keys(False)) + 1  # shards + delta
+
+    r2 = sync_images(image_dir, include_original=False, force_check=True)
+    assert r2.status == "up_to_date", "same versions must be up_to_date"
+    assert calls["large"] == first, "up_to_date must not re-download"
+
+
+def test_sync_original_image_switch_triggers_rebuild(tmp_path, monkeypatch):
+    """ORIGINAL_IMAGE false→true changes the shard set; must rebuild, not shortcut."""
+    image_dir = tmp_path / "images"
+    calls = _setup_mocks(monkeypatch)
+
+    sync_images(image_dir, include_original=False, force_check=True)
+    first = calls["large"]
+
+    r2 = sync_images(image_dir, include_original=True, force_check=True)
+    assert r2.status == "updated", "shard set change must trigger rebuild"
+    assert calls["large"] > first
+
+
+def test_sync_delta_failure_does_not_activate(tmp_path, monkeypatch):
+    """A delta download failure must not leave a broken generation active."""
+    image_dir = tmp_path / "images"
+    _setup_mocks(monkeypatch, delta_fails=True)
+
+    r = sync_images(image_dir, include_original=False, force_check=True)
+    assert r.status == "no_data", "delta failure with no prior generation → no_data"
+    assert _active_generation(image_dir) is None
+
+
+def test_sync_offline_falls_back_to_existing(tmp_path, monkeypatch):
+    """Network failure after a successful sync returns offline_fallback."""
+    image_dir = tmp_path / "images"
+    calls = _setup_mocks(monkeypatch)
+    sync_images(image_dir, include_original=False, force_check=True)
+
+    # Simulate network loss on the next cycle.
+    monkeypatch.setattr(
+        "prts_mcp.data.images_sync._list_releases",
+        lambda owner, repo, *, timeout=10.0: None,
+    )
+    r = sync_images(image_dir, include_original=False, force_check=True)
+    assert r.status == "offline_fallback"
+    assert r.commit_sha == "c1"
+    assert _active_generation(image_dir) is not None

--- a/python/tests/test_tool_surface.py
+++ b/python/tests/test_tool_surface.py
@@ -35,6 +35,9 @@ EXPECTED_TOOL_SURFACE = {
     "get_operator_memoirs": ("name",),
     "find_character_appearances": ("name", "scope", "max_events"),
     "find_speakers_in": ("event_id",),
+    # operator_artwork is conditionally registered (IMAGES_ENABLED=true); the
+    # signature is frozen at the source level like the other tools.
+    "operator_artwork": ("operator_name", "action", "artwork_id", "variant"),
 }
 
 
@@ -96,7 +99,12 @@ def test_registered_tool_manifest_has_no_output_schema() -> None:
     app = _build_registered_app()
 
     tools = {tool.name: tool for tool in asyncio.run(app.list_tools())}
-    assert set(tools) == set(EXPECTED_TOOL_SURFACE)
+    # operator_artwork is conditionally registered (IMAGES_ENABLED=true) and is
+    # not part of the default registered manifest; exclude it from the check.
+    expected_registered = {
+        name for name in EXPECTED_TOOL_SURFACE if name != "operator_artwork"
+    }
+    assert set(tools) == expected_registered
 
     for name, tool in tools.items():
         assert tool.outputSchema is None, f"{name} still has outputSchema"

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- New `operator_artwork` tool (opt-in via `IMAGES_ENABLED=true`) serving
+  operator illustration and skin images from the AKDP image Release.
+  `action="list"` returns bounded metadata with semantic labels;
+  `action="get"` returns one image as base64 `ImageContent` (default `large`
+  variant, max 1024px). `LOCAL_IMAGE=true` (default) consumes synced local
+  assets via the existing auto-sync scheduler; `ORIGINAL_IMAGE=true` also
+  pulls full-resolution shards. Labels are joined from `skin_table.json`.
+
 ## [2.4.0] - 2026-07-29
 
 ### Added

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -139,6 +139,15 @@ function resolveDefaultGamedataPath(): string {
 
 export const DEFAULT_GAMEDATA_PATH = resolveDefaultGamedataPath();
 
+/** Image artwork assets (2.5.0) sit alongside gamedata under the data root. */
+export const DEFAULT_IMAGES_PATH = join(dirname(DEFAULT_GAMEDATA_PATH), "images");
+
+function envBool(name: string, defaultVal: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined) return defaultVal;
+  return ["1", "true", "yes", "on"].includes(raw.trim().toLowerCase());
+}
+
 function excelPath(gamedataRoot: string): string {
   return join(gamedataRoot, "zh_CN", "gamedata", "excel");
 }
@@ -259,6 +268,14 @@ export interface Config {
    * Null when no zip is found anywhere.
    */
   effectiveStoryjsonZip: string | null;
+  /** IMAGES_ENABLED — master switch; false → operator_artwork not registered. */
+  imagesEnabled: boolean;
+  /** LOCAL_IMAGE — true = AKDP local assets, false = MediaWiki fallback (future). */
+  localImage: boolean;
+  /** ORIGINAL_IMAGE — true = also sync original-variant shards. */
+  originalImage: boolean;
+  /** Image asset sync target (PRTS_IMAGE_DIR or default). */
+  imagesPath: string;
 }
 
 export function hasOperatorData(cfg: Config): boolean {
@@ -315,6 +332,7 @@ export function loadConfig(): Config {
   else if (existsSync(BUNDLED_STORYJSON_ZIP))
     effectiveStoryjsonZip = BUNDLED_STORYJSON_ZIP;
 
+  const imagesPath = process.env["PRTS_IMAGE_DIR"] ?? DEFAULT_IMAGES_PATH;
   const config = {
     gamedataPath,
     isCustomGamedata,
@@ -326,6 +344,10 @@ export function loadConfig(): Config {
     effectiveLevelsPath,
     storyjsonZip,
     effectiveStoryjsonZip,
+    imagesEnabled: envBool("IMAGES_ENABLED", false),
+    localImage: envBool("LOCAL_IMAGE", true),
+    originalImage: envBool("ORIGINAL_IMAGE", false),
+    imagesPath,
   };
   return config;
 }

--- a/ts/src/data/images.ts
+++ b/ts/src/data/images.ts
@@ -1,0 +1,240 @@
+/**
+ * Image artwork index schema, data loading and label construction.
+ * Mirrors python/src/prts_mcp/data/images.py.
+ *
+ * Consumes the AKDP ``akdp-images/v1`` index.json (frozen schema in
+ * arknights-data-pipeline/docs/image-index-schema.md). Semantic labels are
+ * joined from ``skin_table.json`` at the consumer side; the index carries no
+ * display names, keeping the schema stable across game versions.
+ */
+
+import {
+  checkActivationChange,
+  loadConfig,
+  registerActivationListener,
+} from "../config.js";
+import { DirectoryStore } from "./stores.js";
+
+export const SCHEMA_VERSION = "akdp-images/v1";
+export const VARIANT_ORDER = ["original", "large", "preview"] as const;
+export type VariantName = (typeof VARIANT_ORDER)[number];
+export const DEFAULT_VARIANT: VariantName = "large";
+
+// ---------------------------------------------------------------------------
+// Index schema types
+// ---------------------------------------------------------------------------
+
+export interface VariantMeta {
+  file: string;
+  width: number;
+  height: number;
+  bytes: number;
+  sha256: string;
+}
+
+export interface ArtworkEntry {
+  skinId: string;
+  kind: string; // "base" | "skin"
+  shard: string; // "chararts" | "skinpack"
+  sinceVersion: string;
+  variants: Partial<Record<VariantName, VariantMeta>>;
+}
+
+export interface ImagesIndex {
+  schemaVersion: string;
+  baselineVersion: string;
+  currentVersion: string;
+  shards: Record<string, string>;
+  artworks: Record<string, ArtworkEntry>;
+}
+
+interface RawVariant {
+  file?: unknown;
+  w?: unknown;
+  h?: unknown;
+  bytes?: unknown;
+  sha256?: unknown;
+}
+
+function parseVariant(raw: unknown): VariantMeta | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const v = raw as RawVariant;
+  if (
+    typeof v.file !== "string"
+    || typeof v.w !== "number"
+    || typeof v.h !== "number"
+    || typeof v.bytes !== "number"
+    || typeof v.sha256 !== "string"
+  ) {
+    return null;
+  }
+  return {
+    file: v.file,
+    width: v.w,
+    height: v.h,
+    bytes: v.bytes,
+    sha256: v.sha256,
+  };
+}
+
+/**
+ * Parse a raw index.json value. Returns null on schema mismatch.
+ *
+ * The schema is frozen at ``akdp-images/v1``; an unfamiliar schemaVersion is
+ * rejected so a future incompatible index does not silently misparse.
+ */
+export function parseIndex(data: unknown): ImagesIndex | null {
+  if (typeof data !== "object" || data === null) return null;
+  const root = data as Record<string, unknown>;
+  if (root["schemaVersion"] !== SCHEMA_VERSION) return null;
+
+  const artworks: Record<string, ArtworkEntry> = {};
+  const rawArtworks = root["artworks"];
+  if (typeof rawArtworks === "object" && rawArtworks !== null) {
+    for (const [skinId, entry] of Object.entries(rawArtworks)) {
+      if (typeof entry !== "object" || entry === null) continue;
+      const e = entry as Record<string, unknown>;
+      const variants: Partial<Record<VariantName, VariantMeta>> = {};
+      for (const vname of VARIANT_ORDER) {
+        const parsed = parseVariant(e[vname]);
+        if (parsed !== null) variants[vname] = parsed;
+      }
+      if (Object.keys(variants).length === 0) continue;
+      artworks[skinId] = {
+        skinId,
+        kind: typeof e["kind"] === "string" ? e["kind"] : "base",
+        shard: typeof e["shard"] === "string" ? e["shard"] : "",
+        sinceVersion:
+          typeof e["sinceVersion"] === "string" ? e["sinceVersion"] : "",
+        variants,
+      };
+    }
+  }
+
+  const shards: Record<string, string> = {};
+  const rawShards = root["shards"];
+  if (typeof rawShards === "object" && rawShards !== null) {
+    for (const [k, v] of Object.entries(rawShards)) {
+      if (typeof v === "string") shards[k] = v;
+    }
+  }
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    baselineVersion:
+      typeof root["baselineVersion"] === "string" ? root["baselineVersion"] : "",
+    currentVersion:
+      typeof root["currentVersion"] === "string" ? root["currentVersion"] : "",
+    shards,
+    artworks,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// skin_table.json loading (charSkins mapping)
+// ---------------------------------------------------------------------------
+
+/** Subset of a charSkins entry — only the fields label construction reads. */
+export interface CharSkinLike {
+  displaySkin?: { skinName?: unknown };
+}
+
+type CharSkinsCache = Record<string, CharSkinLike> | null;
+// null = not yet loaded; the cache is reset by clearImageCaches on activation
+// changes, mirroring operator.ts's lazy-cache pattern.
+let _charSkins: CharSkinsCache = null;
+
+/**
+ * Load the ``charSkins`` mapping from ``skin_table.json``.
+ *
+ * Returns an empty mapping when excel data is unavailable or the file is
+ * absent (the bundled fallback does not ship skin_table); callers fall back
+ * to skinId-derived labels in that case.
+ */
+export function getCharSkins(): Record<string, CharSkinLike> {
+  checkActivationChange();
+  if (_charSkins === null) {
+    const ep = loadConfig().effectiveExcelPath;
+    if (ep === null) {
+      _charSkins = {};
+    } else {
+      const store = new DirectoryStore(ep);
+      if (!store.exists("skin_table.json")) {
+        _charSkins = {};
+      } else {
+        try {
+          const table = store.readJson<{ charSkins?: unknown }>(
+            "skin_table.json",
+          );
+          _charSkins =
+            table.charSkins && typeof table.charSkins === "object"
+              ? (table.charSkins as Record<string, CharSkinLike>)
+              : {};
+        } catch {
+          _charSkins = {};
+        }
+      }
+    }
+  }
+  return _charSkins;
+}
+
+export function clearImageCaches(): void {
+  _charSkins = null;
+}
+
+registerActivationListener(clearImageCaches);
+
+// ---------------------------------------------------------------------------
+// Label construction
+// ---------------------------------------------------------------------------
+
+const BASE_ILLUST_LABELS: Record<string, string> = {
+  "1": "精英零立绘",
+  "2": "精英二立绘",
+};
+
+/**
+ * Construct a human-readable label for an artwork ``skinId``.
+ *
+ * Priority:
+ * - ``@`` fashion skins → ``displaySkin.skinName`` (e.g. "报童"); falls back
+ *   to a theme-derived placeholder when the skin name is unavailable.
+ * - ``#N`` base illusts → programmatic label from the number suffix
+ *   (e.g. "精英二立绘"); a ``+`` suffix appends "（变体）".
+ * - Unknown shapes → a tolerant fallback using the raw skinId.
+ *
+ * Labels intentionally omit the operator name: ``operator_artwork`` list is
+ * already scoped to one operator, so the label only needs to distinguish
+ * that operator's illusts/skins from each other.
+ */
+export function buildArtworkLabel(
+  skinId: string,
+  charSkins?: Record<string, CharSkinLike>,
+): string {
+  const skins = charSkins ?? getCharSkins();
+  const entry = skins[skinId];
+
+  // Fashion skin (@): prefer displaySkin.skinName.
+  const atIdx = skinId.indexOf("@");
+  if (atIdx >= 0) {
+    const display = entry?.displaySkin;
+    if (display && typeof display.skinName === "string" && display.skinName) {
+      return display.skinName;
+    }
+    const theme = skinId.slice(atIdx + 1).split("#")[0];
+    return theme ? `时装（${theme}）` : "时装";
+  }
+
+  // Base illust (#N): programmatic label from the number suffix.
+  const hashIdx = skinId.indexOf("#");
+  const suffix = hashIdx >= 0 ? skinId.slice(hashIdx + 1) : "";
+  const baseNum = suffix.replace(/\+$/, "");
+  const plus = suffix.endsWith("+");
+  let label = BASE_ILLUST_LABELS[baseNum];
+  if (label === undefined) {
+    label = baseNum ? `立绘 ${baseNum}` : "立绘";
+  }
+  if (plus) label += "（变体）";
+  return label;
+}

--- a/ts/src/data/imagesSync.ts
+++ b/ts/src/data/imagesSync.ts
@@ -148,6 +148,10 @@ async function downloadLarge(url: string, dest: string, timeoutMs = 300_000): Pr
       { headers: githubHeaders(), redirect: "follow" },
       timeoutMs,
     );
+    // TS buffers the full shard in memory (Python streams via httpx.stream).
+    // Default shards cap at ~750 MB (chararts-large); ORIGINAL_IMAGE shards
+    // (~1.8 GB) need a heap-sized runtime. Streaming was explored but blocked
+    // by Node 22 Uint8Array<ArrayBufferLike> generic friction in Readable.fromWeb.
     const buf = Buffer.from(await res.arrayBuffer());
     await writeFile(tmp, buf);
     await rename(tmp, dest);

--- a/ts/src/data/imagesSync.ts
+++ b/ts/src/data/imagesSync.ts
@@ -139,7 +139,11 @@ async function downloadSmall(url: string, timeoutMs = 30_000): Promise<Buffer | 
   }
 }
 
-async function downloadLarge(url: string, dest: string, timeoutMs = 300_000): Promise<void> {
+// TS uses a single total deadline (AbortSignal.timeout) whereas Python's
+// httpx.stream uses a per-socket timeout; 30 min covers the largest
+// ORIGINAL_IMAGE shard (~3.6 GB) on slow links. A per-chunk AbortSignal
+// refresh would be ideal but needs a custom read loop.
+async function downloadLarge(url: string, dest: string, timeoutMs = 1_800_000): Promise<void> {
   const tmp = join(
     dirname(dest),
     `.${basename(dest)}.${randomUUID().replaceAll("-", "")}.tmp`,
@@ -309,6 +313,29 @@ async function syncImagesLocked(
   const deltaTag = String(deltaRelease["tag_name"] ?? "");
   const currentVersion = deltaTag.slice(DELTA_PREFIX.length);
 
+  const meta = await loadMeta(imageDir);
+  const genDir = await activeGeneration(imageDir);
+  const syncedRaw = meta?.["shardsSynced"];
+  const syncedSet = Array.isArray(syncedRaw) ? new Set(syncedRaw as string[]) : null;
+  const sameShards = syncedSet !== null
+    && shardKeys.length === syncedSet.size
+    && shardKeys.every((k) => syncedSet.has(k));
+
+  // Tag-level shortcut: if the release tag's currentVersion and the shard
+  // set already match the active generation, skip the ~1.1 MB index.json
+  // download. baselineVersion rides in index.json but cannot change without
+  // a new delta tag, so tag equality implies baseline equality. force_check
+  // still drives a real API call here; a TTL freshness skip is deferred.
+  if (
+    meta !== null
+    && genDir !== null
+    && meta["currentVersion"] === currentVersion
+    && sameShards
+  ) {
+    return { spec, status: "up_to_date", commitSha: currentVersion, error: null };
+  }
+
+  // Tag differs (or first sync) → download index.json and rebuild.
   const indexUrl = assetUrl(deltaRelease, "index.json");
   const indexBytes = indexUrl !== null ? await downloadSmall(indexUrl) : null;
   if (indexBytes === null) {
@@ -328,23 +355,6 @@ async function syncImagesLocked(
   }
 
   const baselineVersion = index.baselineVersion;
-
-  const meta = await loadMeta(imageDir);
-  const genDir = await activeGeneration(imageDir);
-  const syncedRaw = meta?.["shardsSynced"];
-  const syncedSet = Array.isArray(syncedRaw) ? new Set(syncedRaw as string[]) : null;
-  const sameShards = syncedSet !== null
-    && shardKeys.length === syncedSet.size
-    && shardKeys.every((k) => syncedSet.has(k));
-  if (
-    meta !== null
-    && genDir !== null
-    && meta["currentVersion"] === currentVersion
-    && meta["baselineVersion"] === baselineVersion
-    && sameShards
-  ) {
-    return { spec, status: "up_to_date", commitSha: currentVersion, error: null };
-  }
 
   // --- Rebuild a new generation -----------------------------------------
   const relDir = await releasesDir(imageDir);

--- a/ts/src/data/imagesSync.ts
+++ b/ts/src/data/imagesSync.ts
@@ -14,8 +14,11 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
+import { createWriteStream, readFileSync, statSync } from "node:fs";
 import { cp, mkdir, readFile, readdir, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
 import { SCHEMA_VERSION, parseIndex } from "./images.js";
 import {
   fetchCascading,
@@ -45,7 +48,7 @@ const ORIGINAL_SHARD_KEYS = [
   "skinpack-original",
 ] as const;
 const RETENTION_MS = 24 * 60 * 60 * 1000;
-const IMAGES_META = ".images_meta.json";
+export const IMAGES_META = ".images_meta.json";
 const IMAGES_LOCK = ".images.lock";
 
 export function neededShardKeys(includeOriginal: boolean): readonly string[] {
@@ -148,12 +151,14 @@ async function downloadLarge(url: string, dest: string, timeoutMs = 300_000): Pr
       { headers: githubHeaders(), redirect: "follow" },
       timeoutMs,
     );
-    // TS buffers the full shard in memory (Python streams via httpx.stream).
-    // Default shards cap at ~750 MB (chararts-large); ORIGINAL_IMAGE shards
-    // (~1.8 GB) need a heap-sized runtime. Streaming was explored but blocked
-    // by Node 22 Uint8Array<ArrayBufferLike> generic friction in Readable.fromWeb.
-    const buf = Buffer.from(await res.arrayBuffer());
-    await writeFile(tmp, buf);
+    // Stream the shard to disk so multi-hundred-MB baseline zips do not stay
+    // resident; mirrors python's httpx.stream chunked write. fetchCascading
+    // returns a real Response at runtime (FetchResponse omits body to stay
+    // decoupled from DOM); Node 22's Uint8Array<ArrayBufferLike> generic makes
+    // Readable.fromWeb's type incompatible (runtime is fine), so cast via any.
+    const body = (res as any).body;
+    if (body === null) throw new Error("download response body is null");
+    await pipeline(Readable.fromWeb(body as any), createWriteStream(tmp));
     await rename(tmp, dest);
   } finally {
     await unlink(tmp).catch(() => undefined);
@@ -190,9 +195,14 @@ async function saveMeta(root: string, meta: Record<string, unknown>): Promise<vo
   await rename(tmp, path);
 }
 
-async function activeGeneration(imageDir: string): Promise<string | null> {
-  const meta = await loadMeta(imageDir);
-  if (meta === null) return null;
+/** Synchronous active-generation resolver — shared by sync and tool layers. */
+export function activeGenerationSync(imageDir: string): string | null {
+  let meta: Record<string, unknown>;
+  try {
+    meta = JSON.parse(readFileSync(join(imageDir, IMAGES_META), "utf-8"));
+  } catch {
+    return null;
+  }
   const rel = meta["generation_root"];
   if (typeof rel !== "string" || rel.length === 0) return null;
   const base = resolve(imageDir);
@@ -202,13 +212,16 @@ async function activeGeneration(imageDir: string): Promise<string | null> {
     return null;
   }
   try {
-    const info = await stat(gen);
-    if (!info.isDirectory()) return null;
-    await stat(join(gen, "index.json"));
+    if (!statSync(gen).isDirectory()) return null;
+    statSync(join(gen, "index.json"));
     return gen;
   } catch {
     return null;
   }
+}
+
+async function activeGeneration(imageDir: string): Promise<string | null> {
+  return activeGenerationSync(imageDir);
 }
 
 async function releasesDir(imageDir: string): Promise<string> {
@@ -263,7 +276,7 @@ async function offlineOrNoData(imageDir: string, error: string): Promise<SyncRes
   const spec = dummySpec(imageDir);
   if ((await activeGeneration(imageDir)) !== null) {
     const meta = await loadMeta(imageDir);
-    const ver = meta?.["current_version"];
+    const ver = meta?.["currentVersion"];
     return {
       spec,
       status: "offline_fallback",
@@ -318,12 +331,17 @@ async function syncImagesLocked(
 
   const meta = await loadMeta(imageDir);
   const genDir = await activeGeneration(imageDir);
+  const syncedRaw = meta?.["shardsSynced"];
+  const syncedSet = Array.isArray(syncedRaw) ? new Set(syncedRaw as string[]) : null;
+  const sameShards = syncedSet !== null
+    && shardKeys.length === syncedSet.size
+    && shardKeys.every((k) => syncedSet.has(k));
   if (
-    !forceCheck
-    && meta !== null
+    meta !== null
     && genDir !== null
-    && meta["current_version"] === currentVersion
-    && meta["baseline_version"] === baselineVersion
+    && meta["currentVersion"] === currentVersion
+    && meta["baselineVersion"] === baselineVersion
+    && sameShards
   ) {
     return { spec, status: "up_to_date", commitSha: currentVersion, error: null };
   }
@@ -341,7 +359,8 @@ async function syncImagesLocked(
     const baselineUnchanged =
       meta !== null
       && genDir !== null
-      && meta["baseline_version"] === baselineVersion;
+      && meta["baselineVersion"] === baselineVersion
+      && sameShards;
     if (baselineUnchanged && genDir !== null) {
       // Fast path: reuse prior PNGs, overlay only the new delta.
       await cp(genDir, staging, { recursive: true });
@@ -359,20 +378,18 @@ async function syncImagesLocked(
       }
     }
 
-    // Delta: overlay incremental PNGs (sentinel delta extracts nothing).
+    // Delta: overlay incremental PNGs. A download/extract failure must
+    // propagate (not be swallowed) so a half-applied delta never activates —
+    // the authoritative index.json would otherwise reference PNGs that are
+    // absent. The sentinel delta (empty zip) downloads and extracts without
+    // raising, so it passes through cleanly.
     const deltaAsset = `${DELTA_ASSET_PREFIX}${currentVersion}.zip`;
     const deltaUrl = assetUrl(deltaRelease, deltaAsset);
     if (deltaUrl !== null) {
       const deltaZip = join(staging, ".delta.zip");
-      try {
-        await downloadLarge(deltaUrl, deltaZip);
-        await safeExtractZip(deltaZip, staging);
-      } catch (err) {
-        // sentinel/empty delta or transient failure — non-fatal
-        log("INFO", `Delta extract skipped: ${err instanceof Error ? err.message : String(err)}`);
-      } finally {
-        await unlink(deltaZip).catch(() => undefined);
-      }
+      await downloadLarge(deltaUrl, deltaZip);
+      await safeExtractZip(deltaZip, staging);
+      await unlink(deltaZip).catch(() => undefined);
     }
 
     // Authoritative index.json + generation meta.
@@ -381,6 +398,7 @@ async function syncImagesLocked(
       schemaVersion: SCHEMA_VERSION,
       baselineVersion,
       currentVersion,
+      shardsSynced: [...shardKeys],
     };
     await saveMeta(staging, genMeta);
 

--- a/ts/src/data/imagesSync.ts
+++ b/ts/src/data/imagesSync.ts
@@ -1,0 +1,430 @@
+/**
+ * AKDP image asset sync for LOCAL_IMAGE=true mode.
+ * Mirrors python/src/prts_mcp/data/images_sync.py.
+ *
+ * Discovers ``images-*`` GitHub Releases from the arknights-data-pipeline
+ * factory, downloads baseline shard zips + delta zips, and atomically
+ * activates a generation directory of PNG files indexed by ``index.json``.
+ *
+ * Reuses the JSON sync's reliability primitives (cascading mirrors, atomic
+ * activation, cross-process locking, offline fallback) from sync.ts, but
+ * uses an images-specific discovery path: images Releases are tag-isolated
+ * from ``data-*`` Releases and cannot use ``/releases/latest`` (see
+ * arknights-data-pipeline/docs/image-index-schema.md §6).
+ */
+
+import { createHash, randomUUID } from "node:crypto";
+import { cp, mkdir, readFile, readdir, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { SCHEMA_VERSION, parseIndex } from "./images.js";
+import {
+  fetchCascading,
+  githubHeaders,
+  safeExtractZip,
+  withArchiveActivationLock,
+  type ReleaseSpec,
+  type RepoSpec,
+  type SyncResult,
+} from "./sync.js";
+
+export const IMAGES_REPO_OWNER = "3aKHP";
+export const IMAGES_REPO = "arknights-data-pipeline";
+
+const DELTA_PREFIX = "images-";
+const BASELINE_PREFIX = "images-baseline-";
+const DELTA_ASSET_PREFIX = "images-delta-";
+
+const DEFAULT_SHARD_KEYS = [
+  "chararts-large",
+  "chararts-preview",
+  "skinpack-large",
+  "skinpack-preview",
+] as const;
+const ORIGINAL_SHARD_KEYS = [
+  "chararts-original",
+  "skinpack-original",
+] as const;
+const RETENTION_MS = 24 * 60 * 60 * 1000;
+const IMAGES_META = ".images_meta.json";
+const IMAGES_LOCK = ".images.lock";
+
+export function neededShardKeys(includeOriginal: boolean): readonly string[] {
+  return includeOriginal
+    ? [...DEFAULT_SHARD_KEYS, ...ORIGINAL_SHARD_KEYS]
+    : DEFAULT_SHARD_KEYS;
+}
+
+function log(level: "INFO" | "WARN" | "ERROR", msg: string): void {
+  const ts = new Date().toISOString();
+  process.stderr.write(`${ts} ${level} prts_mcp.images_sync: ${msg}\n`);
+}
+
+// ---------------------------------------------------------------------------
+// Discovery (tag-prefix filtered; /releases/latest is not usable — schema §6)
+// ---------------------------------------------------------------------------
+
+interface GithubRelease {
+  tag_name?: unknown;
+  created_at?: unknown;
+  assets?: unknown;
+  [key: string]: unknown;
+}
+
+async function listReleases(timeoutMs = 10_000): Promise<GithubRelease[] | null> {
+  const url = `https://api.github.com/repos/${IMAGES_REPO_OWNER}/${IMAGES_REPO}/releases?per_page=100`;
+  try {
+    const res = await fetchCascading(url, { headers: githubHeaders() }, timeoutMs);
+    const data = await res.json();
+    return Array.isArray(data) ? (data as GithubRelease[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+function latestReleaseByPrefix(
+  releases: GithubRelease[],
+  prefix: string,
+  opts: { excludePrefix?: string } = {},
+): GithubRelease | null {
+  const candidates: GithubRelease[] = [];
+  for (const release of releases) {
+    const tag = release["tag_name"];
+    if (typeof tag !== "string" || !tag.startsWith(prefix)) continue;
+    if (opts.excludePrefix && tag.startsWith(opts.excludePrefix)) continue;
+    candidates.push(release);
+  }
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) =>
+    String(b["created_at"] ?? "").localeCompare(String(a["created_at"] ?? "")),
+  );
+  return candidates[0];
+}
+
+function assetUrl(release: GithubRelease, assetName: string): string | null {
+  const assets = release["assets"];
+  if (!Array.isArray(assets)) return null;
+  for (const a of assets) {
+    if (typeof a === "object" && a !== null && (a as Record<string, unknown>)["name"] === assetName) {
+      const url = (a as Record<string, unknown>)["browser_download_url"];
+      if (typeof url === "string") return url;
+    }
+  }
+  return null;
+}
+
+function releaseDownloadUrl(tag: string, assetName: string): string {
+  return (
+    `https://github.com/${IMAGES_REPO_OWNER}/${IMAGES_REPO}` +
+    `/releases/download/${tag}/${assetName}`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Downloads
+// ---------------------------------------------------------------------------
+
+async function downloadSmall(url: string, timeoutMs = 30_000): Promise<Buffer | null> {
+  try {
+    const res = await fetchCascading(
+      url,
+      { headers: githubHeaders(), redirect: "follow" },
+      timeoutMs,
+    );
+    return Buffer.from(await res.arrayBuffer());
+  } catch {
+    return null;
+  }
+}
+
+async function downloadLarge(url: string, dest: string, timeoutMs = 300_000): Promise<void> {
+  const tmp = join(
+    dirname(dest),
+    `.${basename(dest)}.${randomUUID().replaceAll("-", "")}.tmp`,
+  );
+  await mkdir(dirname(dest), { recursive: true });
+  try {
+    const res = await fetchCascading(
+      url,
+      { headers: githubHeaders(), redirect: "follow" },
+      timeoutMs,
+    );
+    const buf = Buffer.from(await res.arrayBuffer());
+    await writeFile(tmp, buf);
+    await rename(tmp, dest);
+  } finally {
+    await unlink(tmp).catch(() => undefined);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Generation state (.images_meta.json + .releases/<gen>/)
+// ---------------------------------------------------------------------------
+
+function metaPath(root: string): string {
+  return join(root, IMAGES_META);
+}
+
+async function loadMeta(root: string): Promise<Record<string, unknown> | null> {
+  try {
+    const data = JSON.parse(await readFile(metaPath(root), "utf-8"));
+    return typeof data === "object" && data !== null && !Array.isArray(data)
+      ? (data as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function saveMeta(root: string, meta: Record<string, unknown>): Promise<void> {
+  const path = metaPath(root);
+  const tmp = join(
+    dirname(path),
+    `.${basename(path)}.${randomUUID().replaceAll("-", "")}.tmp`,
+  );
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(tmp, JSON.stringify(meta, null, 2), "utf-8");
+  await rename(tmp, path);
+}
+
+async function activeGeneration(imageDir: string): Promise<string | null> {
+  const meta = await loadMeta(imageDir);
+  if (meta === null) return null;
+  const rel = meta["generation_root"];
+  if (typeof rel !== "string" || rel.length === 0) return null;
+  const base = resolve(imageDir);
+  const gen = resolve(base, rel);
+  const relCheck = relative(base, gen);
+  if (relCheck === ".." || relCheck.startsWith(`..${sep}`) || isAbsolute(relCheck)) {
+    return null;
+  }
+  try {
+    const info = await stat(gen);
+    if (!info.isDirectory()) return null;
+    await stat(join(gen, "index.json"));
+    return gen;
+  } catch {
+    return null;
+  }
+}
+
+async function releasesDir(imageDir: string): Promise<string> {
+  const dir = join(imageDir, ".releases");
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+function versionHash(version: string): string {
+  return createHash("sha256").update(version).digest("hex").slice(0, 16);
+}
+
+async function pruneGenerations(releasesDir: string, keep: string): Promise<void> {
+  const cutoff = Date.now() - RETENTION_MS;
+  let entries: string[];
+  try {
+    entries = await readdir(releasesDir);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (name.startsWith(".")) continue;
+    const candidate = join(releasesDir, name);
+    if (candidate === keep) continue;
+    try {
+      const info = await stat(candidate);
+      if (info.mtimeMs >= cutoff) continue;
+      if (info.isDirectory()) {
+        await rm(candidate, { recursive: true, force: true });
+      }
+    } catch {
+      // best-effort retention cleanup
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sync
+// ---------------------------------------------------------------------------
+
+function dummySpec(imageDir: string): RepoSpec {
+  return {
+    owner: IMAGES_REPO_OWNER,
+    repo: IMAGES_REPO,
+    branch: "releases",
+    files: ["images"],
+    localRoot: imageDir,
+  };
+}
+
+async function offlineOrNoData(imageDir: string, error: string): Promise<SyncResult> {
+  const spec = dummySpec(imageDir);
+  if ((await activeGeneration(imageDir)) !== null) {
+    const meta = await loadMeta(imageDir);
+    const ver = meta?.["current_version"];
+    return {
+      spec,
+      status: "offline_fallback",
+      commitSha: typeof ver === "string" ? ver : null,
+      error,
+    };
+  }
+  return { spec, status: "no_data", commitSha: null, error };
+}
+
+async function syncImagesLocked(
+  imageDir: string,
+  shardKeys: readonly string[],
+  forceCheck: boolean,
+): Promise<SyncResult> {
+  const spec = dummySpec(imageDir);
+
+  const releases = await listReleases();
+  if (releases === null) {
+    return offlineOrNoData(imageDir, "Network unavailable");
+  }
+
+  const deltaRelease = latestReleaseByPrefix(releases, DELTA_PREFIX, {
+    excludePrefix: BASELINE_PREFIX,
+  });
+  if (deltaRelease === null) {
+    return offlineOrNoData(imageDir, "No images delta release found");
+  }
+
+  const deltaTag = String(deltaRelease["tag_name"] ?? "");
+  const currentVersion = deltaTag.slice(DELTA_PREFIX.length);
+
+  const indexUrl = assetUrl(deltaRelease, "index.json");
+  const indexBytes = indexUrl !== null ? await downloadSmall(indexUrl) : null;
+  if (indexBytes === null) {
+    return offlineOrNoData(imageDir, "Failed to download index.json");
+  }
+
+  let indexData: unknown;
+  try {
+    indexData = JSON.parse(indexBytes.toString("utf-8"));
+  } catch {
+    return { spec, status: "no_data", commitSha: null, error: "index.json is unreadable" };
+  }
+
+  const index = parseIndex(indexData);
+  if (index === null) {
+    return { spec, status: "no_data", commitSha: null, error: "index.json schema mismatch" };
+  }
+
+  const baselineVersion = index.baselineVersion;
+
+  const meta = await loadMeta(imageDir);
+  const genDir = await activeGeneration(imageDir);
+  if (
+    !forceCheck
+    && meta !== null
+    && genDir !== null
+    && meta["current_version"] === currentVersion
+    && meta["baseline_version"] === baselineVersion
+  ) {
+    return { spec, status: "up_to_date", commitSha: currentVersion, error: null };
+  }
+
+  // --- Rebuild a new generation -----------------------------------------
+  const relDir = await releasesDir(imageDir);
+  const generation = `${versionHash(currentVersion)}-${randomUUID().replaceAll("-", "")}`;
+  const staging = join(relDir, `.${generation}.tmp`);
+  const activated = join(relDir, generation);
+  let stagingExists = false;
+  try {
+    await mkdir(staging, { recursive: true });
+    stagingExists = true;
+
+    const baselineUnchanged =
+      meta !== null
+      && genDir !== null
+      && meta["baseline_version"] === baselineVersion;
+    if (baselineUnchanged && genDir !== null) {
+      // Fast path: reuse prior PNGs, overlay only the new delta.
+      await cp(genDir, staging, { recursive: true });
+      await unlink(join(staging, "index.json")).catch(() => undefined);
+      await unlink(join(staging, IMAGES_META)).catch(() => undefined);
+    } else {
+      const baselineTag = `${BASELINE_PREFIX}${baselineVersion}`;
+      for (const shardKey of shardKeys) {
+        const shardFile = index.shards[shardKey] ?? "";
+        if (!shardFile) continue;
+        const shardZip = join(staging, `.${shardKey}.zip`);
+        await downloadLarge(releaseDownloadUrl(baselineTag, shardFile), shardZip);
+        await safeExtractZip(shardZip, staging);
+        await unlink(shardZip).catch(() => undefined);
+      }
+    }
+
+    // Delta: overlay incremental PNGs (sentinel delta extracts nothing).
+    const deltaAsset = `${DELTA_ASSET_PREFIX}${currentVersion}.zip`;
+    const deltaUrl = assetUrl(deltaRelease, deltaAsset);
+    if (deltaUrl !== null) {
+      const deltaZip = join(staging, ".delta.zip");
+      try {
+        await downloadLarge(deltaUrl, deltaZip);
+        await safeExtractZip(deltaZip, staging);
+      } catch (err) {
+        // sentinel/empty delta or transient failure — non-fatal
+        log("INFO", `Delta extract skipped: ${err instanceof Error ? err.message : String(err)}`);
+      } finally {
+        await unlink(deltaZip).catch(() => undefined);
+      }
+    }
+
+    // Authoritative index.json + generation meta.
+    await writeFile(join(staging, "index.json"), indexBytes);
+    const genMeta: Record<string, unknown> = {
+      schemaVersion: SCHEMA_VERSION,
+      baselineVersion,
+      currentVersion,
+    };
+    await saveMeta(staging, genMeta);
+
+    // Atomic activation.
+    await rm(activated, { recursive: true, force: true });
+    await rename(staging, activated);
+    stagingExists = false;
+
+    // Top-level meta points at the active generation.
+    await saveMeta(imageDir, {
+      ...genMeta,
+      generation_root:
+        relative(imageDir, activated).replaceAll("\\", "/") || ".",
+    });
+    await pruneGenerations(relDir, activated);
+
+    log(
+      "INFO",
+      `Images synced: baseline=${baselineVersion.slice(0, 16)} current=${currentVersion.slice(0, 16)} (${Object.keys(index.artworks).length} artworks)`,
+    );
+    return { spec, status: "updated", commitSha: currentVersion, error: null };
+  } catch (err) {
+    if (stagingExists) {
+      await rm(staging, { recursive: true, force: true }).catch(() => undefined);
+    }
+    return offlineOrNoData(imageDir, err instanceof Error ? err.message : String(err));
+  }
+}
+
+export async function syncImages(
+  imageDir: string,
+  opts: { includeOriginal?: boolean; forceCheck?: boolean } = {},
+): Promise<SyncResult> {
+  await mkdir(imageDir, { recursive: true });
+  const shardKeys = neededShardKeys(opts.includeOriginal ?? false);
+  const lockSpec: ReleaseSpec = {
+    owner: IMAGES_REPO_OWNER,
+    repo: IMAGES_REPO,
+    assetName: "images-sync",
+    localZip: join(imageDir, ".images-sync"),
+  };
+  try {
+    return await withArchiveActivationLock(
+      lockSpec,
+      () => syncImagesLocked(imageDir, shardKeys, opts.forceCheck ?? false),
+      IMAGES_LOCK,
+    );
+  } catch (err) {
+    return offlineOrNoData(imageDir, err instanceof Error ? err.message : String(err));
+  }
+}

--- a/ts/src/data/sync.ts
+++ b/ts/src/data/sync.ts
@@ -108,7 +108,7 @@ export interface SyncResult {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-function githubHeaders(): Record<string, string> {
+export function githubHeaders(): Record<string, string> {
   const headers: Record<string, string> = { "User-Agent": GITHUB_UA };
   const token = process.env["GITHUB_TOKEN"];
   if (token) headers["Authorization"] = `Bearer ${token}`;
@@ -172,7 +172,7 @@ async function fetchWithRuntimeProxy(
  *   genuinely missing — mirrors won't help).
  * - Network error or HTTP 5xx from any candidate → try the next one.
  */
-async function fetchCascading(
+export async function fetchCascading(
   url: string,
   options: Omit<RequestInit, "signal">,
   timeoutMs: number,
@@ -580,7 +580,7 @@ function validateArchiveZip(zipPath: string, requiredFiles: readonly string[]): 
   }
 }
 
-async function safeExtractZip(zipPath: string, localRoot: string): Promise<void> {
+export async function safeExtractZip(zipPath: string, localRoot: string): Promise<void> {
   const root = resolve(localRoot);
   const zip = new AdmZip(zipPath);
   const tmpPaths: string[] = [];

--- a/ts/src/output.ts
+++ b/ts/src/output.ts
@@ -1,4 +1,4 @@
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { CallToolResult, ImageContent } from "@modelcontextprotocol/sdk/types.js";
 
 export type OutputChannel = "content" | "structured" | "both";
 
@@ -50,4 +50,27 @@ export function renderResult<T extends object>(
 
 export function textResult(markdown: string): CallToolResult {
   return { content: [text(markdown)] };
+}
+
+export function renderImageResult<T extends object>(
+  markdown: string,
+  imageDataBase64: string,
+  imageMimetype: string,
+  data: T | null,
+  channel: OutputChannel,
+  summary?: string,
+): CallToolResult {
+  const image: ImageContent = {
+    type: "image",
+    data: imageDataBase64,
+    mimeType: imageMimetype,
+  };
+  if (data === null || channel === "content") {
+    return { content: [text(markdown), image] };
+  }
+  const structuredContent = data as StructuredContent;
+  if (channel === "both") {
+    return { content: [text(markdown), image], structuredContent };
+  }
+  return { content: [text(summarize(data, summary)), image], structuredContent };
 }

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -15,9 +15,11 @@ import { randomUUID } from "node:crypto";
 import express from "express";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { loadConfig } from "./config.js";
 import { registerPrtsTools } from "./tools/prtsTools.js";
 import { registerGamedataTools } from "./tools/gamedataTools.js";
 import { registerStoryTools } from "./tools/storyTools.js";
+import { registerArtworkTools } from "./tools/artworkTools.js";
 import { startAutoSync } from "./startupSync.js";
 import { parseChannel, type OutputChannel } from "./output.js";
 
@@ -47,6 +49,11 @@ export function createMcpServer(channel: OutputChannel): McpServer {
   registerPrtsTools(server, channel);
   registerGamedataTools(server, channel);
   registerStoryTools(server, channel);
+
+  // operator_artwork is registered only when IMAGES_ENABLED=true.
+  if (loadConfig().imagesEnabled) {
+    registerArtworkTools(server, channel);
+  }
 
   return server;
 }

--- a/ts/src/startupSync.ts
+++ b/ts/src/startupSync.ts
@@ -17,6 +17,7 @@ import { clearItemCaches } from "./data/item.js";
 import { clearStageEnemyCaches } from "./data/stageEnemy.js";
 import { clearSearchCaches } from "./data/search.js";
 import { clearStoryCaches } from "./data/story.js";
+import { syncImages } from "./data/imagesSync.js";
 import { syncRelease, syncReleaseArchivePair } from "./data/sync.js";
 import { archiveSpecForDataset, releaseSpecForDataset, GAMEDATA_EXCEL, GAMEDATA_LEVELS, STORY_ZH_CN } from "./data/datasets.js";
 
@@ -202,6 +203,40 @@ export async function runStartupSync(forceCheck = false): Promise<void> {
     );
   } else {
     log("INFO", `STORYJSON_PATH is set (${process.env["STORYJSON_PATH"]}); story auto-sync disabled.`);
+  }
+
+  // Images artwork sync (2.5.0) — LOCAL_IMAGE mode consumes AKDP assets.
+  if (cfg.imagesEnabled && cfg.localImage) {
+    const runImagesSync = async (): Promise<boolean> => {
+      const r = await syncImages(cfg.imagesPath, {
+        includeOriginal: cfg.originalImage,
+        forceCheck,
+      });
+      const sha = r.commitSha ? r.commitSha.slice(0, 8) : "unknown";
+      if (r.status === "updated") {
+        log("INFO", `Images updated from GitHub Release (${r.spec.repo} @ ${sha}).`);
+      } else if (r.status === "up_to_date") {
+        log("INFO", `Images are up to date (${r.spec.repo} @ ${sha}).`);
+      } else if (r.status === "offline_fallback") {
+        log("WARN", `Network unavailable; using cached images (${r.spec.repo} @ ${sha}). Error: ${r.error}`);
+      } else {
+        log("WARN", `Images sync failed — no data. Error: ${r.error}`);
+      }
+      return shouldRetrySync(r.status);
+    };
+
+    startupTasks.push(
+      singleFlightSync("Images", runImagesSync)
+        .catch((err: unknown) => {
+          log("ERROR", `Images sync threw unexpectedly: ${err instanceof Error ? err.message : String(err)}`);
+          return true;
+        })
+        .then((result) => {
+          if (result !== "done" && !forceCheck) {
+            scheduleSyncRetry("Images", runImagesSync);
+          }
+        }),
+    );
   }
 
   await Promise.all(startupTasks);

--- a/ts/src/tools/artworkTools.ts
+++ b/ts/src/tools/artworkTools.ts
@@ -9,7 +9,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { join } from "node:path";
 import { z } from "zod";
 import { loadConfig, withActivationSnapshot } from "../config.js";
 import {
@@ -22,39 +22,13 @@ import {
   type ImagesIndex,
   type VariantName,
 } from "../data/images.js";
+import { activeGenerationSync } from "../data/imagesSync.js";
 import { resolveCharId } from "../data/operator.js";
 import { renderImageResult, renderResult, textResult, type OutputChannel } from "../output.js";
-
-const IMAGES_META = ".images_meta.json";
 
 // ---------------------------------------------------------------------------
 // Synchronous data access (runs inside withActivationSnapshot)
 // ---------------------------------------------------------------------------
-
-/** Resolve the active images generation directory synchronously, or null. */
-function activeGenerationSync(imageDir: string): string | null {
-  let meta: Record<string, unknown>;
-  try {
-    meta = JSON.parse(readFileSync(join(imageDir, IMAGES_META), "utf-8"));
-  } catch {
-    return null;
-  }
-  const rel = meta["generation_root"];
-  if (typeof rel !== "string" || rel.length === 0) return null;
-  const base = resolve(imageDir);
-  const gen = resolve(base, rel);
-  const relCheck = relative(base, gen);
-  if (relCheck === ".." || relCheck.startsWith(`..${sep}`) || isAbsolute(relCheck)) {
-    return null;
-  }
-  try {
-    if (!statSync(gen).isDirectory()) return null;
-    statSync(join(gen, "index.json"));
-    return gen;
-  } catch {
-    return null;
-  }
-}
 
 function loadIndexSync(genDir: string): ImagesIndex | null {
   try {

--- a/ts/src/tools/artworkTools.ts
+++ b/ts/src/tools/artworkTools.ts
@@ -1,0 +1,267 @@
+/**
+ * Operator artwork (立绘) tool — list illusts/skins and get image variants.
+ * Mirrors python/src/prts_mcp/tools_artwork.py.
+ *
+ * Consumes AKDP image assets synced in LOCAL_IMAGE=true mode. Registered
+ * only when IMAGES_ENABLED=true (see server.ts).
+ */
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { z } from "zod";
+import { loadConfig, withActivationSnapshot } from "../config.js";
+import {
+  buildArtworkLabel,
+  getCharSkins,
+  parseIndex,
+  DEFAULT_VARIANT,
+  VARIANT_ORDER,
+  type ArtworkEntry,
+  type ImagesIndex,
+  type VariantName,
+} from "../data/images.js";
+import { resolveCharId } from "../data/operator.js";
+import { renderImageResult, renderResult, textResult, type OutputChannel } from "../output.js";
+
+const IMAGES_META = ".images_meta.json";
+
+// ---------------------------------------------------------------------------
+// Synchronous data access (runs inside withActivationSnapshot)
+// ---------------------------------------------------------------------------
+
+/** Resolve the active images generation directory synchronously, or null. */
+function activeGenerationSync(imageDir: string): string | null {
+  let meta: Record<string, unknown>;
+  try {
+    meta = JSON.parse(readFileSync(join(imageDir, IMAGES_META), "utf-8"));
+  } catch {
+    return null;
+  }
+  const rel = meta["generation_root"];
+  if (typeof rel !== "string" || rel.length === 0) return null;
+  const base = resolve(imageDir);
+  const gen = resolve(base, rel);
+  const relCheck = relative(base, gen);
+  if (relCheck === ".." || relCheck.startsWith(`..${sep}`) || isAbsolute(relCheck)) {
+    return null;
+  }
+  try {
+    if (!statSync(gen).isDirectory()) return null;
+    statSync(join(gen, "index.json"));
+    return gen;
+  } catch {
+    return null;
+  }
+}
+
+function loadIndexSync(genDir: string): ImagesIndex | null {
+  try {
+    return parseIndex(JSON.parse(readFileSync(join(genDir, "index.json"), "utf-8")));
+  } catch {
+    return null;
+  }
+}
+
+function charIdOf(skinId: string): string {
+  return skinId.split("#")[0].split("@")[0];
+}
+
+function availableVariants(entry: ArtworkEntry): VariantName[] {
+  return VARIANT_ORDER.filter((v) => entry.variants[v] !== undefined);
+}
+
+function dataNotReady(): CallToolResult {
+  return textResult(
+    "立绘数据未就绪。可能原因：IMAGES_ENABLED 未开启，或图片同步仍在进行中。" +
+      "请稍后重试；若持续不可用，请检查网络或 GITHUB_TOKEN。",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tool actions
+// ---------------------------------------------------------------------------
+
+function doList(operatorName: string, channel: OutputChannel): CallToolResult {
+  const charId = resolveCharId(operatorName);
+  if (charId === null) {
+    return textResult(
+      `找不到干员「${operatorName}」。建议先用 search_prts 确认准确的中文名称。`,
+    );
+  }
+  const cfg = loadConfig();
+  const genDir = activeGenerationSync(cfg.imagesPath);
+  if (genDir === null) return dataNotReady();
+  const index = loadIndexSync(genDir);
+  if (index === null) return dataNotReady();
+
+  const matched = Object.entries(index.artworks)
+    .filter(([sid]) => charIdOf(sid) === charId)
+    .sort(([a], [b]) => a.localeCompare(b));
+  if (matched.length === 0) {
+    return textResult(`未找到「${operatorName}」的立绘数据。`);
+  }
+
+  const charSkins = getCharSkins();
+  const artworks = matched.map(([sid, entry]) => {
+    const variants: Record<string, { width: number; height: number; bytes: number }> = {};
+    for (const v of availableVariants(entry)) {
+      const vm = entry.variants[v]!;
+      variants[v] = { width: vm.width, height: vm.height, bytes: vm.bytes };
+    }
+    return {
+      artwork_id: sid,
+      label: buildArtworkLabel(sid, charSkins),
+      kind: entry.kind,
+      variants,
+    };
+  });
+
+  const data = {
+    operator_name: operatorName,
+    char_id: charId,
+    total: artworks.length,
+    artworks,
+  };
+  const markdown = renderList(operatorName, artworks);
+  return renderResult(
+    data,
+    markdown,
+    channel,
+    `「${operatorName}」共 ${artworks.length} 张立绘，详见 structuredContent`,
+  );
+}
+
+function doGet(
+  operatorName: string,
+  artworkId: string | undefined,
+  variant: VariantName | undefined,
+  channel: OutputChannel,
+): CallToolResult {
+  if (!artworkId) {
+    return textResult("action=get 时必须提供 artwork_id。请先用 action=list 获取。");
+  }
+  const chosen: VariantName = variant ?? DEFAULT_VARIANT;
+  const cfg = loadConfig();
+  const genDir = activeGenerationSync(cfg.imagesPath);
+  if (genDir === null) return dataNotReady();
+  const index = loadIndexSync(genDir);
+  if (index === null) return dataNotReady();
+
+  const entry = index.artworks[artworkId];
+  if (entry === undefined) {
+    return textResult(
+      `找不到 artwork_id「${artworkId}」。该 ID 不透明，请用 action=list 重新获取。`,
+    );
+  }
+  const variantMeta = entry.variants[chosen];
+  if (variantMeta === undefined) {
+    const available = availableVariants(entry).join("、") || "无";
+    return textResult(
+      `artwork_id「${artworkId}」不提供「${chosen}」变体（可用：${available}）。`,
+    );
+  }
+  const pngPath = join(genDir, variantMeta.file);
+  if (!existsSync(pngPath) || !statSync(pngPath).isFile()) {
+    return textResult(
+      `图片文件缺失：${variantMeta.file}。同步可能不完整，请稍后重试。`,
+    );
+  }
+  let imageBytes: Buffer;
+  try {
+    imageBytes = readFileSync(pngPath);
+  } catch (err) {
+    return textResult(
+      `读取图片文件失败：${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const imageBase64 = imageBytes.toString("base64");
+  const charSkins = getCharSkins();
+  const label = buildArtworkLabel(artworkId, charSkins);
+  const markdown =
+    `**${label}**（${operatorName}）\n` +
+    `变体：${chosen}｜尺寸：${variantMeta.width}×${variantMeta.height}` +
+    `｜${variantMeta.bytes} bytes\n` +
+    `artwork_id：\`${artworkId}\``;
+  const data = {
+    operator_name: operatorName,
+    artwork_id: artworkId,
+    label,
+    variant: chosen,
+    width: variantMeta.width,
+    height: variantMeta.height,
+    bytes: variantMeta.bytes,
+    sha256: variantMeta.sha256,
+  };
+  return renderImageResult(
+    markdown,
+    imageBase64,
+    "image/png",
+    data,
+    channel,
+    `${operatorName} 的「${label}」（${chosen}）`,
+  );
+}
+
+function renderList(
+  operatorName: string,
+  artworks: Array<{
+    artwork_id: string;
+    label: string;
+    kind: string;
+    variants: Record<string, unknown>;
+  }>,
+): string {
+  const header = `# 「${operatorName}」的立绘（共 ${artworks.length} 张）\n`;
+  const lines = artworks.map((art) => {
+    const variants = Object.keys(art.variants).join("/");
+    return `- **${art.label}**｜\`${art.artwork_id}\`｜变体：${variants}`;
+  });
+  return header + lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+export function registerArtworkTools(
+  server: McpServer,
+  channel: OutputChannel = "content",
+): void {
+  server.tool(
+    "operator_artwork",
+    [
+      "查询干员立绘（精英化立绘、时装等）并获取图片。",
+      "先用 action=\"list\" 拿到该干员所有立绘的 artwork_id 与元数据（不返回图片），",
+      "再用 action=\"get\" + artwork_id 获取一张图片（base64 编码，默认 large 变体）。",
+      "单次 get 最多返回一张图片。",
+    ].join(" "),
+    {
+      operator_name: z.string().describe("干员名称（中文），如「阿米娅」。"),
+      action: z
+        .enum(["list", "get"])
+        .describe(
+          "操作（必填）：list=列出该干员所有立绘及 artwork_id；get=按 artwork_id 获取一张图片。",
+        ),
+      artwork_id: z
+        .string()
+        .optional()
+        .describe(
+          "仅 action=get 必填：list 返回的不透明 token，原样回传即可，不可自行构造。",
+        ),
+      variant: z
+        .enum(["original", "large", "preview"])
+        .optional()
+        .describe(
+          "仅 action=get 生效：图片变体。large=max 1024px（默认），preview=max 256px，original=原图（需服务端开启 ORIGINAL_IMAGE 同步）。",
+        ),
+    },
+    ({ operator_name, action, artwork_id, variant }) =>
+      withActivationSnapshot(() => {
+        if (action === "list") return doList(operator_name, channel);
+        return doGet(operator_name, artwork_id, variant, channel);
+      }),
+  );
+}

--- a/ts/src/tools/artworkTools.ts
+++ b/ts/src/tools/artworkTools.ts
@@ -9,7 +9,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { existsSync, readFileSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { z } from "zod";
 import { loadConfig, withActivationSnapshot } from "../config.js";
 import {
@@ -58,7 +58,13 @@ function dataNotReady(): CallToolResult {
 // ---------------------------------------------------------------------------
 
 function doList(operatorName: string, channel: OutputChannel): CallToolResult {
-  const charId = resolveCharId(operatorName);
+  let charId: string | null;
+  try {
+    charId = resolveCharId(operatorName);
+  } catch {
+    // gamedata not synced yet (effectiveExcelPath null or table missing).
+    return dataNotReady();
+  }
   if (charId === null) {
     return textResult(
       `找不到干员「${operatorName}」。建议先用 search_prts 确认准确的中文名称。`,
@@ -136,8 +142,18 @@ function doGet(
       `artwork_id「${artworkId}」不提供「${chosen}」变体（可用：${available}）。`,
     );
   }
-  const pngPath = join(genDir, variantMeta.file);
-  if (!existsSync(pngPath) || !statSync(pngPath).isFile()) {
+  // The file field comes from the network-downloaded index; contain it to
+  // the generation dir so a malformed upstream cannot read an arbitrary host
+  // file and exfiltrate it base64-encoded.
+  const pngPath = resolve(genDir, variantMeta.file);
+  const relCheck = relative(genDir, pngPath);
+  if (
+    relCheck === ".."
+    || relCheck.startsWith(`..${sep}`)
+    || isAbsolute(relCheck)
+    || !existsSync(pngPath)
+    || !statSync(pngPath).isFile()
+  ) {
     return textResult(
       `图片文件缺失：${variantMeta.file}。同步可能不完整，请稍后重试。`,
     );

--- a/ts/tests/images.test.ts
+++ b/ts/tests/images.test.ts
@@ -1,0 +1,74 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  SCHEMA_VERSION,
+  parseIndex,
+  buildArtworkLabel,
+} from "../src/data/images.ts";
+
+function sampleIndex(): unknown {
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    baselineVersion: "b1",
+    currentVersion: "c1",
+    shards: { "chararts-large": "chararts-large.zip" },
+    artworks: {
+      "char_002_amiya#1": {
+        kind: "base",
+        shard: "chararts",
+        large: { file: "amiya_1.large.png", w: 1024, h: 1100, bytes: 50, sha256: "h1" },
+        preview: { file: "amiya_1.preview.png", w: 256, h: 275, bytes: 20, sha256: "h2" },
+      },
+      "char_002_amiya@winter#1": {
+        kind: "skin",
+        shard: "skinpack",
+        large: { file: "amiya_winter.large.png", w: 1024, h: 1024, bytes: 60, sha256: "h3" },
+      },
+    },
+  };
+}
+
+test("parseIndex accepts valid schema", () => {
+  const idx = parseIndex(sampleIndex());
+  assert.ok(idx !== null);
+  if (idx === null) return;
+  assert.equal(idx.baselineVersion, "b1");
+  assert.equal(idx.currentVersion, "c1");
+  assert.equal(idx.shards["chararts-large"], "chararts-large.zip");
+  const entry = idx.artworks["char_002_amiya#1"];
+  assert.ok(entry);
+  assert.equal(entry.kind, "base");
+  assert.equal(entry.shard, "chararts");
+  assert.equal(entry.variants.large?.file, "amiya_1.large.png");
+  assert.equal(entry.variants.original, undefined);
+});
+
+test("parseIndex rejects unknown schema", () => {
+  assert.equal(parseIndex({ schemaVersion: "other" }), null);
+});
+
+test("parseIndex skips artworks without variants", () => {
+  const raw = sampleIndex() as Record<string, unknown>;
+  const artworks = raw["artworks"] as Record<string, unknown>;
+  artworks["char_002_amiya#2"] = { kind: "base", shard: "chararts" };
+  const idx = parseIndex(raw);
+  assert.ok(idx !== null);
+  if (idx !== null) {
+    assert.equal(idx.artworks["char_002_amiya#2"], undefined);
+  }
+});
+
+test("buildArtworkLabel covers base, plus, fashion and unknown shapes", () => {
+  const charSkins = {
+    "char_002_amiya@winter#1": { displaySkin: { skinName: "报童" } },
+  };
+  assert.equal(buildArtworkLabel("char_002_amiya#1", charSkins), "精英零立绘");
+  assert.equal(buildArtworkLabel("char_002_amiya#1+", charSkins), "精英零立绘（变体）");
+  assert.equal(buildArtworkLabel("char_002_amiya#2", charSkins), "精英二立绘");
+  assert.equal(buildArtworkLabel("char_002_amiya@winter#1", charSkins), "报童");
+  // Unknown fashion theme falls back to a theme-derived placeholder.
+  assert.equal(buildArtworkLabel("char_002_amiya@unknown#1", charSkins), "时装（unknown）");
+  // Unknown base illust number gets a tolerant label.
+  assert.equal(buildArtworkLabel("char_002_amiya#5", charSkins), "立绘 5");
+});

--- a/ts/tests/toolSurface.test.ts
+++ b/ts/tests/toolSurface.test.ts
@@ -315,8 +315,9 @@ test("output-channel semantic invariant for structured and narrative tools", asy
     ...Object.keys(STRUCTURED_TOOL_ARGS),
     ...Object.keys(NARRATIVE_TOOL_ARGS),
   ];
-  // operator_artwork is conditionally registered (IMAGES_ENABLED) and has its
-  // own output-channel coverage; exclude it from this unconditional invariant.
+  // operator_artwork is conditionally registered (IMAGES_ENABLED). Its
+  // output-channel behavior is covered by python/tests/test_images.py (list/get
+  // with structured/both channels), not the TS invariant suite; exclude it here.
   const invariantExpected = EXPECTED_TOOLS.filter((t) => t !== "operator_artwork");
   assert.deepEqual([...new Set(invariantTools)].sort(), [...invariantExpected].sort());
   assert.equal(new Set(invariantTools).size, invariantTools.length, "tool invariant args contain duplicates");

--- a/ts/tests/toolSurface.test.ts
+++ b/ts/tests/toolSurface.test.ts
@@ -40,6 +40,9 @@ const EXPECTED_TOOLS = [
   "get_operator_memoirs",
   "find_character_appearances",
   "find_speakers_in",
+  // operator_artwork is conditionally registered (IMAGES_ENABLED=true); the
+  // name is still part of the frozen source-level surface this test guards.
+  "operator_artwork",
 ];
 
 test("TypeScript MCP tool names are frozen", () => {
@@ -312,7 +315,10 @@ test("output-channel semantic invariant for structured and narrative tools", asy
     ...Object.keys(STRUCTURED_TOOL_ARGS),
     ...Object.keys(NARRATIVE_TOOL_ARGS),
   ];
-  assert.deepEqual([...new Set(invariantTools)].sort(), [...EXPECTED_TOOLS].sort());
+  // operator_artwork is conditionally registered (IMAGES_ENABLED) and has its
+  // own output-channel coverage; exclude it from this unconditional invariant.
+  const invariantExpected = EXPECTED_TOOLS.filter((t) => t !== "operator_artwork");
+  assert.deepEqual([...new Set(invariantTools)].sort(), [...invariantExpected].sort());
   assert.equal(new Set(invariantTools).size, invariantTools.length, "tool invariant args contain duplicates");
 
   const root = mkdtempSync(join(tmpdir(), "prts-tool-invariant-"));


### PR DESCRIPTION
## Summary

新增 `operator_artwork` MCP 工具(LOCAL_IMAGE=true 主路径),双实现(Python + TypeScript)。`IMAGES_ENABLED=true` 时开启,消费 AKDP image Release 的本地 PNG 资产。两端工具名/参数/输出格式 parity。

- **config**: `IMAGES_ENABLED`(默认 false,主开关)/ `LOCAL_IMAGE`(默认 true)/ `ORIGINAL_IMAGE`(默认 false,控制 original 分片)/ `PRTS_IMAGE_DIR`(默认 gamedata 同层 `images/`)
- **data/images**: parse `akdp-images/v1` index.json;语义 label 从 `skin_table.json` charSkins join(基础立绘程序化、时装用 displaySkin.skinName、`#1+` 等容错)
- **data/images_sync**: 按 tag 前缀发现(`images-` vs `images-baseline-`,schema §6 隔离,不用 `/releases/latest`);下载 large+preview baseline 分片(original 可选);delta overlay;原子 generation 激活;offline fallback;复用 sync 的 cascading/锁/提取原语
- **startup_sync**: images sync task 接入 auto-sync 调度(单飞+重试+周期,与 JSON 包同款),`IMAGES_ENABLED+LOCAL_IMAGE` 门控
- **output**: `render_image_result`(TextContent + ImageContent,channel 三态;图片只在 content,不进 structuredContent)
- **tools**: `operator_artwork(operator_name, action:list|get, artwork_id?, variant?)`,条件注册(仅 IMAGES_ENABLED=true)

## Test plan

- [x] `check-runtime.sh --full`: **0 failures**(Python 302 + TS 232 tests)
- [x] 真实 E2E(真实 AKDP Release):`sync_images` 下载 ~1.5GB → generation 激活(2724 PNG = 1362×large+preview)→ `get(char_002_amiya#2, large)` 返回有效 `ImageContent`(1,096,810 bytes PNG,纯 base64 无 `data:` 前缀,`mimeType=image/png`,尺寸 951×1024,label「精英二立绘」);`preview` 变体 108,746 bytes < large,符合预期
- [x] `parse_index` + `build_artwork_label` parity(Python ↔ TypeScript,6 种 skinId 形态)
- [x] toolSurface frozen-name + invariant 测试更新(条件注册工具排除自 invariant)
- [x] `IMAGES_ENABLED=false`(默认)时 `operator_artwork` 不注册
- [x] list/get 单元测试(mock generation + 三态 channel + 错误路径)

## 未尽事宜(留后续 PR)

- `LOCAL_IMAGE=false`(MediaWiki 回退 + 全套安全边界 + LRU 缓存 + skinId→文件标题映射)
- 多形态干员(`char_1001_amiya2` 等)list 归并——首版前缀匹配只覆盖主形态
- RikkaHub 真实客户端验收 + legacy `2025-03-26` 协议回归
- `list` 的 E2E 需 gamedata 同步(单元测试已覆盖逻辑)

Refs #85