### PR TITLE
fix(artwork): env-var defaults, stream-rejection tests, allimages pagination, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ changes to the new factory path must not be backported to LTS as an implicit sou
 
 | Area | Python | TypeScript |
 |------|--------|------------|
-| MCP tools | Same 23 public tool names and required parameters (2.0) / 32 on 1.7 LTS | Same 23 (2.0) / 32 on 1.7 LTS |
+| MCP tools | Same 24 public tool names and required parameters (2.5) / 32 on 1.7 LTS | Same 24 (2.5) / 32 on 1.7 LTS |
 | GameData | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` |
 | Level data | Auto-synced `zh_CN-levels.zip` beside GameData | Auto-synced `zh_CN-levels.zip` beside GameData |
 | Story data | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | `STORYJSON_PATH` or auto-synced `zh_CN.zip` |
-| Image artwork (2.5) | Opt-in via `IMAGES_ENABLED=true`; auto-synced AKDP image Release (local PNG assets) | Opt-in via `IMAGES_ENABLED=true`; auto-synced AKDP image Release (local PNG assets) |
+| Image artwork (2.5) | Enabled by default; MediaWiki on-demand or AKDP local assets (`LOCAL_IMAGE=true`) | Enabled by default; MediaWiki on-demand or AKDP local assets (`LOCAL_IMAGE=true`) |
 | Bundled fallback data | Docker image only | Docker image and published npm package (PyPI stays data-light) |
 
 ### Auto-Sync data contract
@@ -93,6 +93,7 @@ Both implementations expose the same tool set:
 | `get_operator_memoirs(name)` | Resolve an operator's memoir (干员密录) story keys for follow-up `read_story` calls |
 | `find_character_appearances(name, scope?, max_events?)` | Find chapters/events where a character speaks (dialog) or is mentioned (name substring) |
 | `find_speakers_in(event_id)` | List every speaker in an event with dialog line counts |
+| `operator_artwork(operator_name, action, artwork_id?, variant?)` | List operator illustrations/skins and retrieve image variants (base64); MediaWiki by default, AKDP local assets when `LOCAL_IMAGE=true` |
 
 ### Output Channel
 
@@ -108,6 +109,22 @@ The default `content` requires no configuration and is unchanged from 1.x. See
 the [2.0 migration guide](docs/migration-1.x-to-2.0.md) for the per-tool
 mapping and the rationale for choosing a channel over a per-call format
 parameter.
+
+### Image Artwork
+
+The `operator_artwork` tool (2.5.0+) is **enabled by default**. Two data source
+modes are selected by `LOCAL_IMAGE`:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `IMAGES_ENABLED` | `true` | Master switch; `false` hides `operator_artwork`. |
+| `LOCAL_IMAGE` | `false` | `true` = sync AKDP local PNG assets (~1.5 GB); `false` = fetch on-demand from PRTS MediaWiki (zero download). |
+| `PRTS_IMAGE_CACHE` | `true` | In-memory LRU cache (256 MiB) for MediaWiki images; only effective when `LOCAL_IMAGE=false`. |
+| `ORIGINAL_IMAGE` | `false` | Also sync original-resolution shards; only effective when `LOCAL_IMAGE=true`. |
+| `PRTS_IMAGE_DIR` | `~/.local/share/prts-mcp/images/` | AKDP asset sync target; only effective when `LOCAL_IMAGE=true`. Docker: `/data/images`. |
+
+Zero-config: the tool works immediately via MediaWiki with caching. For the full
+offline AKDP experience, set `LOCAL_IMAGE=true` (triggers ~1.5 GB background sync).
 
 ### Quick Start
 
@@ -170,11 +187,11 @@ and macOS development setup.
 
 | 范围 | Python | TypeScript |
 |------|--------|------------|
-| MCP 工具 | 相同的 23 个工具名和必填参数（2.0）/ 1.7 LTS 为 32 个 | 相同的 23 个（2.0）/ 1.7 LTS 为 32 个 |
+| MCP 工具 | 相同的 24 个工具名和必填参数（2.5）/ 1.7 LTS 为 32 个 | 相同的 24 个（2.5）/ 1.7 LTS 为 32 个 |
 | 干员数据 | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` |
 | 关卡战斗数据 | 自动同步与 GameData 并列的 `zh_CN-levels.zip` | 自动同步与 GameData 并列的 `zh_CN-levels.zip` |
 | 剧情数据 | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` |
-| 立绘图片（2.5） | 需 `IMAGES_ENABLED=true` 开启；自动同步 AKDP 图片 Release（本地 PNG 资产） | 需 `IMAGES_ENABLED=true` 开启；自动同步 AKDP 图片 Release（本地 PNG 资产） |
+| 立绘图片（2.5） | 默认开启；MediaWiki 按需获取或 AKDP 本地资产（`LOCAL_IMAGE=true`） | 默认开启；MediaWiki 按需获取或 AKDP 本地资产（`LOCAL_IMAGE=true`） |
 | bundled 兜底数据 | Docker 镜像 | Docker 镜像和正式 npm 包（PyPI 保持轻量） |
 
 ### Auto-Sync 数据契约
@@ -221,6 +238,7 @@ manifest 的旧 Release。下载、结构或 manifest 校验失败时，服务�
 | `get_operator_memoirs(name)` | 解析干员密录的 story_key，便于后续 `read_story` 调用 |
 | `find_character_appearances(name, scope?, max_events?)` | 查找角色在哪些章节/活动中开口（对话）或被提及（名字子串） |
 | `find_speakers_in(event_id)` | 列出指定活动中所有发言角色及其对话行数 |
+| `operator_artwork(operator_name, action, artwork_id?, variant?)` | 列出干员立绘/时装并获取图片变体（base64）；默认走 MediaWiki，`LOCAL_IMAGE=true` 时使用 AKDP 本地资产 |
 
 ### 输出通道
 
@@ -230,6 +248,20 @@ manifest 的旧 Release。下载、结构或 manifest 校验失败时，服务�
 - **TypeScript** — `?output_channel=` 查询字符串、`x-prts-output-channel` 请求头，或 `PRTS_OUTPUT_CHANNEL` 环境变量。
 
 默认 `content` 无需任何配置，与 1.x 一致。各工具的通道映射，以及「为何选连接级通道而非 per-call 格式参数」的设计理由，见 [2.0 迁移指南](docs/migration-1.x-to-2.0.md)。
+
+### 立绘工具
+
+`operator_artwork` 工具（2.5.0+）**默认开启**。通过 `LOCAL_IMAGE` 选择数据源：
+
+| 变量 | 缺省值 | 说明 |
+|----------|---------|-------------|
+| `IMAGES_ENABLED` | `true` | 主开关；`false` 隐藏 `operator_artwork`。 |
+| `LOCAL_IMAGE` | `false` | `true` = 同步 AKDP 本地 PNG 资产（~1.5 GB）；`false` = 从 PRTS MediaWiki 按需获取（零下载）。 |
+| `PRTS_IMAGE_CACHE` | `true` | MediaWiki 图片的内存 LRU 缓存（256 MiB）；仅在 `LOCAL_IMAGE=false` 时生效。 |
+| `ORIGINAL_IMAGE` | `false` | 额外同步原图分辨率分片；仅在 `LOCAL_IMAGE=true` 时生效。 |
+| `PRTS_IMAGE_DIR` | `~/.local/share/prts-mcp/images/` | AKDP 资产同步目标；仅在 `LOCAL_IMAGE=true` 时生效。Docker：`/data/images`。 |
+
+零配置即可使用：默认走 MediaWiki + 缓存。若需离线全量体验，设置 `LOCAL_IMAGE=true`（触发 ~1.5 GB 后台同步）。
 
 ### 快速开始
 

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -456,7 +456,11 @@ async def list_allimages(prefix: str, limit: int = 50) -> list[dict]:
         "format": "json",
     }
     results: list[dict] = []
+    pages = 0
     while True:
+        if pages >= 50:
+            raise RuntimeError("allimages pagination exceeded 50 pages")
+        pages += 1
         await _rate_limit()
         resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
         resp.raise_for_status()

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -444,9 +444,9 @@ async def list_allimages(prefix: str, limit: int = 50) -> list[dict]:
     """List PRTS ``File:`` titles whose name starts with ``prefix``.
 
     Returns dicts with ``name``/``size``/``mime``. Used by operator_artwork's
-    false-mode list to discover ``立绘_<name>_*`` files.
+    false-mode list to discover ``立绘_<name>_*`` files. Paginates via
+    MediaWiki continuation when results exceed ``limit``.
     """
-    await _rate_limit()
     params = {
         "action": "query",
         "list": "allimages",
@@ -455,17 +455,25 @@ async def list_allimages(prefix: str, limit: int = 50) -> list[dict]:
         "aiprop": "name|size|mime",
         "format": "json",
     }
-    resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
-    resp.raise_for_status()
-    data = resp.json()
-    return [
-        {
-            "name": a.get("name", ""),
-            "size": a.get("size", 0),
-            "mime": a.get("mime", ""),
-        }
-        for a in data.get("query", {}).get("allimages", [])
-    ]
+    results: list[dict] = []
+    while True:
+        await _rate_limit()
+        resp = await _get_client().get(PRTS_API_ENDPOINT, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        results.extend(
+            {
+                "name": a.get("name", ""),
+                "size": a.get("size", 0),
+                "mime": a.get("mime", ""),
+            }
+            for a in data.get("query", {}).get("allimages", [])
+        )
+        cont = data.get("continue")
+        if not cont:
+            break
+        params.update({k: str(v) for k, v in cont.items()})
+    return results
 
 
 async def get_imageinfo(title: str, width: int | None = None) -> dict | None:

--- a/python/src/prts_mcp/config.py
+++ b/python/src/prts_mcp/config.py
@@ -258,7 +258,7 @@ class Config:
     storyjson_zip: Path          # storyjson zip path (custom, volume, or default)
     is_custom_gamedata: bool     # True when GAMEDATA_PATH was set by the user
     images_enabled: bool         # IMAGES_ENABLED; False → operator_artwork not registered
-    local_image: bool            # LOCAL_IMAGE; True = AKDP local assets, False = MediaWiki (future)
+    local_image: bool            # LOCAL_IMAGE; True = AKDP local assets, False = MediaWiki
     original_image: bool         # ORIGINAL_IMAGE; True = also sync original-variant shards
     prts_image_cache: bool       # PRTS_IMAGE_CACHE; True = LRU-cache MediaWiki images (false mode)
     images_path: Path            # image asset sync target (PRTS_IMAGE_DIR or default)
@@ -380,10 +380,10 @@ class Config:
             gamedata_path=gamedata,
             storyjson_zip=storyjson_zip,
             is_custom_gamedata=custom,
-            images_enabled=_env_bool("IMAGES_ENABLED", False),
-            local_image=_env_bool("LOCAL_IMAGE", True),
+            images_enabled=_env_bool("IMAGES_ENABLED", True),
+            local_image=_env_bool("LOCAL_IMAGE", False),
             original_image=_env_bool("ORIGINAL_IMAGE", False),
-            prts_image_cache=_env_bool("PRTS_IMAGE_CACHE", False),
+            prts_image_cache=_env_bool("PRTS_IMAGE_CACHE", True),
             images_path=images_path,
         )
         return config

--- a/python/tests/test_artwork_mediawiki.py
+++ b/python/tests/test_artwork_mediawiki.py
@@ -97,3 +97,83 @@ def test_download_image_safe_rejects_bad_url():
     # wrong host.
     with pytest.raises(ValueError, match="not allowed"):
         asyncio.run(download_image_safe("https://evil.com/x.png"))
+
+
+# ---------------------------------------------------------------------------
+# download_image_safe: in-stream rejection paths (httpx MockTransport)
+# ---------------------------------------------------------------------------
+
+
+def _mock_image_download(monkeypatch, handler):
+    """Patch _rate_limit (no-op) + _get_client (MockTransport); return coroutine."""
+    import httpx
+    import prts_mcp.api.prts_wiki as pw
+
+    async def _noop():
+        pass
+
+    monkeypatch.setattr(pw, "_rate_limit", _noop)
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(pw, "_get_client", lambda: client)
+
+    async def _coro():
+        try:
+            return await pw.download_image_safe("https://media.prts.wiki/img.png")
+        finally:
+            await client.aclose()
+
+    return _coro()
+
+
+def test_download_safe_rejects_redirect_to_bad_host(monkeypatch):
+    """Post-redirect scheme/host change is caught after the stream opens."""
+    import asyncio
+    import httpx
+
+    def handler(request):
+        if request.url.host == "media.prts.wiki":
+            return httpx.Response(302, headers={"location": "http://evil.com/img.png"})
+        return httpx.Response(200, content=b"\x89PNG\r\n\x1a\n",
+                              headers={"content-type": "image/png"})
+
+    with pytest.raises(ValueError, match="disallowed"):
+        asyncio.run(_mock_image_download(monkeypatch, handler))
+
+
+def test_download_safe_rejects_bad_content_type(monkeypatch):
+    """Non-allowlist Content-Type is rejected before reading the body."""
+    import asyncio
+    import httpx
+
+    def handler(request):
+        return httpx.Response(200, content=b"x", headers={"content-type": "text/html"})
+
+    with pytest.raises(ValueError, match="content-type"):
+        asyncio.run(_mock_image_download(monkeypatch, handler))
+
+
+def test_download_safe_rejects_magic_mismatch(monkeypatch):
+    """Valid Content-Type but wrong magic bytes → rejection after full read."""
+    import asyncio
+    import httpx
+
+    def handler(request):
+        return httpx.Response(200, content=b"not-an-image",
+                              headers={"content-type": "image/png"})
+
+    with pytest.raises(ValueError, match="magic"):
+        asyncio.run(_mock_image_download(monkeypatch, handler))
+
+
+def test_download_safe_rejects_oversized_body(monkeypatch):
+    """Body exceeding the 1 MiB cap is rejected mid-stream."""
+    import asyncio
+    import httpx
+    import prts_mcp.api.prts_wiki as pw
+
+    def handler(request):
+        body = b"\x89PNG\r\n\x1a\n" + b"\x00" * (pw._MAX_IMAGE_BYTES + 1)
+        return httpx.Response(200, content=body, headers={"content-type": "image/png"})
+
+    with pytest.raises(ValueError, match="exceeds"):
+        asyncio.run(_mock_image_download(monkeypatch, handler))

--- a/python/tests/test_artwork_mediawiki.py
+++ b/python/tests/test_artwork_mediawiki.py
@@ -1,16 +1,14 @@
 """Tests for LOCAL_IMAGE=false MediaWiki path.
 
 Covers filename→label parsing, the image magic-byte check, the LRU cache
-eviction, and the download_image_safe URL pre-check (bad scheme/host). The
-streaming-rejection paths inside download_image_safe (post-redirect scheme/
-host, Content-Type, magic, 1 MiB cap) require an httpx transport mock and
-are deferred — see PR #92 未尽事宜.
+eviction, the download_image_safe boundary (URL pre-check + in-stream
+rejection paths via httpx MockTransport), and list_allimages pagination.
 """
 from __future__ import annotations
 
 import pytest
 
-from prts_mcp.api.prts_wiki import _image_magic_ok, download_image_safe
+from prts_mcp.api.prts_wiki import _image_magic_ok, download_image_safe, list_allimages
 from prts_mcp.data.artwork_mediawiki import (
     _image_cache,
     _image_cache_get,
@@ -177,3 +175,48 @@ def test_download_safe_rejects_oversized_body(monkeypatch):
 
     with pytest.raises(ValueError, match="exceeds"):
         asyncio.run(_mock_image_download(monkeypatch, handler))
+
+
+# ---------------------------------------------------------------------------
+# list_allimages pagination
+# ---------------------------------------------------------------------------
+
+
+def test_list_allimages_paginates(monkeypatch):
+    """allimages loops on MediaWiki continue tokens to collect all pages."""
+    import asyncio
+    import httpx
+    import prts_mcp.api.prts_wiki as pw
+
+    async def _noop():
+        pass
+
+    monkeypatch.setattr(pw, "_rate_limit", _noop)
+
+    def handler(request):
+        if "aicontinue" in str(request.url):
+            return httpx.Response(200, json={
+                "query": {"allimages": [
+                    {"name": "立绘_阿米娅_2.png", "size": 200, "mime": "image/png"},
+                ]},
+            })
+        return httpx.Response(200, json={
+            "query": {"allimages": [
+                {"name": "立绘_阿米娅_1.png", "size": 100, "mime": "image/png"},
+            ]},
+            "continue": {"aicontinue": "立绘_阿米娅_2.png", "continue": "-||"},
+        })
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(pw, "_get_client", lambda: client)
+
+    async def _run():
+        try:
+            return await list_allimages("立绘_阿米娅_")
+        finally:
+            await client.aclose()
+
+    result = asyncio.run(_run())
+    assert len(result) == 2
+    assert result[0]["name"] == "立绘_阿米娅_1.png"
+    assert result[1]["name"] == "立绘_阿米娅_2.png"

--- a/python/tests/test_e2e.py
+++ b/python/tests/test_e2e.py
@@ -97,6 +97,7 @@ def server():
     env = os.environ.copy()
     env["GAMEDATA_PATH"] = str(GAMEDATA_PATH)
     env["GITHUB_MIRRORS"] = ""
+    env["IMAGES_ENABLED"] = "true"
     # Prevent auto-sync interfering with the test
     env.setdefault("STORYJSON_PATH", str(GAMEDATA_PATH / "does-not-exist.zip"))
 

--- a/python/tests/test_e2e.py
+++ b/python/tests/test_e2e.py
@@ -150,6 +150,7 @@ EXPECTED_TOOLS = {
     "get_story_summary",
     "get_operator_memoirs",
     "find_character_appearances", "find_speakers_in",
+    "operator_artwork",
 }
 
 
@@ -180,7 +181,7 @@ def test_tools_list(server: subprocess.Popen) -> None:
     tools = resp["result"]["tools"]
     names = {t["name"] for t in tools}
 
-    assert len(names) == 23, f"Expected 23 tools, got {len(names)}: {sorted(names)}"
+    assert len(names) == 24, f"Expected 24 tools, got {len(names)}: {sorted(names)}"
     for name in EXPECTED_TOOLS:
         assert name in names, f"Missing tool: {name}"
 

--- a/python/tests/test_images.py
+++ b/python/tests/test_images.py
@@ -116,6 +116,7 @@ def test_build_artwork_labels():
 @pytest.fixture
 def mock_images(monkeypatch, tmp_path):
     """Stand up a fake active generation directory with index.json + PNGs."""
+    monkeypatch.setenv("LOCAL_IMAGE", "true")
     gen = tmp_path / "gen"
     gen.mkdir()
     (gen / "index.json").write_text(json.dumps(_sample_index()), "utf-8")

--- a/ts/scripts/smoke-http.mjs
+++ b/ts/scripts/smoke-http.mjs
@@ -38,6 +38,7 @@ const EXPECTED_TOOLS = [
   "get_operator_memoirs",
   "find_character_appearances",
   "find_speakers_in",
+  "operator_artwork",
 ];
 
 const DEFAULT_TIMEOUT_MS = 30_000;

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -522,7 +522,9 @@ export async function listAllimages(prefix: string, limit = 50): Promise<Allimag
     format: "json",
   };
   const results: AllimagesEntry[] = [];
+  let pages = 0;
   for (;;) {
+    if (++pages > 50) throw new Error("allimages pagination exceeded 50 pages");
     const data = (await prtsGet(params)) as {
       query?: { allimages?: Array<{ name?: string; size?: number; mime?: string }> };
       continue?: Record<string, string>;

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -513,19 +513,28 @@ export interface AllimagesEntry {
 
 /** Mirrors prts_wiki.list_allimages(). */
 export async function listAllimages(prefix: string, limit = 50): Promise<AllimagesEntry[]> {
-  const data = (await prtsGet({
+  const params: Record<string, string | number> = {
     action: "query",
     list: "allimages",
     aiprefix: prefix,
     ailimit: limit,
     aiprop: "name|size|mime",
     format: "json",
-  })) as { query?: { allimages?: Array<{ name?: string; size?: number; mime?: string }> } };
-  return (data.query?.allimages ?? []).map((a) => ({
-    name: a.name ?? "",
-    size: a.size ?? 0,
-    mime: a.mime ?? "",
-  }));
+  };
+  const results: AllimagesEntry[] = [];
+  for (;;) {
+    const data = (await prtsGet(params)) as {
+      query?: { allimages?: Array<{ name?: string; size?: number; mime?: string }> };
+      continue?: Record<string, string>;
+    };
+    for (const a of data.query?.allimages ?? []) {
+      results.push({ name: a.name ?? "", size: a.size ?? 0, mime: a.mime ?? "" });
+    }
+    const cont = data.continue;
+    if (!cont) break;
+    Object.assign(params, cont);
+  }
+  return results;
 }
 
 export interface ImageinfoResult {

--- a/ts/src/config.ts
+++ b/ts/src/config.ts
@@ -270,7 +270,7 @@ export interface Config {
   effectiveStoryjsonZip: string | null;
   /** IMAGES_ENABLED — master switch; false → operator_artwork not registered. */
   imagesEnabled: boolean;
-  /** LOCAL_IMAGE — true = AKDP local assets, false = MediaWiki fallback (future). */
+  /** LOCAL_IMAGE — true = AKDP local assets, false = MediaWiki (default). */
   localImage: boolean;
   /** ORIGINAL_IMAGE — true = also sync original-variant shards. */
   originalImage: boolean;
@@ -346,10 +346,10 @@ export function loadConfig(): Config {
     effectiveLevelsPath,
     storyjsonZip,
     effectiveStoryjsonZip,
-    imagesEnabled: envBool("IMAGES_ENABLED", false),
-    localImage: envBool("LOCAL_IMAGE", true),
+    imagesEnabled: envBool("IMAGES_ENABLED", true),
+    localImage: envBool("LOCAL_IMAGE", false),
     originalImage: envBool("ORIGINAL_IMAGE", false),
-    prtsImageCache: envBool("PRTS_IMAGE_CACHE", false),
+    prtsImageCache: envBool("PRTS_IMAGE_CACHE", true),
     imagesPath,
   };
   return config;

--- a/ts/tests/artworkMediawiki.test.ts
+++ b/ts/tests/artworkMediawiki.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import { labelFromFilename } from "../src/data/artworkMediawiki.ts";
-import { downloadImageSafe, imageMagicOk } from "../src/api/prtsWiki.ts";
+import { downloadImageSafe, imageMagicOk, listAllimages } from "../src/api/prtsWiki.ts";
 
 const CHARINFO: Record<string, unknown> = {
   "时装1名称": "报童",
@@ -134,7 +134,7 @@ test("downloadImageSafe rejects magic-byte mismatch", async () => {
 
 test("downloadImageSafe rejects body exceeding 1 MiB cap", async () => {
   const oversized = Buffer.alloc(1024 * 1024 + 10, 0);
-  oversized[0] = 0x89; oversized[1] = 0x50; oversized[2] = 0x4e; oversized[3] = 0x47;
+  Buffer.from("\x89PNG\r\n\x1a\n").copy(oversized);
   const res = mockImageRes(oversized, {
     url: "https://media.prts.wiki/img.png",
     contentType: "image/png",
@@ -145,4 +145,38 @@ test("downloadImageSafe rejects body exceeding 1 MiB cap", async () => {
       /exceeds/,
     );
   });
+});
+
+// ---------------------------------------------------------------------------
+// listAllimages pagination
+// ---------------------------------------------------------------------------
+
+test("listAllimages paginates via continue token", async () => {
+  const realFetch = globalThis.fetch;
+  const realDateNow = Date.now;
+  if (_mockClock === 0) _mockClock = realDateNow() + 100_000;
+  Date.now = () => (_mockClock += 2000);
+
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const body = input.toString().includes("aicontinue")
+      ? { query: { allimages: [{ name: "立绘_阿米娅_2.png", size: 200, mime: "image/png" }] } }
+      : {
+          query: { allimages: [{ name: "立绘_阿米娅_1.png", size: 100, mime: "image/png" }] },
+          continue: { aicontinue: "立绘_阿米娅_2.png", continue: "-||" },
+        };
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const result = await listAllimages("立绘_阿米娅_");
+    assert.equal(result.length, 2);
+    assert.equal(result[0].name, "立绘_阿米娅_1.png");
+    assert.equal(result[1].name, "立绘_阿米娅_2.png");
+  } finally {
+    globalThis.fetch = realFetch;
+    Date.now = realDateNow;
+  }
 });

--- a/ts/tests/artworkMediawiki.test.ts
+++ b/ts/tests/artworkMediawiki.test.ts
@@ -62,3 +62,87 @@ test("downloadImageSafe rejects bad scheme/host before any network call", async 
     /not allowed/,
   );
 });
+
+// ---------------------------------------------------------------------------
+// downloadImageSafe: in-stream rejection paths (fetch mock + Date.now override
+// to neutralise rate-limit delay)
+// ---------------------------------------------------------------------------
+
+// Module-level mock clock — persists across tests so nextAllowedTime (module
+// state in prtsWiki) never outruns the mock Date.now.
+let _mockClock = 0;
+
+function withMockFetch<T>(mockRes: Response, fn: () => Promise<T>): Promise<T> {
+  const realFetch = globalThis.fetch;
+  const realDateNow = Date.now;
+  if (_mockClock === 0) _mockClock = realDateNow() + 100_000;
+  Date.now = () => (_mockClock += 2000); // always ahead of nextAllowedTime → 0 wait
+  globalThis.fetch = (async () => mockRes) as typeof fetch;
+  return fn().finally(() => {
+    globalThis.fetch = realFetch;
+    Date.now = realDateNow;
+  });
+}
+
+function mockImageRes(body: BodyInit, opts: { url: string; contentType: string; status?: number }): Response {
+  const res = new Response(body, {
+    status: opts.status ?? 200,
+    headers: { "content-type": opts.contentType },
+  });
+  Object.defineProperty(res, "url", { value: opts.url });
+  return res;
+}
+
+test("downloadImageSafe rejects post-redirect scheme downgrade", async () => {
+  const res = mockImageRes(new Uint8Array([0x89, 0x50, 0x4e, 0x47]), {
+    url: "http://evil.com/img.png",
+    contentType: "image/png",
+  });
+  await withMockFetch(res, async () => {
+    await assert.rejects(
+      () => downloadImageSafe("https://media.prts.wiki/img.png"),
+      /disallowed/,
+    );
+  });
+});
+
+test("downloadImageSafe rejects bad Content-Type", async () => {
+  const res = mockImageRes(new Uint8Array([0x89, 0x50]), {
+    url: "https://media.prts.wiki/img.png",
+    contentType: "text/html",
+  });
+  await withMockFetch(res, async () => {
+    await assert.rejects(
+      () => downloadImageSafe("https://media.prts.wiki/img.png"),
+      /content-type/,
+    );
+  });
+});
+
+test("downloadImageSafe rejects magic-byte mismatch", async () => {
+  const res = mockImageRes(Buffer.from("notanimage"), {
+    url: "https://media.prts.wiki/img.png",
+    contentType: "image/png",
+  });
+  await withMockFetch(res, async () => {
+    await assert.rejects(
+      () => downloadImageSafe("https://media.prts.wiki/img.png"),
+      /magic/,
+    );
+  });
+});
+
+test("downloadImageSafe rejects body exceeding 1 MiB cap", async () => {
+  const oversized = Buffer.alloc(1024 * 1024 + 10, 0);
+  oversized[0] = 0x89; oversized[1] = 0x50; oversized[2] = 0x4e; oversized[3] = 0x47;
+  const res = mockImageRes(oversized, {
+    url: "https://media.prts.wiki/img.png",
+    contentType: "image/png",
+  });
+  await withMockFetch(res, async () => {
+    await assert.rejects(
+      () => downloadImageSafe("https://media.prts.wiki/img.png"),
+      /exceeds/,
+    );
+  });
+});

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -129,6 +129,7 @@ test("E2E", async (t) => {
         XDG_DATA_HOME: dataHome,
         LOCALAPPDATA: localAppData,
         GITHUB_MIRRORS: "",
+        IMAGES_ENABLED: "true",
         SESSION_IDLE_TIMEOUT_MS: "30000",
       },
       stdio: ["ignore", "pipe", "pipe"],

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -165,7 +165,7 @@ test("E2E", async (t) => {
   });
 
   // --- tools/list ---
-  await t.test("tools/list returns all 23 tools", async () => {
+  await t.test("tools/list returns all 24 tools", async () => {
     const tl = await mcpPost(
       origin,
       { jsonrpc: "2.0", method: "tools/list", id: 2 },
@@ -175,7 +175,7 @@ test("E2E", async (t) => {
     assert.equal(tl.status, 200);
     const tools = (tl.body?.result as Record<string, unknown>)?.tools as Array<{ name: string }> | undefined;
     assert.ok(tools, "tools/list should return tools");
-    assert.equal(tools!.length, 23, `got ${tools!.length} tools`);
+    assert.equal(tools!.length, 24, `got ${tools!.length} tools`);
 
     const expected = new Set([
       "search_prts", "prts_page",
@@ -189,6 +189,7 @@ test("E2E", async (t) => {
       "get_story_summary",
       "get_operator_memoirs",
       "find_character_appearances", "find_speakers_in",
+      "operator_artwork",
     ]);
     const names = new Set(tools!.map((t) => t.name));
     for (const name of expected) {


### PR DESCRIPTION
## Summary

Polish batch for the 2.5.0 artwork feature. Four independent commits:

1. **`fix(artwork): default to MediaWiki mode with LRU cache`** — Flip three env-var defaults so `operator_artwork` works zero-config:
   - `IMAGES_ENABLED` false→true (tool registered by default)
   - `LOCAL_IMAGE` true→false (MediaWiki on-demand, no ~1.5 GB sync)
   - `PRTS_IMAGE_CACHE` false→true (256 MiB in-memory LRU)

2. **`test(artwork): cover download_image_safe stream-rejection paths`** — Mock-backed tests for the four in-stream rejection paths: post-redirect scheme downgrade, bad Content-Type, magic-byte mismatch, >1 MiB body cap. Python uses `httpx.MockTransport`; TS mocks `globalThis.fetch` with a module-level mock clock to neutralise rate-limit delay.

3. **`fix(wiki): paginate allimages to avoid >50 file truncation`** — `list_allimages` / `listAllimages` now loop on MediaWiki's `continue` token. Operators with >50 matching `File:` entries no longer get a truncated list.

4. **`docs(artwork): document image env vars and new defaults`** — README Image Artwork subsection (EN + ZH) with the five env vars and their defaults. Tool count 23→24, tool list updated, data-source table updated.

## Test plan

- [x] Python: `uv run --directory python --locked python -m pytest tests -q` → 317 passed, 23 skipped
- [x] TypeScript: `npm run typecheck` → clean; `npm test` → 237 passed (previously) + 4 new mock tests
- [x] E2e tool count: 24 (both implementations)
- [x] Stream-rejection mock tests: all 4 paths pass in <0.2s (rate-limit neutralised)

## 未尽事宜

- Multi-form operator grouping (`char_1001_amiya2` → main operator) — deferred, needs spike on character_table.json linkage
- RikkaHub real-client E2E — post-2.5.0