### PR TITLE
refactor(artwork): move false-mode label+cache to data layer

### DIFF
--- a/python/src/prts_mcp/data/artwork_mediawiki.py
+++ b/python/src/prts_mcp/data/artwork_mediawiki.py
@@ -1,0 +1,105 @@
+"""LOCAL_IMAGE=false path: filename→label parsing and LRU image cache.
+
+Mirrors ts/src/data/artworkMediawiki.ts. Lives in the data layer so
+tools_artwork.py stays orchestration-only, matching the true-mode boundary
+(data/images.py ↔ tools_artwork.py).
+"""
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from typing import Any, Mapping
+
+_IMAGE_CACHE_LOCK = threading.Lock()
+_image_cache: "OrderedDict[str, bytes]" = OrderedDict()
+_IMAGE_CACHE_MAX_BYTES = 256 * 1024 * 1024  # 256 MiB (#85 §4.2)
+
+_MEDIAWIKI_BASE_LABELS: Mapping[str, str] = {"1": "精英零立绘", "2": "精英二立绘"}
+_VARIANT_WIDTH: Mapping[str, int] = {"large": 1024, "preview": 256}
+
+
+def _image_cache_key(artwork_id: str, variant: str) -> str:
+    return f"{artwork_id}|{variant}"
+
+
+def _image_cache_get(artwork_id: str, variant: str) -> bytes | None:
+    key = _image_cache_key(artwork_id, variant)
+    with _IMAGE_CACHE_LOCK:
+        if key in _image_cache:
+            _image_cache.move_to_end(key)
+            return _image_cache[key]
+    return None
+
+
+def _image_cache_put(artwork_id: str, variant: str, data: bytes) -> None:
+    key = _image_cache_key(artwork_id, variant)
+    with _IMAGE_CACHE_LOCK:
+        _image_cache[key] = data
+        _image_cache.move_to_end(key)
+        total = sum(len(v) for v in _image_cache.values())
+        while total > _IMAGE_CACHE_MAX_BYTES and _image_cache:
+            _, evicted = _image_cache.popitem(last=False)
+            total -= len(evicted)
+
+
+def _mediawiki_base_label(suffix: str) -> str:
+    base = suffix.rstrip("+")
+    plus = "+" in suffix
+    label = _MEDIAWIKI_BASE_LABELS.get(base)
+    if label is None:
+        label = f"立绘 {base}" if base else "立绘"
+    if plus:
+        label += "（变体）"
+    return label
+
+
+def _mediawiki_fashion_label(rest: str, charinfo: Mapping[str, Any]) -> str:
+    """rest is like 'skin3' (optionally 'skin2_sp'); leading digits = skin N."""
+    num = ""
+    for ch in rest[4:]:
+        if ch.isdigit():
+            num += ch
+        else:
+            break
+    label: str | None = None
+    if num:
+        val = charinfo.get(f"时装{num}名称")
+        if isinstance(val, str) and val:
+            label = val
+    if label is None:
+        label = f"时装 {num}" if num else "时装"
+    return label
+
+
+def _label_from_filename(
+    filename: str, charinfo: Mapping[str, Any],
+) -> str | None:
+    """Derive a label from a PRTS filename like ``立绘_阿米娅_2.png``.
+
+    Returns None for files we do not expose (建筑小人 ``_Nb``, non-png, or
+    names that don't match the ``立绘_<name>_<suffix>`` shape). Multi-form
+    operators carry the form in the name segment: ``立绘_阿米娅(近卫)_2.png``.
+    """
+    if not filename.endswith(".png"):
+        return None
+    base = filename[:-4]
+    parts = base.split("_", 2)
+    if len(parts) < 3:
+        return None
+    name = parts[1]
+    suffix = parts[2]
+    form: str | None = None
+    if "(" in name:
+        b = name.find("(")
+        e = name.find(")", b)
+        if 0 <= b < e:
+            form = name[b + 1:e]
+    if suffix.startswith("skin"):
+        label = _mediawiki_fashion_label(suffix, charinfo)
+    elif suffix.endswith("b"):
+        return None  # 建筑小人
+    else:
+        label = _mediawiki_base_label(suffix)
+    if form:
+        label += f"（{form}）"
+    return label

--- a/python/src/prts_mcp/tools_artwork.py
+++ b/python/src/prts_mcp/tools_artwork.py
@@ -8,10 +8,8 @@ from __future__ import annotations
 import base64
 import json
 import logging
-import threading
-from collections import OrderedDict
 from pathlib import Path
-from typing import Annotated, Any, Literal, Mapping
+from typing import Annotated, Literal, Mapping
 
 from pydantic import Field
 
@@ -27,6 +25,12 @@ from prts_mcp.data.images import (
     _load_char_skins,
     build_artwork_label,
     parse_index,
+)
+from prts_mcp.data.artwork_mediawiki import (
+    _VARIANT_WIDTH,
+    _image_cache_get,
+    _image_cache_put,
+    _label_from_filename,
 )
 from prts_mcp.data.images_sync import _active_generation
 from prts_mcp.data.operator import _resolve_char_id
@@ -68,110 +72,6 @@ def _data_not_ready() -> object:
         "立绘数据未就绪。可能原因：IMAGES_ENABLED 未开启，或图片同步仍在进行中。"
         "请稍后重试；若持续不可用，请检查网络或 GITHUB_TOKEN。"
     )
-
-
-# ---------------------------------------------------------------------------
-# LOCAL_IMAGE=false MediaWiki path
-#
-# Data flows entirely from PRTS: allimages for file discovery, parsetree
-# (CharinfoV2 时装N名称) for fashion labels, imageinfo for variant URLs,
-# and download_image_safe for the pixel payload under the #85 boundary.
-# True (AKDP) and false (MediaWiki) modes share no data dependency.
-# ---------------------------------------------------------------------------
-
-_IMAGE_CACHE_LOCK = threading.Lock()
-_image_cache: "OrderedDict[str, bytes]" = OrderedDict()
-_IMAGE_CACHE_MAX_BYTES = 256 * 1024 * 1024  # 256 MiB (#85 §4.2)
-
-_MEDIAWIKI_BASE_LABELS: Mapping[str, str] = {"1": "精英零立绘", "2": "精英二立绘"}
-_VARIANT_WIDTH: Mapping[str, int] = {"large": 1024, "preview": 256}
-
-
-def _image_cache_key(artwork_id: str, variant: str) -> str:
-    return f"{artwork_id}|{variant}"
-
-
-def _image_cache_get(artwork_id: str, variant: str) -> bytes | None:
-    key = _image_cache_key(artwork_id, variant)
-    with _IMAGE_CACHE_LOCK:
-        if key in _image_cache:
-            _image_cache.move_to_end(key)
-            return _image_cache[key]
-    return None
-
-
-def _image_cache_put(artwork_id: str, variant: str, data: bytes) -> None:
-    key = _image_cache_key(artwork_id, variant)
-    with _IMAGE_CACHE_LOCK:
-        _image_cache[key] = data
-        _image_cache.move_to_end(key)
-        total = sum(len(v) for v in _image_cache.values())
-        while total > _IMAGE_CACHE_MAX_BYTES and _image_cache:
-            _, evicted = _image_cache.popitem(last=False)
-            total -= len(evicted)
-
-
-def _mediawiki_base_label(suffix: str) -> str:
-    base = suffix.rstrip("+")
-    plus = "+" in suffix
-    label = _MEDIAWIKI_BASE_LABELS.get(base)
-    if label is None:
-        label = f"立绘 {base}" if base else "立绘"
-    if plus:
-        label += "（变体）"
-    return label
-
-
-def _mediawiki_fashion_label(rest: str, charinfo: Mapping[str, Any]) -> str:
-    """rest is like 'skin3' (optionally 'skin2_sp'); leading digits = skin N."""
-    num = ""
-    for ch in rest[4:]:
-        if ch.isdigit():
-            num += ch
-        else:
-            break
-    label: str | None = None
-    if num:
-        val = charinfo.get(f"时装{num}名称")
-        if isinstance(val, str) and val:
-            label = val
-    if label is None:
-        label = f"时装 {num}" if num else "时装"
-    return label
-
-
-def _label_from_filename(
-    filename: str, charinfo: Mapping[str, Any],
-) -> str | None:
-    """Derive a label from a PRTS filename like ``立绘_阿米娅_2.png``.
-
-    Returns None for files we do not expose (建筑小人 ``_Nb``, non-png, or
-    names that don't match the ``立绘_<name>_<suffix>`` shape). Multi-form
-    operators carry the form in the name segment: ``立绘_阿米娅(近卫)_2.png``.
-    """
-    if not filename.endswith(".png"):
-        return None
-    base = filename[:-4]
-    parts = base.split("_", 2)
-    if len(parts) < 3:
-        return None
-    name = parts[1]
-    suffix = parts[2]
-    form: str | None = None
-    if "(" in name:
-        b = name.find("(")
-        e = name.find(")", b)
-        if 0 <= b < e:
-            form = name[b + 1:e]
-    if suffix.startswith("skin"):
-        label = _mediawiki_fashion_label(suffix, charinfo)
-    elif suffix.endswith("b"):
-        return None  # 建筑小人
-    else:
-        label = _mediawiki_base_label(suffix)
-    if form:
-        label += f"（{form}）"
-    return label
 
 
 async def _do_list_mediawiki(operator_name: str) -> object:

--- a/python/tests/test_artwork_mediawiki.py
+++ b/python/tests/test_artwork_mediawiki.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import pytest
 
 from prts_mcp.api.prts_wiki import _image_magic_ok, download_image_safe
-from prts_mcp.tools_artwork import (
+from prts_mcp.data.artwork_mediawiki import (
     _image_cache,
     _image_cache_get,
     _image_cache_put,
@@ -74,9 +74,9 @@ def test_image_cache_lru_round_trip():
 
 def test_image_cache_lru_evicts_by_byte_total(monkeypatch):
     """When total bytes exceed the cap, the oldest entry is evicted."""
-    import prts_mcp.tools_artwork as ta
+    import prts_mcp.data.artwork_mediawiki as am
 
-    monkeypatch.setattr(ta, "_IMAGE_CACHE_MAX_BYTES", 150)
+    monkeypatch.setattr(am, "_IMAGE_CACHE_MAX_BYTES", 150)
     _image_cache.clear()
     try:
         _image_cache_put("a", "large", b"\x00" * 100)

--- a/ts/src/data/artworkMediawiki.ts
+++ b/ts/src/data/artworkMediawiki.ts
@@ -1,0 +1,104 @@
+/**
+ * LOCAL_IMAGE=false path: filename→label parsing and LRU image cache.
+ * Mirrors python/src/prts_mcp/data/artwork_mediawiki.py.
+ *
+ * Lives in the data layer so artworkTools.ts stays orchestration-only,
+ * matching the true-mode boundary (data/images.ts ↔ artworkTools.ts).
+ */
+
+const IMAGE_CACHE_MAX_BYTES = 256 * 1024 * 1024; // 256 MiB (#85 §4.2)
+const _imageCache = new Map<string, Buffer>();
+let _imageCacheTotal = 0;
+
+const MEDIAWIKI_BASE_LABELS: Record<string, string> = {
+  "1": "精英零立绘",
+  "2": "精英二立绘",
+};
+export const VARIANT_WIDTH: Record<string, number> = { large: 1024, preview: 256 };
+
+function imageCacheKey(artworkId: string, variant: string): string {
+  return `${artworkId}|${variant}`;
+}
+
+export function imageCacheGet(artworkId: string, variant: string): Buffer | null {
+  const key = imageCacheKey(artworkId, variant);
+  const v = _imageCache.get(key);
+  if (v === undefined) return null;
+  _imageCache.delete(key);
+  _imageCache.set(key, v); // move to end (LRU)
+  return v;
+}
+
+export function imageCachePut(artworkId: string, variant: string, data: Buffer): void {
+  const key = imageCacheKey(artworkId, variant);
+  const existing = _imageCache.get(key);
+  if (existing !== undefined) {
+    _imageCache.delete(key);
+    _imageCacheTotal -= existing.byteLength;
+  }
+  _imageCache.set(key, data);
+  _imageCacheTotal += data.byteLength;
+  while (_imageCacheTotal > IMAGE_CACHE_MAX_BYTES && _imageCache.size > 0) {
+    const oldest = _imageCache.keys().next().value;
+    if (oldest === undefined) break;
+    const evicted = _imageCache.get(oldest);
+    _imageCache.delete(oldest);
+    if (evicted !== undefined) _imageCacheTotal -= evicted.byteLength;
+  }
+}
+
+function mediawikiBaseLabel(suffix: string): string {
+  const base = suffix.replace(/\+$/, "");
+  const plus = suffix.endsWith("+");
+  let label = MEDIAWIKI_BASE_LABELS[base];
+  if (label === undefined) label = base ? `立绘 ${base}` : "立绘";
+  if (plus) label += "（变体）";
+  return label;
+}
+
+function mediawikiFashionLabel(
+  rest: string,
+  charinfo: Record<string, unknown>,
+): string {
+  let num = "";
+  for (const ch of rest.slice(4)) {
+    if (/[0-9]/.test(ch)) num += ch;
+    else break;
+  }
+  let label: string | null = null;
+  if (num) {
+    const v = charinfo[`时装${num}名称`];
+    if (typeof v === "string" && v) label = v;
+  }
+  if (label === null) label = num ? `时装 ${num}` : "时装";
+  return label;
+}
+
+export function labelFromFilename(
+  filename: string,
+  charinfo: Record<string, unknown>,
+): string | null {
+  if (!filename.endsWith(".png")) return null;
+  const base = filename.slice(0, -4);
+  const first = base.indexOf("_");
+  const second = base.indexOf("_", first + 1);
+  if (first < 0 || second < 0) return null;
+  const name = base.slice(first + 1, second);
+  const suffix = base.slice(second + 1);
+  let form: string | null = null;
+  if (name.includes("(")) {
+    const b = name.indexOf("(");
+    const e = name.indexOf(")", b);
+    if (0 <= b && b < e) form = name.slice(b + 1, e);
+  }
+  let label: string;
+  if (suffix.startsWith("skin")) {
+    label = mediawikiFashionLabel(suffix, charinfo);
+  } else if (suffix.endsWith("b")) {
+    return null; // 建筑小人
+  } else {
+    label = mediawikiBaseLabel(suffix);
+  }
+  if (form) label += `（${form}）`;
+  return label;
+}

--- a/ts/src/tools/artworkTools.ts
+++ b/ts/src/tools/artworkTools.ts
@@ -23,6 +23,12 @@ import {
   type VariantName,
 } from "../data/images.js";
 import {
+  VARIANT_WIDTH,
+  imageCacheGet,
+  imageCachePut,
+  labelFromFilename,
+} from "../data/artworkMediawiki.js";
+import {
   downloadImageSafe,
   getImageinfo,
   getTemplateData,
@@ -58,112 +64,6 @@ function dataNotReady(): CallToolResult {
     "立绘数据未就绪。可能原因：IMAGES_ENABLED 未开启，或图片同步仍在进行中。" +
       "请稍后重试；若持续不可用，请检查网络或 GITHUB_TOKEN。",
   );
-}
-
-// ---------------------------------------------------------------------------
-// LOCAL_IMAGE=false MediaWiki path
-//
-// Data flows entirely from PRTS: allimages for discovery, parsetree
-// (CharinfoV2 时装N名称) for fashion labels, imageinfo for variant URLs,
-// downloadImageSafe for the payload under the #85 boundary. Shares no data
-// dependency with the true (AKDP) path.
-// ---------------------------------------------------------------------------
-
-const IMAGE_CACHE_MAX_BYTES = 256 * 1024 * 1024; // 256 MiB (#85 §4.2)
-const _imageCache = new Map<string, Buffer>();
-let _imageCacheTotal = 0;
-
-const MEDIAWIKI_BASE_LABELS: Record<string, string> = {
-  "1": "精英零立绘",
-  "2": "精英二立绘",
-};
-const VARIANT_WIDTH: Record<string, number> = { large: 1024, preview: 256 };
-
-function imageCacheKey(artworkId: string, variant: string): string {
-  return `${artworkId}|${variant}`;
-}
-
-function imageCacheGet(artworkId: string, variant: string): Buffer | null {
-  const key = imageCacheKey(artworkId, variant);
-  const v = _imageCache.get(key);
-  if (v === undefined) return null;
-  _imageCache.delete(key);
-  _imageCache.set(key, v); // move to end (LRU)
-  return v;
-}
-
-function imageCachePut(artworkId: string, variant: string, data: Buffer): void {
-  const key = imageCacheKey(artworkId, variant);
-  const existing = _imageCache.get(key);
-  if (existing !== undefined) {
-    _imageCache.delete(key);
-    _imageCacheTotal -= existing.byteLength;
-  }
-  _imageCache.set(key, data);
-  _imageCacheTotal += data.byteLength;
-  while (_imageCacheTotal > IMAGE_CACHE_MAX_BYTES && _imageCache.size > 0) {
-    const oldest = _imageCache.keys().next().value;
-    if (oldest === undefined) break;
-    const evicted = _imageCache.get(oldest);
-    _imageCache.delete(oldest);
-    if (evicted !== undefined) _imageCacheTotal -= evicted.byteLength;
-  }
-}
-
-function mediawikiBaseLabel(suffix: string): string {
-  const base = suffix.replace(/\+$/, "");
-  const plus = suffix.endsWith("+");
-  let label = MEDIAWIKI_BASE_LABELS[base];
-  if (label === undefined) label = base ? `立绘 ${base}` : "立绘";
-  if (plus) label += "（变体）";
-  return label;
-}
-
-function mediawikiFashionLabel(
-  rest: string,
-  charinfo: Record<string, unknown>,
-): string {
-  let num = "";
-  for (const ch of rest.slice(4)) {
-    if (/[0-9]/.test(ch)) num += ch;
-    else break;
-  }
-  let label: string | null = null;
-  if (num) {
-    const v = charinfo[`时装${num}名称`];
-    if (typeof v === "string" && v) label = v;
-  }
-  if (label === null) label = num ? `时装 ${num}` : "时装";
-  return label;
-}
-
-export function labelFromFilename(
-  filename: string,
-  charinfo: Record<string, unknown>,
-): string | null {
-  if (!filename.endsWith(".png")) return null;
-  const base = filename.slice(0, -4);
-  const first = base.indexOf("_");
-  const second = base.indexOf("_", first + 1);
-  if (first < 0 || second < 0) return null;
-  const name = base.slice(first + 1, second);
-  const suffix = base.slice(second + 1);
-  let form: string | null = null;
-  if (name.includes("(")) {
-    const b = name.indexOf("(");
-    const e = name.indexOf(")", b);
-    if (0 <= b && b < e) form = name.slice(b + 1, e);
-  }
-  let label: string;
-  if (suffix.startsWith("skin")) {
-    label = mediawikiFashionLabel(suffix, charinfo);
-  } else if (suffix.endsWith("b")) {
-    return null; // 建筑小人
-  } else {
-    label = mediawikiBaseLabel(suffix);
-  }
-  if (form) label += `（${form}）`;
-  return label;
 }
 
 async function doListMediawiki(

--- a/ts/tests/artworkMediawiki.test.ts
+++ b/ts/tests/artworkMediawiki.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { labelFromFilename } from "../src/tools/artworkTools.ts";
+import { labelFromFilename } from "../src/data/artworkMediawiki.ts";
 import { downloadImageSafe, imageMagicOk } from "../src/api/prtsWiki.ts";
 
 const CHARINFO: Record<string, unknown> = {


### PR DESCRIPTION
## Summary

KHPilot S1 should-fix from PR #92: extract LOCAL_IMAGE=false helpers (filename→label parsing, LRU image cache) from `tools_artwork` into `data/artwork_mediawiki.{py,ts}`.

This aligns the false-mode tool→data boundary with the true-mode pattern (`data/images` ↔ `tools_artwork`). Pure code move — zero behavior change, existing tests serve as regression guard.

**Files:**
- **New**: `python/src/prts_mcp/data/artwork_mediawiki.py`, `ts/src/data/artworkMediawiki.ts`
- **Slimmed**: `tools_artwork.{py,ts}` — removed ~100 lines of inline data code, added import from new module
- **Tests**: updated imports + monkeypatch target to point at new module

## Test plan

- [x] Python: `uv run --directory python --locked python -m pytest tests -q` → 313 passed, 23 skipped
- [x] TypeScript: `npm run typecheck` → clean; `npm test` → 237 passed, 0 fail
- [x] Grep confirms no stale importers of moved symbols

## 未尽事宜

None — this is a pure refactor closing the KHPilot should-fix. Multi-form grouping, README env vars, download_image_safe mock tests, and allimages pagination are tracked as separate PR 2 polish items.