### PR TITLE
chore(release): open v2.6.0 development

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,8 +6,8 @@ _Last updated: 2026-08-07_
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 2.5.1 | Stable |
-| TypeScript | 2.5.1 | Stable |
+| Python | 2.6.0.dev0 | Development |
+| TypeScript | 2.6.0-dev.0 | Development |
 
 - 当前稳定发布：2.5.1（24 个 MCP 工具）
 - 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.5.1] - 2026-08-07
 
 ### Fixed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.5.1"
+version = "2.6.0.dev0"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "prts-mcp"
-version = "2.5.1"
+version = "2.6.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.5.1] - 2026-08-07
 
 ### Fixed

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.5.1",
+  "version": "2.6.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.5.1",
+      "version": "2.6.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.5.1",
+  "version": "2.6.0-dev.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP + stdio)",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Restore the develop line to its pre-release state after the v2.5.1 patch release (#106 / #107). Closes the transitional version window flagged by KHPilot on #107.

- Version: `2.5.1` → `2.6.0.dev0` (Python) / `2.6.0-dev.0` (TS) — `pyproject.toml` + `uv.lock`, `package.json` + `package-lock.json`
- Reopen empty `## [Unreleased]` in both CHANGELOGs
- STATUS.md current-version table back to `2.6.0.dev0 / Development` (addresses #107 Bot NIT)

## Test plan

- [x] `uv lock` + `uv sync --locked` — environment synced at 2.6.0.dev0
- [ ] 双轨 CR
- [ ] CI green

## 未尽事宜

None. develop resumes normal 2.6.0 development after this merge.