### PR TITLE
fix(ts): guard JSON-sourced ?? [] against {} placeholders

### DIFF
--- a/ts/src/data/enemy.ts
+++ b/ts/src/data/enemy.ts
@@ -240,7 +240,7 @@ function getDbIndex(): Record<string, EnemyDbEntry> {
     if (!store.exists(DATABASE_FILE)) { _dbIndex = {}; return _dbIndex; }
     const raw = store.readJson<EnemyDatabase>(DATABASE_FILE);
     const index: Record<string, EnemyDbEntry> = {};
-    for (const row of raw.enemies ?? []) {
+    for (const row of Array.isArray(raw.enemies) ? raw.enemies : []) {
       if (row.Key && row.Value && row.Value[0]?.enemyData) {
         index[row.Key] = row.Value[0].enemyData;
       }
@@ -439,7 +439,7 @@ export function buildEnemyInfo(name: string): EnemyInfoPayload | string {
   if (!info) return `敌人 '${name}' 暂无详细信息。`;
 
   const levelRaw = info.enemyLevel ?? "";
-  const damageTypesRaw = info.damageType ?? [];
+  const damageTypesRaw = Array.isArray(info.damageType) ? info.damageType : [];
   const payload: EnemyInfoPayload = {
     name: info.name ?? "",
     enemy_id: info.enemyId ?? "",
@@ -451,7 +451,7 @@ export function buildEnemyInfo(name: string): EnemyInfoPayload | string {
     ability: info.ability ?? "",
     damage_types_raw: damageTypesRaw,
     damage_types_label: damageTypesRaw.map((dt) => DAMAGE_TYPE_ZH[dt] ?? dt).join("、"),
-    enemy_tags: info.enemyTags ?? [],
+    enemy_tags: Array.isArray(info.enemyTags) ? info.enemyTags : [],
     stats: null,
   };
 
@@ -484,7 +484,7 @@ function extractEnemyStats(dbEntry: EnemyDbEntry): EnemyStatsPayload {
     if (mValue<boolean>(attrs[key], false)) immunities.push(label);
   }
 
-  const skills = (dbEntry.skills ?? []).map((s) => {
+  const skills = (Array.isArray(dbEntry.skills) ? dbEntry.skills : []).map((s) => {
     const prefab = s.prefabKey ?? "未知";
     const cd = s.cooldown;
     const initCd = s.initCooldown;
@@ -493,7 +493,7 @@ function extractEnemyStats(dbEntry: EnemyDbEntry): EnemyStatsPayload {
     if (cd) cdParts.push(`冷却 ${cd}s`);
     if (initCd && initCd !== cd) cdParts.push(`初始 ${initCd}s`);
     if (spCost) cdParts.push(`SP ${spCost}`);
-    const bbStrs = (s.blackboard ?? [])
+    const bbStrs = (Array.isArray(s.blackboard) ? s.blackboard : [])
       .slice(0, 6)
       .filter((b) => b.value != null)
       .map((b) => {
@@ -638,7 +638,7 @@ export function renderEnemySearch(data: EnemySearchPayload): string {
 function enemySearchEntry(record: EnemySearchRecord): EnemySearchPayload["results"][number] {
   const info = record.info;
   const levelRaw = info.enemyLevel ?? "";
-  const damageTypesRaw = info.damageType ?? [];
+  const damageTypesRaw = Array.isArray(info.damageType) ? info.damageType : [];
   return {
     enemy_id: record.enemyId,
     name: info.name ?? "",
@@ -650,7 +650,7 @@ function enemySearchEntry(record: EnemySearchRecord): EnemySearchPayload["result
     ability: info.ability ?? "",
     damage_types_raw: damageTypesRaw,
     damage_types_label: damageTypesRaw.map((dt) => DAMAGE_TYPE_ZH[dt] ?? dt).join("、"),
-    enemy_tags: info.enemyTags ?? [],
+    enemy_tags: Array.isArray(info.enemyTags) ? info.enemyTags : [],
   };
 }
 
@@ -680,7 +680,7 @@ function getEnemySearchRecords(): EnemySearchRecord[] {
         info.name ?? "",
         info.description ?? "",
         info.ability ?? "",
-        ...(info.enemyTags ?? []),
+        ...(Array.isArray(info.enemyTags) ? info.enemyTags : []),
       ].join(" "),
     }));
   return _enemySearchRecords;

--- a/ts/src/data/item.ts
+++ b/ts/src/data/item.ts
@@ -377,7 +377,7 @@ export function buildItemInfo(name: string): ItemInfoPayload | string {
     obtain_approach: info.obtainApproach || null,
     description: info.description || null,
     usage: info.usage || null,
-    stage_drop_list: info.stageDropList ?? [],
+    stage_drop_list: Array.isArray(info.stageDropList) ? info.stageDropList : [],
     building_product_list: info.buildingProductList ?? null,
     shop_relate_list: info.shopRelateInfoList ?? null,
     voucher_relate_list: info.voucherRelateList ?? null,

--- a/ts/src/data/operator.ts
+++ b/ts/src/data/operator.ts
@@ -228,9 +228,9 @@ export function getOperatorArchives(name: string): string {
   if (!entry) return `干员 '${name}' 暂无档案数据。`;
 
   const sections: string[] = [];
-  for (const story of entry.storyTextAudio ?? []) {
+  for (const story of Array.isArray(entry.storyTextAudio) ? entry.storyTextAudio : []) {
     const title = story.storyTitle ?? "";
-    const texts = (story.stories ?? [])
+    const texts = (Array.isArray(story.stories) ? story.stories : [])
       .map((s) => s.storyText ?? "")
       .filter(Boolean);
     if (texts.length > 0) {
@@ -340,8 +340,8 @@ export function buildOperatorBasicInfo(name: string): OperatorBasicInfoPayload |
   const affiliation = affiliationParts.length > 0 ? affiliationParts.join(" / ") : "-";
 
   const talents: OperatorTalentPayload[] = [];
-  for (const slot of info.talents ?? []) {
-    const candidates = slot.candidates ?? [];
+  for (const slot of Array.isArray(info.talents) ? info.talents : []) {
+    const candidates = Array.isArray(slot.candidates) ? slot.candidates : [];
     let chosen: TalentCandidate | undefined;
     for (let i = candidates.length - 1; i >= 0; i--) {
       const c = candidates[i];
@@ -370,7 +370,7 @@ export function buildOperatorBasicInfo(name: string): OperatorBasicInfoPayload |
     position,
     position_raw: info.position ?? "",
     affiliation,
-    tag_list: info.tagList ?? [],
+    tag_list: Array.isArray(info.tagList) ? info.tagList : [],
     attack_attribute: info.description ? stripWikitext(info.description) : null,
     item_usage: info.itemUsage || null,
     item_desc: info.itemDesc || null,

--- a/ts/src/data/stage.ts
+++ b/ts/src/data/stage.ts
@@ -387,7 +387,7 @@ export function buildStageInfo(stageId: string): StageInfoPayload | string {
   const rawDesc = entry.description || "";
   const desc = cleanDescription(rawDesc) || "（无描述）";
   const drops = entry.stageDropInfo as Record<string, unknown> | null | undefined;
-  const unlocks = entry.unlockCondition ?? [];
+  const unlocks = Array.isArray(entry.unlockCondition) ? entry.unlockCondition : [];
   const hardId = entry.hardStagedId;
   const levelId = entry.levelId;
   const sixStarId = entry.sixStarStageId;

--- a/ts/src/data/stageEnemy.ts
+++ b/ts/src/data/stageEnemy.ts
@@ -165,10 +165,10 @@ function loadEnemyDatabase(): Record<string, Record<number, EnemyData>> {
       enemies?: Array<{ Key?: string; Value?: Array<{ level?: number | string; enemyData?: EnemyData }> }>;
     }>(DATABASE_FILE);
     const index: Record<string, Record<number, EnemyData>> = {};
-    for (const row of raw.enemies ?? []) {
+    for (const row of Array.isArray(raw.enemies) ? raw.enemies : []) {
       if (!row.Key) continue;
       const levelMap: Record<number, EnemyData> = {};
-      for (const value of row.Value ?? []) {
+      for (const value of Array.isArray(row.Value) ? row.Value : []) {
         if (value.enemyData) levelMap[parseLevel(value.level)] = value.enemyData;
       }
       index[row.Key] = levelMap;
@@ -235,9 +235,9 @@ function mergeDefined(base: unknown, override: unknown): unknown {
 
 function spawnCounts(level: LevelJson): Map<string, number> {
   const counts = new Map<string, number>();
-  for (const wave of level.waves ?? []) {
-    for (const fragment of wave.fragments ?? []) {
-      for (const action of fragment.actions ?? []) {
+  for (const wave of Array.isArray(level.waves) ? level.waves : []) {
+    for (const fragment of Array.isArray(wave.fragments) ? wave.fragments : []) {
+      for (const action of Array.isArray(fragment.actions) ? fragment.actions : []) {
         if (action.actionType !== "SPAWN" && action.actionType !== 0) continue;
         if (!action.key) continue;
         const rawCount = Number(action.count ?? 1);
@@ -251,7 +251,7 @@ function spawnCounts(level: LevelJson): Map<string, number> {
 
 function enemyRefs(level: LevelJson): Map<string, EnemyRef> {
   const refs = new Map<string, EnemyRef>();
-  for (const ref of level.enemyDbRefs ?? []) {
+  for (const ref of Array.isArray(level.enemyDbRefs) ? level.enemyDbRefs : []) {
     if (ref.id) refs.set(ref.id, ref);
   }
   return refs;

--- a/ts/tests/stage.test.ts
+++ b/ts/tests/stage.test.ts
@@ -511,3 +511,40 @@ test("searchStages max_results cap", async () => {
   const out = stage.searchStages(".", 1);
   assert.match(out, /共 1 个/);
 });
+
+test("getStageInfo tolerates unlockCondition = {}", async () => {
+  // Regression: upstream AKDP data sometimes has unlockCondition as {}
+  // instead of []. TS ?? [] didn't catch {} (not null/undefined), so
+  // conditions.map() crashed with "conditions.map is not a function".
+  const root = tempGamedataRoot();
+  const excel = join(root, "zh_CN", "gamedata", "excel");
+  mkdirSync(excel, { recursive: true });
+  for (const f of SENTINEL_FILES) {
+    writeFileSync(join(excel, f), "{}", "utf-8");
+  }
+  writeFileSync(join(excel, "item_table.json"), "{}", "utf-8");
+  writeFileSync(join(excel, "stage_table.json"), JSON.stringify({
+    stages: {
+      weird_stage: {
+        stageId: "weird_stage",
+        code: "WS-1",
+        name: "空对象解锁条件关",
+        stageType: "ACTIVITY",
+        difficulty: "NORMAL",
+        zoneId: "zone_ws",
+        levelId: null,
+        apCost: 1,
+        dangerLevel: "LV.1",
+        description: "测试",
+        stageDropInfo: null,
+        unlockCondition: {},
+        hardStagedId: null,
+        bossMark: false,
+      },
+    },
+  }), "utf-8");
+  process.env["GAMEDATA_PATH"] = root;
+  const stage = await loadStageModule();
+  const out = stage.getStageInfo("weird_stage");
+  assert.match(out, /无条件/);
+});

--- a/ts/tests/stageEnemy.test.ts
+++ b/ts/tests/stageEnemy.test.ts
@@ -57,6 +57,12 @@ function writeFixture(root: string): string {
         name: "空关",
         levelId: null,
       },
+      act42side_10: {
+        stageId: "act42side_10",
+        code: "AS-10",
+        name: "空对象占位关",
+        levelId: "Obt/Main/level_act42side_10",
+      },
     },
   });
   writeJson(join(excel, "enemy_handbook_table.json"), {
@@ -147,6 +153,15 @@ function writeFixture(root: string): string {
       },
     ],
   });
+  // Level file with {} placeholders where arrays are expected (upstream AKDP
+  // data has ~12 of these). The index builder must skip them gracefully.
+  writeJson(join(levelRoot, "level_act42side_10.json"), {
+    enemyDbRefs: [],
+    waves: [
+      { fragments: {} },
+      { fragments: [{ actions: {} }] },
+    ],
+  });
   return gamedata;
 }
 
@@ -235,4 +250,16 @@ test("missing levels data message", async () => {
   process.env["GAMEDATA_PATH"] = gamedata;
   const mod = await loadModule();
   assert.match(mod.getStageEnemies("main_00-01"), /关卡战斗数据暂不可用/);
+});
+
+test("getEnemyAppearances tolerates {} fragments/actions in level data", async () => {
+  // Regression: upstream AKDP data has ~12 stages where waves[*].fragments
+  // or fragment.actions is {} instead of []. The index builder scans all
+  // stages, so one bad stage blocked ALL enemy appearance queries.
+  const root = tempRoot();
+  process.env["GAMEDATA_PATH"] = writeFixture(root);
+  const mod = await loadModule();
+  // Should not crash — act42side_10 with {} fragments is skipped silently.
+  const out = mod.getEnemyAppearances("源石虫");
+  assert.match(out, /main_00-01/);
 });


### PR DESCRIPTION
## Summary

Production defect: upstream AKDP data uses `{}` (empty object) instead of `[]` for some array fields. TS `?? []` only catches `null`/`undefined`, so `{}` passed through and crashed at `.map()` / `for...of`. Python's `or []` is immune because `{}` is falsy in Python.

**21 sites** across 5 TS data modules fixed: `x ?? []` → `Array.isArray(x) ? x : []`.

### Production crashes fixed

| Tool | Field | Crash |
|---|---|---|
| `get_stage_info(main_00-01)` | `unlockCondition = {}` | `conditions.map is not a function` |
| `get_enemy_appearances(any)` | `waves[*].fragments = {}` / `actions = {}` | `{} is not iterable` — index builder scans all stages, one bad stage blocked ALL queries |

### Full audit (21 sites)

| File | Fields |
|---|---|
| `stageEnemy.ts` | waves, fragments, actions, enemyDbRefs, enemies, Value |
| `stage.ts` | unlockCondition |
| `enemy.ts` | enemies, damageType×2, enemyTags×3, skills, blackboard |
| `operator.ts` | storyTextAudio, stories, talents, candidates, tagList |
| `item.ts` | stageDropList |

2 sites confirmed safe (not changed): `Map.get() ?? []` (not JSON), `displayRewards` (already guarded by `Array.isArray`).

## Test plan

- [x] TypeScript: typecheck clean, 245 passed (+2 regression tests)
- [x] Regression: `getEnemyAppearances` with `{}` fragments in fixture → returns results
- [x] Regression: `getStageInfo` with `unlockCondition = {}` → returns "（无条件）"

## 未尽事宜

None. Python already handles `{}` correctly via `or []` (empty dict is falsy).