### PR TITLE
docs: unwrap CHANGELOG entries to natural single lines

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -58,8 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- Added Streamable HTTP transport: `PRTS_TRANSPORT=http` starts a Starlette
-  + uvicorn server with `/mcp` endpoint, `/health` probe, and `HOST`/`PORT` env control (defaults `0.0.0.0:3000`). `stdio` remains the default. Breaks the 2.0 transport split — the Python implementation now supports both stdio and Streamable HTTP.
+- Added Streamable HTTP transport: `PRTS_TRANSPORT=http` starts a Starlette + uvicorn server with `/mcp` endpoint, `/health` probe, and `HOST`/`PORT` env control (defaults `0.0.0.0:3000`). `stdio` remains the default. Breaks the 2.0 transport split — the Python implementation now supports both stdio and Streamable HTTP.
 - Added `test_e2e_http.py` covering HTTP health, initialize + tools/list, and env-only output_channel behavior.
 - Declared `starlette>=0.27` and `uvicorn>=0.31` as explicit dependencies (previously transitive via `mcp[cli]`).
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -10,24 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
-- **Gamedata pair retry no longer fires on commit_sha mismatch.** When both
-  the excel and levels archives are up-to-date but carry divergent
-  `commit_sha` values (stale local metadata, not missing data), the sync no
-  longer schedules dense 30s/120s/600s retries. The next periodic cycle
-  resolves the metadata drift; only `offline_fallback` / `no_data` statuses
-  trigger retries.
-- **Release manifest 404 handling.** When a mirror confirms a release has no
-  `manifest.json` via HTTP 404, the sync skips that mirror cleanly instead of
-  letting a later mirror's generic network 404 overwrite the explicit absence
-  signal. A new `_AssetNotFoundError` distinguishes "this release genuinely
-  has no manifest" from "we couldn't reach this mirror".
-- **Image shard sha256 verification.** After downloading AKDP image shards,
-  the sync verifies each wanted variant's sha256 before activation. A missing
-  PNG for a wanted variant counts as a mismatch and blocks activation
-  (previously silently skipped).
-- **MCP `initialize` version handshake fallback.** When package metadata is
-  unavailable (e.g. running from source without install), the handshake
-  reports `0.0.0` instead of crashing on `PackageNotFoundError`.
+- **Gamedata pair retry no longer fires on commit_sha mismatch.** When both the excel and levels archives are up-to-date but carry divergent `commit_sha` values (stale local metadata, not missing data), the sync no longer schedules dense 30s/120s/600s retries. The next periodic cycle resolves the metadata drift; only `offline_fallback` / `no_data` statuses trigger retries.
+- **Release manifest 404 handling.** When a mirror confirms a release has no `manifest.json` via HTTP 404, the sync skips that mirror cleanly instead of letting a later mirror's generic network 404 overwrite the explicit absence signal. A new `_AssetNotFoundError` distinguishes "this release genuinely has no manifest" from "we couldn't reach this mirror".
+- **Image shard sha256 verification.** After downloading AKDP image shards, the sync verifies each wanted variant's sha256 before activation. A missing PNG for a wanted variant counts as a mismatch and blocks activation (previously silently skipped).
+- **MCP `initialize` version handshake fallback.** When package metadata is unavailable (e.g. running from source without install), the handshake reports `0.0.0` instead of crashing on `PackageNotFoundError`.
 
 ### Changed
 
@@ -37,259 +23,100 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- New `operator_artwork` tool (enabled by default). `action="list"` returns
-  bounded metadata with semantic labels; `action="get"` returns one image as
-  base64 `ImageContent` (default `large` variant, max 1024px). Default mode
-  (`LOCAL_IMAGE=false`) fetches on-demand from PRTS MediaWiki under the full
-  #85 security boundary (hostname/MIME/magic/1MiB/streaming/redirect) with a
-  256 MiB LRU cache (`PRTS_IMAGE_CACHE=true`). Set `LOCAL_IMAGE=true` to sync
-  ~1.5 GB of AKDP local PNG assets; `ORIGINAL_IMAGE=true` adds full-resolution
-  shards. MediaWiki labels via CharinfoV2 `时装N名称`; AKDP labels via
-  `skin_table.json`. The `original` variant is rejected in MediaWiki mode
-  (PRTS originals exceed the 1 MiB cap). Tool surface 23 → 24.
+- New `operator_artwork` tool (enabled by default). `action="list"` returns bounded metadata with semantic labels; `action="get"` returns one image as base64 `ImageContent` (default `large` variant, max 1024px). Default mode (`LOCAL_IMAGE=false`) fetches on-demand from PRTS MediaWiki under the full #85 security boundary (hostname/MIME/magic/1MiB/streaming/redirect) with a 256 MiB LRU cache (`PRTS_IMAGE_CACHE=true`). Set `LOCAL_IMAGE=true` to sync ~1.5 GB of AKDP local PNG assets; `ORIGINAL_IMAGE=true` adds full-resolution shards. MediaWiki labels via CharinfoV2 `时装N名称`; AKDP labels via `skin_table.json`. The `original` variant is rejected in MediaWiki mode (PRTS originals exceed the 1 MiB cap). Tool surface 23 → 24.
 
 ### Changed
 
-- **Auto-sync data source switched to self-hosted `arknights-data-pipeline`.**
-  The default sync now consumes `zh_CN-excel.zip`, `zh_CN-levels.zip`, and
-  story `zh_CN.zip` Releases from `3aKHP/arknights-data-pipeline` (the factory
-  repo). The legacy upstream repos are no longer data dependencies on the
-  2.5.0 line. Release manifest verification tightened so a partial or corrupt
-  archive cannot be treated as healthy data.
+- **Auto-sync data source switched to self-hosted `arknights-data-pipeline`.** The default sync now consumes `zh_CN-excel.zip`, `zh_CN-levels.zip`, and story `zh_CN.zip` Releases from `3aKHP/arknights-data-pipeline` (the factory repo). The legacy upstream repos are no longer data dependencies on the 2.5.0 line. Release manifest verification tightened so a partial or corrupt archive cannot be treated as healthy data.
 
 ### Fixed
 
-- **Data sync uses tag-prefix filtering instead of `/releases/latest`.** The
-  `arknights-data-pipeline` repo now hosts both `data-*` and `images-*` GitHub
-  Releases. `check_latest_release` switched from the `/releases/latest`
-  endpoint to the releases list API with `data-` tag-prefix filtering,
-  preventing silent sync stalls if GitHub auto-promotes an `images-*` release
-  to "Latest". Shared `_list_releases` / `_latest_release_by_prefix` /
-  `_asset_url` helpers were lifted from `images_sync` into `sync` to avoid
-  duplication.
-- **Product version reported in MCP `initialize` handshake.** The server now
-  reports its actual package version via `importlib.metadata` instead of an
-  empty placeholder, so MCP clients can display the correct version.
-- **`operator_artwork` allimages pagination.** MediaWiki `allimages` now
-  paginates with `aifrom` continuation (50 per page) to avoid silent
-  truncation when an operator has more than 50 skin images.
+- **Data sync uses tag-prefix filtering instead of `/releases/latest`.** The `arknights-data-pipeline` repo now hosts both `data-*` and `images-*` GitHub Releases. `check_latest_release` switched from the `/releases/latest` endpoint to the releases list API with `data-` tag-prefix filtering, preventing silent sync stalls if GitHub auto-promotes an `images-*` release to "Latest". Shared `_list_releases` / `_latest_release_by_prefix` / `_asset_url` helpers were lifted from `images_sync` into `sync` to avoid duplication.
+- **Product version reported in MCP `initialize` handshake.** The server now reports its actual package version via `importlib.metadata` instead of an empty placeholder, so MCP clients can display the correct version.
+- **`operator_artwork` allimages pagination.** MediaWiki `allimages` now paginates with `aifrom` continuation (50 per page) to avoid silent truncation when an operator has more than 50 skin images.
 
 ## [2.4.0] - 2026-07-29
 
 ### Fixed
 
-- Capped the MCP Python SDK below 2.0 so Docker and other unlocked `pip`
-  installs retain the compatible `mcp.server.fastmcp` API.
+- Capped the MCP Python SDK below 2.0 so Docker and other unlocked `pip` installs retain the compatible `mcp.server.fastmcp` API.
 
 ### Added
 
-- Added process-lifetime auto-sync: after the startup check, GameData excel,
-  GameData levels, and StoryJson Releases are checked hourly without a service
-  restart. `PRTS_AUTO_SYNC_INTERVAL_SECONDS` configures the interval or keeps
-  startup-only behavior with `0`.
-- Added archive activation metadata so an interrupted extraction is retried on
-  the next cycle before the downloaded Release is treated as active.
-- GameData excel and levels now become visible as one atomic generation, so
-  tools never observe a mixed old/new pair while a periodic update is running.
-- Shared-volume publication locks now renew their lease while held, preventing
-  long downloads or extraction work from being mistaken for abandoned locks.
+- Added process-lifetime auto-sync: after the startup check, GameData excel, GameData levels, and StoryJson Releases are checked hourly without a service restart. `PRTS_AUTO_SYNC_INTERVAL_SECONDS` configures the interval or keeps startup-only behavior with `0`.
+- Added archive activation metadata so an interrupted extraction is retried on the next cycle before the downloaded Release is treated as active.
+- GameData excel and levels now become visible as one atomic generation, so tools never observe a mixed old/new pair while a periodic update is running.
+- Shared-volume publication locks now renew their lease while held, preventing long downloads or extraction work from being mistaken for abandoned locks.
 
 ## [2.3.1] - 2026-07-10
 
 ### Changed
 
-- Kept the Python package version aligned with the TypeScript 2.3.1 security
-  update.
+- Kept the Python package version aligned with the TypeScript 2.3.1 security update.
 
 ## [2.3.0] - 2026-07-08
 
 ### Added
 
 - Added Streamable HTTP transport: `PRTS_TRANSPORT=http` starts a Starlette
-  + uvicorn server with `/mcp` endpoint, `/health` probe, and `HOST`/`PORT`
-  env control (defaults `0.0.0.0:3000`). `stdio` remains the default.
-  Breaks the 2.0 transport split — the Python implementation now supports
-  both stdio and Streamable HTTP.
-- Added `test_e2e_http.py` covering HTTP health, initialize + tools/list,
-  and env-only output_channel behavior.
-- Declared `starlette>=0.27` and `uvicorn>=0.31` as explicit dependencies
-  (previously transitive via `mcp[cli]`).
+  + uvicorn server with `/mcp` endpoint, `/health` probe, and `HOST`/`PORT` env control (defaults `0.0.0.0:3000`). `stdio` remains the default. Breaks the 2.0 transport split — the Python implementation now supports both stdio and Streamable HTTP.
+- Added `test_e2e_http.py` covering HTTP health, initialize + tools/list, and env-only output_channel behavior.
+- Declared `starlette>=0.27` and `uvicorn>=0.31` as explicit dependencies (previously transitive via `mcp[cli]`).
 
 ### Changed
 
-- Refactored `OUTPUT_CHANNEL` from a module-level constant to a
-  `contextvars.ContextVar`, paving the way for transport-level overrides.
-  Tool code is unchanged; `render_result` resolves the channel via
-  `get_output_channel()` at call time. **Note**: Python HTTP
-  output_channel is currently process-level (env-only) — FastMCP's session
-  model makes per-request contextvars invisible to tool code. The
-  TypeScript HTTP transport supports per-request resolution.
+- Refactored `OUTPUT_CHANNEL` from a module-level constant to a `contextvars.ContextVar`, paving the way for transport-level overrides. Tool code is unchanged; `render_result` resolves the channel via `get_output_channel()` at call time. **Note**: Python HTTP output_channel is currently process-level (env-only) — FastMCP's session model makes per-request contextvars invisible to tool code. The TypeScript HTTP transport supports per-request resolution.
 
 ## [2.2.0] - 2026-07-08
 
 ### Changed
 
-- No user-facing Python changes. This release keeps the Python package version
-  aligned with the 2.2.0 repository release (TypeScript default-runtime flip).
+- No user-facing Python changes. This release keeps the Python package version aligned with the 2.2.0 repository release (TypeScript default-runtime flip).
 
 ## [2.1.0] - 2026-07-07
 
 ### Changed
 
-- No user-facing Python changes. This release keeps the Python package version
-  aligned with the 2.1.0 repository release.
+- No user-facing Python changes. This release keeps the Python package version aligned with the 2.1.0 repository release.
 
 ## [2.0.2] - 2026-07-07
 
 ### Fixed
 
-- `search_prts` now resolves redirect-like PRTS Wiki search hits to their
-  target page when the search response lacks redirect metadata, while falling
-  back to the original result if the follow-up lookup fails.
-- `search_prts` filters technical/wiki implementation pages more precisely
-  and keeps `totalhits` stable even when visible results are filtered out.
+- `search_prts` now resolves redirect-like PRTS Wiki search hits to their target page when the search response lacks redirect metadata, while falling back to the original result if the follow-up lookup fails.
+- `search_prts` filters technical/wiki implementation pages more precisely and keeps `totalhits` stable even when visible results are filtered out.
 
 ## [2.0.1] - 2026-07-03
 
 ### Fixed
 
-- `list_story_events` no longer emits a spurious `structuredContent` wrapper
-  when story data is not yet available, matching the other eight story tools
-  (which already delivered the missing-data message as content-only text).
+- `list_story_events` no longer emits a spurious `structuredContent` wrapper when story data is not yet available, matching the other eight story tools (which already delivered the missing-data message as content-only text).
 
 ## [2.0.0] - 2026-07-03
 
 ### Added
 
-- **Output channel design replaces the per-call `output_format` parameter
-  (2.0 design decision).** The original roadmap proposed an optional
-  `output_format=markdown|json` parameter with 2.0 flipping the default to
-  `json`. **That shape was rejected during design.** The primary consumer is an
-  LLM agent, and JSON inflates prompt tokens ~15–30% versus markdown — which
-  would negate the context-budget savings the tool-surface consolidation
-  delivers. 2.0 instead keeps markdown as the always-on `content` text and
-  carries structured data on MCP's native `structuredContent` field, selected
-  by a **connection-level** `output_channel` knob (`content` (default) /
-  `structured` / `both`) via the `PRTS_OUTPUT_CHANNEL` env var. The default is
-  **not** flipped to JSON. See [`docs/migration-1.x-to-2.0.md`](../docs/migration-1.x-to-2.0.md)
-  for the per-tool channel mapping and client configuration.
-- **Output channel (2.0).** Optional structured-content delivery via MCP's
-  native `structuredContent` channel, controlled by a connection-level
-  `PRTS_OUTPUT_CHANNEL` env var (`content` (default) / `structured` / `both`).
-  The default `content` channel preserves the human-readable markdown content
-  for clients that only consume MCP `content`. Migrated tools intentionally
-  change the MCP manifest/wire shape by replacing FastMCP's automatic
-  `outputSchema={result:string}` plus `structuredContent={"result": markdown}`
-  wrapper with explicit `CallToolResult` delivery, so capable clients no
-  longer receive duplicate markdown unless `both` is selected. `list_stages`
-  is the pilot tool; its `structuredContent` carries both raw enums (e.g.
-  `type=ACTIVITY`) and rendered labels (`type_label=活动`), and legitimate empty
-  pages (filter no-match / offset past end) return structured empty payloads
-  while preserving the original markdown text. The remaining structural tools
-  and the TypeScript implementation follow in subsequent commits. Note:
-  `structured` mode is intended for deployments known to use a
-  structuredContent-capable client — an incapable client (e.g. Chatbox)
-  receives only a one-line summary, so leave the default `content` unless the
-  client is confirmed capable.
-- **Narrative-tool wire slimming (2.0).** The six narrative/prose tools
-  (`get_operator_archives`, `get_operator_voicelines`, `read_story`,
-  `read_activity`, `get_story_summary`, `prts_page`) migrated from `-> str`
-  to explicit `CallToolResult` delivery via the new `text_result(markdown)`
-  helper. Their content text is unchanged, but they no longer derive
-  FastMCP's automatic `outputSchema` nor emit a duplicate
-  `structuredContent={"result": markdown}` — narrative output has no useful
-  structured form. The remaining structural tools keep their structured
-  payloads behind `output_channel`.
-- **Detail-tool structuredContent (2.0, P2b PR1).** The four detail tools
-  (`get_operator_basic_info`, `get_enemy_info`, `get_stage_info`,
-  `get_item_info`) migrated to the build/render split with real
-  `structuredContent` payloads. `render_result` gains an optional `summary`
-  override so detail tools (single-record, no `total`) can provide a
-  meaningful one-liner in `structured` mode instead of the generic fallback.
-  Their `structuredContent` carries both raw enums and rendered labels
-  (e.g. `profession_raw=CASTER` + `profession=术师`), so downstream
-  automation can filter on raw values while Chinese consumers get
-  localized text.
-  The list/fusion tools (`list_enemies`, `search`, …) and the `search`
-  consolidation follow in P2b PR2/PR3.
-- **Gamedata list/fusion structuredContent (2.0, P2b PR2a).** The four
-  gamedata list/fusion tools (`list_enemies`, `list_items`,
-  `get_stage_enemies`, `get_enemy_appearances`) migrated to the build/render
-  split with real structuredContent. Listing payloads carry pagination
-  metadata + filters (raw user input + normalized filter) + entries with
-  chainable IDs and raw/label field pairs; the fusion tool
-  (`get_stage_enemies`) carries per-enemy spawn counts, level, overwrite
-  flag, and stats text. **Empty-result contract**: legitimate-but-empty
-  results (filter no-match, offset past end) now return a structured
-  payload `{total:0, entries:[]}` that the structured channel carries,
-  while the content channel still emits the original human message
-  verbatim — so structured consumers can uniformly rely on
-  "empty ⇒ {total:0}". True errors (invalid params, missing data) stay
-  content-only. The story-list/wiki-search tools and the heterogeneous
-  `search` follow in P2b PR2b/PR3.
-- **Story navigation and wiki-search structuredContent (2.0, P2b PR2b).**
-  The six story/wiki navigation tools (`list_story_events`, `list_stories`,
-  `get_operator_memoirs`, `find_character_appearances`, `find_speakers_in`,
-  `search_prts`) migrated to explicit `CallToolResult` delivery with
-  build/render payloads. Story payloads carry chainable event/story IDs,
-  raw story entry tags, and boolean speaks/mentioned flags; `search_prts`
-  now exposes `total` as MediaWiki `totalhits`, which can exceed the returned
-  page of results. Legitimate empty results carry `{total:0}` on the
-  structured channel while preserving the existing markdown text; invalid
-  parameters, missing story data, and PRTS network failures remain content-only.
-- **Search structuredContent (2.0, P3).** The remaining Python search tools
-  (`search` and `search_stories`) migrated to explicit `CallToolResult`
-  delivery with structured search envelopes. `search` now returns a stable
-  outer envelope (`scope`, `pattern`, `total`, `results`) while keeping
-  scope-specific entries for operators, enemies, stages, and items; each entry
-  carries chainable IDs and the fields needed to re-render the existing
-  markdown cards. `search_stories` now exposes raw filters and structured
-  context lines with `is_match` flags plus `story_key` for follow-up reads.
-  Legitimate no-match searches carry `{total:0, results:[]}` on the structured
-  channel; invalid regexes, invalid filters, and missing data remain
-  content-only. The all-tool outputSchema invariant is left to the dedicated
-  PR4 test-layer follow-up.
+- **Output channel design replaces the per-call `output_format` parameter (2.0 design decision).** The original roadmap proposed an optional `output_format=markdown|json` parameter with 2.0 flipping the default to `json`. **That shape was rejected during design.** The primary consumer is an LLM agent, and JSON inflates prompt tokens ~15–30% versus markdown — which would negate the context-budget savings the tool-surface consolidation delivers. 2.0 instead keeps markdown as the always-on `content` text and carries structured data on MCP's native `structuredContent` field, selected by a **connection-level** `output_channel` knob (`content` (default) / `structured` / `both`) via the `PRTS_OUTPUT_CHANNEL` env var. The default is **not** flipped to JSON. See [`docs/migration-1.x-to-2.0.md`](../docs/migration-1.x-to-2.0.md) for the per-tool channel mapping and client configuration.
+- **Output channel (2.0).** Optional structured-content delivery via MCP's native `structuredContent` channel, controlled by a connection-level `PRTS_OUTPUT_CHANNEL` env var (`content` (default) / `structured` / `both`). The default `content` channel preserves the human-readable markdown content for clients that only consume MCP `content`. Migrated tools intentionally change the MCP manifest/wire shape by replacing FastMCP's automatic `outputSchema={result:string}` plus `structuredContent={"result": markdown}` wrapper with explicit `CallToolResult` delivery, so capable clients no longer receive duplicate markdown unless `both` is selected. `list_stages` is the pilot tool; its `structuredContent` carries both raw enums (e.g. `type=ACTIVITY`) and rendered labels (`type_label=活动`), and legitimate empty pages (filter no-match / offset past end) return structured empty payloads while preserving the original markdown text. The remaining structural tools and the TypeScript implementation follow in subsequent commits. Note: `structured` mode is intended for deployments known to use a structuredContent-capable client — an incapable client (e.g. Chatbox) receives only a one-line summary, so leave the default `content` unless the client is confirmed capable.
+- **Narrative-tool wire slimming (2.0).** The six narrative/prose tools (`get_operator_archives`, `get_operator_voicelines`, `read_story`, `read_activity`, `get_story_summary`, `prts_page`) migrated from `-> str` to explicit `CallToolResult` delivery via the new `text_result(markdown)` helper. Their content text is unchanged, but they no longer derive FastMCP's automatic `outputSchema` nor emit a duplicate `structuredContent={"result": markdown}` — narrative output has no useful structured form. The remaining structural tools keep their structured payloads behind `output_channel`.
+- **Detail-tool structuredContent (2.0, P2b PR1).** The four detail tools (`get_operator_basic_info`, `get_enemy_info`, `get_stage_info`, `get_item_info`) migrated to the build/render split with real `structuredContent` payloads. `render_result` gains an optional `summary` override so detail tools (single-record, no `total`) can provide a meaningful one-liner in `structured` mode instead of the generic fallback. Their `structuredContent` carries both raw enums and rendered labels (e.g. `profession_raw=CASTER` + `profession=术师`), so downstream automation can filter on raw values while Chinese consumers get localized text. The list/fusion tools (`list_enemies`, `search`, …) and the `search` consolidation follow in P2b PR2/PR3.
+- **Gamedata list/fusion structuredContent (2.0, P2b PR2a).** The four gamedata list/fusion tools (`list_enemies`, `list_items`, `get_stage_enemies`, `get_enemy_appearances`) migrated to the build/render split with real structuredContent. Listing payloads carry pagination metadata + filters (raw user input + normalized filter) + entries with chainable IDs and raw/label field pairs; the fusion tool (`get_stage_enemies`) carries per-enemy spawn counts, level, overwrite flag, and stats text. **Empty-result contract**: legitimate-but-empty results (filter no-match, offset past end) now return a structured payload `{total:0, entries:[]}` that the structured channel carries, while the content channel still emits the original human message verbatim — so structured consumers can uniformly rely on "empty ⇒ {total:0}". True errors (invalid params, missing data) stay content-only. The story-list/wiki-search tools and the heterogeneous `search` follow in P2b PR2b/PR3.
+- **Story navigation and wiki-search structuredContent (2.0, P2b PR2b).** The six story/wiki navigation tools (`list_story_events`, `list_stories`, `get_operator_memoirs`, `find_character_appearances`, `find_speakers_in`, `search_prts`) migrated to explicit `CallToolResult` delivery with build/render payloads. Story payloads carry chainable event/story IDs, raw story entry tags, and boolean speaks/mentioned flags; `search_prts` now exposes `total` as MediaWiki `totalhits`, which can exceed the returned page of results. Legitimate empty results carry `{total:0}` on the structured channel while preserving the existing markdown text; invalid parameters, missing story data, and PRTS network failures remain content-only.
+- **Search structuredContent (2.0, P3).** The remaining Python search tools (`search` and `search_stories`) migrated to explicit `CallToolResult` delivery with structured search envelopes. `search` now returns a stable outer envelope (`scope`, `pattern`, `total`, `results`) while keeping scope-specific entries for operators, enemies, stages, and items; each entry carries chainable IDs and the fields needed to re-render the existing markdown cards. `search_stories` now exposes raw filters and structured context lines with `is_match` flags plus `story_key` for follow-up reads. Legitimate no-match searches carry `{total:0, results:[]}` on the structured channel; invalid regexes, invalid filters, and missing data remain content-only. The all-tool outputSchema invariant is left to the dedicated PR4 test-layer follow-up.
 
 ### Changed
 
-- **Parameter naming normalization (2.0, breaking).** Operator tools
-  (`get_operator_archives`, `get_operator_voicelines`, `get_operator_basic_info`,
-  `get_operator_memoirs`) now take `name` instead of `operator_name`, matching
-  the `name` convention already used by the enemy/stage/item/character tools.
-- **Unified search (2.0, breaking).** `search_data`, `search_enemies`,
-  `search_stages`, and `search_items` are consolidated into a single
-  `search(scope, pattern, max_results)` tool with a required `scope` enum
-  (`operators` / `enemies` / `stages` / `items`). Story dialogue search remains a
-  separate `search_stories` (its filters differ). Tool surface drops 32 → 28.
-- **Unified PRTS page tool (2.0, breaking).** `read_prts_page`,
-  `list_prts_sections`, `get_prts_categories`, `get_prts_links`, and
-  `get_prts_template` are consolidated into a single `prts_page(page_title,
-  action, ...)` tool with a required `action` enum (`read` / `sections` /
-  `categories` / `links` / `template`). Wiki keyword search remains a separate
-  `search_prts`. Tool surface drops 28 → 24.
-- **`list_stories` absorbs the event-level summary (2.0, breaking).**
-  `list_stories(event_id, include_summaries=True)` now prepends the event's LLM
-  overview (from `event_summaries.json`) when present, on top of the per-chapter
-  one-liners it already returned — making it a superset of the former
-  `get_event_summary`. Tool surface drops 24 → 23.
-- **Tool descriptions standardized (2.0).** All tool descriptions were rewritten
-  to a consistent house style (verb-first purpose, output-shape note, at most one
-  cross-reference, parameter semantics kept in the parameter schema) and trimmed
-  ~20% to reduce context budget on smaller-context models. No change to tool
-  names, parameters, or output format.
+- **Parameter naming normalization (2.0, breaking).** Operator tools (`get_operator_archives`, `get_operator_voicelines`, `get_operator_basic_info`, `get_operator_memoirs`) now take `name` instead of `operator_name`, matching the `name` convention already used by the enemy/stage/item/character tools.
+- **Unified search (2.0, breaking).** `search_data`, `search_enemies`, `search_stages`, and `search_items` are consolidated into a single `search(scope, pattern, max_results)` tool with a required `scope` enum (`operators` / `enemies` / `stages` / `items`). Story dialogue search remains a separate `search_stories` (its filters differ). Tool surface drops 32 → 28.
+- **Unified PRTS page tool (2.0, breaking).** `read_prts_page`, `list_prts_sections`, `get_prts_categories`, `get_prts_links`, and `get_prts_template` are consolidated into a single `prts_page(page_title, action, ...)` tool with a required `action` enum (`read` / `sections` / `categories` / `links` / `template`). Wiki keyword search remains a separate `search_prts`. Tool surface drops 28 → 24.
+- **`list_stories` absorbs the event-level summary (2.0, breaking).** `list_stories(event_id, include_summaries=True)` now prepends the event's LLM overview (from `event_summaries.json`) when present, on top of the per-chapter one-liners it already returned — making it a superset of the former `get_event_summary`. Tool surface drops 24 → 23.
+- **Tool descriptions standardized (2.0).** All tool descriptions were rewritten to a consistent house style (verb-first purpose, output-shape note, at most one cross-reference, parameter semantics kept in the parameter schema) and trimmed ~20% to reduce context budget on smaller-context models. No change to tool names, parameters, or output format.
 
 ### Removed
 
-- **`search_data`, `search_enemies`, `search_stages`, `search_items`,
-  `list_search_scopes` (2.0, breaking).** Replaced by unified `search(scope, ...)`;
-  the scope catalogue previously returned by `list_search_scopes` is folded into
-  the `search` tool description.
-- **`read_prts_page`, `list_prts_sections`, `get_prts_categories`,
-  `get_prts_links`, `get_prts_template` (2.0, breaking).** Replaced by unified
-  `prts_page(page_title, action, ...)`.
-- **`get_event_summary` (2.0, breaking).** Folded into
-  `list_stories(include_summaries=True)`; `get_story_summary` (single-chapter
-  deep summary) is unchanged.
+- **`search_data`, `search_enemies`, `search_stages`, `search_items`, `list_search_scopes` (2.0, breaking).** Replaced by unified `search(scope, ...)`; the scope catalogue previously returned by `list_search_scopes` is folded into the `search` tool description.
+- **`read_prts_page`, `list_prts_sections`, `get_prts_categories`, `get_prts_links`, `get_prts_template` (2.0, breaking).** Replaced by unified `prts_page(page_title, action, ...)`.
+- **`get_event_summary` (2.0, breaking).** Folded into `list_stories(include_summaries=True)`; `get_story_summary` (single-chapter deep summary) is unchanged.
 
 ## [1.7.0] - 2026-07-02
 
@@ -297,275 +124,149 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- **Story character tracking.** Two new tools reuse the existing story search
-  index (no new data source): `find_character_appearances(name, scope?,
-  max_events?)` returns chapters where a character **speaks** (dialog role
-  exact match) or is **mentioned** (name substring in any line text);
-  `find_speakers_in(event_id)` lists every speaker in an event with dialog
-  line counts. Brings the tool surface to 32.
+- **Story character tracking.** Two new tools reuse the existing story search index (no new data source): `find_character_appearances(name, scope?, max_events?)` returns chapters where a character **speaks** (dialog role exact match) or is **mentioned** (name substring in any line text); `find_speakers_in(event_id)` lists every speaker in an event with dialog line counts. Brings the tool surface to 32.
 
 ### Changed
 
-- **Module split: story and server god files.** `data/story.py` (916 lines) and
-  `server.py` (914 lines) were split into focused submodules to meet the
-  STYLE.md file-size guideline (~300 lines). `story.py` is now a re-export shim
-  over `story_reader`, `story_search`, `story_memoir`, and `story_summary`.
-  `server.py` is now a ~60-line entry point that delegates tool registration to
-  `tools_prts`, `tools_gamedata`, and `tools_story`, and sync orchestration to
-  `startup_sync`. All public symbols are re-exported — no behaviour change.
-- **Dead code removal in sync.** The original GitHub raw file sync path
-  (`sync_repo`, `download_files`, `check_upstream_sha`, `sync_all`) had no
-  external callers and has been removed. `sync.py` shrank from 626 to 479 lines.
-  Shared symbols (`CacheMeta`, `SyncResult`, `RepoSpec`, `GAMEDATA_FILES`)
-  are retained for the Release-based sync path.
+- **Module split: story and server god files.** `data/story.py` (916 lines) and `server.py` (914 lines) were split into focused submodules to meet the STYLE.md file-size guideline (~300 lines). `story.py` is now a re-export shim over `story_reader`, `story_search`, `story_memoir`, and `story_summary`. `server.py` is now a ~60-line entry point that delegates tool registration to `tools_prts`, `tools_gamedata`, and `tools_story`, and sync orchestration to `startup_sync`. All public symbols are re-exported — no behaviour change.
+- **Dead code removal in sync.** The original GitHub raw file sync path (`sync_repo`, `download_files`, `check_upstream_sha`, `sync_all`) had no external callers and has been removed. `sync.py` shrank from 626 to 479 lines. Shared symbols (`CacheMeta`, `SyncResult`, `RepoSpec`, `GAMEDATA_FILES`) are retained for the Release-based sync path.
 
 ## [1.6.1] - 2026-06-03
 
 ### Added
 
-- **Operator memoir discovery.** New `get_operator_memoirs(operator_name)` tool
-  resolves operator Chinese name to memoir story keys via `chardict.json`,
-  enabling LLM agents to find and read operator memoir (干员密录) dialogue.
-- This new tool is treated as a one-off patch-line exception because it exposes
-  story data that already existed in the synced StoryJson archive but was not
-  discoverable through the public tool surface.
-- `list_story_events(category="memoirs")` now exposes 372 previously hidden
-  operator memoir events.
+- **Operator memoir discovery.** New `get_operator_memoirs(operator_name)` tool resolves operator Chinese name to memoir story keys via `chardict.json`, enabling LLM agents to find and read operator memoir (干员密录) dialogue.
+- This new tool is treated as a one-off patch-line exception because it exposes story data that already existed in the synced StoryJson archive but was not discoverable through the public tool surface.
+- `list_story_events(category="memoirs")` now exposes 372 previously hidden operator memoir events.
 - Operator memoir dialogue is now indexed by `search_stories`.
 
 ### Changed
 
-- Search tools backed by local game/story data now reuse cached search records
-  instead of rebuilding parsed text on every call, substantially improving
-  repeated full-story and full-table regex searches.
+- Search tools backed by local game/story data now reuse cached search records instead of rebuilding parsed text on every call, substantially improving repeated full-story and full-table regex searches.
 - Enemy search records now include `enemyTags` in searchable text.
 
 ### Fixed
 
-- Story search now caps `max_results` and `context_lines` consistently to
-  prevent oversized MCP responses from long-running full-dataset searches.
-- `search_stages` and `search_items` now enforce `max_results` bounds (1–100)
-  for parity with other search tools.
-- `list_story_events` and `search_stories` no longer ignore entries with
-  `entryType: "NONE"` when those entries have valid story data (was the
-  root cause of memoirs being undiscoverable).
+- Story search now caps `max_results` and `context_lines` consistently to prevent oversized MCP responses from long-running full-dataset searches.
+- `search_stages` and `search_items` now enforce `max_results` bounds (1–100) for parity with other search tools.
+- `list_story_events` and `search_stories` no longer ignore entries with `entryType: "NONE"` when those entries have valid story data (was the root cause of memoirs being undiscoverable).
 
 ## [1.6.0] - 2026-05-28
 
 ### Added
 
-- **Item/material data domain.** Three new tools — `list_items`,
-  `get_item_info`, and `search_items` — read `item_table.json` to expose
-  material/item lists, details, obtain methods, stage drops, production, and
-  shop/voucher links.
-- **Stage/enemy cross-source fusion.** Added `get_stage_enemies(stage_id)` and
-  `get_enemy_appearances(name, limit, offset)` backed by `zh_CN-levels.zip`.
-  `get_enemy_info(name)` now accepts optional `stage_id` for stage-specific
-  enemy levels and overwritten combat stats while preserving the default
-  handbook behavior.
-- Tool surface expanded from 24 to 29. `list_search_scopes` now includes the
-  items domain.
-- Runtime data sync now handles three datasets: `zh_CN-excel.zip`,
-  `zh_CN-levels.zip`, and story `zh_CN.zip`. Docker images prewarm
-  `data/gamedata-levels` alongside existing bundled fallback data.
+- **Item/material data domain.** Three new tools — `list_items`, `get_item_info`, and `search_items` — read `item_table.json` to expose material/item lists, details, obtain methods, stage drops, production, and shop/voucher links.
+- **Stage/enemy cross-source fusion.** Added `get_stage_enemies(stage_id)` and `get_enemy_appearances(name, limit, offset)` backed by `zh_CN-levels.zip`. `get_enemy_info(name)` now accepts optional `stage_id` for stage-specific enemy levels and overwritten combat stats while preserving the default handbook behavior.
+- Tool surface expanded from 24 to 29. `list_search_scopes` now includes the items domain.
+- Runtime data sync now handles three datasets: `zh_CN-excel.zip`, `zh_CN-levels.zip`, and story `zh_CN.zip`. Docker images prewarm `data/gamedata-levels` alongside existing bundled fallback data.
 
 ### Changed
 
-- Stage drop formatting now resolves item IDs through `item_table.json` when
-  available, e.g. `招聘许可（7001）`.
-- `fetch_gamedata.py` now prewarms both the excel and levels Release archives;
-  `check_package_data.py` verifies bundled level data before packaging.
+- Stage drop formatting now resolves item IDs through `item_table.json` when available, e.g. `招聘许可（7001）`.
+- `fetch_gamedata.py` now prewarms both the excel and levels Release archives; `check_package_data.py` verifies bundled level data before packaging.
 
 ### Fixed
 
-- **Release archive validation.** Archive sync validates required zip entries
-  before extraction and rechecks required files after extraction, so a partial
-  or corrupt `zh_CN-levels.zip` cannot be logged as healthy data.
-- **Enemy appearance lookup memory profile.** `get_enemy_appearances` now scans
-  for the requested enemy instead of permanently caching an all-enemy
-  appearance index on first use.
-- **ZipStore lifecycle hardening.** `ZipStore` now supports explicit
-  `close()` and context-manager use. Zip-path story helpers close their
-  transient stores after each call, avoiding lingering `ZipFile` handles in
-  repeated story reads/searches.
+- **Release archive validation.** Archive sync validates required zip entries before extraction and rechecks required files after extraction, so a partial or corrupt `zh_CN-levels.zip` cannot be logged as healthy data.
+- **Enemy appearance lookup memory profile.** `get_enemy_appearances` now scans for the requested enemy instead of permanently caching an all-enemy appearance index on first use.
+- **ZipStore lifecycle hardening.** `ZipStore` now supports explicit `close()` and context-manager use. Zip-path story helpers close their transient stores after each call, avoiding lingering `ZipFile` handles in repeated story reads/searches.
 
 ## [1.5.0] - 2026-05-25
 
 ### Added
 
-- **Stage data domain.** Three new tools — `list_stages`, `get_stage_info`,
-  `search_stages` — sourced from `stage_table.json` (3319 stages) and
-  `zone_table.json` (434 zones) in ArknightsGameData. `list_stages` supports
-  zone and stage-type filters with pagination; `get_stage_info` returns
-  detailed per-stage data (drops, unlocks, related variants); `search_stages`
-  performs regex search across names, codes, descriptions, and types.
-- Tool surface expanded from 21 to 24. `list_search_scopes` updated with
-  stages and enemies entries.
-- `stage_table.json` and `zone_table.json` added to sync manifests for
-  integrity validation.
+- **Stage data domain.** Three new tools — `list_stages`, `get_stage_info`, `search_stages` — sourced from `stage_table.json` (3319 stages) and `zone_table.json` (434 zones) in ArknightsGameData. `list_stages` supports zone and stage-type filters with pagination; `get_stage_info` returns detailed per-stage data (drops, unlocks, related variants); `search_stages` performs regex search across names, codes, descriptions, and types.
+- Tool surface expanded from 21 to 24. `list_search_scopes` updated with stages and enemies entries.
+- `stage_table.json` and `zone_table.json` added to sync manifests for integrity validation.
 
 ## [1.4.2] - 2026-05-25
 
 ### Changed
 
-- **Version sync with TS 1.4.2.** No Python-side changes — the session pool
-  fix in this release applies only to the TypeScript Streamable HTTP transport.
-  Python's stdio transport is not affected by the stale-session issue.
+- **Version sync with TS 1.4.2.** No Python-side changes — the session pool fix in this release applies only to the TypeScript Streamable HTTP transport. Python's stdio transport is not affected by the stale-session issue.
 
 ## [1.4.1] - 2026-05-19
 
 ### Fixed
 
-- **ZipStore zip instance caching.** `ZipFile` is now cached instead of
-  re-opened on every `exists()`/`read_text()` call. `exists()` switches
-  from O(n) `namelist()` to O(1) `getinfo()`. In `search_stories` without
-  an `event_id` filter this was ~3000 redundant zip opens, exceeding the
-  120 s MCP client timeout.
-- **HTTP client reuse.** Module-level shared `httpx.AsyncClient` replaces
-  per-call instantiation (7 call sites), recovering connection pooling and
-  avoiding repeated TLS handshakes.
-- **Rate limiter race condition.** Slot-based reservation scheme (matching
-  the TS implementation) replaces the check-then-act pattern that could
-  allow concurrent coroutines to exceed the configured rate.
-- **Parsetree `.tail` preservation.** Text after nested `<comment>` and
-  `<template>` elements in title/value extraction is now preserved instead
-  of silently dropped.
-- **Story search robustness.** `read_activity` gains `page >= 1` validation.
-  Exception handling in `search_stories` and `read_activity` narrowed from
-  bare `except Exception` to expected error types. Convenience wrappers
-  (`search_stories`, `get_event_summary`, `get_story_summary`) now use
-  `_story_store()` for consistency.
-- **API error semantics.** `ValueError` replaced with `RuntimeError` for
-  MediaWiki API errors, matching the Python exception hierarchy convention.
+- **ZipStore zip instance caching.** `ZipFile` is now cached instead of re-opened on every `exists()`/`read_text()` call. `exists()` switches from O(n) `namelist()` to O(1) `getinfo()`. In `search_stories` without an `event_id` filter this was ~3000 redundant zip opens, exceeding the 120 s MCP client timeout.
+- **HTTP client reuse.** Module-level shared `httpx.AsyncClient` replaces per-call instantiation (7 call sites), recovering connection pooling and avoiding repeated TLS handshakes.
+- **Rate limiter race condition.** Slot-based reservation scheme (matching the TS implementation) replaces the check-then-act pattern that could allow concurrent coroutines to exceed the configured rate.
+- **Parsetree `.tail` preservation.** Text after nested `<comment>` and `<template>` elements in title/value extraction is now preserved instead of silently dropped.
+- **Story search robustness.** `read_activity` gains `page >= 1` validation. Exception handling in `search_stories` and `read_activity` narrowed from bare `except Exception` to expected error types. Convenience wrappers (`search_stories`, `get_event_summary`, `get_story_summary`) now use `_story_store()` for consistency.
+- **API error semantics.** `ValueError` replaced with `RuntimeError` for MediaWiki API errors, matching the Python exception hierarchy convention.
 
 ### Added
 
-- **E2E test suite.** MCP protocol-level test (`test_e2e.py`) covering
-  handshake, tool surface (all 21 tools), operator data, and graceful
-  degradation when optional data is unavailable.
+- **E2E test suite.** MCP protocol-level test (`test_e2e.py`) covering handshake, tool surface (all 21 tools), operator data, and graceful degradation when optional data is unavailable.
 
 ## [1.4.0] - 2026-05-19
 
 ### Added
 
-- **PRTS template data extraction.** `get_prts_template(page_title)` returns
-  structured key-value data from MediaWiki template calls on a page. Supports
-  `CharinfoV2` (operator), `敌人信息/common2` (enemy), `道具信息` (item), and
-  other name=value pattern templates via `action=parse&prop=parsetree`. Only
-  top-level templates are returned; nested templates inside a value are
-  stripped from the value text.
-- **Enemy handbook tools.** Three new tools backed by `enemy_handbook_table.json`
-  with optional combat-stats merge from `levels/enemydata/enemy_database.json`:
-  - `list_enemies(threat_level, limit, offset, full)` — paginated listing
-    with optional filter by `boss` / `elite` / `normal`. Defaults to first 50
-    entries; `full=true` returns all 1500+ entries (discouraged for normal use).
-  - `get_enemy_info(name)` — handbook entry merged with full combat stats:
-    HP / ATK / DEF / RES, attack interval, mass level, status immunities, and
-    skill list with cooldowns and blackboard parameters.
-  - `search_enemies(pattern, max_results)` — regex search across enemy
-    names, descriptions, and ability text.
+- **PRTS template data extraction.** `get_prts_template(page_title)` returns structured key-value data from MediaWiki template calls on a page. Supports `CharinfoV2` (operator), `敌人信息/common2` (enemy), `道具信息` (item), and other name=value pattern templates via `action=parse&prop=parsetree`. Only top-level templates are returned; nested templates inside a value are stripped from the value text.
+- **Enemy handbook tools.** Three new tools backed by `enemy_handbook_table.json` with optional combat-stats merge from `levels/enemydata/enemy_database.json`:
+  - `list_enemies(threat_level, limit, offset, full)` — paginated listing with optional filter by `boss` / `elite` / `normal`. Defaults to first 50 entries; `full=true` returns all 1500+ entries (discouraged for normal use).
+  - `get_enemy_info(name)` — handbook entry merged with full combat stats: HP / ATK / DEF / RES, attack interval, mass level, status immunities, and skill list with cooldowns and blackboard parameters.
+  - `search_enemies(pattern, max_results)` — regex search across enemy names, descriptions, and ability text.
 
 ## [1.3.1] - 2026-05-19
 
 ### Fixed
 
-- **Operator name-to-ID collision.** `_build_name_to_id()` in `operator.py` now
-  filters to `char_*` entries only, preventing `trap_*` and `token_*` entries from
-  silently overwriting real operator IDs when they share the same Chinese name.
-  Fixes `get_operator_basic_info`, `get_operator_archives`,
-  `get_operator_voicelines`, and `search_data` for affected operators (阿米娅,
-  森蚺, 狮蝎, 佩佩, 断罪者, etc.).
+- **Operator name-to-ID collision.** `_build_name_to_id()` in `operator.py` now filters to `char_*` entries only, preventing `trap_*` and `token_*` entries from silently overwriting real operator IDs when they share the same Chinese name. Fixes `get_operator_basic_info`, `get_operator_archives`, `get_operator_voicelines`, and `search_data` for affected operators (阿米娅, 森蚺, 狮蝎, 佩佩, 断罪者, etc.).
 
 ## [1.3.0] - 2026-05-18
 
 ### Added
 
-- **PRTS page table of contents.** `list_prts_sections(page_title)` returns the
-  section index for a wiki page. Each section is labeled with its index (e.g.
-  `[1]`, `[T-1]` for template-transcluded), heading level, and title.
-- **PRTS page categories.** `get_prts_categories(page_title)` returns the
-  category tags for a wiki page (e.g. "干员", "术师干员").
-- **PRTS page links.** `get_prts_links(page_title, direction, limit)` returns
-  outbound links from a page or inbound backlinks to a page, with pagination.
+- **PRTS page table of contents.** `list_prts_sections(page_title)` returns the section index for a wiki page. Each section is labeled with its index (e.g. `[1]`, `[T-1]` for template-transcluded), heading level, and title.
+- **PRTS page categories.** `get_prts_categories(page_title)` returns the category tags for a wiki page (e.g. "干员", "术师干员").
+- **PRTS page links.** `get_prts_links(page_title, direction, limit)` returns outbound links from a page or inbound backlinks to a page, with pagination.
 
 ### Changed
 
-- **`read_prts_page` gains `section_index` parameter.** When set, only the
-  specified section's plain-text content is returned instead of the full page.
-  Backwards-compatible: the parameter defaults to `None` (whole page).
-- **`search_prts` enhanced.** New `search_mode` parameter (`text` / `title`),
-  `filter_technical` toggle (default `true`, filters `/spine`, `/data`, etc.
-  technical pages), and `totalhits` count in search results. Backwards-compatible:
-  new parameters have safe defaults.
+- **`read_prts_page` gains `section_index` parameter.** When set, only the specified section's plain-text content is returned instead of the full page. Backwards-compatible: the parameter defaults to `None` (whole page).
+- **`search_prts` enhanced.** New `search_mode` parameter (`text` / `title`), `filter_technical` toggle (default `true`, filters `/spine`, `/data`, etc. technical pages), and `totalhits` count in search results. Backwards-compatible: new parameters have safe defaults.
 
 ## [1.2.0] - 2026-05-14
 
 ### Added
 
-- **Story chapter summaries.** Two new tools and one enhancement built on the
-  previously-unused `zh_CN/storyinfo.json` index (1,945 entries), plus an
-  LLM summarization pipeline in the data-source fork:
-  - `get_event_summary(event_id)` — narrative overview of every chapter in an
-    event, with chapter codes, tags, names, and summary text. When LLM event
-    summaries are available (`zh_CN/event_summaries.json`), a full-dialogue
-    V2 synopsis is prepended above the chapter listing.
-  - `get_story_summary(story_key)` — single-chapter summary with a three-tier
-    fallback chain: LLM long summary (`zh_CN/summaries.json`, 5~7:1 compression),
-    official one-liner (`zh_CN/storyinfo.json`), and chapter `storyInfo` field.
-  - `list_stories` now accepts `include_summaries` (bool). When `true`, each
-    chapter line includes an indented summary below it.
-- **LLM summarization pipeline** (`3aKHP/ArknightsStoryJson` fork):
-  `scripts/summarize.py` generates per-chapter (5~7:1) and per-event (10:1)
-  summaries via DeepSeek V4 Flash API during CI release, injecting them into
-  `zh_CN.zip` for transparent consumption by the MCP server.
+- **Story chapter summaries.** Two new tools and one enhancement built on the previously-unused `zh_CN/storyinfo.json` index (1,945 entries), plus an LLM summarization pipeline in the data-source fork:
+  - `get_event_summary(event_id)` — narrative overview of every chapter in an event, with chapter codes, tags, names, and summary text. When LLM event summaries are available (`zh_CN/event_summaries.json`), a full-dialogue V2 synopsis is prepended above the chapter listing.
+  - `get_story_summary(story_key)` — single-chapter summary with a three-tier fallback chain: LLM long summary (`zh_CN/summaries.json`, 5~7:1 compression), official one-liner (`zh_CN/storyinfo.json`), and chapter `storyInfo` field.
+  - `list_stories` now accepts `include_summaries` (bool). When `true`, each chapter line includes an indented summary below it.
+- **LLM summarization pipeline** (`3aKHP/ArknightsStoryJson` fork): `scripts/summarize.py` generates per-chapter (5~7:1) and per-event (10:1) summaries via DeepSeek V4 Flash API during CI release, injecting them into `zh_CN.zip` for transparent consumption by the MCP server.
 
 ## [1.1.1] - 2026-05-14
 
 ### Fixed
 
-- **`read_prts_page` now returns full page content.** Switched from
-  `action=query&prop=extracts` (which strips all template-rendered content)
-  to `action=parse&prop=text`. Character pages now return 22K+ chars of
-  readable text instead of ~400 chars of empty section headers.
-- **`search_prts` restricts to main namespace.** Added `srnamespace=0`
-  so search results are no longer polluted by technical data pages from
-  other MediaWiki namespaces.
-- **Search snippets are cleaned of HTML entities and JSON fragments.**
-  Added `html.unescape` decoding and residual-wikitext cleanup after
-  `strip_wikitext`.
+- **`read_prts_page` now returns full page content.** Switched from `action=query&prop=extracts` (which strips all template-rendered content) to `action=parse&prop=text`. Character pages now return 22K+ chars of readable text instead of ~400 chars of empty section headers.
+- **`search_prts` restricts to main namespace.** Added `srnamespace=0` so search results are no longer polluted by technical data pages from other MediaWiki namespaces.
+- **Search snippets are cleaned of HTML entities and JSON fragments.** Added `html.unescape` decoding and residual-wikitext cleanup after `strip_wikitext`.
 
 ## [1.1.0] - 2026-05-14
 
 ### Added
 
-- **Search tools.** Three new MCP tools provide full-text regex search across
-  operator data and story dialogue, enabling exploratory queries without
-  knowing exact operator names or story keys upfront:
+- **Search tools.** Three new MCP tools provide full-text regex search across operator data and story dialogue, enabling exploratory queries without knowing exact operator names or story keys upfront:
   - `list_search_scopes` — list searchable data domains and their content types.
-  - `search_data(pattern, scope, max_results)` — search operator names,
-    descriptions, archive texts, and voice lines.
-  - `search_stories(pattern, character, line_type, context_lines, max_results, event_id)`
-    — search story dialogue, narration, and choice lines with filtering by
-    speaker and line type, plus configurable context lines around each match.
+  - `search_data(pattern, scope, max_results)` — search operator names, descriptions, archive texts, and voice lines.
+  - `search_stories(pattern, character, line_type, context_lines, max_results, event_id)` — search story dialogue, narration, and choice lines with filtering by speaker and line type, plus configurable context lines around each match.
 
 ## [1.0.0] - 2026-05-13
 
 ### Changed
 
-- **Public tool surface frozen.** The 9 MCP tool names, required parameters,
-  and response formats are locked. Automated tests enforce this in CI for
-  both Python and TypeScript.
-- CI now downloads the storyjson `zh_CN.zip` fixture before running Python
-  tests so story integration tests are no longer silently skipped.
-- Migration guide expanded with behavioral changes from 0.x: Release archive
-  sync, `archives/` cache metadata, `local_repo.jsonc` removal, and
-  `story_review_table.json` as a required gamedata file.
+- **Public tool surface frozen.** The 9 MCP tool names, required parameters, and response formats are locked. Automated tests enforce this in CI for both Python and TypeScript.
+- CI now downloads the storyjson `zh_CN.zip` fixture before running Python tests so story integration tests are no longer silently skipped.
+- Migration guide expanded with behavioral changes from 0.x: Release archive sync, `archives/` cache metadata, `local_repo.jsonc` removal, and `story_review_table.json` as a required gamedata file.
 
 ### Fixed
 
-- `include_narration=false` in `read_story` now also filters unnamed speaker
-  lines (stage directions displayed as `（旁白）：text`) instead of only
-  filtering `type="narration"` sticker/subtitle/animation lines.
+- `include_narration=false` in `read_story` now also filters unnamed speaker lines (stage directions displayed as `（旁白）：text`) instead of only filtering `type="narration"` sticker/subtitle/animation lines.
 
 ## [1.0.0-beta.1] - 2026-05-12
 
@@ -573,15 +274,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- Bounded retry loop for startup sync: `offline_fallback` and `no_data`
-  results schedule daemon-thread retries at 30s, 120s, and 600s before
-  giving up until the next process start. Matches the existing TypeScript
-  behavior so both implementations recover from transient network failures
-  without manual restart.
-- The first sync attempt is wrapped in `_run_initial_sync`, so an
-  unexpected exception in `sync_release` / `sync_release_archive` no longer
-  kills the daemon sync thread; it is logged and treated as retry-needed,
-  matching the TypeScript `.catch(() => true)` baseline.
+- Bounded retry loop for startup sync: `offline_fallback` and `no_data` results schedule daemon-thread retries at 30s, 120s, and 600s before giving up until the next process start. Matches the existing TypeScript behavior so both implementations recover from transient network failures without manual restart.
+- The first sync attempt is wrapped in `_run_initial_sync`, so an unexpected exception in `sync_release` / `sync_release_archive` no longer kills the daemon sync thread; it is logged and treated as retry-needed, matching the TypeScript `.catch(() => true)` baseline.
 
 ## [1.0.0-alpha.1] - 2026-05-03
 
@@ -593,42 +287,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
-- Operator and story parsers now read through the new store abstraction while preserving
-  current MCP tool names, parameters, and output formatting.
-- Runtime sync setup now consumes dataset specs instead of repeating Release metadata in
-  server startup code and prewarm scripts.
+- Operator and story parsers now read through the new store abstraction while preserving current MCP tool names, parameters, and output formatting.
+- Runtime sync setup now consumes dataset specs instead of repeating Release metadata in server startup code and prewarm scripts.
 
 ## [0.4.2] - 2026-05-03
 
 ### Changed
 
-- ArknightsGameData auto-sync now downloads the `zh_CN-excel.zip` Release asset from
-  `3aKHP/ArknightsGameData` and extracts it into the existing `gamedata` layout, aligning
-  the game-data and story-data sync paths around GitHub Release archives.
-- `fetch_gamedata.py` now prewarms bundled game data from the same Release archive instead
-  of downloading individual raw JSON files.
-- Python operator-data completeness now requires `story_review_table.json`, matching the
-  TypeScript implementation and the new full-excel archive.
-- Operator data config is re-resolved on each tool call, and table caches are cleared after
-  startup auto-sync writes updated game data.
+- ArknightsGameData auto-sync now downloads the `zh_CN-excel.zip` Release asset from `3aKHP/ArknightsGameData` and extracts it into the existing `gamedata` layout, aligning the game-data and story-data sync paths around GitHub Release archives.
+- `fetch_gamedata.py` now prewarms bundled game data from the same Release archive instead of downloading individual raw JSON files.
+- Python operator-data completeness now requires `story_review_table.json`, matching the TypeScript implementation and the new full-excel archive.
+- Operator data config is re-resolved on each tool call, and table caches are cleared after startup auto-sync writes updated game data.
 - Added regression coverage for data becoming available later in the same process.
 
 ## [0.4.0] - 2026-04-25
 
 ### Added
 
-- `GITHUB_MIRRORS` environment variable: comma-separated list of ghproxy-style proxy base URLs
-  (e.g. `GITHUB_MIRRORS=https://ghproxy.net`) tried in order after the direct GitHub URL fails,
-  enabling auto-sync on servers behind the GFW
-- Blind download path in `sync_repo` and `sync_release`: when the GitHub API is unreachable but
-  mirrors are configured and no local data exists, files are fetched directly via mirrors without a
-  prior SHA check; storyjson uses the `releases/latest/download/` redirect URL which does not
-  require an API call
+- `GITHUB_MIRRORS` environment variable: comma-separated list of ghproxy-style proxy base URLs (e.g. `GITHUB_MIRRORS=https://ghproxy.net`) tried in order after the direct GitHub URL fails, enabling auto-sync on servers behind the GFW
+- Blind download path in `sync_repo` and `sync_release`: when the GitHub API is unreachable but mirrors are configured and no local data exists, files are fetched directly via mirrors without a prior SHA check; storyjson uses the `releases/latest/download/` redirect URL which does not require an API call
 
 ### Changed
 
-- `download_files` replaced shared `httpx.Client` with per-file `_get_cascading` calls to enable
-  independent mirror cascade per file
+- `download_files` replaced shared `httpx.Client` with per-file `_get_cascading` calls to enable independent mirror cascade per file
 
 ## [0.2.2] - 2026-04-10
 

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -10,21 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
-- **Gamedata pair retry no longer fires on commit_sha mismatch.** When both
-  the excel and levels archives are up-to-date but carry divergent
-  `commit_sha` values (stale local metadata, not missing data), the sync no
-  longer schedules dense 30s/120s/600s retries. The next periodic cycle
-  resolves the metadata drift; only `offline_fallback` / `no_data` statuses
-  trigger retries.
-- **Release manifest 404 handling.** When a mirror confirms a release has no
-  `manifest.json` via HTTP 404, the sync skips that mirror cleanly instead of
-  letting a later mirror's generic network 404 overwrite the explicit absence
-  signal. A new `AssetNotFoundError` distinguishes "this release genuinely
-  has no manifest" from "we couldn't reach this mirror".
-- **Image shard sha256 verification.** After downloading AKDP image shards,
-  the sync verifies each wanted variant's sha256 (now async) before
-  activation. A missing PNG for a wanted variant counts as a mismatch and
-  blocks activation (previously silently skipped).
+- **Gamedata pair retry no longer fires on commit_sha mismatch.** When both the excel and levels archives are up-to-date but carry divergent `commit_sha` values (stale local metadata, not missing data), the sync no longer schedules dense 30s/120s/600s retries. The next periodic cycle resolves the metadata drift; only `offline_fallback` / `no_data` statuses trigger retries.
+- **Release manifest 404 handling.** When a mirror confirms a release has no `manifest.json` via HTTP 404, the sync skips that mirror cleanly instead of letting a later mirror's generic network 404 overwrite the explicit absence signal. A new `AssetNotFoundError` distinguishes "this release genuinely has no manifest" from "we couldn't reach this mirror".
+- **Image shard sha256 verification.** After downloading AKDP image shards, the sync verifies each wanted variant's sha256 (now async) before activation. A missing PNG for a wanted variant counts as a mismatch and blocks activation (previously silently skipped).
 
 ### Changed
 
@@ -34,76 +22,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- New `operator_artwork` tool (enabled by default). `action="list"` returns
-  bounded metadata with semantic labels; `action="get"` returns one image as
-  base64 `ImageContent` (default `large` variant, max 1024px). Default mode
-  (`LOCAL_IMAGE=false`) fetches on-demand from PRTS MediaWiki under the full
-  #85 security boundary (hostname/MIME/magic/1MiB/streaming/redirect) with a
-  256 MiB LRU cache (`PRTS_IMAGE_CACHE=true`). Set `LOCAL_IMAGE=true` to sync
-  ~1.5 GB of AKDP local PNG assets; `ORIGINAL_IMAGE=true` adds full-resolution
-  shards. MediaWiki labels via CharinfoV2 `时装N名称`; AKDP labels via
-  `skin_table.json`. The `original` variant is rejected in MediaWiki mode
-  (PRTS originals exceed the 1 MiB cap). Tool surface 23 → 24.
+- New `operator_artwork` tool (enabled by default). `action="list"` returns bounded metadata with semantic labels; `action="get"` returns one image as base64 `ImageContent` (default `large` variant, max 1024px). Default mode (`LOCAL_IMAGE=false`) fetches on-demand from PRTS MediaWiki under the full #85 security boundary (hostname/MIME/magic/1MiB/streaming/redirect) with a 256 MiB LRU cache (`PRTS_IMAGE_CACHE=true`). Set `LOCAL_IMAGE=true` to sync ~1.5 GB of AKDP local PNG assets; `ORIGINAL_IMAGE=true` adds full-resolution shards. MediaWiki labels via CharinfoV2 `时装N名称`; AKDP labels via `skin_table.json`. The `original` variant is rejected in MediaWiki mode (PRTS originals exceed the 1 MiB cap). Tool surface 23 → 24.
 
 ### Changed
 
-- **Auto-sync data source switched to self-hosted `arknights-data-pipeline`.**
-  The default sync now consumes `zh_CN-excel.zip`, `zh_CN-levels.zip`, and
-  story `zh_CN.zip` Releases from `3aKHP/arknights-data-pipeline` (the factory
-  repo). The legacy upstream repos are no longer data dependencies on the
-  2.5.0 line. Release manifest verification tightened so a partial or corrupt
-  archive cannot be treated as healthy data.
+- **Auto-sync data source switched to self-hosted `arknights-data-pipeline`.** The default sync now consumes `zh_CN-excel.zip`, `zh_CN-levels.zip`, and story `zh_CN.zip` Releases from `3aKHP/arknights-data-pipeline` (the factory repo). The legacy upstream repos are no longer data dependencies on the 2.5.0 line. Release manifest verification tightened so a partial or corrupt archive cannot be treated as healthy data.
 - `tsx` devDependency updated from 4.21 to 4.23.
 
 ### Fixed
 
-- **Data sync uses tag-prefix filtering instead of `/releases/latest`.** The
-  `arknights-data-pipeline` repo now hosts both `data-*` and `images-*` GitHub
-  Releases. `checkLatestRelease` switched from the `/releases/latest` endpoint
-  to the releases list API with `data-` tag-prefix filtering, preventing silent
-  sync stalls if GitHub auto-promotes an `images-*` release to "Latest". Shared
-  `listReleases` / `latestReleaseByPrefix` / `assetUrl` helpers were lifted from
-  `imagesSync` into `sync` to avoid duplication. CI `gh release download` now
-  resolves the latest `data-*` tag before downloading.
-- **TS stdio entry no longer starts an HTTP listener.** The stdio entry point
-  (`server-stdio.ts`) previously imported from `server.ts`, whose module-load
-  side effect called `app.listen()` — spawning a rogue HTTP server on the
-  configured `PORT` alongside the stdio transport. Extracted a side-effect-free
-  `server-core.ts` factory shared by both entry points.
-- **`operator_artwork` allimages pagination.** MediaWiki `allimages` now
-  paginates with `aifrom` continuation (50 per page) to avoid silent
-  truncation when an operator has more than 50 skin images.
-- **Docker images volume for `LOCAL_IMAGE=true`.** All three Dockerfiles now
-  create `/data/images` so the `LOCAL_IMAGE=true` sync path has a writable
-  target directory when running with a named volume.
-- **TS `{}` empty-object placeholder crash.** Upstream AKDP data sometimes
-  emits `{}` instead of `[]` for array fields (`waves`, `fragments`,
-  `actions`, `unlockCondition`, `talents`, `tagList`, etc.). TS `?? []` only
-  catches `null`/`undefined`, so `{}` slipped through and crashed `.map()` /
-  `for...of`. All 21 JSON-sourced `?? []` sites now use
-  `Array.isArray(x) ? x : []` to match Python's falsy `or []` tolerance.
+- **Data sync uses tag-prefix filtering instead of `/releases/latest`.** The `arknights-data-pipeline` repo now hosts both `data-*` and `images-*` GitHub Releases. `checkLatestRelease` switched from the `/releases/latest` endpoint to the releases list API with `data-` tag-prefix filtering, preventing silent sync stalls if GitHub auto-promotes an `images-*` release to "Latest". Shared `listReleases` / `latestReleaseByPrefix` / `assetUrl` helpers were lifted from `imagesSync` into `sync` to avoid duplication. CI `gh release download` now resolves the latest `data-*` tag before downloading.
+- **TS stdio entry no longer starts an HTTP listener.** The stdio entry point (`server-stdio.ts`) previously imported from `server.ts`, whose module-load side effect called `app.listen()` — spawning a rogue HTTP server on the configured `PORT` alongside the stdio transport. Extracted a side-effect-free `server-core.ts` factory shared by both entry points.
+- **`operator_artwork` allimages pagination.** MediaWiki `allimages` now paginates with `aifrom` continuation (50 per page) to avoid silent truncation when an operator has more than 50 skin images.
+- **Docker images volume for `LOCAL_IMAGE=true`.** All three Dockerfiles now create `/data/images` so the `LOCAL_IMAGE=true` sync path has a writable target directory when running with a named volume.
+- **TS `{}` empty-object placeholder crash.** Upstream AKDP data sometimes emits `{}` instead of `[]` for array fields (`waves`, `fragments`, `actions`, `unlockCondition`, `talents`, `tagList`, etc.). TS `?? []` only catches `null`/`undefined`, so `{}` slipped through and crashed `.map()` / `for...of`. All 21 JSON-sourced `?? []` sites now use `Array.isArray(x) ? x : []` to match Python's falsy `or []` tolerance.
 
 ## [2.4.0] - 2026-07-29
 
 ### Added
 
-- Added process-lifetime auto-sync: after the startup check, GameData excel,
-  GameData levels, and StoryJson Releases are checked hourly without a service
-  restart. `PRTS_AUTO_SYNC_INTERVAL_SECONDS` configures the interval or keeps
-  startup-only behavior with `0`.
-- Added archive activation metadata so an interrupted extraction is retried on
-  the next cycle before the downloaded Release is treated as active.
-- GameData excel and levels now become visible as one atomic generation, so
-  tools never observe a mixed old/new pair while a periodic update is running.
-- Shared-volume publication locks now renew their lease while held, preventing
-  long downloads or extraction work from being mistaken for abandoned locks.
+- Added process-lifetime auto-sync: after the startup check, GameData excel, GameData levels, and StoryJson Releases are checked hourly without a service restart. `PRTS_AUTO_SYNC_INTERVAL_SECONDS` configures the interval or keeps startup-only behavior with `0`.
+- Added archive activation metadata so an interrupted extraction is retried on the next cycle before the downloaded Release is treated as active.
+- GameData excel and levels now become visible as one atomic generation, so tools never observe a mixed old/new pair while a periodic update is running.
+- Shared-volume publication locks now renew their lease while held, preventing long downloads or extraction work from being mistaken for abandoned locks.
 
 ## [2.3.1] - 2026-07-10
 
 ### Security
 
-- Updated transitive production dependencies to resolve known vulnerabilities
-  in HTTP and JSON-schema support packages.
+- Updated transitive production dependencies to resolve known vulnerabilities in HTTP and JSON-schema support packages.
 
 ### Fixed
 
@@ -113,194 +60,91 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- Added stdio transport support: new `prts-mcp-ts-stdio` npm bin and
-  `ts/src/server-stdio.ts` entry point. Reuses the existing
-  `createMcpServer` factory and `runStartupSync`; connects an
-  `StdioServerTransport` for single-session local MCP clients (Claude
-  Desktop, Claude Code, Cursor). Breaks the 2.0 transport split — the
-  TypeScript implementation now supports both Streamable HTTP (existing
-  `prts-mcp-ts` / `prts-mcp-ts-bun` bins) and stdio.
+- Added stdio transport support: new `prts-mcp-ts-stdio` npm bin and `ts/src/server-stdio.ts` entry point. Reuses the existing `createMcpServer` factory and `runStartupSync`; connects an `StdioServerTransport` for single-session local MCP clients (Claude Desktop, Claude Code, Cursor). Breaks the 2.0 transport split — the TypeScript implementation now supports both Streamable HTTP (existing `prts-mcp-ts` / `prts-mcp-ts-bun` bins) and stdio.
 - Added `start:stdio` / `start:stdio:bun` npm scripts.
-- Added `e2eStdio.test.ts` covering stdio initialize handshake, tools/list,
-  and graceful error handling.
-- Extended `smoke-package-bun.mjs` to assert the `prts-mcp-ts-stdio` bin
-  shim is installed and non-empty after `npm pack` + `bun add`.
+- Added `e2eStdio.test.ts` covering stdio initialize handshake, tools/list, and graceful error handling.
+- Extended `smoke-package-bun.mjs` to assert the `prts-mcp-ts-stdio` bin shim is installed and non-empty after `npm pack` + `bun add`.
 
 ### Changed
 
-- `server.ts` now exports `createMcpServer`, `SERVER_VERSION`, and `log`
-  (previously module-private) so the stdio entry point can reuse them
-  without duplicating tool registration logic.
+- `server.ts` now exports `createMcpServer`, `SERVER_VERSION`, and `log` (previously module-private) so the stdio entry point can reuse them without duplicating tool registration logic.
 
 ## [2.2.0] - 2026-07-08
 
 ### Added
 
 - Added `ts/Dockerfile.node` as the supported Node.js legacy Docker build path.
-- Added Node legacy npm scripts: `start:node`, `smoke:http:node`,
-  `smoke:http:fixture:node`, and `dev:bun` for Bun-native development.
-- Added an explicit `bun.lock`/`package.json` drift check in `verify-ts` so
-  dual-lockfile desync fails fast with an actionable message.
-- Extended `build-image-ts` to also run on `release/**` pull requests so the
-  default Bun image is validated before shipping to main.
+- Added Node legacy npm scripts: `start:node`, `smoke:http:node`, `smoke:http:fixture:node`, and `dev:bun` for Bun-native development.
+- Added an explicit `bun.lock`/`package.json` drift check in `verify-ts` so dual-lockfile desync fails fast with an actionable message.
+- Extended `build-image-ts` to also run on `release/**` pull requests so the default Bun image is validated before shipping to main.
 
 ### Fixed
 
-- Fixed the default Docker image shipping without bundled fallback data:
-  `.dockerignore`'s `*.zip` rule stripped the CI-pre-fetched
-  `data/storyjson/zh_CN.zip` (and gamedata archives) from `COPY data/ data/`,
-  leaving the container without offline storyjson fallback. Added negation
-  rules so bundled data zips reach the image.
+- Fixed the default Docker image shipping without bundled fallback data: `.dockerignore`'s `*.zip` rule stripped the CI-pre-fetched `data/storyjson/zh_CN.zip` (and gamedata archives) from `COPY data/ data/`, leaving the container without offline storyjson fallback. Added negation rules so bundled data zips reach the image.
 
 ### Changed
 
-- Bun is now the default production runtime for the TypeScript implementation:
-  the default `ts/Dockerfile`, the primary CI verification path (`verify-ts`),
-  and the recommended Docker deployment all run under Bun (verified against
-  Bun `1.3.14`). **Node.js remains a supported legacy/optional runtime** via
-  the `prts-mcp-ts` npm bin (so `npx prts-mcp-ts` stays zero-dependency),
-  `npm install -g`, and the new `ts/Dockerfile.node` build path. The npm
-  publishing path is unchanged (`npm publish --provenance`, runtime-agnostic).
-- Default npm scripts (`start`, `smoke:http`, `smoke:http:fixture`) now drive
-  the Bun entrypoint; `start:bun` / `smoke:bun` / `smoke:bun:package` retained
-  verbatim for 2.1.0 backward compatibility.
-- CI matrix flipped: `verify-ts` is now Bun-based (type-check, build, runtime
-  smoke, packed-package smoke); the `node:test` unit suite moved to a new
-  `test-ts` job; `build-image-ts` builds the default Bun image; a new
-  `build-image-ts-node` job covers the legacy Node image.
+- Bun is now the default production runtime for the TypeScript implementation: the default `ts/Dockerfile`, the primary CI verification path (`verify-ts`), and the recommended Docker deployment all run under Bun (verified against Bun `1.3.14`). **Node.js remains a supported legacy/optional runtime** via the `prts-mcp-ts` npm bin (so `npx prts-mcp-ts` stays zero-dependency), `npm install -g`, and the new `ts/Dockerfile.node` build path. The npm publishing path is unchanged (`npm publish --provenance`, runtime-agnostic).
+- Default npm scripts (`start`, `smoke:http`, `smoke:http:fixture`) now drive the Bun entrypoint; `start:bun` / `smoke:bun` / `smoke:bun:package` retained verbatim for 2.1.0 backward compatibility.
+- CI matrix flipped: `verify-ts` is now Bun-based (type-check, build, runtime smoke, packed-package smoke); the `node:test` unit suite moved to a new `test-ts` job; `build-image-ts` builds the default Bun image; a new `build-image-ts-node` job covers the legacy Node image.
 
 ### Removed
 
-- Removed the now-redundant `ts/Dockerfile.bun`; its content is promoted to
-  the default `ts/Dockerfile`.
-- Removed the `verify-ts-bun` and `build-image-ts-bun` CI jobs; their
-  coverage is absorbed by the new Bun-default `verify-ts` and
-  `build-image-ts`.
+- Removed the now-redundant `ts/Dockerfile.bun`; its content is promoted to the default `ts/Dockerfile`.
+- Removed the `verify-ts-bun` and `build-image-ts-bun` CI jobs; their coverage is absorbed by the new Bun-default `verify-ts` and `build-image-ts`.
 
 ## [2.1.0] - 2026-07-07
 
 ### Added
 
-- Added the `prts-mcp-ts-bun` public bin as the supported optional Bun runtime
-  entry point. The default `prts-mcp-ts` bin remains Node.js-based.
-- Added a packed-package Bun smoke test that runs `npm pack`, installs the
-  tarball with Bun in a temporary project, starts `prts-mcp-ts-bun`, and reuses
-  the HTTP MCP smoke harness.
+- Added the `prts-mcp-ts-bun` public bin as the supported optional Bun runtime entry point. The default `prts-mcp-ts` bin remains Node.js-based.
+- Added a packed-package Bun smoke test that runs `npm pack`, installs the tarball with Bun in a temporary project, starts `prts-mcp-ts-bun`, and reuses the HTTP MCP smoke harness.
 
 ### Changed
 
-- Promoted the Bun runtime and `ts/Dockerfile.bun` from candidate coverage to a
-  supported optional TypeScript runtime path, verified against Bun `1.3.14`.
-  Node/npm remains the default runtime, Dockerfile, and Trusted Publishing path.
+- Promoted the Bun runtime and `ts/Dockerfile.bun` from candidate coverage to a supported optional TypeScript runtime path, verified against Bun `1.3.14`. Node/npm remains the default runtime, Dockerfile, and Trusted Publishing path.
 
 ## [2.0.2] - 2026-07-07
 
 ### Added
 
-- Added a reusable HTTP MCP smoke harness for the TypeScript server and CI
-  coverage for Node, Bun, and the candidate Bun Docker image.
-- Added an optional Bun candidate runtime path with Bun scripts, a committed
-  `bun.lock`, `ts/Dockerfile.bun`, and CI smoke coverage. Node/npm remains the
-  default TypeScript runtime and npm Trusted Publishing path.
+- Added a reusable HTTP MCP smoke harness for the TypeScript server and CI coverage for Node, Bun, and the candidate Bun Docker image.
+- Added an optional Bun candidate runtime path with Bun scripts, a committed `bun.lock`, `ts/Dockerfile.bun`, and CI smoke coverage. Node/npm remains the default TypeScript runtime and npm Trusted Publishing path.
 
 ### Fixed
 
-- `search_prts` now resolves redirect-like PRTS Wiki search hits to their
-  target page when the search response lacks redirect metadata, while falling
-  back to the original result if the follow-up lookup fails.
-- `search_prts` filters technical/wiki implementation pages more precisely
-  and keeps `totalHits` stable even when visible results are filtered out.
+- `search_prts` now resolves redirect-like PRTS Wiki search hits to their target page when the search response lacks redirect metadata, while falling back to the original result if the follow-up lookup fails.
+- `search_prts` filters technical/wiki implementation pages more precisely and keeps `totalHits` stable even when visible results are filtered out.
 
 ## [2.0.1] - 2026-07-03
 
 ### Changed
 
-- Content-only tool handlers now consistently route through the shared
-  `textResult(...)` helper, keeping text-result construction centralized
-  without changing the returned MCP payload shape.
+- Content-only tool handlers now consistently route through the shared `textResult(...)` helper, keeping text-result construction centralized without changing the returned MCP payload shape.
 
 ## [2.0.0] - 2026-07-03
 
 ### Added
 
-- **Output channel design replaces the per-call `output_format` parameter
-  (2.0 design decision).** The original roadmap proposed an optional
-  `output_format=markdown|json` parameter with 2.0 flipping the default to
-  `json`. **That shape was rejected during design.** The primary consumer is an
-  LLM agent, and JSON inflates prompt tokens ~15–30% versus markdown — which
-  would negate the context-budget savings the tool-surface consolidation
-  delivers. 2.0 instead keeps markdown as the always-on `content` text and
-  carries structured data on MCP's native `structuredContent` field, selected
-  by a **connection-level** `output_channel` knob (`content` (default) /
-  `structured` / `both`) via query string / `x-prts-output-channel` header /
-  `PRTS_OUTPUT_CHANNEL` env. The default is **not** flipped to JSON. See
-  [`docs/migration-1.x-to-2.0.md`](../docs/migration-1.x-to-2.0.md) for the
-  per-tool channel mapping and client configuration. _(The Python implementation
-  additionally documents a "narrative-tool wire slimming" entry for dropping
-  FastMCP's automatic `outputSchema={result:string}` wrapper; the TS transport
-  has no equivalent auto-wrapper, so narrative tools are simply part of the
-  content-only delivery path here.)_
-- **Output channel pilot (2.0).** Streamable HTTP sessions can opt into
-  `output_channel=structured` or `output_channel=both` via query string,
-  `x-prts-output-channel` header, or `PRTS_OUTPUT_CHANNEL`. This first TS
-  migration slice enables structuredContent for `list_stages` while preserving
-  the default content-only markdown output, including legitimate empty pages
-  (filter no-match / offset past end) as structured empty payloads.
-- **Output channel coverage for structured data tools (2.0).** The remaining
-  game-data and story navigation tools now support structuredContent in TS:
-  operator/item/enemy/stage details and listings, stage-enemy fusion,
-  story event/chapter listings, operator memoirs, character appearances, and
-  event speaker counts.
-- **Output channel coverage for search tools (2.0).** The TS `search`,
-  `search_stories`, and `search_prts` tools now emit structuredContent in
-  `structured`/`both` channels, including structured-empty payloads for legal
-  no-match results and parity fixtures shared with the Python implementation.
+- **Output channel design replaces the per-call `output_format` parameter (2.0 design decision).** The original roadmap proposed an optional `output_format=markdown|json` parameter with 2.0 flipping the default to `json`. **That shape was rejected during design.** The primary consumer is an LLM agent, and JSON inflates prompt tokens ~15–30% versus markdown — which would negate the context-budget savings the tool-surface consolidation delivers. 2.0 instead keeps markdown as the always-on `content` text and carries structured data on MCP's native `structuredContent` field, selected by a **connection-level** `output_channel` knob (`content` (default) / `structured` / `both`) via query string / `x-prts-output-channel` header / `PRTS_OUTPUT_CHANNEL` env. The default is **not** flipped to JSON. See [`docs/migration-1.x-to-2.0.md`](../docs/migration-1.x-to-2.0.md) for the per-tool channel mapping and client configuration. _(The Python implementation additionally documents a "narrative-tool wire slimming" entry for dropping FastMCP's automatic `outputSchema={result:string}` wrapper; the TS transport has no equivalent auto-wrapper, so narrative tools are simply part of the content-only delivery path here.)_
+- **Output channel pilot (2.0).** Streamable HTTP sessions can opt into `output_channel=structured` or `output_channel=both` via query string, `x-prts-output-channel` header, or `PRTS_OUTPUT_CHANNEL`. This first TS migration slice enables structuredContent for `list_stages` while preserving the default content-only markdown output, including legitimate empty pages (filter no-match / offset past end) as structured empty payloads.
+- **Output channel coverage for structured data tools (2.0).** The remaining game-data and story navigation tools now support structuredContent in TS: operator/item/enemy/stage details and listings, stage-enemy fusion, story event/chapter listings, operator memoirs, character appearances, and event speaker counts.
+- **Output channel coverage for search tools (2.0).** The TS `search`, `search_stories`, and `search_prts` tools now emit structuredContent in `structured`/`both` channels, including structured-empty payloads for legal no-match results and parity fixtures shared with the Python implementation.
 
 ### Changed
 
-- **Parameter naming normalization (2.0, breaking).** Operator tools
-  (`get_operator_archives`, `get_operator_voicelines`, `get_operator_basic_info`,
-  `get_operator_memoirs`) now take `name` instead of `operator_name`, matching
-  the `name` convention already used by the enemy/stage/item/character tools.
-- **Unified search (2.0, breaking).** `search_data`, `search_enemies`,
-  `search_stages`, and `search_items` are consolidated into a single
-  `search(scope, pattern, max_results)` tool with a required `scope` enum
-  (`operators` / `enemies` / `stages` / `items`). Story dialogue search remains a
-  separate `search_stories` (its filters differ). Tool surface drops 32 → 28.
-- **Unified PRTS page tool (2.0, breaking).** `read_prts_page`,
-  `list_prts_sections`, `get_prts_categories`, `get_prts_links`, and
-  `get_prts_template` are consolidated into a single `prts_page(page_title,
-  action, ...)` tool with a required `action` enum (`read` / `sections` /
-  `categories` / `links` / `template`). Wiki keyword search remains a separate
-  `search_prts`. Tool surface drops 28 → 24.
-- **`list_stories` absorbs the event-level summary (2.0, breaking).**
-  `list_stories(event_id, include_summaries=true)` now prepends the event's LLM
-  overview (from `event_summaries.json`) when present, on top of the per-chapter
-  one-liners it already returned — making it a superset of the former
-  `get_event_summary`. Tool surface drops 24 → 23.
-- **Tool descriptions standardized (2.0).** All tool descriptions were rewritten
-  to a consistent house style (verb-first purpose, output-shape note, at most one
-  cross-reference, parameter semantics kept in the parameter schema) and trimmed
-  ~20% to reduce context budget on smaller-context models. No change to tool
-  names, parameters, or output format.
-- **Story empty-result wording aligned with Python (2.0).** TS story navigation
-  tools now use the Python-compatible empty messages for event/chapter listings,
-  character appearances, and speaker counts (including Python-style quoted
-  filter values). This is an intentional TS-dev text change in otherwise
-  content-compatible output-channel migration paths.
+- **Parameter naming normalization (2.0, breaking).** Operator tools (`get_operator_archives`, `get_operator_voicelines`, `get_operator_basic_info`, `get_operator_memoirs`) now take `name` instead of `operator_name`, matching the `name` convention already used by the enemy/stage/item/character tools.
+- **Unified search (2.0, breaking).** `search_data`, `search_enemies`, `search_stages`, and `search_items` are consolidated into a single `search(scope, pattern, max_results)` tool with a required `scope` enum (`operators` / `enemies` / `stages` / `items`). Story dialogue search remains a separate `search_stories` (its filters differ). Tool surface drops 32 → 28.
+- **Unified PRTS page tool (2.0, breaking).** `read_prts_page`, `list_prts_sections`, `get_prts_categories`, `get_prts_links`, and `get_prts_template` are consolidated into a single `prts_page(page_title, action, ...)` tool with a required `action` enum (`read` / `sections` / `categories` / `links` / `template`). Wiki keyword search remains a separate `search_prts`. Tool surface drops 28 → 24.
+- **`list_stories` absorbs the event-level summary (2.0, breaking).** `list_stories(event_id, include_summaries=true)` now prepends the event's LLM overview (from `event_summaries.json`) when present, on top of the per-chapter one-liners it already returned — making it a superset of the former `get_event_summary`. Tool surface drops 24 → 23.
+- **Tool descriptions standardized (2.0).** All tool descriptions were rewritten to a consistent house style (verb-first purpose, output-shape note, at most one cross-reference, parameter semantics kept in the parameter schema) and trimmed ~20% to reduce context budget on smaller-context models. No change to tool names, parameters, or output format.
+- **Story empty-result wording aligned with Python (2.0).** TS story navigation tools now use the Python-compatible empty messages for event/chapter listings, character appearances, and speaker counts (including Python-style quoted filter values). This is an intentional TS-dev text change in otherwise content-compatible output-channel migration paths.
 
 ### Removed
 
-- **`search_data`, `search_enemies`, `search_stages`, `search_items`,
-  `list_search_scopes` (2.0, breaking).** Replaced by unified `search(scope, ...)`;
-  the scope catalogue previously returned by `list_search_scopes` is folded into
-  the `search` tool description.
-- **`read_prts_page`, `list_prts_sections`, `get_prts_categories`,
-  `get_prts_links`, `get_prts_template` (2.0, breaking).** Replaced by unified
-  `prts_page(page_title, action, ...)`.
-- **`get_event_summary` (2.0, breaking).** Folded into
-  `list_stories(include_summaries=true)`; `get_story_summary` (single-chapter
-  deep summary) is unchanged.
+- **`search_data`, `search_enemies`, `search_stages`, `search_items`, `list_search_scopes` (2.0, breaking).** Replaced by unified `search(scope, ...)`; the scope catalogue previously returned by `list_search_scopes` is folded into the `search` tool description.
+- **`read_prts_page`, `list_prts_sections`, `get_prts_categories`, `get_prts_links`, `get_prts_template` (2.0, breaking).** Replaced by unified `prts_page(page_title, action, ...)`.
+- **`get_event_summary` (2.0, breaking).** Folded into `list_stories(include_summaries=true)`; `get_story_summary` (single-chapter deep summary) is unchanged.
 
 ## [1.7.0] - 2026-07-02
 
@@ -308,277 +152,153 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- **Story character tracking.** Two new tools reuse the existing story search
-  index (no new data source): `find_character_appearances(name, scope?,
-  max_events?)` returns chapters where a character **speaks** (dialog role
-  exact match) or is **mentioned** (name substring in any line text);
-  `find_speakers_in(event_id)` lists every speaker in an event with dialog
-  line counts. Brings the tool surface to 32.
+- **Story character tracking.** Two new tools reuse the existing story search index (no new data source): `find_character_appearances(name, scope?, max_events?)` returns chapters where a character **speaks** (dialog role exact match) or is **mentioned** (name substring in any line text); `find_speakers_in(event_id)` lists every speaker in an event with dialog line counts. Brings the tool surface to 32.
 
 ### Changed
 
-- **Module split: story and server god files.** `data/story.ts` (907 lines) and
-  `server.ts` (1173 lines) were split into focused submodules to meet the
-  STYLE.md file-size guideline (~300 lines). `story.ts` is now a re-export shim
-  over `storyReader`, `storySearch`, `storyMemoir`, and `storySummary`.
-  `server.ts` is now a ~200-line entry point (Express + session management) that
-  delegates tool registration to `tools/prtsTools`, `tools/gamedataTools`, and
-  `tools/storyTools`, and sync orchestration to `startupSync`. All public
-  symbols are re-exported — no behaviour change.
-- **Dead code removal in sync.** The original GitHub raw file sync path
-  (`syncRepo`, `downloadFiles`, `checkUpstreamSha`, `syncAll`, `cacheMetaPath`,
-  `loadCacheMeta`, `saveCacheMeta`, `filesPresent`) had no external callers and
-  has been removed. `sync.ts` shrank from 700 to 504 lines. The remaining
-  exported sync symbols (`SyncResult`, `RepoSpec`, `GAMEDATA_FILES`) are retained
-  for the Release-based sync path.
+- **Module split: story and server god files.** `data/story.ts` (907 lines) and `server.ts` (1173 lines) were split into focused submodules to meet the STYLE.md file-size guideline (~300 lines). `story.ts` is now a re-export shim over `storyReader`, `storySearch`, `storyMemoir`, and `storySummary`. `server.ts` is now a ~200-line entry point (Express + session management) that delegates tool registration to `tools/prtsTools`, `tools/gamedataTools`, and `tools/storyTools`, and sync orchestration to `startupSync`. All public symbols are re-exported — no behaviour change.
+- **Dead code removal in sync.** The original GitHub raw file sync path (`syncRepo`, `downloadFiles`, `checkUpstreamSha`, `syncAll`, `cacheMetaPath`, `loadCacheMeta`, `saveCacheMeta`, `filesPresent`) had no external callers and has been removed. `sync.ts` shrank from 700 to 504 lines. The remaining exported sync symbols (`SyncResult`, `RepoSpec`, `GAMEDATA_FILES`) are retained for the Release-based sync path.
 
 ## [1.6.1] - 2026-06-03
 
 ### Added
 
-- **Operator memoir discovery.** New `get_operator_memoirs(operator_name)` tool
-  resolves operator Chinese name to memoir story keys via `chardict.json`,
-  enabling LLM agents to find and read operator memoir (干员密录) dialogue.
-- This new tool is treated as a one-off patch-line exception because it exposes
-  story data that already existed in the synced StoryJson archive but was not
-  discoverable through the public tool surface.
-- `list_story_events(category="memoirs")` now exposes 372 previously hidden
-  operator memoir events.
+- **Operator memoir discovery.** New `get_operator_memoirs(operator_name)` tool resolves operator Chinese name to memoir story keys via `chardict.json`, enabling LLM agents to find and read operator memoir (干员密录) dialogue.
+- This new tool is treated as a one-off patch-line exception because it exposes story data that already existed in the synced StoryJson archive but was not discoverable through the public tool surface.
+- `list_story_events(category="memoirs")` now exposes 372 previously hidden operator memoir events.
 - Operator memoir dialogue is now indexed by `search_stories`.
 
 ### Changed
 
-- Search tools backed by local game/story data now reuse cached search records
-  instead of rebuilding parsed text on every call, substantially improving
-  repeated full-story and full-table regex searches.
+- Search tools backed by local game/story data now reuse cached search records instead of rebuilding parsed text on every call, substantially improving repeated full-story and full-table regex searches.
 - Enemy search records now include `enemyTags` in searchable text.
 
 ### Fixed
 
-- Story search now caps `max_results` and `context_lines` consistently to
-  prevent oversized MCP responses from long-running full-dataset searches.
-- `search_stages` and `search_items` now enforce `max_results` bounds (1–100)
-  for parity with other search tools.
-- `list_story_events` and `search_stories` no longer ignore entries with
-  `entryType: "NONE"` when those entries have valid story data (was the
-  root cause of memoirs being undiscoverable).
+- Story search now caps `max_results` and `context_lines` consistently to prevent oversized MCP responses from long-running full-dataset searches.
+- `search_stages` and `search_items` now enforce `max_results` bounds (1–100) for parity with other search tools.
+- `list_story_events` and `search_stories` no longer ignore entries with `entryType: "NONE"` when those entries have valid story data (was the root cause of memoirs being undiscoverable).
 
 ## [1.6.0] - 2026-05-28
 
 ### Added
 
-- **Item/material data domain.** Three new tools — `list_items`,
-  `get_item_info`, and `search_items` — read `item_table.json` to expose
-  material/item lists, details, obtain methods, stage drops, production, and
-  shop/voucher links.
-- **Stage/enemy cross-source fusion.** Added `get_stage_enemies(stage_id)` and
-  `get_enemy_appearances(name, limit, offset)` backed by `zh_CN-levels.zip`.
-  `get_enemy_info(name)` now accepts optional `stage_id` for stage-specific
-  enemy levels and overwritten combat stats while preserving the default
-  handbook behavior.
-- Tool surface expanded from 24 to 29. `list_search_scopes` now includes the
-  items domain.
-- Runtime data sync now handles three datasets: `zh_CN-excel.zip`,
-  `zh_CN-levels.zip`, and story `zh_CN.zip`. Docker images and npm packages
-  prewarm `data/gamedata-levels` alongside existing bundled fallback data.
+- **Item/material data domain.** Three new tools — `list_items`, `get_item_info`, and `search_items` — read `item_table.json` to expose material/item lists, details, obtain methods, stage drops, production, and shop/voucher links.
+- **Stage/enemy cross-source fusion.** Added `get_stage_enemies(stage_id)` and `get_enemy_appearances(name, limit, offset)` backed by `zh_CN-levels.zip`. `get_enemy_info(name)` now accepts optional `stage_id` for stage-specific enemy levels and overwritten combat stats while preserving the default handbook behavior.
+- Tool surface expanded from 24 to 29. `list_search_scopes` now includes the items domain.
+- Runtime data sync now handles three datasets: `zh_CN-excel.zip`, `zh_CN-levels.zip`, and story `zh_CN.zip`. Docker images and npm packages prewarm `data/gamedata-levels` alongside existing bundled fallback data.
 
 ### Changed
 
-- Stage drop formatting now resolves item IDs through `item_table.json` when
-  available, e.g. `招聘许可（7001）`.
+- Stage drop formatting now resolves item IDs through `item_table.json` when available, e.g. `招聘许可（7001）`.
 
 ### Fixed
 
-- **Release archive validation.** Archive sync validates required zip entries
-  before extraction and rechecks required files after extraction, so a partial
-  or corrupt `zh_CN-levels.zip` cannot be logged as healthy data.
-- **Enemy appearance lookup memory profile.** `get_enemy_appearances` now scans
-  for the requested enemy instead of permanently caching an all-enemy
-  appearance index on first use.
-- **Release zip cache validation parity.** `syncRelease` now treats a cached
-  zip that fails the dataset validator as unusable during network fallback,
-  matching Python behavior and preventing corrupt story archives from being
-  reported as healthy fallback data.
-- **Session timer lifecycle.** Idle-session timers now call `unref()` so they
-  do not keep an otherwise idle Node process alive.
+- **Release archive validation.** Archive sync validates required zip entries before extraction and rechecks required files after extraction, so a partial or corrupt `zh_CN-levels.zip` cannot be logged as healthy data.
+- **Enemy appearance lookup memory profile.** `get_enemy_appearances` now scans for the requested enemy instead of permanently caching an all-enemy appearance index on first use.
+- **Release zip cache validation parity.** `syncRelease` now treats a cached zip that fails the dataset validator as unusable during network fallback, matching Python behavior and preventing corrupt story archives from being reported as healthy fallback data.
+- **Session timer lifecycle.** Idle-session timers now call `unref()` so they do not keep an otherwise idle Node process alive.
 
 ## [1.5.0] - 2026-05-25
 
 ### Added
 
-- **Stage data domain.** Three new tools — `list_stages`, `get_stage_info`,
-  `search_stages` — sourced from `stage_table.json` (3319 stages) and
-  `zone_table.json` (434 zones) in ArknightsGameData. `list_stages` supports
-  zone and stage-type filters with pagination; `get_stage_info` returns
-  detailed per-stage data (drops, unlocks, related variants); `search_stages`
-  performs regex search across names, codes, descriptions, and types.
-- Tool surface expanded from 21 to 24. `list_search_scopes` updated with
-  stages and enemies entries.
-- `stage_table.json` and `zone_table.json` added to sync manifests for
-  integrity validation.
+- **Stage data domain.** Three new tools — `list_stages`, `get_stage_info`, `search_stages` — sourced from `stage_table.json` (3319 stages) and `zone_table.json` (434 zones) in ArknightsGameData. `list_stages` supports zone and stage-type filters with pagination; `get_stage_info` returns detailed per-stage data (drops, unlocks, related variants); `search_stages` performs regex search across names, codes, descriptions, and types.
+- Tool surface expanded from 21 to 24. `list_search_scopes` updated with stages and enemies entries.
+- `stage_table.json` and `zone_table.json` added to sync manifests for integrity validation.
 
 ## [1.4.2] - 2026-05-25
 
 ### Fixed
 
-- **Session pool 400 on stale session ID.** When a client reuses a session ID
-  that was evicted by idle timeout or lost across server restart, the server
-  now returns a spec-compliant 404 (error code `-32002`) with an
-  LLM-actionable message instead of the previous 400 "Server not initialized".
-  Initialize requests with a stale session ID auto-recover (strip old ID,
-  treat as fresh handshake) — an intentional relaxation of MCP Streamable
-  HTTP §3.2 for clients that don't retry with a fresh handshake on error.
+- **Session pool 400 on stale session ID.** When a client reuses a session ID that was evicted by idle timeout or lost across server restart, the server now returns a spec-compliant 404 (error code `-32002`) with an LLM-actionable message instead of the previous 400 "Server not initialized". Initialize requests with a stale session ID auto-recover (strip old ID, treat as fresh handshake) — an intentional relaxation of MCP Streamable HTTP §3.2 for clients that don't retry with a fresh handshake on error.
 
 ### Changed
 
-- **Session idle timeout default extended** from 30 minutes to 24 hours,
-  reducing the chance of session eviction during normal interactive use.
-  Configurable via `SESSION_IDLE_TIMEOUT_MS` env var.
-- **Session idle timeout test** tightened to assert exact 404 status and
-  error code, plus a new sub-test for init auto-recovery path.
+- **Session idle timeout default extended** from 30 minutes to 24 hours, reducing the chance of session eviction during normal interactive use. Configurable via `SESSION_IDLE_TIMEOUT_MS` env var.
+- **Session idle timeout test** tightened to assert exact 404 status and error code, plus a new sub-test for init auto-recovery path.
 
 ## [1.4.1] - 2026-05-19
 
 ### Fixed
 
-- **ZipStore zip instance caching.** `AdmZip` is now cached instead of
-  re-instantiated on every `exists()`/`readText()` call. In `search_stories`
-  without an `event_id` filter this was ~3000 redundant zip parses,
-  exceeding the 120 s MCP client timeout.
-- **Session memory leak.** `SESSION_IDLE_TIMEOUT_MS` (default 30 min)
-  evicts MCP transports left behind by clients that disconnect without
-  cleanly closing their session, preventing unbounded memory growth.
-- **Enemy blackboard parity.** Filter/slice order corrected to match
-  Python: slice first 6 entries, then filter null values.
-- **HTML entity decoding.** `String.fromCodePoint` replaces
-  `String.fromCharCode` for correct non-BMP Unicode handling. Named entity
-  table extended from 6 hardcoded replacements to a lookup table with
-  regex-based fallback for unrecognized entities.
-- **Story search robustness.** `read_activity` gains `page >= 1` validation.
-  Exception handling in `search_stories` and `read_activity` narrowed from
-  bare `catch {}` to expected error types. Convenience wrappers
-  (`searchStories`, `getEventSummary`, `getStorySummary`) now use
-  `storyStore()` for consistency.
+- **ZipStore zip instance caching.** `AdmZip` is now cached instead of re-instantiated on every `exists()`/`readText()` call. In `search_stories` without an `event_id` filter this was ~3000 redundant zip parses, exceeding the 120 s MCP client timeout.
+- **Session memory leak.** `SESSION_IDLE_TIMEOUT_MS` (default 30 min) evicts MCP transports left behind by clients that disconnect without cleanly closing their session, preventing unbounded memory growth.
+- **Enemy blackboard parity.** Filter/slice order corrected to match Python: slice first 6 entries, then filter null values.
+- **HTML entity decoding.** `String.fromCodePoint` replaces `String.fromCharCode` for correct non-BMP Unicode handling. Named entity table extended from 6 hardcoded replacements to a lookup table with regex-based fallback for unrecognized entities.
+- **Story search robustness.** `read_activity` gains `page >= 1` validation. Exception handling in `search_stories` and `read_activity` narrowed from bare `catch {}` to expected error types. Convenience wrappers (`searchStories`, `getEventSummary`, `getStorySummary`) now use `storyStore()` for consistency.
 
 ### Added
 
-- **E2E test suite.** MCP protocol-level test (`e2e.test.ts`) covering
-  handshake, tool surface (all 21 tools), operator data, and graceful
-  degradation when optional data is unavailable.
+- **E2E test suite.** MCP protocol-level test (`e2e.test.ts`) covering handshake, tool surface (all 21 tools), operator data, and graceful degradation when optional data is unavailable.
 
 ## [1.4.0] - 2026-05-19
 
 ### Added
 
-- **PRTS template data extraction.** `get_prts_template(page_title)` returns
-  structured key-value data from MediaWiki template calls on a page via
-  `action=parse&prop=parsetree`. Only top-level templates are returned;
-  nested templates inside values are stripped.
-- **Enemy handbook tools.** Three new tools backed by `enemy_handbook_table.json`
-  with optional combat-stats merge from `levels/enemydata/enemy_database.json`:
-  - `list_enemies(threat_level?, limit, offset, full)` — paginated listing
-    with `boss` / `elite` / `normal` filter. Defaults to first 50 entries.
-  - `get_enemy_info(name)` — handbook entry merged with HP / ATK / DEF / RES,
-    immunities, and skill list with blackboard params.
-  - `search_enemies(pattern, max_results)` — regex search across enemy
-    names, descriptions, and abilities.
+- **PRTS template data extraction.** `get_prts_template(page_title)` returns structured key-value data from MediaWiki template calls on a page via `action=parse&prop=parsetree`. Only top-level templates are returned; nested templates inside values are stripped.
+- **Enemy handbook tools.** Three new tools backed by `enemy_handbook_table.json` with optional combat-stats merge from `levels/enemydata/enemy_database.json`:
+  - `list_enemies(threat_level?, limit, offset, full)` — paginated listing with `boss` / `elite` / `normal` filter. Defaults to first 50 entries.
+  - `get_enemy_info(name)` — handbook entry merged with HP / ATK / DEF / RES, immunities, and skill list with blackboard params.
+  - `search_enemies(pattern, max_results)` — regex search across enemy names, descriptions, and abilities.
 
 ## [1.3.1] - 2026-05-19
 
 ### Fixed
 
-- **Operator name-to-ID collision.** `resolveCharId()` and `searchOperatorData()`
-  now filter to `char_*` entries only, preventing `trap_*` and `token_*` entries
-  from silently overwriting real operator IDs when they share the same Chinese
-  name. Fixes `get_operator_basic_info`, `get_operator_archives`,
-  `get_operator_voicelines`, and `search_data` for affected operators (阿米娅,
-  森蚺, 狮蝎, 佩佩, 断罪者, etc.).
+- **Operator name-to-ID collision.** `resolveCharId()` and `searchOperatorData()` now filter to `char_*` entries only, preventing `trap_*` and `token_*` entries from silently overwriting real operator IDs when they share the same Chinese name. Fixes `get_operator_basic_info`, `get_operator_archives`, `get_operator_voicelines`, and `search_data` for affected operators (阿米娅, 森蚺, 狮蝎, 佩佩, 断罪者, etc.).
 
 ## [1.3.0] - 2026-05-18
 
 ### Added
 
-- **PRTS page table of contents.** `list_prts_sections(page_title)` returns the
-  section index for a wiki page.
-- **PRTS page categories.** `get_prts_categories(page_title)` returns category
-  tags for a wiki page.
-- **PRTS page links.** `get_prts_links(page_title, direction, limit)` returns
-  outbound links or inbound backlinks with pagination.
+- **PRTS page table of contents.** `list_prts_sections(page_title)` returns the section index for a wiki page.
+- **PRTS page categories.** `get_prts_categories(page_title)` returns category tags for a wiki page.
+- **PRTS page links.** `get_prts_links(page_title, direction, limit)` returns outbound links or inbound backlinks with pagination.
 
 ### Changed
 
 - **`read_prts_page` gains `section_index` parameter.** Backwards-compatible.
-- **`search_prts` enhanced.** New `search_mode` (`text` / `title`),
-  `filter_technical` toggle, and `totalHits` in results. Backwards-compatible.
+- **`search_prts` enhanced.** New `search_mode` (`text` / `title`), `filter_technical` toggle, and `totalHits` in results. Backwards-compatible.
 
 ## [1.2.0] - 2026-05-14
 
 ### Added
 
-- **Story chapter summaries.** Two new tools and one enhancement built on the
-  previously-unused `zh_CN/storyinfo.json` index (1,945 entries), plus an
-  LLM summarization pipeline in the data-source fork:
-  - `get_event_summary(event_id)` — narrative overview of every chapter in an
-    event, with chapter codes, tags, names, and summary text. When LLM event
-    summaries are available (`zh_CN/event_summaries.json`), a full-dialogue
-    V2 synopsis is prepended above the chapter listing.
-  - `get_story_summary(story_key)` — single-chapter summary with a three-tier
-    fallback chain: LLM long summary (`zh_CN/summaries.json`, 5~7:1 compression),
-    official one-liner (`zh_CN/storyinfo.json`), and chapter `storyInfo` field.
-  - `list_stories` now accepts `include_summaries` (bool). When `true`, each
-    chapter line includes an indented summary below it.
-- **LLM summarization pipeline** (`3aKHP/ArknightsStoryJson` fork):
-  `scripts/summarize.py` generates per-chapter (5~7:1) and per-event (10:1)
-  summaries via DeepSeek V4 Flash API during CI release, injecting them into
-  `zh_CN.zip` for transparent consumption by the MCP server.
+- **Story chapter summaries.** Two new tools and one enhancement built on the previously-unused `zh_CN/storyinfo.json` index (1,945 entries), plus an LLM summarization pipeline in the data-source fork:
+  - `get_event_summary(event_id)` — narrative overview of every chapter in an event, with chapter codes, tags, names, and summary text. When LLM event summaries are available (`zh_CN/event_summaries.json`), a full-dialogue V2 synopsis is prepended above the chapter listing.
+  - `get_story_summary(story_key)` — single-chapter summary with a three-tier fallback chain: LLM long summary (`zh_CN/summaries.json`, 5~7:1 compression), official one-liner (`zh_CN/storyinfo.json`), and chapter `storyInfo` field.
+  - `list_stories` now accepts `include_summaries` (bool). When `true`, each chapter line includes an indented summary below it.
+- **LLM summarization pipeline** (`3aKHP/ArknightsStoryJson` fork): `scripts/summarize.py` generates per-chapter (5~7:1) and per-event (10:1) summaries via DeepSeek V4 Flash API during CI release, injecting them into `zh_CN.zip` for transparent consumption by the MCP server.
 
 ## [1.1.1] - 2026-05-14
 
 ### Fixed
 
-- **`read_prts_page` now returns full page content.** Switched from
-  `action=query&prop=extracts` (which strips all template-rendered content)
-  to `action=parse&prop=text`. Character pages now return 22K+ chars of
-  readable text instead of ~400 chars of empty section headers.
-- **`search_prts` restricts to main namespace.** Added `srnamespace=0`
-  so search results are no longer polluted by technical data pages from
-  other MediaWiki namespaces.
-- **Search snippets are cleaned of HTML entities and JSON fragments.**
-  Added HTML entity decoding and residual-wikitext cleanup after
-  `stripWikitext`.
+- **`read_prts_page` now returns full page content.** Switched from `action=query&prop=extracts` (which strips all template-rendered content) to `action=parse&prop=text`. Character pages now return 22K+ chars of readable text instead of ~400 chars of empty section headers.
+- **`search_prts` restricts to main namespace.** Added `srnamespace=0` so search results are no longer polluted by technical data pages from other MediaWiki namespaces.
+- **Search snippets are cleaned of HTML entities and JSON fragments.** Added HTML entity decoding and residual-wikitext cleanup after `stripWikitext`.
 
 ## [1.1.0] - 2026-05-14
 
 ### Added
 
-- **Search tools.** Three new MCP tools provide full-text regex search across
-  operator data and story dialogue, enabling exploratory queries without
-  knowing exact operator names or story keys upfront:
+- **Search tools.** Three new MCP tools provide full-text regex search across operator data and story dialogue, enabling exploratory queries without knowing exact operator names or story keys upfront:
   - `list_search_scopes` — list searchable data domains and their content types.
-  - `search_data(pattern, scope, max_results)` — search operator names,
-    descriptions, archive texts, and voice lines.
-  - `search_stories(pattern, character, line_type, context_lines, max_results, event_id)`
-    — search story dialogue, narration, and choice lines with filtering by
-    speaker and line type, plus configurable context lines around each match.
+  - `search_data(pattern, scope, max_results)` — search operator names, descriptions, archive texts, and voice lines.
+  - `search_stories(pattern, character, line_type, context_lines, max_results, event_id)` — search story dialogue, narration, and choice lines with filtering by speaker and line type, plus configurable context lines around each match.
 
 ## [1.0.0] - 2026-05-13
 
 ### Changed
 
-- **Public tool surface frozen.** The 9 MCP tool names, required parameters,
-  and response formats are locked. Automated tests enforce this in CI for
-  both Python and TypeScript.
-- CI now downloads the storyjson `zh_CN.zip` fixture before running Python
-  tests so story integration tests are no longer silently skipped.
-- Migration guide expanded with behavioral changes from 0.x: Release archive
-  sync, `archives/` cache metadata, `local_repo.jsonc` removal, and
-  `story_review_table.json` as a required gamedata file.
+- **Public tool surface frozen.** The 9 MCP tool names, required parameters, and response formats are locked. Automated tests enforce this in CI for both Python and TypeScript.
+- CI now downloads the storyjson `zh_CN.zip` fixture before running Python tests so story integration tests are no longer silently skipped.
+- Migration guide expanded with behavioral changes from 0.x: Release archive sync, `archives/` cache metadata, `local_repo.jsonc` removal, and `story_review_table.json` as a required gamedata file.
 
 ### Fixed
 
-- `include_narration=false` in `readStory` now also excludes unnamed speaker
-  lines (stage directions displayed as `（旁白）：text`) instead of only
-  excluding `type="narration"` sticker/subtitle/animation lines.
+- `include_narration=false` in `readStory` now also excludes unnamed speaker lines (stage directions displayed as `（旁白）：text`) instead of only excluding `type="narration"` sticker/subtitle/animation lines.
 
 ## [1.0.0-beta.1] - 2026-05-12
 
@@ -586,12 +306,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
-- Post-download zip integrity validation for the storyjson Release asset:
-  every chapter referenced by `story_review_table.json` must exist in the
-  downloaded zip before it replaces the cached copy. A missing or unreadable
-  archive is rejected and falls through the normal `offline_fallback` /
-  retry path instead of silently corrupting the local cache. Matches the
-  pre-existing Python behavior.
+- Post-download zip integrity validation for the storyjson Release asset: every chapter referenced by `story_review_table.json` must exist in the downloaded zip before it replaces the cached copy. A missing or unreadable archive is rejected and falls through the normal `offline_fallback` / retry path instead of silently corrupting the local cache. Matches the pre-existing Python behavior.
 
 ## [1.0.0-alpha.1] - 2026-05-03
 
@@ -603,76 +318,54 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
-- Operator and story parsers now read through the new store abstraction while preserving
-  current MCP tool names, parameters, and output formatting.
-- Runtime sync setup now consumes dataset specs instead of repeating Release metadata in
-  server startup code.
+- Operator and story parsers now read through the new store abstraction while preserving current MCP tool names, parameters, and output formatting.
+- Runtime sync setup now consumes dataset specs instead of repeating Release metadata in server startup code.
 
 ## [0.3.3] - 2026-05-03
 
 ### Fixed
 
-- The HTTP server now starts listening before GameData and story auto-sync run
-  in the background, so slow GitHub Release downloads no longer leave systemd
-  active while the port is unavailable.
+- The HTTP server now starts listening before GameData and story auto-sync run in the background, so slow GitHub Release downloads no longer leave systemd active while the port is unavailable.
 
 ## [0.3.2] - 2026-05-03
 
 ### Changed
 
-- ArknightsGameData auto-sync now downloads the `zh_CN-excel.zip` Release asset from
-  `3aKHP/ArknightsGameData` and extracts it into the existing `gamedata` layout, aligning
-  the game-data and story-data sync paths around GitHub Release archives.
-- npm bundled game data is now prewarmed through `python/scripts/fetch_gamedata.py`, using
-  the same Release archive as runtime sync instead of downloading raw JSON files directly.
+- ArknightsGameData auto-sync now downloads the `zh_CN-excel.zip` Release asset from `3aKHP/ArknightsGameData` and extracts it into the existing `gamedata` layout, aligning the game-data and story-data sync paths around GitHub Release archives.
+- npm bundled game data is now prewarmed through `python/scripts/fetch_gamedata.py`, using the same Release archive as runtime sync instead of downloading raw JSON files directly.
 - Package metadata now targets `0.3.2` for this transition release.
-- Operator table caches are cleared after startup auto-sync writes updated game data, and
-  core operator behavior is covered by Node test-runner smoke tests.
+- Operator table caches are cleared after startup auto-sync writes updated game data, and core operator behavior is covered by Node test-runner smoke tests.
 
 ## [0.3.0] - 2026-04-10
 
 ### Added
 
-- `GITHUB_MIRRORS` environment variable: comma-separated list of ghproxy-style proxy base URLs
-  (e.g. `GITHUB_MIRRORS=https://ghproxy.net`) tried in order after the direct GitHub URL fails,
-  enabling auto-sync on servers behind the GFW
-- Blind download path in `sync_release`: when the GitHub API is unreachable but mirrors are
-  configured and no local data exists, the storyjson zip is fetched via the
-  `releases/latest/download/` redirect URL which does not require an API call
-- `list_story_events`, `list_stories`, `read_story`, `read_activity` tools for querying
-  Arknights story scripts and event metadata from ArknightsStoryJson
-- Bundled game data (`data/gamedata/`, `data/storyjson/`) included in the npm package so the
-  server starts with offline fallback data without requiring a prior sync
-- `config.ts` now resolves data paths relative to `import.meta.url` (package root) so bundled
-  paths work correctly for both npm installs and Docker
+- `GITHUB_MIRRORS` environment variable: comma-separated list of ghproxy-style proxy base URLs (e.g. `GITHUB_MIRRORS=https://ghproxy.net`) tried in order after the direct GitHub URL fails, enabling auto-sync on servers behind the GFW
+- Blind download path in `sync_release`: when the GitHub API is unreachable but mirrors are configured and no local data exists, the storyjson zip is fetched via the `releases/latest/download/` redirect URL which does not require an API call
+- `list_story_events`, `list_stories`, `read_story`, `read_activity` tools for querying Arknights story scripts and event metadata from ArknightsStoryJson
+- Bundled game data (`data/gamedata/`, `data/storyjson/`) included in the npm package so the server starts with offline fallback data without requiring a prior sync
+- `config.ts` now resolves data paths relative to `import.meta.url` (package root) so bundled paths work correctly for both npm installs and Docker
 
 ### Fixed
 
-- `story_review_table.json` added to bundled data and `cache_meta.json`; was missing after the
-  story feature added it to `REQUIRED_OPERATOR_FILES`, causing `filesComplete()` to always return
-  false for the bundled path
-- Dead code (`STORYINFO` constant) removed; unused import dropped; null role format aligned with
-  Python implementation
+- `story_review_table.json` added to bundled data and `cache_meta.json`; was missing after the story feature added it to `REQUIRED_OPERATOR_FILES`, causing `filesComplete()` to always return false for the bundled path
+- Dead code (`STORYINFO` constant) removed; unused import dropped; null role format aligned with Python implementation
 
 ## [0.2.0] - 2026-04-08
 
 ### Added
 
-- `get_operator_basic_info` tool exposing operator rarity, class, faction, and description from
-  `character_table.json`
-- Streamable HTTP transport (MCP 2025-03-26 spec) replacing the earlier SSE-based approach;
-  endpoint at `/mcp`, health check at `/health`
+- `get_operator_basic_info` tool exposing operator rarity, class, faction, and description from `character_table.json`
+- Streamable HTTP transport (MCP 2025-03-26 spec) replacing the earlier SSE-based approach; endpoint at `/mcp`, health check at `/health`
 - Docker image for self-hosted HTTP server deployment
 - npm package (`prts-mcp-ts`) for `npx` / global install usage
-- GitHub Actions CD workflow (`cd-ts.yml`) publishing to npm with Trusted Publishing and pushing
-  Docker image to GHCR
+- GitHub Actions CD workflow (`cd-ts.yml`) publishing to npm with Trusted Publishing and pushing Docker image to GHCR
 
 ## [0.1.0] - 2026-03-18
 
 ### Added
 
-- FastMCP TypeScript server with 4 tools: `search_prts`, `read_prts_page`,
-  `get_operator_archives`, `get_operator_voicelines`
+- FastMCP TypeScript server with 4 tools: `search_prts`, `read_prts_page`, `get_operator_archives`, `get_operator_voicelines`
 - PRTS MediaWiki API integration with rate limiting and custom User-Agent
 - Local ArknightsGameData JSON reader with LRU caching
 - Wikitext sanitizer for stripping templates, file links, and HTML tags


### PR DESCRIPTION
## Summary

Batch 2 of #110 的硬换行清理：把同一条 CJK 感知展开策略应用到 `python/CHANGELOG.md` 与 `ts/CHANGELOG.md`。这两个文件在 #110 中被有意推迟，以隔离 diff 噪音。每个多行 changelog bullet 现折成一行，与其余公开文档的自然换行风格一致。

- **连接策略**：与 #110 完全相同（CJK↔CJK 不加空格、其余加单空格）。
- **不动**：代码栅栏、表格、版本段 `## [X.Y.Z]`、子段 `### Added/Changed/Fixed/...`、HR、链接引用定义。
- **净改动**：2 文件，+229 / −855（合并掉 626 行）。

合并后整条 changelog entry 为单行（有些 400+ 列）——这是该风格的有意取舍：一条 entry = 一行，便于按条目而非按折行查阅 blame。未来如需让 blame 忽略这两文件的纯重排，可考虑 `.gitattributes` 的 `git-blame-ignore-rewrites`（本次未做）。

## Test plan

- [x] char-保留不变量：2/2 文件非空白字符序列变换前后一致。
- [x] 硬换行探测器复扫：0 残留折行。
- [x] 幂等：二次运行 no-change。
- [x] 空行计数 before=after（python 148→148，ts 141→141）→ 段落边界未变。
- [x] 列表标记行计数 before=after（python 155→155，ts 141→141）→ bullet 完整、无跨条目合并。
- [x] 版本段标题 `## ` 计数 before=after（33→33 / 32→32）。
- [x] 子段标题 `### ` 计数 before=after（56→56 / 53→53）。
- [x] link-ref 定义计数 0→0（两文件均无底部比较链接）。
- [x] diff 肉眼：Unreleased + 多个版本段，连接质量正常（bold lead、代码 span、em-dash、CJK 全保留）。
- [ ] **KHPilot Bot CR**（PR 打开后自动审）。

注：纯文档重排，无源码改动，未跑 Python/TS 测试套件。

## 未尽事宜

- **独立子代理 CR 本轮不再尝试**：#110 期间子代理后端系统性故障（4× API 400 + 3× 完成不回传）。Batch 2 是同脚本同策略在新文件上的复用，脚本行为已在 #110 被 KHPilot 深度独立验证；本轮独立轨仍由 KHPilot 在 PR 打开时自动审。
- **`.gitattributes` blame 豁免（可选，未做）**：如希望 git blame 自动忽略本 PR 的纯重排，可在后续 chore PR 加 `python/CHANGELOG.md ts/CHANGELOG.md` 的 blame-rewrites 配置（需这些文件标记 `encoding`/`replace` 语义）。本次未做，避免扩大范围。
- 至此全仓公开文档的 80 列硬换行清理（Batch 1 + Batch 2）收尾完成。