### PR TITLE
feat(artwork): LOCAL_IMAGE=false MediaWiki fallback (Py+TS)

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -15,6 +15,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   variant, max 1024px). `LOCAL_IMAGE=true` (default) consumes synced local
   assets via the existing auto-sync scheduler; `ORIGINAL_IMAGE=true` also
   pulls full-resolution shards. Labels are joined from `skin_table.json`.
+- `operator_artwork` LOCAL_IMAGE=false mode (PRTS MediaWiki fallback): list
+  via `allimages` + CharinfoV2 `时装N名称` labels, get via `imageinfo` under
+  the full #85 security boundary (hostname/MIME/magic/1MiB/streaming/redirect).
+  `PRTS_IMAGE_CACHE=true` enables a 256MiB LRU. `original` variant rejected
+  (PRTS originals exceed the 1MiB cap). True (AKDP) and false (MediaWiki)
+  paths share no data dependency.
 
 ## [2.4.0] - 2026-07-29
 

--- a/python/scripts/check_package_data.py
+++ b/python/scripts/check_package_data.py
@@ -49,6 +49,7 @@ def main() -> int:
         images_enabled=False,
         local_image=True,
         original_image=False,
+        prts_image_cache=False,
         images_path=gamedata_root.parent / "images",
     )
 

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -412,3 +412,127 @@ def _clean_snippet(snippet: str) -> str:
     snippet = re.sub(r",{2,}", "", snippet)
     snippet = re.sub(r"\n{2,}", "\n", snippet)
     return snippet.strip(" ,\n")
+
+
+# ---------------------------------------------------------------------------
+# Image helpers (LOCAL_IMAGE=false MediaWiki fallback)
+#
+# These serve operator_artwork when LOCAL_IMAGE=false: discover File: titles
+# via allimages, fetch variant URLs via imageinfo, and download the pixel data
+# under the full #85 security boundary. Mirrors the python-side path A (local
+# AKDP assets) at the tool-contract level but pulls everything from PRTS.
+# ---------------------------------------------------------------------------
+
+_ALLOWED_IMAGE_HOSTS: tuple[str, ...] = ("media.prts.wiki",)
+_ALLOWED_IMAGE_MIMES: tuple[str, ...] = ("image/png", "image/jpeg", "image/webp")
+_MAX_IMAGE_BYTES = 1024 * 1024  # 1 MiB decoded cap (#85)
+
+
+def _image_magic_ok(data: bytes, mime: str) -> bool:
+    """Verify the payload's magic bytes against its declared MIME type."""
+    if mime == "image/png":
+        return data.startswith(b"\x89PNG\r\n\x1a\n")
+    if mime == "image/jpeg":
+        return data.startswith(b"\xff\xd8\xff")
+    if mime == "image/webp":
+        # RIFF <4 size bytes> WEBP
+        return data[:4] == b"RIFF" and data[8:12] == b"WEBP"
+    return False
+
+
+async def list_allimages(prefix: str, limit: int = 50) -> list[dict]:
+    """List PRTS ``File:`` titles whose name starts with ``prefix``.
+
+    Returns dicts with ``name``/``size``/``mime``. Used by operator_artwork's
+    false-mode list to discover ``立绘_<name>_*`` files.
+    """
+    await _rate_limit()
+    params = {
+        "action": "query",
+        "list": "allimages",
+        "aiprefix": prefix,
+        "ailimit": str(limit),
+        "aiprop": "name|size|mime",
+        "format": "json",
+    }
+    resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
+    resp.raise_for_status()
+    data = resp.json()
+    return [
+        {
+            "name": a.get("name", ""),
+            "size": a.get("size", 0),
+            "mime": a.get("mime", ""),
+        }
+        for a in data.get("query", {}).get("allimages", [])
+    ]
+
+
+async def get_imageinfo(title: str, width: int | None = None) -> dict | None:
+    """Fetch image URLs/metadata for a ``File:`` title.
+
+    With ``width`` set, the result carries ``thumburl`` at that pixel width
+    (large=1024 / preview=256). Without it only the original ``url`` is set.
+    """
+    await _rate_limit()
+    full_title = title if title.startswith("File:") else f"File:{title}"
+    params: dict = {
+        "action": "query",
+        "titles": full_title,
+        "prop": "imageinfo",
+        "iiprop": "url|size|mime",
+        "format": "json",
+    }
+    if width is not None:
+        params["iiurlwidth"] = str(width)
+    resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
+    resp.raise_for_status()
+    data = resp.json()
+    for page in data.get("query", {}).get("pages", {}).values():
+        ii = page.get("imageinfo") or []
+        if ii:
+            info = ii[0]
+            return {
+                "url": info.get("url"),
+                "thumburl": info.get("thumburl"),
+                "width": info.get("width"),
+                "height": info.get("height"),
+                "mime": info.get("mime"),
+                "size": info.get("size"),
+            }
+    return None
+
+
+async def download_image_safe(url: str) -> bytes:
+    """Download an image under the full #85 security boundary.
+
+    Checks: HTTPS + hostname ``media.prts.wiki`` (re-validated after redirect),
+    Content-Type in the MIME allowlist, streaming read capped at 1 MiB, and
+    magic-byte verification of the final payload. Raises ``ValueError`` on any
+    violation; the tool layer degrades that to a text-only result (no partial
+    image is ever returned).
+    """
+    parsed = httpx.URL(url)
+    if parsed.scheme != "https" or parsed.host not in _ALLOWED_IMAGE_HOSTS:
+        raise ValueError(f"image URL host not allowed: {parsed.host}")
+    await _rate_limit()
+    async with _get_client().stream(
+        "GET", url, follow_redirects=True, timeout=httpx.Timeout(30.0),
+    ) as resp:
+        if resp.status_code != 200:
+            raise ValueError(f"image fetch HTTP {resp.status_code}")
+        final = resp.url
+        if final.scheme != "https" or final.host not in _ALLOWED_IMAGE_HOSTS:
+            raise ValueError(f"redirected to disallowed host: {final.host}")
+        ctype = resp.headers.get("content-type", "").split(";")[0].strip().lower()
+        if ctype not in _ALLOWED_IMAGE_MIMES:
+            raise ValueError(f"bad content-type: {ctype!r}")
+        buf = bytearray()
+        async for chunk in resp.aiter_bytes(chunk_size=8192):
+            buf.extend(chunk)
+            if len(buf) > _MAX_IMAGE_BYTES:
+                raise ValueError(f"image exceeds {_MAX_IMAGE_BYTES} byte cap")
+        data = bytes(buf)
+    if not _image_magic_ok(data, ctype):
+        raise ValueError(f"magic bytes mismatch for {ctype!r}")
+    return data

--- a/python/src/prts_mcp/config.py
+++ b/python/src/prts_mcp/config.py
@@ -260,6 +260,7 @@ class Config:
     images_enabled: bool         # IMAGES_ENABLED; False → operator_artwork not registered
     local_image: bool            # LOCAL_IMAGE; True = AKDP local assets, False = MediaWiki (future)
     original_image: bool         # ORIGINAL_IMAGE; True = also sync original-variant shards
+    prts_image_cache: bool       # PRTS_IMAGE_CACHE; True = LRU-cache MediaWiki images (false mode)
     images_path: Path            # image asset sync target (PRTS_IMAGE_DIR or default)
 
     # Derived paths — set in __post_init__, never passed to __init__.
@@ -382,6 +383,7 @@ class Config:
             images_enabled=_env_bool("IMAGES_ENABLED", False),
             local_image=_env_bool("LOCAL_IMAGE", True),
             original_image=_env_bool("ORIGINAL_IMAGE", False),
+            prts_image_cache=_env_bool("PRTS_IMAGE_CACHE", False),
             images_path=images_path,
         )
         return config

--- a/python/src/prts_mcp/tools_artwork.py
+++ b/python/src/prts_mcp/tools_artwork.py
@@ -8,11 +8,19 @@ from __future__ import annotations
 import base64
 import json
 import logging
+import threading
+from collections import OrderedDict
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal, Mapping
 
 from pydantic import Field
 
+from prts_mcp.api.prts_wiki import (
+    download_image_safe as _download_image_safe,
+    get_imageinfo as _get_imageinfo,
+    get_template_data as _get_template_data,
+    list_allimages as _list_allimages,
+)
 from prts_mcp.config import Config, activation_snapshot
 from prts_mcp.data.images import (
     DEFAULT_VARIANT,
@@ -62,7 +70,220 @@ def _data_not_ready() -> object:
     )
 
 
+# ---------------------------------------------------------------------------
+# LOCAL_IMAGE=false MediaWiki path
+#
+# Data flows entirely from PRTS: allimages for file discovery, parsetree
+# (CharinfoV2 时装N名称) for fashion labels, imageinfo for variant URLs,
+# and download_image_safe for the pixel payload under the #85 boundary.
+# True (AKDP) and false (MediaWiki) modes share no data dependency.
+# ---------------------------------------------------------------------------
+
+_IMAGE_CACHE_LOCK = threading.Lock()
+_image_cache: "OrderedDict[str, bytes]" = OrderedDict()
+_IMAGE_CACHE_MAX_BYTES = 256 * 1024 * 1024  # 256 MiB (#85 §4.2)
+
+_MEDIAWIKI_BASE_LABELS: Mapping[str, str] = {"1": "精英零立绘", "2": "精英二立绘"}
+_VARIANT_WIDTH: Mapping[str, int] = {"large": 1024, "preview": 256}
+
+
+def _image_cache_key(artwork_id: str, variant: str) -> str:
+    return f"{artwork_id}|{variant}"
+
+
+def _image_cache_get(artwork_id: str, variant: str) -> bytes | None:
+    key = _image_cache_key(artwork_id, variant)
+    with _IMAGE_CACHE_LOCK:
+        if key in _image_cache:
+            _image_cache.move_to_end(key)
+            return _image_cache[key]
+    return None
+
+
+def _image_cache_put(artwork_id: str, variant: str, data: bytes) -> None:
+    key = _image_cache_key(artwork_id, variant)
+    with _IMAGE_CACHE_LOCK:
+        _image_cache[key] = data
+        _image_cache.move_to_end(key)
+        total = sum(len(v) for v in _image_cache.values())
+        while total > _IMAGE_CACHE_MAX_BYTES and _image_cache:
+            _, evicted = _image_cache.popitem(last=False)
+            total -= len(evicted)
+
+
+def _mediawiki_base_label(suffix: str) -> str:
+    base = suffix.rstrip("+")
+    plus = "+" in suffix
+    label = _MEDIAWIKI_BASE_LABELS.get(base)
+    if label is None:
+        label = f"立绘 {base}" if base else "立绘"
+    if plus:
+        label += "（变体）"
+    return label
+
+
+def _mediawiki_fashion_label(rest: str, charinfo: Mapping[str, Any]) -> str:
+    """rest is like 'skin3' (optionally 'skin2_sp'); leading digits = skin N."""
+    num = ""
+    for ch in rest[4:]:
+        if ch.isdigit():
+            num += ch
+        else:
+            break
+    label: str | None = None
+    if num:
+        val = charinfo.get(f"时装{num}名称")
+        if isinstance(val, str) and val:
+            label = val
+    if label is None:
+        label = f"时装 {num}" if num else "时装"
+    return label
+
+
+def _label_from_filename(
+    filename: str, charinfo: Mapping[str, Any],
+) -> str | None:
+    """Derive a label from a PRTS filename like ``立绘_阿米娅_2.png``.
+
+    Returns None for files we do not expose (建筑小人 ``_Nb``, non-png, or
+    names that don't match the ``立绘_<name>_<suffix>`` shape). Multi-form
+    operators carry the form in the name segment: ``立绘_阿米娅(近卫)_2.png``.
+    """
+    if not filename.endswith(".png"):
+        return None
+    base = filename[:-4]
+    parts = base.split("_", 2)
+    if len(parts) < 3:
+        return None
+    name = parts[1]
+    suffix = parts[2]
+    form: str | None = None
+    if "(" in name:
+        b = name.find("(")
+        e = name.find(")", b)
+        if 0 <= b < e:
+            form = name[b + 1:e]
+    if suffix.startswith("skin"):
+        label = _mediawiki_fashion_label(suffix, charinfo)
+    elif suffix.endswith("b"):
+        return None  # 建筑小人
+    else:
+        label = _mediawiki_base_label(suffix)
+    if form:
+        label += f"（{form}）"
+    return label
+
+
+async def _do_list_mediawiki(operator_name: str) -> object:
+    """LOCAL_IMAGE=false list: discover PRTS File: titles + CharinfoV2 labels."""
+    prefix = f"立绘_{operator_name}_"
+    try:
+        files = await _list_allimages(prefix)
+        templates = await _get_template_data(operator_name)
+    except Exception as exc:  # noqa: BLE001
+        return text_result(f"查询 PRTS 立绘失败：{exc}")
+    charinfo = templates.get("CharinfoV2")
+    if not isinstance(charinfo, Mapping):
+        charinfo = {}
+    artworks: list[dict] = []
+    for f in files:
+        name = f.get("name", "")
+        label = _label_from_filename(name, charinfo)
+        if label is None:
+            continue
+        artworks.append({
+            "artwork_id": name,
+            "label": label,
+            "kind": "skin" if "skin" in name else "base",
+            "variants": {"large": {}, "preview": {}},
+        })
+    artworks.sort(key=lambda a: a["artwork_id"])
+    if not artworks:
+        return text_result(
+            f"未找到「{operator_name}」的立绘。建议先用 search_prts 确认名称。"
+        )
+    data = {
+        "operator_name": operator_name,
+        "source": "mediawiki",
+        "total": len(artworks),
+        "artworks": artworks,
+    }
+    markdown = _render_list(operator_name, artworks)
+    return render_result(
+        data,
+        markdown,
+        summary=f"「{operator_name}」共 {len(artworks)} 张立绘（PRTS MediaWiki），详见 structuredContent",
+    )
+
+
+async def _do_get_mediawiki(
+    operator_name: str,
+    artwork_id: str | None,
+    variant: str | None,
+    cfg: Config,
+) -> object:
+    """LOCAL_IMAGE=false get: MediaWiki imageinfo + safe download (+ LRU)."""
+    if not artwork_id:
+        return text_result("action=get 时必须提供 artwork_id。请先用 action=list 获取。")
+    if variant == "original":
+        return text_result(
+            "LOCAL_IMAGE=false 模式不提供 original 变体（PRTS 原图常超 1 MiB 安全上限）。"
+            "请使用 large 或 preview。"
+        )
+    chosen = variant or DEFAULT_VARIANT
+    width = _VARIANT_WIDTH.get(chosen)
+    if width is None:
+        return text_result(f"不支持的变体：{chosen}。false 模式可选 large / preview。")
+    try:
+        info = await _get_imageinfo(artwork_id, width=width)
+    except Exception as exc:  # noqa: BLE001
+        return text_result(f"查询 PRTS 图片信息失败：{exc}")
+    if not info:
+        return text_result(f"找不到文件「{artwork_id}」。请用 action=list 重新获取。")
+    img_url = info.get("thumburl") or info.get("url")
+    if not img_url:
+        return text_result(f"「{artwork_id}」无 {chosen} 变体。")
+    image_bytes = _image_cache_get(artwork_id, chosen) if cfg.prts_image_cache else None
+    if image_bytes is None:
+        try:
+            image_bytes = await _download_image_safe(img_url)
+        except (ValueError, OSError) as exc:
+            return text_result(f"下载图片失败：{exc}")
+        if cfg.prts_image_cache:
+            _image_cache_put(artwork_id, chosen, image_bytes)
+    image_b64 = base64.b64encode(image_bytes).decode("ascii")
+    # CharinfoV2 is not re-fetched in get (list already provided the precise
+    # label); derive a best-effort label from the filename.
+    label = _label_from_filename(artwork_id, {}) or artwork_id
+    mime = info.get("mime") or "image/png"
+    markdown = (
+        f"**{label}**（{operator_name}）\n"
+        f"变体：{chosen}｜来源：PRTS MediaWiki\n"
+        f"artwork_id：`{artwork_id}`"
+    )
+    data = {
+        "operator_name": operator_name,
+        "artwork_id": artwork_id,
+        "label": label,
+        "variant": chosen,
+        "source": "mediawiki",
+        "width": info.get("width"),
+        "height": info.get("height"),
+        "bytes": len(image_bytes),
+    }
+    return render_image_result(
+        markdown,
+        image_b64,
+        mime,
+        data,
+        summary=f"{operator_name} 的「{label}」（{chosen}，PRTS MediaWiki）",
+    )
+
+
 async def _do_list(operator_name: str) -> object:
+    cfg = Config.load()
+    if not cfg.local_image:
+        return await _do_list_mediawiki(operator_name)
     try:
         char_id = _resolve_char_id(operator_name)
     except (OSError, AssertionError):
@@ -126,6 +347,9 @@ async def _do_get(
     artwork_id: str | None,
     variant: str | None,
 ) -> object:
+    cfg = Config.load()
+    if not cfg.local_image:
+        return await _do_get_mediawiki(operator_name, artwork_id, variant, cfg)
     if not artwork_id:
         return text_result("action=get 时必须提供 artwork_id。请先用 action=list 获取。")
     chosen = variant or DEFAULT_VARIANT

--- a/python/src/prts_mcp/tools_artwork.py
+++ b/python/src/prts_mcp/tools_artwork.py
@@ -247,7 +247,7 @@ async def _do_get_mediawiki(
     if image_bytes is None:
         try:
             image_bytes = await _download_image_safe(img_url)
-        except (ValueError, OSError) as exc:
+        except Exception as exc:  # noqa: BLE001 — ValueError (boundary) or httpx.HTTPError (network)
             return text_result(f"下载图片失败：{exc}")
         if cfg.prts_image_cache:
             _image_cache_put(artwork_id, chosen, image_bytes)

--- a/python/tests/test_artwork_mediawiki.py
+++ b/python/tests/test_artwork_mediawiki.py
@@ -1,15 +1,16 @@
 """Tests for LOCAL_IMAGE=false MediaWiki path.
 
-Covers filename→label parsing (base/plus/building-skip/fashion/multi-form),
-the image magic-byte check, and the LRU image cache. Network helpers
-(list_allimages / get_imageinfo / download_image_safe) are exercised via the
-tool-layer mock in test_images.py and are intentionally not re-mocked here —
-the security boundary of download_image_safe is validated through its pure
-helpers (magic check) plus the documented #85 constraints.
+Covers filename→label parsing, the image magic-byte check, the LRU cache
+eviction, and the download_image_safe URL pre-check (bad scheme/host). The
+streaming-rejection paths inside download_image_safe (post-redirect scheme/
+host, Content-Type, magic, 1 MiB cap) require an httpx transport mock and
+are deferred — see PR #92 未尽事宜.
 """
 from __future__ import annotations
 
-from prts_mcp.api.prts_wiki import _image_magic_ok
+import pytest
+
+from prts_mcp.api.prts_wiki import _image_magic_ok, download_image_safe
 from prts_mcp.tools_artwork import (
     _image_cache,
     _image_cache_get,
@@ -69,3 +70,30 @@ def test_image_cache_lru_round_trip():
         assert _image_cache_get("amiya_2", "preview") == b"\x01" * 50
     finally:
         _image_cache.clear()
+
+
+def test_image_cache_lru_evicts_by_byte_total(monkeypatch):
+    """When total bytes exceed the cap, the oldest entry is evicted."""
+    import prts_mcp.tools_artwork as ta
+
+    monkeypatch.setattr(ta, "_IMAGE_CACHE_MAX_BYTES", 150)
+    _image_cache.clear()
+    try:
+        _image_cache_put("a", "large", b"\x00" * 100)
+        _image_cache_put("b", "large", b"\x00" * 100)  # total 200 > 150 → evict "a"
+        assert _image_cache_get("a", "large") is None
+        assert _image_cache_get("b", "large") == b"\x00" * 100
+    finally:
+        _image_cache.clear()
+
+
+def test_download_image_safe_rejects_bad_url():
+    """The URL pre-check (scheme + host) rejects before any network call."""
+    import asyncio
+
+    # http (not https) — rejected pre-stream.
+    with pytest.raises(ValueError, match="not allowed"):
+        asyncio.run(download_image_safe("http://media.prts.wiki/x.png"))
+    # wrong host.
+    with pytest.raises(ValueError, match="not allowed"):
+        asyncio.run(download_image_safe("https://evil.com/x.png"))

--- a/python/tests/test_artwork_mediawiki.py
+++ b/python/tests/test_artwork_mediawiki.py
@@ -1,0 +1,71 @@
+"""Tests for LOCAL_IMAGE=false MediaWiki path.
+
+Covers filename→label parsing (base/plus/building-skip/fashion/multi-form),
+the image magic-byte check, and the LRU image cache. Network helpers
+(list_allimages / get_imageinfo / download_image_safe) are exercised via the
+tool-layer mock in test_images.py and are intentionally not re-mocked here —
+the security boundary of download_image_safe is validated through its pure
+helpers (magic check) plus the documented #85 constraints.
+"""
+from __future__ import annotations
+
+from prts_mcp.api.prts_wiki import _image_magic_ok
+from prts_mcp.tools_artwork import (
+    _image_cache,
+    _image_cache_get,
+    _image_cache_put,
+    _label_from_filename,
+)
+
+_CHARINFO = {"时装1名称": "报童", "时装2名称": "见习联结者", "时装3名称": "播种者"}
+
+
+def test_label_from_filename():
+    cases = {
+        "立绘_阿米娅_1.png": "精英零立绘",
+        "立绘_阿米娅_1+.png": "精英零立绘（变体）",
+        "立绘_阿米娅_2.png": "精英二立绘",
+        "立绘_阿米娅_2b.png": None,  # 建筑小人 — not exposed
+        "立绘_阿米娅_skin1.png": "报童",
+        "立绘_阿米娅_skin2.png": "见习联结者",
+        "立绘_阿米娅_skin3.png": "播种者",
+        "立绘_阿米娅(近卫)_2.png": "精英二立绘（近卫）",
+        "立绘_阿米娅(医疗)_skin1.png": "报童（医疗）",
+        "立绘_阿米娅(近卫)_2b.png": None,
+    }
+    for filename, expected in cases.items():
+        assert _label_from_filename(filename, _CHARINFO) == expected, filename
+
+
+def test_label_fashion_fallback_without_charinfo():
+    # No CharinfoV2 → fashion falls back to "时装 N".
+    assert _label_from_filename("立绘_阿米娅_skin1.png", {}) == "时装 1"
+    assert _label_from_filename("立绘_阿米娅_skin12.png", {}) == "时装 12"
+
+
+def test_label_rejects_non_png_and_malformed():
+    assert _label_from_filename("立绘_阿米娅_2.jpg", _CHARINFO) is None
+    assert _label_from_filename("立绘阿米娅", _CHARINFO) is None  # no second underscore
+
+
+def test_image_magic_ok():
+    assert _image_magic_ok(b"\x89PNG\r\n\x1a\n\x00\x00", "image/png")
+    assert _image_magic_ok(b"\xff\xd8\xff\xe1\x02", "image/jpeg")
+    assert _image_magic_ok(b"RIFF\x00\x00\x00\x00WEBPVP8", "image/webp")
+    assert not _image_magic_ok(b"notanimage", "image/png")
+    assert not _image_magic_ok(b"\x89PNG\r\n\x1a\n", "image/jpeg")  # wrong mime
+    assert not _image_magic_ok(b"RIFF\x00\x00\x00\x00NOTW", "image/webp")
+
+
+def test_image_cache_lru_round_trip():
+    _image_cache.clear()
+    try:
+        assert _image_cache_get("amiya_2", "large") is None
+        _image_cache_put("amiya_2", "large", b"\x00" * 100)
+        assert _image_cache_get("amiya_2", "large") == b"\x00" * 100
+        # Different variant misses.
+        assert _image_cache_get("amiya_2", "preview") is None
+        _image_cache_put("amiya_2", "preview", b"\x01" * 50)
+        assert _image_cache_get("amiya_2", "preview") == b"\x01" * 50
+    finally:
+        _image_cache.clear()

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -15,6 +15,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
   variant, max 1024px). `LOCAL_IMAGE=true` (default) consumes synced local
   assets via the existing auto-sync scheduler; `ORIGINAL_IMAGE=true` also
   pulls full-resolution shards. Labels are joined from `skin_table.json`.
+- `operator_artwork` LOCAL_IMAGE=false mode (PRTS MediaWiki fallback): list
+  via `allimages` + CharinfoV2 `时装N名称` labels, get via `imageinfo` under
+  the full #85 security boundary (hostname/MIME/magic/1MiB/streaming/redirect).
+  `PRTS_IMAGE_CACHE=true` enables a 256MiB LRU. `original` variant rejected
+  (PRTS originals exceed the 1MiB cap). True (AKDP) and false (MediaWiki)
+  paths share no data dependency.
 
 ## [2.4.0] - 2026-07-29
 

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -581,9 +581,9 @@ export async function downloadImageSafe(url: string): Promise<Uint8Array> {
     signal: AbortSignal.timeout(30_000),
   });
   if (!res.ok) throw new Error(`image fetch HTTP ${res.status}`);
-  const finalHost = new URL(res.url).hostname;
-  if (!(ALLOWED_IMAGE_HOSTS as readonly string[]).includes(finalHost)) {
-    throw new Error(`redirected to disallowed host: ${finalHost}`);
+  const finalUrl = new URL(res.url);
+  if (finalUrl.protocol !== "https:" || !(ALLOWED_IMAGE_HOSTS as readonly string[]).includes(finalUrl.hostname)) {
+    throw new Error(`redirected to disallowed URL: ${res.url}`);
   }
   const ctype = (res.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
   if (!(ALLOWED_IMAGE_MIMES as readonly string[]).includes(ctype)) {

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -476,3 +476,146 @@ export async function getTemplateData(
 
   return parseParsetreeXml(xml);
 }
+
+// ---------------------------------------------------------------------------
+// Image helpers (LOCAL_IMAGE=false MediaWiki fallback)
+//
+// Mirrors prts_wiki.list_allimages / get_imageinfo / download_image_safe.
+// Used by operator_artwork when LOCAL_IMAGE=false to discover File: titles,
+// fetch variant URLs, and download pixel data under the full #85 boundary.
+// ---------------------------------------------------------------------------
+
+const ALLOWED_IMAGE_HOSTS = ["media.prts.wiki"] as const;
+const ALLOWED_IMAGE_MIMES = ["image/png", "image/jpeg", "image/webp"] as const;
+const MAX_IMAGE_BYTES = 1024 * 1024; // 1 MiB decoded cap (#85)
+
+export function imageMagicOk(data: Uint8Array, mime: string): boolean {
+  if (mime === "image/png") {
+    const sig = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+    return sig.every((b, i) => data[i] === b);
+  }
+  if (mime === "image/jpeg") {
+    return data[0] === 0xff && data[1] === 0xd8 && data[2] === 0xff;
+  }
+  if (mime === "image/webp") {
+    const riff = [0x52, 0x49, 0x46, 0x46];
+    const webp = [0x57, 0x45, 0x42, 0x50];
+    return riff.every((b, i) => data[i] === b) && webp.every((b, i) => data[i + 8] === b);
+  }
+  return false;
+}
+
+export interface AllimagesEntry {
+  name: string;
+  size: number;
+  mime: string;
+}
+
+/** Mirrors prts_wiki.list_allimages(). */
+export async function listAllimages(prefix: string, limit = 50): Promise<AllimagesEntry[]> {
+  const data = (await prtsGet({
+    action: "query",
+    list: "allimages",
+    aiprefix: prefix,
+    ailimit: limit,
+    aiprop: "name|size|mime",
+    format: "json",
+  })) as { query?: { allimages?: Array<{ name?: string; size?: number; mime?: string }> } };
+  return (data.query?.allimages ?? []).map((a) => ({
+    name: a.name ?? "",
+    size: a.size ?? 0,
+    mime: a.mime ?? "",
+  }));
+}
+
+export interface ImageinfoResult {
+  url?: string;
+  thumburl?: string;
+  width?: number;
+  height?: number;
+  mime?: string;
+  size?: number;
+}
+
+/** Mirrors prts_wiki.get_imageinfo(). */
+export async function getImageinfo(title: string, width?: number): Promise<ImageinfoResult | null> {
+  const fullTitle = title.startsWith("File:") ? title : `File:${title}`;
+  const params: Record<string, string | number> = {
+    action: "query",
+    titles: fullTitle,
+    prop: "imageinfo",
+    iiprop: "url|size|mime",
+    format: "json",
+  };
+  if (width !== undefined) params.iiurlwidth = width;
+  const data = (await prtsGet(params)) as {
+    query?: { pages?: Record<string, { imageinfo?: Array<Record<string, unknown>> }> };
+  };
+  for (const page of Object.values(data.query?.pages ?? {})) {
+    const ii = page.imageinfo;
+    if (ii && ii.length > 0) {
+      const info = ii[0];
+      return {
+        url: info["url"] as string | undefined,
+        thumburl: info["thumburl"] as string | undefined,
+        width: info["width"] as number | undefined,
+        height: info["height"] as number | undefined,
+        mime: info["mime"] as string | undefined,
+        size: info["size"] as number | undefined,
+      };
+    }
+  }
+  return null;
+}
+
+/** Mirrors prts_wiki.download_image_safe(). */
+export async function downloadImageSafe(url: string): Promise<Uint8Array> {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "https:" || !(ALLOWED_IMAGE_HOSTS as readonly string[]).includes(parsed.hostname)) {
+    throw new Error(`image URL host not allowed: ${parsed.hostname}`);
+  }
+  await rateLimit();
+  const res = await fetch(url, {
+    headers: DEFAULT_HEADERS,
+    redirect: "follow",
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) throw new Error(`image fetch HTTP ${res.status}`);
+  const finalHost = new URL(res.url).hostname;
+  if (!(ALLOWED_IMAGE_HOSTS as readonly string[]).includes(finalHost)) {
+    throw new Error(`redirected to disallowed host: ${finalHost}`);
+  }
+  const ctype = (res.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
+  if (!(ALLOWED_IMAGE_MIMES as readonly string[]).includes(ctype)) {
+    throw new Error(`bad content-type: ${JSON.stringify(ctype)}`);
+  }
+  if (res.body === null) throw new Error("response body is null");
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const reader = res.body.getReader();
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value) {
+        total += value.byteLength;
+        if (total > MAX_IMAGE_BYTES) {
+          throw new Error(`image exceeds ${MAX_IMAGE_BYTES} byte cap`);
+        }
+        chunks.push(value);
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const data = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    data.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  if (!imageMagicOk(data, ctype)) {
+    throw new Error(`magic bytes mismatch for ${JSON.stringify(ctype)}`);
+  }
+  return data;
+}

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -274,6 +274,8 @@ export interface Config {
   localImage: boolean;
   /** ORIGINAL_IMAGE — true = also sync original-variant shards. */
   originalImage: boolean;
+  /** PRTS_IMAGE_CACHE — true = LRU-cache MediaWiki images in LOCAL_IMAGE=false mode. */
+  prtsImageCache: boolean;
   /** Image asset sync target (PRTS_IMAGE_DIR or default). */
   imagesPath: string;
 }
@@ -347,6 +349,7 @@ export function loadConfig(): Config {
     imagesEnabled: envBool("IMAGES_ENABLED", false),
     localImage: envBool("LOCAL_IMAGE", true),
     originalImage: envBool("ORIGINAL_IMAGE", false),
+    prtsImageCache: envBool("PRTS_IMAGE_CACHE", false),
     imagesPath,
   };
   return config;

--- a/ts/src/tools/artworkTools.ts
+++ b/ts/src/tools/artworkTools.ts
@@ -22,6 +22,12 @@ import {
   type ImagesIndex,
   type VariantName,
 } from "../data/images.js";
+import {
+  downloadImageSafe,
+  getImageinfo,
+  getTemplateData,
+  listAllimages,
+} from "../api/prtsWiki.js";
 import { activeGenerationSync } from "../data/imagesSync.js";
 import { resolveCharId } from "../data/operator.js";
 import { renderImageResult, renderResult, textResult, type OutputChannel } from "../output.js";
@@ -50,6 +56,233 @@ function dataNotReady(): CallToolResult {
   return textResult(
     "立绘数据未就绪。可能原因：IMAGES_ENABLED 未开启，或图片同步仍在进行中。" +
       "请稍后重试；若持续不可用，请检查网络或 GITHUB_TOKEN。",
+  );
+}
+
+// ---------------------------------------------------------------------------
+// LOCAL_IMAGE=false MediaWiki path
+//
+// Data flows entirely from PRTS: allimages for discovery, parsetree
+// (CharinfoV2 时装N名称) for fashion labels, imageinfo for variant URLs,
+// downloadImageSafe for the payload under the #85 boundary. Shares no data
+// dependency with the true (AKDP) path.
+// ---------------------------------------------------------------------------
+
+const IMAGE_CACHE_MAX_BYTES = 256 * 1024 * 1024; // 256 MiB (#85 §4.2)
+const _imageCache = new Map<string, Buffer>();
+let _imageCacheTotal = 0;
+
+const MEDIAWIKI_BASE_LABELS: Record<string, string> = {
+  "1": "精英零立绘",
+  "2": "精英二立绘",
+};
+const VARIANT_WIDTH: Record<string, number> = { large: 1024, preview: 256 };
+
+function imageCacheKey(artworkId: string, variant: string): string {
+  return `${artworkId}|${variant}`;
+}
+
+function imageCacheGet(artworkId: string, variant: string): Buffer | null {
+  const key = imageCacheKey(artworkId, variant);
+  const v = _imageCache.get(key);
+  if (v === undefined) return null;
+  _imageCache.delete(key);
+  _imageCache.set(key, v); // move to end (LRU)
+  return v;
+}
+
+function imageCachePut(artworkId: string, variant: string, data: Buffer): void {
+  const key = imageCacheKey(artworkId, variant);
+  const existing = _imageCache.get(key);
+  if (existing !== undefined) {
+    _imageCache.delete(key);
+    _imageCacheTotal -= existing.byteLength;
+  }
+  _imageCache.set(key, data);
+  _imageCacheTotal += data.byteLength;
+  while (_imageCacheTotal > IMAGE_CACHE_MAX_BYTES && _imageCache.size > 0) {
+    const oldest = _imageCache.keys().next().value;
+    if (oldest === undefined) break;
+    const evicted = _imageCache.get(oldest);
+    _imageCache.delete(oldest);
+    if (evicted !== undefined) _imageCacheTotal -= evicted.byteLength;
+  }
+}
+
+function mediawikiBaseLabel(suffix: string): string {
+  const base = suffix.replace(/\+$/, "");
+  const plus = suffix.endsWith("+");
+  let label = MEDIAWIKI_BASE_LABELS[base];
+  if (label === undefined) label = base ? `立绘 ${base}` : "立绘";
+  if (plus) label += "（变体）";
+  return label;
+}
+
+function mediawikiFashionLabel(
+  rest: string,
+  charinfo: Record<string, unknown>,
+): string {
+  let num = "";
+  for (const ch of rest.slice(4)) {
+    if (/[0-9]/.test(ch)) num += ch;
+    else break;
+  }
+  let label: string | null = null;
+  if (num) {
+    const v = charinfo[`时装${num}名称`];
+    if (typeof v === "string" && v) label = v;
+  }
+  if (label === null) label = num ? `时装 ${num}` : "时装";
+  return label;
+}
+
+export function labelFromFilename(
+  filename: string,
+  charinfo: Record<string, unknown>,
+): string | null {
+  if (!filename.endsWith(".png")) return null;
+  const base = filename.slice(0, -4);
+  const first = base.indexOf("_");
+  const second = base.indexOf("_", first + 1);
+  if (first < 0 || second < 0) return null;
+  const name = base.slice(first + 1, second);
+  const suffix = base.slice(second + 1);
+  let form: string | null = null;
+  if (name.includes("(")) {
+    const b = name.indexOf("(");
+    const e = name.indexOf(")", b);
+    if (0 <= b && b < e) form = name.slice(b + 1, e);
+  }
+  let label: string;
+  if (suffix.startsWith("skin")) {
+    label = mediawikiFashionLabel(suffix, charinfo);
+  } else if (suffix.endsWith("b")) {
+    return null; // 建筑小人
+  } else {
+    label = mediawikiBaseLabel(suffix);
+  }
+  if (form) label += `（${form}）`;
+  return label;
+}
+
+async function doListMediawiki(
+  operatorName: string,
+  channel: OutputChannel,
+): Promise<CallToolResult> {
+  const prefix = `立绘_${operatorName}_`;
+  let files: { name: string; size: number; mime: string }[];
+  let templates: Record<string, Record<string, unknown>>;
+  try {
+    files = await listAllimages(prefix);
+    templates = await getTemplateData(operatorName);
+  } catch (err) {
+    return textResult(`查询 PRTS 立绘失败：${err instanceof Error ? err.message : String(err)}`);
+  }
+  const rawCharinfo = templates["CharinfoV2"];
+  const charinfo = rawCharinfo && typeof rawCharinfo === "object"
+    ? (rawCharinfo as Record<string, unknown>)
+    : {};
+  const artworks: Array<{
+    artwork_id: string;
+    label: string;
+    kind: string;
+    variants: Record<string, Record<string, never>>;
+  }> = [];
+  for (const f of files) {
+    const label = labelFromFilename(f.name, charinfo);
+    if (label === null) continue;
+    artworks.push({
+      artwork_id: f.name,
+      label,
+      kind: f.name.includes("skin") ? "skin" : "base",
+      variants: { large: {}, preview: {} },
+    });
+  }
+  artworks.sort((a, b) => a.artwork_id.localeCompare(b.artwork_id));
+  if (artworks.length === 0) {
+    return textResult(`未找到「${operatorName}」的立绘。建议先用 search_prts 确认名称。`);
+  }
+  const data = {
+    operator_name: operatorName,
+    source: "mediawiki",
+    total: artworks.length,
+    artworks,
+  };
+  const markdown = renderList(operatorName, artworks);
+  return renderResult(
+    data,
+    markdown,
+    channel,
+    `「${operatorName}」共 ${artworks.length} 张立绘（PRTS MediaWiki），详见 structuredContent`,
+  );
+}
+
+async function doGetMediawiki(
+  operatorName: string,
+  artworkId: string | undefined,
+  variant: VariantName | undefined,
+  channel: OutputChannel,
+): Promise<CallToolResult> {
+  if (!artworkId) {
+    return textResult("action=get 时必须提供 artwork_id。请先用 action=list 获取。");
+  }
+  if (variant === "original") {
+    return textResult(
+      "LOCAL_IMAGE=false 模式不提供 original 变体（PRTS 原图常超 1 MiB 安全上限）。请使用 large 或 preview。",
+    );
+  }
+  const chosen: VariantName = variant ?? DEFAULT_VARIANT;
+  const width = VARIANT_WIDTH[chosen];
+  if (width === undefined) {
+    return textResult(`不支持的变体：${chosen}。false 模式可选 large / preview。`);
+  }
+  let info;
+  try {
+    info = await getImageinfo(artworkId, width);
+  } catch (err) {
+    return textResult(`查询 PRTS 图片信息失败：${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (info === null) {
+    return textResult(`找不到文件「${artworkId}」。请用 action=list 重新获取。`);
+  }
+  const imgUrl = info.thumburl ?? info.url;
+  if (!imgUrl) return textResult(`「${artworkId}」无 ${chosen} 变体。`);
+  const cfg = loadConfig();
+  let imageBytes: Buffer | null = cfg.prtsImageCache ? imageCacheGet(artworkId, chosen) : null;
+  if (imageBytes === null) {
+    try {
+      imageBytes = Buffer.from(await downloadImageSafe(imgUrl));
+    } catch (err) {
+      return textResult(`下载图片失败：${err instanceof Error ? err.message : String(err)}`);
+    }
+    if (cfg.prtsImageCache && imageBytes !== null) {
+      imageCachePut(artworkId, chosen, imageBytes);
+    }
+  }
+  const imageBase64 = imageBytes.toString("base64");
+  const label = labelFromFilename(artworkId, {}) ?? artworkId;
+  const mime = info.mime ?? "image/png";
+  const markdown =
+    `**${label}**（${operatorName}）\n` +
+    `变体：${chosen}｜来源：PRTS MediaWiki\n` +
+    `artwork_id：\`${artworkId}\``;
+  const data = {
+    operator_name: operatorName,
+    artwork_id: artworkId,
+    label,
+    variant: chosen,
+    source: "mediawiki",
+    width: info.width,
+    height: info.height,
+    bytes: imageBytes.byteLength,
+  };
+  return renderImageResult(
+    markdown,
+    imageBase64,
+    mime,
+    data,
+    channel,
+    `${operatorName} 的「${label}」（${chosen}，PRTS MediaWiki）`,
   );
 }
 
@@ -248,10 +481,18 @@ export function registerArtworkTools(
           "仅 action=get 生效：图片变体。large=max 1024px（默认），preview=max 256px，original=原图（需服务端开启 ORIGINAL_IMAGE 同步）。",
         ),
     },
-    ({ operator_name, action, artwork_id, variant }) =>
-      withActivationSnapshot(() => {
+    async ({ operator_name, action, artwork_id, variant }) => {
+      const cfg = loadConfig();
+      if (!cfg.localImage) {
+        // LOCAL_IMAGE=false: MediaWiki path, no activation snapshot (PRTS is
+        // the source of truth, not a local generation that can swap mid-call).
+        if (action === "list") return doListMediawiki(operator_name, channel);
+        return doGetMediawiki(operator_name, artwork_id, variant, channel);
+      }
+      return withActivationSnapshot(() => {
         if (action === "list") return doList(operator_name, channel);
         return doGet(operator_name, artwork_id, variant, channel);
-      }),
+      });
+    },
   );
 }

--- a/ts/src/tools/artworkTools.ts
+++ b/ts/src/tools/artworkTools.ts
@@ -11,7 +11,7 @@ import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { z } from "zod";
-import { loadConfig, withActivationSnapshot } from "../config.js";
+import { loadConfig, withActivationSnapshot, type Config } from "../config.js";
 import {
   buildArtworkLabel,
   getCharSkins,
@@ -27,6 +27,7 @@ import {
   getImageinfo,
   getTemplateData,
   listAllimages,
+  type ImageinfoResult,
 } from "../api/prtsWiki.js";
 import { activeGenerationSync } from "../data/imagesSync.js";
 import { resolveCharId } from "../data/operator.js";
@@ -222,6 +223,7 @@ async function doGetMediawiki(
   artworkId: string | undefined,
   variant: VariantName | undefined,
   channel: OutputChannel,
+  cfg: Config,
 ): Promise<CallToolResult> {
   if (!artworkId) {
     return textResult("action=get 时必须提供 artwork_id。请先用 action=list 获取。");
@@ -236,7 +238,7 @@ async function doGetMediawiki(
   if (width === undefined) {
     return textResult(`不支持的变体：${chosen}。false 模式可选 large / preview。`);
   }
-  let info;
+  let info: ImageinfoResult | null;
   try {
     info = await getImageinfo(artworkId, width);
   } catch (err) {
@@ -247,7 +249,6 @@ async function doGetMediawiki(
   }
   const imgUrl = info.thumburl ?? info.url;
   if (!imgUrl) return textResult(`「${artworkId}」无 ${chosen} 变体。`);
-  const cfg = loadConfig();
   let imageBytes: Buffer | null = cfg.prtsImageCache ? imageCacheGet(artworkId, chosen) : null;
   if (imageBytes === null) {
     try {
@@ -487,7 +488,7 @@ export function registerArtworkTools(
         // LOCAL_IMAGE=false: MediaWiki path, no activation snapshot (PRTS is
         // the source of truth, not a local generation that can swap mid-call).
         if (action === "list") return doListMediawiki(operator_name, channel);
-        return doGetMediawiki(operator_name, artwork_id, variant, channel);
+        return doGetMediawiki(operator_name, artwork_id, variant, channel, cfg);
       }
       return withActivationSnapshot(() => {
         if (action === "list") return doList(operator_name, channel);

--- a/ts/tests/artworkMediawiki.test.ts
+++ b/ts/tests/artworkMediawiki.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { labelFromFilename } from "../src/tools/artworkTools.ts";
+import { imageMagicOk } from "../src/api/prtsWiki.ts";
+
+const CHARINFO: Record<string, unknown> = {
+  "时装1名称": "报童",
+  "时装2名称": "见习联结者",
+  "时装3名称": "播种者",
+};
+
+test("labelFromFilename: base / plus / building-skip / fashion / multi-form", () => {
+  const cases: Record<string, string | null> = {
+    "立绘_阿米娅_1.png": "精英零立绘",
+    "立绘_阿米娅_1+.png": "精英零立绘（变体）",
+    "立绘_阿米娅_2.png": "精英二立绘",
+    "立绘_阿米娅_2b.png": null,
+    "立绘_阿米娅_skin1.png": "报童",
+    "立绘_阿米娅_skin2.png": "见习联结者",
+    "立绘_阿米娅(近卫)_2.png": "精英二立绘（近卫）",
+    "立绘_阿米娅(医疗)_skin1.png": "报童（医疗）",
+    "立绘_阿米娅(近卫)_2b.png": null,
+  };
+  for (const [f, expected] of Object.entries(cases)) {
+    assert.equal(labelFromFilename(f, CHARINFO), expected, f);
+  }
+});
+
+test("labelFromFilename: fashion fallback without CharinfoV2", () => {
+  assert.equal(labelFromFilename("立绘_阿米娅_skin1.png", {}), "时装 1");
+  assert.equal(labelFromFilename("立绘_阿米娅_skin12.png", {}), "时装 12");
+});
+
+test("labelFromFilename: rejects non-png and malformed", () => {
+  assert.equal(labelFromFilename("立绘_阿米娅_2.jpg", CHARINFO), null);
+  assert.equal(labelFromFilename("立绘阿米娅", CHARINFO), null);
+});
+
+test("imageMagicOk: png/jpeg/webp signatures", () => {
+  assert.equal(
+    imageMagicOk(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00]), "image/png"),
+    true,
+  );
+  assert.equal(imageMagicOk(Buffer.from([0xff, 0xd8, 0xff, 0xe1]), "image/jpeg"), true);
+  const webp = Buffer.alloc(12);
+  webp.write("RIFF", 0);
+  webp.write("WEBP", 8);
+  assert.equal(imageMagicOk(webp, "image/webp"), true);
+  assert.equal(imageMagicOk(Buffer.from("notanimage"), "image/png"), false);
+});

--- a/ts/tests/artworkMediawiki.test.ts
+++ b/ts/tests/artworkMediawiki.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { labelFromFilename } from "../src/tools/artworkTools.ts";
-import { imageMagicOk } from "../src/api/prtsWiki.ts";
+import { downloadImageSafe, imageMagicOk } from "../src/api/prtsWiki.ts";
 
 const CHARINFO: Record<string, unknown> = {
   "时装1名称": "报童",
@@ -48,4 +48,17 @@ test("imageMagicOk: png/jpeg/webp signatures", () => {
   webp.write("WEBP", 8);
   assert.equal(imageMagicOk(webp, "image/webp"), true);
   assert.equal(imageMagicOk(Buffer.from("notanimage"), "image/png"), false);
+});
+
+test("downloadImageSafe rejects bad scheme/host before any network call", async () => {
+  // http (not https) — rejected pre-stream.
+  await assert.rejects(
+    () => downloadImageSafe("http://media.prts.wiki/x.png"),
+    /not allowed/,
+  );
+  // wrong host.
+  await assert.rejects(
+    () => downloadImageSafe("https://evil.com/x.png"),
+    /not allowed/,
+  );
 });


### PR DESCRIPTION
## Summary

`operator_artwork` LOCAL_IMAGE=false(PRTS MediaWiki 回退),双实现。与 true 模式(AKDP)**完全解耦**——数据全部来自 PRTS(allimages + CharinfoV2 + imageinfo),不碰本地 index/skin_table。

**途径 B 决策(spike 驱动)**:放弃 skinId↔文件标题映射(时装编号 AKDP `@theme#num` vs PRTS `_skinN` 不一致,skin_table 无排序字段,extmetadata 空),改用 PRTS 直查 + CharinfoV2 `时装N名称`。

- **config**: `PRTS_IMAGE_CACHE`(默认 false)门控 256 MiB LRU
- **api/prts_wiki + prtsWiki**: `list_allimages` / `get_imageinfo` / `download_image_safe` + 全套 #85 安全边界(hostname `media.prts.wiki`、MIME allowlist、magic bytes、≤1 MiB、流式有界、重定向复验)
- **tools(false branch)**: list = allimages + CharinfoV2 label;get = imageinfo(iiurlwidth 1024/256)+ safe download + LRU;`original` 变体拒绝(PRTS 原图超 1 MiB)
- **label**: 文件名解析(`_N`→精零/精二、`_skinN`→CharinfoV2 时装名、`(形态)_N`→多形态、`_Nb` 建筑小人跳过)

## Test plan

- [x] `check-runtime.sh --full`: **0 failures**(Python 311 + TS 236)
- [x] 单测:文件名 label(10 case,含多形态/建筑小人/时装 fallback)+ magic byte(PNG/JPEG/WebP)+ LRU 往返(Py+TS)
- [x] 真实 E2E(单 event loop,server 语义):list 阿米娅 → 6 张立绘(精英零/零(变体)/二/报童/见习联结者/播种者,label 精确);get(立绘_阿米娅_2.png, preview)→ 有效 PNG(112 KB,签名正确)
- [x] spike:PRTS 文件命名 + CharinfoV2 `时装N名称`(阿米娅验证:skin1=报童=@winter#1)

## 未尽事宜

- RikkaHub 真实客户端验收(true + false 都待)
- `download_image_safe` 安全边界的 mock 集成测试(当前覆盖 magic byte 单元;mock 流式拒绝 bad host/mime/oversized 留 CR 后补强)
- false 模式 list 的 `variants` 无尺寸(true 有 width/height/bytes)——不预取每文件 imageinfo

Refs #85