### PR TITLE
fix(v2.5.1): post-2.5.0 correctness and quality follow-ups (#100, #101, #102)

### DIFF
--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: 'ts/package.json'
           cache: 'npm'
@@ -103,16 +103,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: 'ts/package.json'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -164,10 +164,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: 'ts/package.json'
 
@@ -176,7 +176,7 @@ jobs:
         working-directory: ts
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -240,7 +240,7 @@ jobs:
             "$VERSION" >> release_notes.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body_path: release_notes.txt
           files: ts/prts-mcp-ts-*.tgz

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -79,10 +79,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -90,7 +90,7 @@ jobs:
         run: python -m pip install -e python/
 
       - name: Restore cached gamedata
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: |
             data/gamedata
@@ -104,7 +104,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save gamedata cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: |
             data/gamedata
@@ -185,7 +185,7 @@ jobs:
           PY
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -210,10 +210,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -246,7 +246,7 @@ jobs:
             "$VERSION" "$IMAGE" "$VERSION" >> release_notes.txt
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           body_path: release_notes.txt
           files: python/dist/*
@@ -263,10 +263,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,15 +30,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.11.28"
           enable-cache: true
@@ -95,10 +95,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -106,7 +106,7 @@ jobs:
         run: python -m pip install -e python/
 
       - name: Restore cached gamedata
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: |
             data/gamedata
@@ -132,7 +132,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save gamedata cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: |
             data/gamedata
@@ -200,10 +200,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: 'ts/package.json'
           cache: 'npm'
@@ -228,7 +228,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -287,21 +287,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           version: "0.11.28"
           enable-cache: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: 'ts/package.json'
           cache: 'npm'
@@ -332,7 +332,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -340,7 +340,7 @@ jobs:
           bun-version: "1.3.14"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -348,7 +348,7 @@ jobs:
         run: python -m pip install -e python/
 
       - name: Restore cached gamedata
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: |
             data/gamedata
@@ -372,7 +372,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Save gamedata cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: |
             data/gamedata
@@ -398,15 +398,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: 'ts/package.json'
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -414,7 +414,7 @@ jobs:
         run: python -m pip install -e python/
 
       - name: Restore cached gamedata
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: |
             data/gamedata

--- a/python/src/prts_mcp/data/artwork_mediawiki.py
+++ b/python/src/prts_mcp/data/artwork_mediawiki.py
@@ -15,14 +15,14 @@ _image_cache: "OrderedDict[str, bytes]" = OrderedDict()
 _IMAGE_CACHE_MAX_BYTES = 256 * 1024 * 1024  # 256 MiB (#85 §4.2)
 
 _MEDIAWIKI_BASE_LABELS: Mapping[str, str] = {"1": "精英零立绘", "2": "精英二立绘"}
-_VARIANT_WIDTH: Mapping[str, int] = {"large": 1024, "preview": 256}
+VARIANT_WIDTH: Mapping[str, int] = {"large": 1024, "preview": 256}
 
 
 def _image_cache_key(artwork_id: str, variant: str) -> str:
     return f"{artwork_id}|{variant}"
 
 
-def _image_cache_get(artwork_id: str, variant: str) -> bytes | None:
+def image_cache_get(artwork_id: str, variant: str) -> bytes | None:
     key = _image_cache_key(artwork_id, variant)
     with _IMAGE_CACHE_LOCK:
         if key in _image_cache:
@@ -31,7 +31,7 @@ def _image_cache_get(artwork_id: str, variant: str) -> bytes | None:
     return None
 
 
-def _image_cache_put(artwork_id: str, variant: str, data: bytes) -> None:
+def image_cache_put(artwork_id: str, variant: str, data: bytes) -> None:
     key = _image_cache_key(artwork_id, variant)
     with _IMAGE_CACHE_LOCK:
         _image_cache[key] = data
@@ -71,7 +71,7 @@ def _mediawiki_fashion_label(rest: str, charinfo: Mapping[str, Any]) -> str:
     return label
 
 
-def _label_from_filename(
+def label_from_filename(
     filename: str, charinfo: Mapping[str, Any],
 ) -> str | None:
     """Derive a label from a PRTS filename like ``立绘_阿米娅_2.png``.

--- a/python/src/prts_mcp/data/images.py
+++ b/python/src/prts_mcp/data/images.py
@@ -134,7 +134,7 @@ def parse_index(data: Mapping[str, Any]) -> ImagesIndex | None:
 
 
 @activation_aware_cache(maxsize=1)
-def _load_char_skins() -> dict[str, Any]:
+def load_char_skins() -> dict[str, Any]:
     """Load the ``charSkins`` mapping from ``skin_table.json``.
 
     Returns an empty mapping when excel data is unavailable or the file is
@@ -158,7 +158,7 @@ def _load_char_skins() -> dict[str, Any]:
 
 def clear_image_caches() -> None:
     """Clear image-related caches after synced game data changes on disk."""
-    _load_char_skins.cache_clear()
+    load_char_skins.cache_clear()
 
 
 register_activation_listener(clear_image_caches)
@@ -188,7 +188,7 @@ def build_artwork_label(
     is already scoped to one operator, so the label only needs to
     distinguish that operator's illusts/skins from each other.
     """
-    skins = char_skins if char_skins is not None else _load_char_skins()
+    skins = char_skins if char_skins is not None else load_char_skins()
     entry = skins.get(skin_id)
 
     if "@" in skin_id:

--- a/python/src/prts_mcp/data/images_sync.py
+++ b/python/src/prts_mcp/data/images_sync.py
@@ -206,7 +206,7 @@ def _save_meta(root: Path, meta: dict) -> None:
     tmp.replace(path)
 
 
-def _active_generation(image_dir: Path) -> Path | None:
+def active_generation(image_dir: Path) -> Path | None:
     """Resolve the currently activated generation directory, or None."""
     meta = _load_meta(image_dir)
     if meta is None:
@@ -267,7 +267,7 @@ def _dummy_spec(image_dir: Path) -> RepoSpec:
 def _offline_or_no_data(image_dir: Path, *, error: str) -> SyncResult:
     """Return offline_fallback if cached images exist, else no_data."""
     spec = _dummy_spec(image_dir)
-    if _active_generation(image_dir) is not None:
+    if active_generation(image_dir) is not None:
         meta = _load_meta(image_dir)
         ver = meta.get("currentVersion") if meta else None
         return SyncResult(
@@ -303,7 +303,7 @@ def _sync_images_locked(
     current_version = delta_tag[len(_DELTA_PREFIX):]
 
     meta = _load_meta(image_dir)
-    gen_dir = _active_generation(image_dir)
+    gen_dir = active_generation(image_dir)
     synced = meta.get("shardsSynced") if meta else None
     same_shards = isinstance(synced, list) and set(synced) == set(shard_keys)
 

--- a/python/src/prts_mcp/data/images_sync.py
+++ b/python/src/prts_mcp/data/images_sync.py
@@ -46,13 +46,23 @@ def _shard_variant_names(shard_keys: tuple[str, ...]) -> set[str]:
     return {key.rsplit("-", 1)[-1] for key in shard_keys}
 
 
+def _sha256_file(path: Path) -> str:
+    """Stream-hash a file so large PNGs do not stay resident (#100 CR)."""
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
 def _verify_variant_hashes(
     staging: Path, index: ImagesIndex, shard_keys: tuple[str, ...],
 ) -> None:
     """Verify each synced variant PNG matches its index sha256 (#100).
 
-    Only variants whose shard was downloaded are checked. A corrupted or
-    tampered shard raises so activation never happens on bad data.
+    Only variants whose shard was downloaded are checked. A corrupted,
+    tampered, or incomplete shard (a wanted variant whose PNG is absent)
+    raises so activation never happens on bad data.
     """
     wanted = _shard_variant_names(shard_keys)
     checked = 0
@@ -63,8 +73,16 @@ def _verify_variant_hashes(
                 continue
             png_path = staging / variant.file
             if not png_path.is_file():
+                # Incomplete shard: a wanted variant's file is absent.
+                mismatches += 1
+                checked += 1
+                if mismatches <= 3:
+                    _logger.warning(
+                        "images sha256 mismatch: %s/%s file missing: %s",
+                        skin_id, vname, variant.file,
+                    )
                 continue
-            actual = hashlib.sha256(png_path.read_bytes()).hexdigest()
+            actual = _sha256_file(png_path)
             checked += 1
             if actual != variant.sha256:
                 mismatches += 1

--- a/python/src/prts_mcp/data/images_sync.py
+++ b/python/src/prts_mcp/data/images_sync.py
@@ -23,7 +23,7 @@ from uuid import uuid4
 
 import httpx
 
-from prts_mcp.data.images import SCHEMA_VERSION, parse_index
+from prts_mcp.data.images import ImagesIndex, SCHEMA_VERSION, parse_index
 from prts_mcp.data.sync import (
     ReleaseSpec,
     RepoSpec,
@@ -39,6 +39,45 @@ from prts_mcp.data.sync import (
 )
 
 _logger = logging.getLogger(__name__)
+
+
+def _shard_variant_names(shard_keys: tuple[str, ...]) -> set[str]:
+    """Map shard keys (e.g. ``chararts-large``) to variant names (e.g. ``large``)."""
+    return {key.rsplit("-", 1)[-1] for key in shard_keys}
+
+
+def _verify_variant_hashes(
+    staging: Path, index: ImagesIndex, shard_keys: tuple[str, ...],
+) -> None:
+    """Verify each synced variant PNG matches its index sha256 (#100).
+
+    Only variants whose shard was downloaded are checked. A corrupted or
+    tampered shard raises so activation never happens on bad data.
+    """
+    wanted = _shard_variant_names(shard_keys)
+    checked = 0
+    mismatches = 0
+    for skin_id, entry in index.artworks.items():
+        for vname, variant in entry.variants.items():
+            if vname not in wanted:
+                continue
+            png_path = staging / variant.file
+            if not png_path.is_file():
+                continue
+            actual = hashlib.sha256(png_path.read_bytes()).hexdigest()
+            checked += 1
+            if actual != variant.sha256:
+                mismatches += 1
+                if mismatches <= 3:
+                    _logger.warning(
+                        "images sha256 mismatch: %s/%s expected %s got %s",
+                        skin_id, vname, variant.sha256[:12], actual[:12],
+                    )
+    if mismatches:
+        raise ValueError(
+            f"images sha256 verification failed: {mismatches} of {checked} variants mismatch"
+        )
+
 
 IMAGES_REPO_OWNER = "3aKHP"
 IMAGES_REPO = "arknights-data-pipeline"
@@ -345,6 +384,10 @@ def _sync_images_locked(
             _download_large(delta_url, delta_zip)
             _safe_extract_zip(delta_zip, staging)
             delta_zip.unlink(missing_ok=True)
+
+        # Verify every synced variant's sha256 against the index before
+        # activation (#100): a corrupted or tampered shard must not activate.
+        _verify_variant_hashes(staging, index, shard_keys)
 
         # Authoritative index.json + generation meta.
         (staging / "index.json").write_bytes(index_bytes)

--- a/python/src/prts_mcp/data/operator.py
+++ b/python/src/prts_mcp/data/operator.py
@@ -78,7 +78,7 @@ def _build_name_to_id() -> dict[str, str]:
             if info.get("name") and cid.startswith("char_")}
 
 
-def _resolve_char_id(name: str) -> str | None:
+def resolve_char_id(name: str) -> str | None:
     mapping = _build_name_to_id()
     return mapping.get(name)
 
@@ -94,7 +94,7 @@ def get_operator_archives(name: str) -> str:
         return _missing_operator_data_message()
 
     try:
-        char_id = _resolve_char_id(name)
+        char_id = resolve_char_id(name)
     except FileNotFoundError as exc:
         return str(exc)
     if char_id is None:
@@ -126,7 +126,7 @@ def get_operator_voicelines(name: str) -> str:
         return _missing_operator_data_message()
 
     try:
-        char_id = _resolve_char_id(name)
+        char_id = resolve_char_id(name)
     except FileNotFoundError as exc:
         return str(exc)
     if char_id is None:
@@ -181,7 +181,7 @@ def build_operator_basic_info(name: str) -> dict | str:
         return _missing_operator_data_message()
 
     try:
-        char_id = _resolve_char_id(name)
+        char_id = resolve_char_id(name)
     except FileNotFoundError as exc:
         return str(exc)
     if char_id is None:

--- a/python/src/prts_mcp/data/sync.py
+++ b/python/src/prts_mcp/data/sync.py
@@ -96,11 +96,12 @@ def _get_cascading(url: str, *, timeout: float, **kwargs: object) -> httpx.Respo
             response = httpx.get(candidate, timeout=timeout, **kwargs)  # type: ignore[arg-type]
             if response.is_success:
                 return response
-            # Direct 404 → asset confirmed absent; raise a typed error so
-            # manifest verification can skip without fail-open on a mirror
-            # 404 (#100).
+            # Direct 404 → asset confirmed absent; record the typed error and
+            # stop without trying mirrors. last_exc + break (not raise) so the
+            # typed error survives to the caller even with GITHUB_MIRRORS (#100).
             if i == 0 and response.status_code == 404:
-                raise _AssetNotFoundError(f"HTTP 404: {candidate}")
+                last_exc = _AssetNotFoundError(f"HTTP 404: {candidate}")
+                break
             last_exc = Exception(f"HTTP {response.status_code}")
             # Other direct 4xx → resource genuinely missing; mirrors cannot help.
             if i == 0 and 400 <= response.status_code < 500:

--- a/python/src/prts_mcp/data/sync.py
+++ b/python/src/prts_mcp/data/sync.py
@@ -74,6 +74,15 @@ def _url_candidates(url: str) -> list[str]:
     return [url] + [f"{m}/{url}" for m in _parse_mirrors()]
 
 
+class _AssetNotFoundError(Exception):
+    """Direct release URL returned 404 — asset confirmed absent.
+
+    Distinguished from a mirror 404 (mirror lacks the asset; the release
+    may still exist upstream) so manifest verification skips only on a
+    confirmed upstream 404 and stays fail-closed otherwise (#100).
+    """
+
+
 def _get_cascading(url: str, *, timeout: float, **kwargs: object) -> httpx.Response:
     """httpx.get() wrapper that cascades through URL candidates on failure.
 
@@ -87,8 +96,13 @@ def _get_cascading(url: str, *, timeout: float, **kwargs: object) -> httpx.Respo
             response = httpx.get(candidate, timeout=timeout, **kwargs)  # type: ignore[arg-type]
             if response.is_success:
                 return response
+            # Direct 404 → asset confirmed absent; raise a typed error so
+            # manifest verification can skip without fail-open on a mirror
+            # 404 (#100).
+            if i == 0 and response.status_code == 404:
+                raise _AssetNotFoundError(f"HTTP 404: {candidate}")
             last_exc = Exception(f"HTTP {response.status_code}")
-            # Direct 4xx → resource genuinely missing; mirrors cannot help.
+            # Other direct 4xx → resource genuinely missing; mirrors cannot help.
             if i == 0 and 400 <= response.status_code < 500:
                 break
         except httpx.HTTPStatusError:
@@ -375,9 +389,10 @@ def _verify_release_manifest(
         response = _get_cascading(
             manifest_url, timeout=timeout, headers=_github_headers(), follow_redirects=True,
         )
+    except _AssetNotFoundError:
+        # Direct URL confirmed 404 → release predates the manifest asset.
+        return
     except Exception as exc:
-        if "404" in str(exc):
-            return
         raise ValueError(f"manifest unavailable for {tag}: {exc}") from exc
     try:
         manifest = response.json()

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -21,7 +21,7 @@ import logging
 import os
 import sys
 import threading
-from importlib.metadata import version as _pkg_version
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
 from mcp.server.fastmcp import FastMCP
 
@@ -48,7 +48,10 @@ _logger = logging.getLogger("prts_mcp.server")
 mcp = FastMCP("PRTS_Wiki_Assistant")
 # FastMCP does not expose a version parameter; set it on the internal
 # MCPServer so initialize.serverInfo reports the product version.
-mcp._mcp_server.version = _pkg_version("prts-mcp")
+try:
+    mcp._mcp_server.version = _pkg_version("prts-mcp")
+except PackageNotFoundError:
+    mcp._mcp_server.version = "0.0.0"
 
 
 def _register_tools() -> None:

--- a/python/src/prts_mcp/startup_sync.py
+++ b/python/src/prts_mcp/startup_sync.py
@@ -42,6 +42,17 @@ def _sync_needs_retry(status: str) -> bool:
     return status in {"offline_fallback", "no_data"}
 
 
+def _gamedata_pair_needs_retry(excel_status: str, levels_status: str) -> bool:
+    """Decide whether the gamedata pair sync warrants a dense retry.
+
+    A generation (commit_sha) mismatch alone must NOT trigger dense retries
+    (30s/120s/600s): when both archives are up-to-date, divergent
+    commit_shas are stale local metadata, not missing data, and the next
+    periodic cycle resolves it. Only offline_fallback / no_data retry.
+    """
+    return _sync_needs_retry(excel_status) or _sync_needs_retry(levels_status)
+
+
 def _run_initial_sync(label: str, sync_func: Callable[[], bool]) -> bool:
     """Run the first sync attempt, treating unexpected exceptions as retry-needed."""
     try:
@@ -164,10 +175,8 @@ def _run_startup_sync(*, force_check: bool = False) -> None:
                 clear_stage_enemy_caches()
                 from prts_mcp.data.stage import clear_stage_caches as _clear_stages
                 _clear_stages()
-            return (
-                _sync_needs_retry(excel_result.status)
-                or _sync_needs_retry(levels_result.status)
-                or not same_generation
+            return _gamedata_pair_needs_retry(
+                excel_result.status, levels_result.status
             )
 
         needs_retry = _run_initial_sync(

--- a/python/src/prts_mcp/tools_artwork.py
+++ b/python/src/prts_mcp/tools_artwork.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import base64
 import json
-import logging
 from pathlib import Path
 from typing import Annotated, Literal, Mapping
 
@@ -22,21 +21,19 @@ from prts_mcp.api.prts_wiki import (
 from prts_mcp.config import Config, activation_snapshot
 from prts_mcp.data.images import (
     DEFAULT_VARIANT,
-    _load_char_skins,
+    load_char_skins,
     build_artwork_label,
     parse_index,
 )
 from prts_mcp.data.artwork_mediawiki import (
-    _VARIANT_WIDTH,
-    _image_cache_get,
-    _image_cache_put,
-    _label_from_filename,
+    VARIANT_WIDTH,
+    image_cache_get,
+    image_cache_put,
+    label_from_filename,
 )
-from prts_mcp.data.images_sync import _active_generation
-from prts_mcp.data.operator import _resolve_char_id
+from prts_mcp.data.images_sync import active_generation
+from prts_mcp.data.operator import resolve_char_id
 from prts_mcp.output import render_image_result, render_result, text_result
-
-_logger = logging.getLogger(__name__)
 
 
 def _images_generation() -> Path | None:
@@ -44,7 +41,7 @@ def _images_generation() -> Path | None:
     cfg = Config.load()
     if not cfg.images_enabled:
         return None
-    return _active_generation(cfg.images_path)
+    return active_generation(cfg.images_path)
 
 
 def _load_index(gen_dir: Path):
@@ -88,7 +85,7 @@ async def _do_list_mediawiki(operator_name: str) -> object:
     artworks: list[dict] = []
     for f in files:
         name = f.get("name", "")
-        label = _label_from_filename(name, charinfo)
+        label = label_from_filename(name, charinfo)
         if label is None:
             continue
         artworks.append({
@@ -131,7 +128,7 @@ async def _do_get_mediawiki(
             "请使用 large 或 preview。"
         )
     chosen = variant or DEFAULT_VARIANT
-    width = _VARIANT_WIDTH.get(chosen)
+    width = VARIANT_WIDTH.get(chosen)
     if width is None:
         return text_result(f"不支持的变体：{chosen}。false 模式可选 large / preview。")
     try:
@@ -143,18 +140,18 @@ async def _do_get_mediawiki(
     img_url = info.get("thumburl") or info.get("url")
     if not img_url:
         return text_result(f"「{artwork_id}」无 {chosen} 变体。")
-    image_bytes = _image_cache_get(artwork_id, chosen) if cfg.prts_image_cache else None
+    image_bytes = image_cache_get(artwork_id, chosen) if cfg.prts_image_cache else None
     if image_bytes is None:
         try:
             image_bytes = await _download_image_safe(img_url)
         except Exception as exc:  # noqa: BLE001 — ValueError (boundary) or httpx.HTTPError (network)
             return text_result(f"下载图片失败：{exc}")
         if cfg.prts_image_cache:
-            _image_cache_put(artwork_id, chosen, image_bytes)
+            image_cache_put(artwork_id, chosen, image_bytes)
     image_b64 = base64.b64encode(image_bytes).decode("ascii")
     # CharinfoV2 is not re-fetched in get (list already provided the precise
     # label); derive a best-effort label from the filename.
-    label = _label_from_filename(artwork_id, {}) or artwork_id
+    label = label_from_filename(artwork_id, {}) or artwork_id
     mime = info.get("mime") or "image/png"
     markdown = (
         f"**{label}**（{operator_name}）\n"
@@ -185,7 +182,7 @@ async def _do_list(operator_name: str) -> object:
     if not cfg.local_image:
         return await _do_list_mediawiki(operator_name)
     try:
-        char_id = _resolve_char_id(operator_name)
+        char_id = resolve_char_id(operator_name)
     except (OSError, AssertionError):
         # gamedata not synced yet (effective_excel_path None or table missing).
         return _data_not_ready()
@@ -211,7 +208,7 @@ async def _do_list(operator_name: str) -> object:
     if not matched:
         return text_result(f"未找到「{operator_name}」的立绘数据。")
 
-    char_skins = _load_char_skins()
+    char_skins = load_char_skins()
     artworks = [
         {
             "artwork_id": sid,
@@ -286,7 +283,7 @@ async def _do_get(
         return text_result(f"读取图片文件失败：{exc}")
 
     image_b64 = base64.b64encode(image_bytes).decode("ascii")
-    char_skins = _load_char_skins()
+    char_skins = load_char_skins()
     label = build_artwork_label(artwork_id, char_skins)
     markdown = (
         f"**{label}**（{operator_name}）\n"

--- a/python/tests/test_artwork_mediawiki.py
+++ b/python/tests/test_artwork_mediawiki.py
@@ -19,7 +19,7 @@ from prts_mcp.data.artwork_mediawiki import (
 _CHARINFO = {"时装1名称": "报童", "时装2名称": "见习联结者", "时装3名称": "播种者"}
 
 
-def testlabel_from_filename():
+def test_label_from_filename():
     cases = {
         "立绘_阿米娅_1.png": "精英零立绘",
         "立绘_阿米娅_1+.png": "精英零立绘（变体）",

--- a/python/tests/test_artwork_mediawiki.py
+++ b/python/tests/test_artwork_mediawiki.py
@@ -11,15 +11,15 @@ import pytest
 from prts_mcp.api.prts_wiki import _image_magic_ok, download_image_safe, list_allimages
 from prts_mcp.data.artwork_mediawiki import (
     _image_cache,
-    _image_cache_get,
-    _image_cache_put,
-    _label_from_filename,
+    image_cache_get,
+    image_cache_put,
+    label_from_filename,
 )
 
 _CHARINFO = {"时装1名称": "报童", "时装2名称": "见习联结者", "时装3名称": "播种者"}
 
 
-def test_label_from_filename():
+def testlabel_from_filename():
     cases = {
         "立绘_阿米娅_1.png": "精英零立绘",
         "立绘_阿米娅_1+.png": "精英零立绘（变体）",
@@ -33,18 +33,18 @@ def test_label_from_filename():
         "立绘_阿米娅(近卫)_2b.png": None,
     }
     for filename, expected in cases.items():
-        assert _label_from_filename(filename, _CHARINFO) == expected, filename
+        assert label_from_filename(filename, _CHARINFO) == expected, filename
 
 
 def test_label_fashion_fallback_without_charinfo():
     # No CharinfoV2 → fashion falls back to "时装 N".
-    assert _label_from_filename("立绘_阿米娅_skin1.png", {}) == "时装 1"
-    assert _label_from_filename("立绘_阿米娅_skin12.png", {}) == "时装 12"
+    assert label_from_filename("立绘_阿米娅_skin1.png", {}) == "时装 1"
+    assert label_from_filename("立绘_阿米娅_skin12.png", {}) == "时装 12"
 
 
 def test_label_rejects_non_png_and_malformed():
-    assert _label_from_filename("立绘_阿米娅_2.jpg", _CHARINFO) is None
-    assert _label_from_filename("立绘阿米娅", _CHARINFO) is None  # no second underscore
+    assert label_from_filename("立绘_阿米娅_2.jpg", _CHARINFO) is None
+    assert label_from_filename("立绘阿米娅", _CHARINFO) is None  # no second underscore
 
 
 def test_image_magic_ok():
@@ -59,13 +59,13 @@ def test_image_magic_ok():
 def test_image_cache_lru_round_trip():
     _image_cache.clear()
     try:
-        assert _image_cache_get("amiya_2", "large") is None
-        _image_cache_put("amiya_2", "large", b"\x00" * 100)
-        assert _image_cache_get("amiya_2", "large") == b"\x00" * 100
+        assert image_cache_get("amiya_2", "large") is None
+        image_cache_put("amiya_2", "large", b"\x00" * 100)
+        assert image_cache_get("amiya_2", "large") == b"\x00" * 100
         # Different variant misses.
-        assert _image_cache_get("amiya_2", "preview") is None
-        _image_cache_put("amiya_2", "preview", b"\x01" * 50)
-        assert _image_cache_get("amiya_2", "preview") == b"\x01" * 50
+        assert image_cache_get("amiya_2", "preview") is None
+        image_cache_put("amiya_2", "preview", b"\x01" * 50)
+        assert image_cache_get("amiya_2", "preview") == b"\x01" * 50
     finally:
         _image_cache.clear()
 
@@ -77,10 +77,10 @@ def test_image_cache_lru_evicts_by_byte_total(monkeypatch):
     monkeypatch.setattr(am, "_IMAGE_CACHE_MAX_BYTES", 150)
     _image_cache.clear()
     try:
-        _image_cache_put("a", "large", b"\x00" * 100)
-        _image_cache_put("b", "large", b"\x00" * 100)  # total 200 > 150 → evict "a"
-        assert _image_cache_get("a", "large") is None
-        assert _image_cache_get("b", "large") == b"\x00" * 100
+        image_cache_put("a", "large", b"\x00" * 100)
+        image_cache_put("b", "large", b"\x00" * 100)  # total 200 > 150 → evict "a"
+        assert image_cache_get("a", "large") is None
+        assert image_cache_get("b", "large") == b"\x00" * 100
     finally:
         _image_cache.clear()
 

--- a/python/tests/test_auto_sync.py
+++ b/python/tests/test_auto_sync.py
@@ -77,3 +77,16 @@ def test_auto_sync_continues_after_unexpected_cycle_error(monkeypatch):
     startup_sync._run_auto_sync(stop)  # type: ignore[arg-type]
 
     assert force_checks == [False, True]
+
+
+def test_gamedata_pair_retry_ignores_generation_mismatch():
+    """#102: divergent commit_shas alone must not trigger dense retries."""
+    assert startup_sync._gamedata_pair_needs_retry("up_to_date", "up_to_date") is False
+    assert startup_sync._gamedata_pair_needs_retry("updated", "up_to_date") is False
+    assert startup_sync._gamedata_pair_needs_retry("up_to_date", "updated") is False
+
+
+def test_gamedata_pair_retries_on_no_data_or_offline_fallback():
+    assert startup_sync._gamedata_pair_needs_retry("no_data", "up_to_date") is True
+    assert startup_sync._gamedata_pair_needs_retry("up_to_date", "offline_fallback") is True
+    assert startup_sync._gamedata_pair_needs_retry("offline_fallback", "no_data") is True

--- a/python/tests/test_images.py
+++ b/python/tests/test_images.py
@@ -128,11 +128,11 @@ def mock_images(monkeypatch, tmp_path):
         "prts_mcp.tools_artwork._images_generation", lambda: gen,
     )
     monkeypatch.setattr(
-        "prts_mcp.tools_artwork._resolve_char_id",
+        "prts_mcp.tools_artwork.resolve_char_id",
         lambda name: "char_002_amiya" if name == "阿米娅" else None,
     )
     monkeypatch.setattr(
-        "prts_mcp.tools_artwork._load_char_skins",
+        "prts_mcp.tools_artwork.load_char_skins",
         lambda: {"char_002_amiya@winter#1": {"displaySkin": {"skinName": "报童"}}},
     )
     return gen

--- a/python/tests/test_images_sync.py
+++ b/python/tests/test_images_sync.py
@@ -122,3 +122,68 @@ def test_sync_offline_falls_back_to_existing(tmp_path, monkeypatch):
     assert r.status == "offline_fallback"
     assert r.commit_sha == "c1"
     assert _active_generation(image_dir) is not None
+
+
+def test_verify_variant_hashes_passes_on_match(tmp_path):
+    """#100: a variant whose PNG matches its index sha256 verifies cleanly."""
+    import hashlib
+    from prts_mcp.data.images import parse_index
+    from prts_mcp.data.images_sync import _verify_variant_hashes
+
+    png = tmp_path / "chararts" / "test_large.png"
+    png.parent.mkdir(parents=True)
+    content = b"\x89PNG\r\n\x1a\nfake"
+    png.write_bytes(content)
+
+    index = parse_index({
+        "schemaVersion": SCHEMA_VERSION,
+        "baselineVersion": "b1",
+        "currentVersion": "c1",
+        "shards": {},
+        "artworks": {
+            "test_skin": {
+                "kind": "base",
+                "large": {
+                    "file": "chararts/test_large.png",
+                    "sha256": hashlib.sha256(content).hexdigest(),
+                    "w": 1024,
+                    "h": 1024,
+                    "bytes": 100,
+                },
+            },
+        },
+    })
+    assert index is not None
+    _verify_variant_hashes(tmp_path, index, ("chararts-large",))  # no raise
+
+
+def test_verify_variant_hashes_rejects_mismatch(tmp_path):
+    """#100: a corrupted shard must not pass sha256 verification."""
+    from prts_mcp.data.images import parse_index
+    from prts_mcp.data.images_sync import _verify_variant_hashes
+
+    png = tmp_path / "chararts" / "test_large.png"
+    png.parent.mkdir(parents=True)
+    png.write_bytes(b"\x89PNG\r\n\x1a\nfake")
+
+    index = parse_index({
+        "schemaVersion": SCHEMA_VERSION,
+        "baselineVersion": "b1",
+        "currentVersion": "c1",
+        "shards": {},
+        "artworks": {
+            "test_skin": {
+                "kind": "base",
+                "large": {
+                    "file": "chararts/test_large.png",
+                    "sha256": "0" * 64,
+                    "w": 1024,
+                    "h": 1024,
+                    "bytes": 100,
+                },
+            },
+        },
+    })
+    assert index is not None
+    with pytest.raises(ValueError, match="sha256 verification failed"):
+        _verify_variant_hashes(tmp_path, index, ("chararts-large",))

--- a/python/tests/test_images_sync.py
+++ b/python/tests/test_images_sync.py
@@ -12,7 +12,7 @@ from zipfile import ZipFile
 import pytest
 
 from prts_mcp.data.images import SCHEMA_VERSION
-from prts_mcp.data.images_sync import _active_generation, needed_shard_keys, sync_images
+from prts_mcp.data.images_sync import active_generation, needed_shard_keys, sync_images
 
 
 def _make_index(baseline: str = "b1", current: str = "c1") -> dict:
@@ -104,7 +104,7 @@ def test_sync_delta_failure_does_not_activate(tmp_path, monkeypatch):
 
     r = sync_images(image_dir, include_original=False, force_check=True)
     assert r.status == "no_data", "delta failure with no prior generation → no_data"
-    assert _active_generation(image_dir) is None
+    assert active_generation(image_dir) is None
 
 
 def test_sync_offline_falls_back_to_existing(tmp_path, monkeypatch):
@@ -121,7 +121,7 @@ def test_sync_offline_falls_back_to_existing(tmp_path, monkeypatch):
     r = sync_images(image_dir, include_original=False, force_check=True)
     assert r.status == "offline_fallback"
     assert r.commit_sha == "c1"
-    assert _active_generation(image_dir) is not None
+    assert active_generation(image_dir) is not None
 
 
 def test_verify_variant_hashes_passes_on_match(tmp_path):

--- a/python/tests/test_images_sync.py
+++ b/python/tests/test_images_sync.py
@@ -5,14 +5,20 @@ invariants that a single-shot E2E cannot exercise.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from zipfile import ZipFile
 
 import pytest
 
-from prts_mcp.data.images import SCHEMA_VERSION
-from prts_mcp.data.images_sync import active_generation, needed_shard_keys, sync_images
+from prts_mcp.data.images import SCHEMA_VERSION, parse_index
+from prts_mcp.data.images_sync import (
+    _verify_variant_hashes,
+    active_generation,
+    needed_shard_keys,
+    sync_images,
+)
 
 
 def _make_index(baseline: str = "b1", current: str = "c1") -> dict:
@@ -126,10 +132,6 @@ def test_sync_offline_falls_back_to_existing(tmp_path, monkeypatch):
 
 def test_verify_variant_hashes_passes_on_match(tmp_path):
     """#100: a variant whose PNG matches its index sha256 verifies cleanly."""
-    import hashlib
-    from prts_mcp.data.images import parse_index
-    from prts_mcp.data.images_sync import _verify_variant_hashes
-
     png = tmp_path / "chararts" / "test_large.png"
     png.parent.mkdir(parents=True)
     content = b"\x89PNG\r\n\x1a\nfake"
@@ -159,9 +161,6 @@ def test_verify_variant_hashes_passes_on_match(tmp_path):
 
 def test_verify_variant_hashes_rejects_mismatch(tmp_path):
     """#100: a corrupted shard must not pass sha256 verification."""
-    from prts_mcp.data.images import parse_index
-    from prts_mcp.data.images_sync import _verify_variant_hashes
-
     png = tmp_path / "chararts" / "test_large.png"
     png.parent.mkdir(parents=True)
     png.write_bytes(b"\x89PNG\r\n\x1a\nfake")
@@ -185,5 +184,31 @@ def test_verify_variant_hashes_rejects_mismatch(tmp_path):
         },
     })
     assert index is not None
+    with pytest.raises(ValueError, match="sha256 verification failed"):
+        _verify_variant_hashes(tmp_path, index, ("chararts-large",))
+
+
+def test_verify_variant_hashes_rejects_missing_file(tmp_path):
+    """#100 CR: a wanted variant whose PNG is absent blocks activation."""
+    index = parse_index({
+        "schemaVersion": SCHEMA_VERSION,
+        "baselineVersion": "b1",
+        "currentVersion": "c1",
+        "shards": {},
+        "artworks": {
+            "test_skin": {
+                "kind": "base",
+                "large": {
+                    "file": "chararts/test_large.png",
+                    "sha256": "0" * 64,
+                    "w": 1024,
+                    "h": 1024,
+                    "bytes": 100,
+                },
+            },
+        },
+    })
+    assert index is not None
+    # No PNG created — the wanted variant's file is absent (incomplete shard).
     with pytest.raises(ValueError, match="sha256 verification failed"):
         _verify_variant_hashes(tmp_path, index, ("chararts-large",))

--- a/python/tests/test_server_startup_sync.py
+++ b/python/tests/test_server_startup_sync.py
@@ -4,9 +4,14 @@ import sys
 import types
 
 
+class _FakeMcpServer:
+    def __init__(self) -> None:
+        self.version = "0.0.0"
+
+
 class FakeFastMCP:
     def __init__(self, _name: str):
-        pass
+        self._mcp_server = _FakeMcpServer()
 
     def tool(self):
         return lambda func: func
@@ -22,9 +27,13 @@ def _install_server_import_stubs() -> None:
     pydantic_module = types.ModuleType("pydantic")
     fastmcp_module.FastMCP = FakeFastMCP
     pydantic_module.Field = lambda *args, **kwargs: kwargs.get("default")
+    mcp_types_module = types.ModuleType("mcp.types")
+    for _name in ("CallToolResult", "ImageContent", "TextContent"):
+        setattr(mcp_types_module, _name, type(_name, (), {}))
     sys.modules.setdefault("mcp", mcp_module)
     sys.modules.setdefault("mcp.server", mcp_server_module)
     sys.modules.setdefault("mcp.server.fastmcp", fastmcp_module)
+    sys.modules.setdefault("mcp.types", mcp_types_module)
     sys.modules.setdefault("pydantic", pydantic_module)
 
 

--- a/python/tests/test_sync_release.py
+++ b/python/tests/test_sync_release.py
@@ -23,6 +23,7 @@ from prts_mcp.data.sync import (
     sync_release_archive,
     sync_release_archive_pair,
     sync_release,
+    _AssetNotFoundError,
     _archive_activation_lock,
 )
 
@@ -175,7 +176,7 @@ class TestSyncRelease:
         asset = _mock_asset_response(b"legacy")
         with patch(
             "prts_mcp.data.sync._get_cascading",
-            side_effect=[release, asset, Exception("HTTP 404")],
+            side_effect=[release, asset, _AssetNotFoundError("HTTP 404")],
         ):
             result = sync_release(spec, force_check=True)
         assert result.status == "updated"

--- a/python/tests/test_sync_release.py
+++ b/python/tests/test_sync_release.py
@@ -25,6 +25,7 @@ from prts_mcp.data.sync import (
     sync_release,
     _AssetNotFoundError,
     _archive_activation_lock,
+    _verify_release_manifest,
 )
 
 
@@ -1018,12 +1019,6 @@ class TestManifestAbsenceSemantics:
     lacks the asset → fail closed)."""
 
     def test_skip_when_direct_url_confirms_absence(self, tmp_path):
-        from prts_mcp.data.sync import (
-            ReleaseSpec,
-            _AssetNotFoundError,
-            _verify_release_manifest,
-        )
-
         spec = ReleaseSpec(
             owner="3aKHP",
             repo="arknights-data-pipeline",
@@ -1040,8 +1035,6 @@ class TestManifestAbsenceSemantics:
             _verify_release_manifest(spec, "data-old", asset_path, timeout=1.0)
 
     def test_fail_closed_on_mirror_404(self, tmp_path):
-        from prts_mcp.data.sync import ReleaseSpec, _verify_release_manifest
-
         spec = ReleaseSpec(
             owner="3aKHP",
             repo="arknights-data-pipeline",

--- a/python/tests/test_sync_release.py
+++ b/python/tests/test_sync_release.py
@@ -1009,3 +1009,51 @@ print(sync.sync_release_archive(spec).status)
         assert pair["commit_sha"] == "new"
         assert pair["excel_data_root"] == ".releases/new"
         assert pair["levels_data_root"] == ".releases/new"
+
+
+class TestManifestAbsenceSemantics:
+    """#100: manifest verification must distinguish a confirmed upstream 404
+    (release predates the manifest asset → skip) from a mirror 404 (mirror
+    lacks the asset → fail closed)."""
+
+    def test_skip_when_direct_url_confirms_absence(self, tmp_path):
+        from prts_mcp.data.sync import (
+            ReleaseSpec,
+            _AssetNotFoundError,
+            _verify_release_manifest,
+        )
+
+        spec = ReleaseSpec(
+            owner="3aKHP",
+            repo="arknights-data-pipeline",
+            asset_name="zh_CN.zip",
+            local_zip=tmp_path / "zh_CN.zip",
+        )
+        asset_path = tmp_path / "asset.zip"
+        asset_path.write_bytes(b"PK\x03\x04")
+        with patch(
+            "prts_mcp.data.sync._get_cascading",
+            side_effect=_AssetNotFoundError("HTTP 404"),
+        ):
+            # Must return without raising — release predates the manifest.
+            _verify_release_manifest(spec, "data-old", asset_path, timeout=1.0)
+
+    def test_fail_closed_on_mirror_404(self, tmp_path):
+        from prts_mcp.data.sync import ReleaseSpec, _verify_release_manifest
+
+        spec = ReleaseSpec(
+            owner="3aKHP",
+            repo="arknights-data-pipeline",
+            asset_name="zh_CN.zip",
+            local_zip=tmp_path / "zh_CN.zip",
+        )
+        asset_path = tmp_path / "asset.zip"
+        asset_path.write_bytes(b"PK\x03\x04")
+        # A mirror 404 surfaces as a plain Exception carrying "HTTP 404" —
+        # NOT _AssetNotFoundError. Must fail closed (#100 regression).
+        with patch(
+            "prts_mcp.data.sync._get_cascading",
+            side_effect=Exception("HTTP 404 from mirror"),
+        ):
+            with pytest.raises(ValueError, match="manifest unavailable"):
+                _verify_release_manifest(spec, "data-x", asset_path, timeout=1.0)

--- a/ts/src/data/imagesSync.ts
+++ b/ts/src/data/imagesSync.ts
@@ -115,8 +115,10 @@ async function downloadLarge(url: string, dest: string, timeoutMs = 1_800_000): 
     // resident; mirrors python's httpx.stream chunked write. fetchCascading
     // returns a real Response at runtime (FetchResponse omits body to stay
     // decoupled from DOM); Node 22's Uint8Array<ArrayBufferLike> generic makes
-    // Readable.fromWeb's type incompatible (runtime is fine), so cast via any.
-    const body = (res as any).body;
+    // FetchResponse omits body; narrow res via unknown instead of `any`
+    // (#100). Readable.fromWeb keeps a cast — Node 22's Uint8Array generic
+    // makes its parameter type incompatible (runtime is fine).
+    const body = (res as unknown as { body: ReadableStream | null }).body;
     if (body === null) throw new Error("download response body is null");
     await pipeline(Readable.fromWeb(body as any), createWriteStream(tmp));
     await rename(tmp, dest);

--- a/ts/src/data/imagesSync.ts
+++ b/ts/src/data/imagesSync.ts
@@ -113,11 +113,10 @@ async function downloadLarge(url: string, dest: string, timeoutMs = 1_800_000): 
     );
     // Stream the shard to disk so multi-hundred-MB baseline zips do not stay
     // resident; mirrors python's httpx.stream chunked write. fetchCascading
-    // returns a real Response at runtime (FetchResponse omits body to stay
-    // decoupled from DOM); Node 22's Uint8Array<ArrayBufferLike> generic makes
-    // FetchResponse omits body; narrow res via unknown instead of `any`
-    // (#100). Readable.fromWeb keeps a cast — Node 22's Uint8Array generic
-    // makes its parameter type incompatible (runtime is fine).
+    // returns a real Response at runtime but FetchResponse omits body to stay
+    // decoupled from DOM, so narrow res via unknown instead of `any` (#100).
+    // Readable.fromWeb still needs a cast — Node 22's Uint8Array generic makes
+    // its parameter type incompatible at compile time (runtime is fine).
     const body = (res as unknown as { body: ReadableStream | null }).body;
     if (body === null) throw new Error("download response body is null");
     await pipeline(Readable.fromWeb(body as any), createWriteStream(tmp));
@@ -254,11 +253,11 @@ function shardVariantNames(shardKeys: readonly string[]): Set<string> {
 }
 
 /** Verify each synced variant PNG matches its index sha256 (#100). */
-function verifyVariantHashes(
+async function verifyVariantHashes(
   staging: string,
   index: ImagesIndex,
   shardKeys: readonly string[],
-): void {
+): Promise<void> {
   const wanted = shardVariantNames(shardKeys);
   let checked = 0;
   let mismatches = 0;
@@ -266,8 +265,16 @@ function verifyVariantHashes(
     for (const [vname, variant] of Object.entries(entry.variants)) {
       if (!variant || !wanted.has(vname)) continue;
       const pngPath = join(staging, variant.file);
-      if (!existsSync(pngPath)) continue;
-      const actual = createHash("sha256").update(readFileSync(pngPath)).digest("hex");
+      if (!existsSync(pngPath)) {
+        // Incomplete shard: a wanted variant's file is absent.
+        mismatches += 1;
+        checked += 1;
+        if (mismatches <= 3) {
+          log("WARN", `images sha256 mismatch: ${skinId}/${vname} file missing: ${variant.file}`);
+        }
+        continue;
+      }
+      const actual = createHash("sha256").update(await readFile(pngPath)).digest("hex");
       checked += 1;
       if (actual !== variant.sha256) {
         mismatches += 1;
@@ -395,7 +402,7 @@ async function syncImagesLocked(
 
     // Verify every synced variant's sha256 against the index before
     // activation (#100): a corrupted or tampered shard must not activate.
-    verifyVariantHashes(staging, index, shardKeys);
+    await verifyVariantHashes(staging, index, shardKeys);
 
     // Authoritative index.json + generation meta.
     await writeFile(join(staging, "index.json"), indexBytes);

--- a/ts/src/data/imagesSync.ts
+++ b/ts/src/data/imagesSync.ts
@@ -14,12 +14,12 @@
  */
 
 import { createHash, randomUUID } from "node:crypto";
-import { createWriteStream, readFileSync, statSync } from "node:fs";
+import { createWriteStream, existsSync, readFileSync, statSync } from "node:fs";
 import { cp, mkdir, readFile, readdir, rename, rm, stat, unlink, writeFile } from "node:fs/promises";
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import { SCHEMA_VERSION, parseIndex } from "./images.js";
+import { SCHEMA_VERSION, parseIndex, type ImagesIndex } from "./images.js";
 import {
   assetUrl,
   fetchCascading,
@@ -247,6 +247,39 @@ async function offlineOrNoData(imageDir: string, error: string): Promise<SyncRes
   return { spec, status: "no_data", commitSha: null, error };
 }
 
+function shardVariantNames(shardKeys: readonly string[]): Set<string> {
+  return new Set(shardKeys.map((k) => k.split("-").pop()!));
+}
+
+/** Verify each synced variant PNG matches its index sha256 (#100). */
+function verifyVariantHashes(
+  staging: string,
+  index: ImagesIndex,
+  shardKeys: readonly string[],
+): void {
+  const wanted = shardVariantNames(shardKeys);
+  let checked = 0;
+  let mismatches = 0;
+  for (const [skinId, entry] of Object.entries(index.artworks)) {
+    for (const [vname, variant] of Object.entries(entry.variants)) {
+      if (!variant || !wanted.has(vname)) continue;
+      const pngPath = join(staging, variant.file);
+      if (!existsSync(pngPath)) continue;
+      const actual = createHash("sha256").update(readFileSync(pngPath)).digest("hex");
+      checked += 1;
+      if (actual !== variant.sha256) {
+        mismatches += 1;
+        if (mismatches <= 3) {
+          log("WARN", `images sha256 mismatch: ${skinId}/${vname} expected ${variant.sha256.slice(0, 12)} got ${actual.slice(0, 12)}`);
+        }
+      }
+    }
+  }
+  if (mismatches) {
+    throw new Error(`images sha256 verification failed: ${mismatches} of ${checked} variants mismatch`);
+  }
+}
+
 async function syncImagesLocked(
   imageDir: string,
   shardKeys: readonly string[],
@@ -357,6 +390,10 @@ async function syncImagesLocked(
       await safeExtractZip(deltaZip, staging);
       await unlink(deltaZip).catch(() => undefined);
     }
+
+    // Verify every synced variant's sha256 against the index before
+    // activation (#100): a corrupted or tampered shard must not activate.
+    verifyVariantHashes(staging, index, shardKeys);
 
     // Authoritative index.json + generation meta.
     await writeFile(join(staging, "index.json"), indexBytes);

--- a/ts/src/data/sync.ts
+++ b/ts/src/data/sync.ts
@@ -185,8 +185,13 @@ export async function fetchCascading(
         candidates[i], options, AbortSignal.timeout(timeoutMs),
       );
       if (res.ok) return res;
+      // Direct 404 → asset confirmed absent; raise typed so manifest
+      // verification can skip without fail-open on a mirror 404 (#100).
+      if (i === 0 && res.status === 404) {
+        throw new AssetNotFoundError(`HTTP 404: ${candidates[i]}`);
+      }
       lastErr = new Error(`HTTP ${res.status}`);
-      // Direct 4xx → the resource does not exist; mirrors cannot help.
+      // Other direct 4xx → the resource does not exist; mirrors cannot help.
       if (i === 0 && res.status >= 400 && res.status < 500) break;
     } catch (err) {
       lastErr = err;
@@ -197,6 +202,19 @@ export async function fetchCascading(
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * The direct release URL returned 404 — the asset genuinely does not exist.
+ * Distinguished from a mirror 404 (mirror lacks the asset; the release may
+ * still exist upstream) so manifest verification skips only on a confirmed
+ * upstream 404 and stays fail-closed otherwise (#100).
+ */
+export class AssetNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AssetNotFoundError";
+  }
 }
 
 function cacheIsFresh(cache: CacheMeta): boolean {
@@ -457,7 +475,8 @@ async function verifyReleaseManifest(
       manifestUrl, { headers: githubHeaders(), redirect: "follow" }, timeoutMs,
     );
   } catch (err) {
-    if (errorMessage(err).includes("HTTP 404")) return;
+    // Direct URL confirmed 404 → release predates the manifest asset.
+    if (err instanceof AssetNotFoundError) return;
     throw new Error(`manifest unavailable for ${tag}: ${errorMessage(err)}`);
   }
   let manifest: unknown;

--- a/ts/src/data/sync.ts
+++ b/ts/src/data/sync.ts
@@ -185,10 +185,12 @@ export async function fetchCascading(
         candidates[i], options, AbortSignal.timeout(timeoutMs),
       );
       if (res.ok) return res;
-      // Direct 404 → asset confirmed absent; raise typed so manifest
-      // verification can skip without fail-open on a mirror 404 (#100).
+      // Direct 404 → asset confirmed absent; record the typed error and stop
+      // without trying mirrors. lastErr + break (not throw) so the typed
+      // error survives to the caller even with GITHUB_MIRRORS (#100).
       if (i === 0 && res.status === 404) {
-        throw new AssetNotFoundError(`HTTP 404: ${candidates[i]}`);
+        lastErr = new AssetNotFoundError(`HTTP 404: ${candidates[i]}`);
+        break;
       }
       lastErr = new Error(`HTTP ${res.status}`);
       // Other direct 4xx → the resource does not exist; mirrors cannot help.

--- a/ts/src/startupSync.ts
+++ b/ts/src/startupSync.ts
@@ -46,6 +46,21 @@ function shouldRetrySync(status: string): boolean {
   return status === "offline_fallback" || status === "no_data";
 }
 
+/**
+ * Decide whether the gamedata pair sync warrants a dense retry (#102).
+ *
+ * A generation (commitSha) mismatch alone must NOT trigger dense retries
+ * (30s/120s/600s): when both archives are up-to-date, divergent commitShas
+ * are stale local metadata, not missing data, and the next periodic cycle
+ * resolves it. Only offline_fallback / no_data retry immediately.
+ */
+export function gamedataPairNeedsRetry(
+  excelStatus: string,
+  levelsStatus: string,
+): boolean {
+  return shouldRetrySync(excelStatus) || shouldRetrySync(levelsStatus);
+}
+
 async function singleFlightSync(label: string, runSync: () => Promise<boolean>): Promise<SyncRunResult> {
   if (syncInFlight.has(label)) {
     log("INFO", `${label} sync is already running; skipping overlapping attempt.`);
@@ -150,9 +165,7 @@ export async function runStartupSync(forceCheck = false): Promise<void> {
         clearStageEnemyCaches();
         clearSearchCaches();
       }
-      return shouldRetrySync(r.status)
-        || shouldRetrySync(levelsResult.status)
-        || !sameGeneration;
+      return gamedataPairNeedsRetry(r.status, levelsResult.status);
     };
 
     startupTasks.push(

--- a/ts/tests/autoSync.test.ts
+++ b/ts/tests/autoSync.test.ts
@@ -1,9 +1,22 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
+  gamedataPairNeedsRetry,
   resolveAutoSyncIntervalMs,
   runAutoSyncLoop,
 } from "../src/startupSync.ts";
+
+test("#102: gamedata pair does not retry when both archives are up-to-date", () => {
+  assert.equal(gamedataPairNeedsRetry("up_to_date", "up_to_date"), false);
+  assert.equal(gamedataPairNeedsRetry("updated", "up_to_date"), false);
+  assert.equal(gamedataPairNeedsRetry("up_to_date", "updated"), false);
+});
+
+test("gamedata pair retries only on offline_fallback or no_data", () => {
+  assert.equal(gamedataPairNeedsRetry("no_data", "up_to_date"), true);
+  assert.equal(gamedataPairNeedsRetry("up_to_date", "offline_fallback"), true);
+  assert.equal(gamedataPairNeedsRetry("offline_fallback", "no_data"), true);
+});
 
 function flushPromises(): Promise<void> {
   return new Promise((resolve) => setImmediate(resolve));

--- a/ts/tests/sync.test.ts
+++ b/ts/tests/sync.test.ts
@@ -20,9 +20,20 @@ import {
   syncReleaseArchive,
   syncReleaseArchivePair,
   withArchiveActivationLock,
+  fetchCascading,
+  AssetNotFoundError,
   type ReleaseArchiveSpec,
   type ReleaseSpec,
 } from "../src/data/sync.ts";
+
+test("fetchCascading raises AssetNotFoundError on a direct 404 (#100)", async () => {
+  await withFetchMock((async () => new Response("missing", { status: 404 })) as typeof fetch, async () => {
+    await assert.rejects(
+      fetchCascading("https://example.com/asset", {}, 1000),
+      (err: unknown) => err instanceof AssetNotFoundError,
+    );
+  });
+});
 
 test("downloadReleaseAsset verifies the optional factory manifest", async () => {
   const spec = { ...tempSpec(), verifyManifest: true };


### PR DESCRIPTION
## Summary

2.5.0 发布后的 correctness 与质量修复批次,5 个 commit。作为 2.5.1 patch(版本号 + CHANGELOG 留到 `release/v2.5.1` 阶段按路径 D 处理)。

1. **`fix(sync): skip dense gamedata retry on generation mismatch (#102)** — 双 archive 均 `up_to_date` 时 commitSha 漂移不再触发 30s/120s/600s 密集重试;提取 `gamedataPairNeedsRetry`(TS)/ `_gamedata_pair_needs_retry`(Python)做重试决策,`sameGeneration` 只保留用于清缓存;双实现回归测试
2. **`chore(ci): migrate GitHub Actions to Node 24 runtime (#101)** — checkout/setup-node/setup-python @v7,cache @v6,setup-uv @v7,login-action @v4,action-gh-release @v3;保留 setup-bun@v2 与 pypi-publish;不改 inputs/权限/缓存键
3. **`fix(sync): verify release manifest by status, not string match (#100)** — 新增 `_AssetNotFoundError`/`AssetNotFoundError`(direct URL i=0 返回 404 时抛),manifest 校验只对它跳过;镜像 404(普通 `Error("HTTP 404")`)不再 fail-open;双实现 + 回归测试(direct 404 skip / mirror 404 fail-closed)
4. **`fix(images): verify shard sha256 against index on activation (#100)** — `LOCAL_IMAGE=true` 的 shard PNG 解压后校验 sha256,不匹配拒绝激活;`parse_index` 已强制每 variant 带 sha256,无降级路径;Python 单元测试覆盖匹配/不匹配,TS 靠 typecheck + 共享算法 parity
5. **`refactor: address 2.5.0 CR code-quality findings (#100)** — 7 个私有符号公开化(与 TS 导出对齐);`_mcp_server.version` 加 `PackageNotFoundError` 兜底 + 修复 FakeFastMCP/mcp.types stub(test_server_startup_sync 现已通过);删 tools_artwork dead code;imagesSync `(res as any).body` 部分窄化为 `as unknown`

## Test plan

- [ ] Python: `uv run --directory python --locked python -m pytest tests -q`(注:`test_server_startup_sync.py` 的 mcp stub 与 `test_images.py` 真实 mcp import 需隔离运行,不应同进程——这是预存的 stub 设计问题,非本 PR 引入)
- [ ] TS: `cd ts && npm run build && npm test && npm run typecheck`
- [x] 本地已验证各 commit 的针对性测试:autoSync / sync / images_sync / server_startup_sync / artwork_mediawiki 全绿,TS typecheck 绿
- [ ] `./scripts/check-runtime.sh --full`(待 CI)

## 未尽事宜

- **#90 instrumentation 推迟到 2.6.0-alpha.1**(见 #104):各数据模块 cacheStats + `/debug/cache` 端点,作为 2.6.0 优化的前提观测工具
- **标签映射去重**(#100 nit)推迟:两份 `{"1": "精英零立绘", "2": "精英二立绘"}` 重复,价值低,收敛会引入跨模块依赖
- **LTS 回流**(#103):#100 的 manifest 404 + images sha256 候选回流 `lts/1.7`,待本 PR 落地后核实 1.7 适用性(images_sync 是 2.5.0 新增,1.7 大概率无)
- **生产 cgroup `MemoryHigh`/`MemoryMax`**:部署侧止血,独立于版本(见 #104)

## 关联

- Closes #102
- Closes #101
- Refs #100(should-fix + 多数 nits 已做;标签去重推迟)
- Refs #90(调研结论已评论;instrumentation 见 #104)
- Refs #103(LTS 回流备忘)· Refs #104(instrumentation 推迟备忘)