### PR TITLE
fix(docker): create /data/images + document LOCAL_IMAGE=true volume

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -21,6 +21,8 @@ ENV PRTS_MCP_ROOT=/app
 # populate it with the named-volume or bind-mount contents at runtime;
 # if no volume is attached it remains writable by the container so
 # auto-sync can still write data here (data lost on container removal).
-RUN mkdir -p /data/gamedata /data/gamedata-levels /data/storyjson
+# /data/images is only used when LOCAL_IMAGE=true (AKDP local assets);
+# in the default MediaWiki mode it stays empty.
+RUN mkdir -p /data/gamedata /data/gamedata-levels /data/storyjson /data/images
 
 ENTRYPOINT ["prts-mcp"]

--- a/python/docker-compose.override.example.yml
+++ b/python/docker-compose.override.example.yml
@@ -11,6 +11,11 @@ services:
       # Optional: set STORYJSON_PATH to use your own local zh_CN.zip.
       # WARNING: setting this disables story auto-sync entirely.
       # STORYJSON_PATH: /data/custom-storyjson/zh_CN.zip
+      # Optional: use AKDP local image assets instead of MediaWiki on-demand.
+      # Requires mounting /data/images (see volumes below).
+      # LOCAL_IMAGE: "true"
+      # Optional: also sync full-resolution original shards (~3 GB total).
+      # ORIGINAL_IMAGE: "true"
     volumes:
       # Recommended: mount a named volume for persistent data across restarts.
       # Use this pattern in docker-compose.override.yml (copy this file):
@@ -19,6 +24,7 @@ services:
       #     - prts-mcp-data:/data/gamedata
       #     - prts-mcp-levels:/data/gamedata-levels
       #     - prts-mcp-storyjson:/data/storyjson
+      #     - prts-mcp-images:/data/images  # only for LOCAL_IMAGE=true
       #
       # Alternatively, bind-mount your own ArknightsGameData repo root (read-only).
       # The server expects zh_CN/gamedata/excel/*.json under the mounted path.

--- a/python/docs/deployment.md
+++ b/python/docs/deployment.md
@@ -34,6 +34,23 @@ Named volume 由 Docker 自动管理，无需关心宿主机路径，**在所有
 
 > 如需降低 GitHub 匿名 API 限流风险，可追加 `-e GITHUB_TOKEN=ghp_xxx`。
 
+### 本地全量立绘模式（LOCAL_IMAGE=true）
+
+默认的 MediaWiki 按需模式不需要 images 卷。如需使用 AKDP 本地全量立绘资产（~1.5 GB），追加 images 卷和相关环境变量：
+
+```bash
+docker run -i --rm \
+  -v prts-mcp-data:/data/gamedata \
+  -v prts-mcp-levels:/data/gamedata-levels \
+  -v prts-mcp-storyjson:/data/storyjson \
+  -v prts-mcp-images:/data/images \
+  -e LOCAL_IMAGE=true \
+  -e ORIGINAL_IMAGE=true \
+  prts-mcp
+```
+
+> `--rm` 不会删除 named volume；`docker compose down -v` 会。`/data/images` 内必须整体保留（`.images_meta.json`、`.releases/<generation>/index.json` 和解压后的 PNG）；同步完成后 ZIP 分片会被删除，单独保留下载包不能被运行时复用。
+
 ### 使用宿主机目录（仅命令行直接运行，不适用于 MCP 客户端配置）
 
 MCP 客户端（Chatbox、Claude Desktop 等）直接调用 Docker 进程，不经过 shell，因此环境变量（`$HOME`、`$env:USERPROFILE`）不会被展开。**如需绑定宿主机目录，必须写硬编码的绝对路径，且只能在命令行手动运行时使用。**
@@ -262,4 +279,9 @@ Remove-Item "$env:LOCALAPPDATA\prts-mcp\gamedata-levels\archives\extract_meta.js
 | `GITHUB_TOKEN` | 空 | 用于提高 GitHub API 限额，降低限流风险 |
 | `GITHUB_MIRRORS` | 空 | 逗号分隔的 ghproxy 风格代理前缀列表（如 `https://ghproxy.net`），依次在直连失败后尝试；适用于 GitHub 被 GFW 封锁的服务器 |
 | `PRTS_AUTO_SYNC_INTERVAL_SECONDS` | `3600` | GitHub Release 周期检查间隔（秒）；有效范围 `60..604800`，`0` 表示只执行启动同步；非法值回落到默认值 |
+| `IMAGES_ENABLED` | `true` | 立绘工具主开关；`false` 隐藏 `operator_artwork` |
+| `LOCAL_IMAGE` | `false` | `true` = 同步 AKDP 本地 PNG 资产（~1.5 GB，需挂载 `/data/images` 卷）；`false` = 从 PRTS MediaWiki 按需获取（零下载） |
+| `ORIGINAL_IMAGE` | `false` | 额外同步原图分辨率分片（总量 ~3 GB）；仅在 `LOCAL_IMAGE=true` 时生效 |
+| `PRTS_IMAGE_CACHE` | `true` | MediaWiki 图片的内存 LRU 缓存（256 MiB）；仅在 `LOCAL_IMAGE=false` 时生效 |
+| `PRTS_IMAGE_DIR` | `/data/images`（Docker） | AKDP 资产同步目标；仅在 `LOCAL_IMAGE=true` 时生效 |
 | `PRTS_MCP_ROOT` | `/app`（Docker 内） | 标识 Docker 环境，供 config.py 选择正确的默认路径 |

--- a/ts/Dockerfile
+++ b/ts/Dockerfile
@@ -35,7 +35,9 @@ ENV PRTS_MCP_ROOT=/app
 ENV PORT=3000
 
 # Create the volume mount-point as an empty directory.
-RUN mkdir -p /data/gamedata /data/gamedata-levels /data/storyjson
+# /data/images is only used when LOCAL_IMAGE=true (AKDP local assets);
+# in the default MediaWiki mode it stays empty.
+RUN mkdir -p /data/gamedata /data/gamedata-levels /data/storyjson /data/images
 
 EXPOSE 3000
 

--- a/ts/Dockerfile.node
+++ b/ts/Dockerfile.node
@@ -40,7 +40,9 @@ ENV PRTS_MCP_ROOT=/app
 ENV PORT=3000
 
 # Create the volume mount-point as an empty directory.
-RUN mkdir -p /data/gamedata /data/gamedata-levels /data/storyjson
+# /data/images is only used when LOCAL_IMAGE=true (AKDP local assets);
+# in the default MediaWiki mode it stays empty.
+RUN mkdir -p /data/gamedata /data/gamedata-levels /data/storyjson /data/images
 
 EXPOSE 3000
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -25,6 +25,9 @@ docker build -f ts/Dockerfile -t prts-mcp-ts .
 
 # 运行（named volume 持久化游戏数据，推荐）
 docker run -d -p 3000:3000 -v prts-mcp-ts-data:/data/gamedata -v prts-mcp-ts-levels:/data/gamedata-levels -v prts-mcp-ts-storyjson:/data/storyjson prts-mcp-ts
+
+# 本地全量立绘（~1.5 GB AKDP 资产；默认 MediaWiki 按需模式不需要 images 卷）
+docker run -d -p 3000:3000 -v prts-mcp-ts-data:/data/gamedata -v prts-mcp-ts-levels:/data/gamedata-levels -v prts-mcp-ts-storyjson:/data/storyjson -v prts-mcp-ts-images:/data/images -e LOCAL_IMAGE=true prts-mcp-ts
 ```
 
 需要 Node.js 镜像时改用 legacy 构建路径：
@@ -144,6 +147,8 @@ docker run -d -p 3000:3000 -v prts-mcp-ts-data:/data/gamedata -v prts-mcp-ts-lev
 - **游戏表格数据**（`/data/gamedata` volume）：从 [3aKHP/arknights-data-pipeline](https://github.com/3aKHP/arknights-data-pipeline) Release 下载 `zh_CN-excel.zip`
 - **关卡战斗数据**（`/data/gamedata-levels` volume）：从同一 Release 下载 `zh_CN-levels.zip`，用于关卡实际出怪和关卡级敌人数值
 - **剧情数据**（`/data/storyjson` volume）：从同一 Release 下载 `zh_CN.zip`（含剧情 JSON 和 LLM 摘要）
+
+立绘图片默认走 PRTS MediaWiki 按需获取（零下载）。设置 `LOCAL_IMAGE=true` 时额外同步 AKDP 本地 PNG 资产到 `/data/images`（~1.5 GB）；环境变量详见 `python/docs/deployment.md`。
 
 镜像内置 bundled 数据作为网络不可用时的离线保底。
 


### PR DESCRIPTION
## Summary

Docker images were missing the `/data/images` mount-point that the runtime resolves to when `PRTS_MCP_ROOT=/app`.

### Changes

1. **Dockerfiles** (`fix(docker)`): All three Dockerfiles (`python/Dockerfile`, `ts/Dockerfile`, `ts/Dockerfile.node`) now `mkdir -p /data/images` alongside the existing gamedata/levels/storyjson directories. The directory sits empty in default (MediaWiki) mode; it's only used when `LOCAL_IMAGE=true`.

2. **Deployment docs + compose** (`docs(docker)`):
   - New "本地全量立绘模式" subsection in `deployment.md` with the recommended `docker run` command including `-v prts-mcp-images:/data/images -e LOCAL_IMAGE=true -e ORIGINAL_IMAGE=true`.
   - Notes that `--rm` preserves named volumes but `docker compose down -v` deletes them.
   - Notes that `/data/images` must be preserved wholesale (meta + index + extracted PNGs; shard ZIPs deleted after sync).
   - Environment variable reference table extended with `IMAGES_ENABLED`, `LOCAL_IMAGE`, `ORIGINAL_IMAGE`, `PRTS_IMAGE_CACHE`, `PRTS_IMAGE_DIR`.
   - `docker-compose.override.example.yml` updated with commented `LOCAL_IMAGE`/`ORIGINAL_IMAGE` env vars and the images volume.

Does **not** add `VOLUME /data/images` to any Dockerfile (per design decision: anonymous volumes are hard to manage; named volumes in the run command are the recommended path).

## Test plan

- [x] No code changes — Dockerfile/docs only
- [x] CI verify-* and test-* jobs will confirm no regressions

## 未尽事宜

None.