### PR TITLE
feat: 2.6.0-alpha.1 cache instrumentation + #100 remaining items

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Cache instrumentation (`/debug/cache` endpoint).** Each data module exports `cache_stats()` returning per-cache `{loaded, count}` (and `bytes` for the MediaWiki image LRU). The read-only `/debug/cache` HTTP endpoint aggregates all 9 modules' stats for observability (#104).
+
+### Changed
+
+- Base illust label mapping (`BASE_ILLUST_LABELS`) consolidated to a single owner in `data/images.py`; `data/artwork_mediawiki.py` imports it instead of maintaining a duplicate (#100).
+
 ## [2.5.1] - 2026-08-07
 
 ### Fixed

--- a/python/src/prts_mcp/config.py
+++ b/python/src/prts_mcp/config.py
@@ -440,3 +440,20 @@ def activation_aware_cache(maxsize: int = 1) -> Callable[[Callable[..., Any]], C
         return wrapped
 
     return decorate
+
+
+def cache_stat(cached_func: Callable[..., Any]) -> dict[str, Any]:
+    """Best-effort ``{loaded, count}`` for an activation_aware_cache function.
+
+    Uses ``cache_info().currsize`` to determine whether the cache is populated
+    without side effects.  When populated, calling the function hits the
+    lru_cache (no disk I/O) so ``len(result)`` gives the record count.
+    """
+    info = cached_func.cache_info()
+    if info.currsize == 0:
+        return {"loaded": False, "count": 0}
+    try:
+        result = cached_func()
+        return {"loaded": True, "count": len(result) if hasattr(result, "__len__") else 1}
+    except Exception:  # noqa: BLE001
+        return {"loaded": False, "count": 0}

--- a/python/src/prts_mcp/config.py
+++ b/python/src/prts_mcp/config.py
@@ -469,4 +469,5 @@ def cache_stat(
             return {"loaded": True, "count": count_fn(result)}
         return {"loaded": True, "count": len(result) if hasattr(result, "__len__") else 1}
     except Exception:  # noqa: BLE001
+        _logger.debug("cache_stat: failed to read cached value", exc_info=True)
         return {"loaded": False, "count": 0}

--- a/python/src/prts_mcp/config.py
+++ b/python/src/prts_mcp/config.py
@@ -442,18 +442,31 @@ def activation_aware_cache(maxsize: int = 1) -> Callable[[Callable[..., Any]], C
     return decorate
 
 
-def cache_stat(cached_func: Callable[..., Any]) -> dict[str, Any]:
+def cache_stat(
+    cached_func: Callable[..., Any],
+    count_fn: Callable[[Any], int] | None = None,
+) -> dict[str, Any]:
     """Best-effort ``{loaded, count}`` for an activation_aware_cache function.
 
-    Uses ``cache_info().currsize`` to determine whether the cache is populated
-    without side effects.  When populated, calling the function hits the
-    lru_cache (no disk I/O) so ``len(result)`` gives the record count.
+    Uses ``cache_info().currsize`` to determine whether the cache is populated.
+    When populated, calling the function hits the lru_cache in steady state so
+    ``len(result)`` (or *count_fn*) gives the record count.  If the activation
+    signature changed between the check and the call, the try/except catches
+    any reload failure.
+
+    *count_fn* overrides the default ``len()`` for caches whose top-level
+    structure is nested (e.g. a JSON wrapper whose record count lives in a
+    sub-dict).
     """
     info = cached_func.cache_info()
     if info.currsize == 0:
         return {"loaded": False, "count": 0}
     try:
         result = cached_func()
+        if result is None:
+            return {"loaded": False, "count": 0}
+        if count_fn is not None:
+            return {"loaded": True, "count": count_fn(result)}
         return {"loaded": True, "count": len(result) if hasattr(result, "__len__") else 1}
     except Exception:  # noqa: BLE001
         return {"loaded": False, "count": 0}

--- a/python/src/prts_mcp/data/artwork_mediawiki.py
+++ b/python/src/prts_mcp/data/artwork_mediawiki.py
@@ -43,6 +43,16 @@ def image_cache_put(artwork_id: str, variant: str, data: bytes) -> None:
             total -= len(evicted)
 
 
+def cache_stats() -> dict[str, dict]:
+    """Return ``{cache_name: {loaded, count, bytes}}`` for instrumentation (#104)."""
+    with _IMAGE_CACHE_LOCK:
+        count = len(_image_cache)
+        total = sum(len(v) for v in _image_cache.values())
+    return {
+        "image_cache": {"loaded": count > 0, "count": count, "bytes": total},
+    }
+
+
 def _mediawiki_base_label(suffix: str) -> str:
     base = suffix.rstrip("+")
     plus = "+" in suffix

--- a/python/src/prts_mcp/data/artwork_mediawiki.py
+++ b/python/src/prts_mcp/data/artwork_mediawiki.py
@@ -10,11 +10,12 @@ import threading
 from collections import OrderedDict
 from typing import Any, Mapping
 
+from prts_mcp.data.images import BASE_ILLUST_LABELS
+
 _IMAGE_CACHE_LOCK = threading.Lock()
 _image_cache: "OrderedDict[str, bytes]" = OrderedDict()
 _IMAGE_CACHE_MAX_BYTES = 256 * 1024 * 1024  # 256 MiB (#85 §4.2)
 
-_MEDIAWIKI_BASE_LABELS: Mapping[str, str] = {"1": "精英零立绘", "2": "精英二立绘"}
 VARIANT_WIDTH: Mapping[str, int] = {"large": 1024, "preview": 256}
 
 
@@ -45,7 +46,7 @@ def image_cache_put(artwork_id: str, variant: str, data: bytes) -> None:
 def _mediawiki_base_label(suffix: str) -> str:
     base = suffix.rstrip("+")
     plus = "+" in suffix
-    label = _MEDIAWIKI_BASE_LABELS.get(base)
+    label = BASE_ILLUST_LABELS.get(base)
     if label is None:
         label = f"立绘 {base}" if base else "立绘"
     if plus:

--- a/python/src/prts_mcp/data/enemy.py
+++ b/python/src/prts_mcp/data/enemy.py
@@ -4,7 +4,7 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from prts_mcp.config import Config, activation_aware_cache, register_activation_listener
+from prts_mcp.config import Config, activation_aware_cache, cache_stat, register_activation_listener
 from prts_mcp.data.stores import DirectoryStore
 
 
@@ -120,6 +120,16 @@ def _build_enemy_name_to_id() -> dict[str, str]:
 def _resolve_enemy_id(name: str) -> str | None:
     mapping = _build_enemy_name_to_id()
     return mapping.get(name)
+
+
+def cache_stats() -> dict[str, dict]:
+    """Return ``{cache_name: {loaded, count}}`` for instrumentation (#104)."""
+    return {
+        "enemy_handbook": cache_stat(_load_enemy_handbook),
+        "enemy_database": cache_stat(_load_enemy_database),
+        "enemy_name_to_id": cache_stat(_build_enemy_name_to_id),
+        "enemy_search_records": cache_stat(_enemy_search_records),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/python/src/prts_mcp/data/enemy.py
+++ b/python/src/prts_mcp/data/enemy.py
@@ -125,8 +125,12 @@ def _resolve_enemy_id(name: str) -> str | None:
 def cache_stats() -> dict[str, dict]:
     """Return ``{cache_name: {loaded, count}}`` for instrumentation (#104)."""
     return {
-        "enemy_handbook": cache_stat(_load_enemy_handbook),
-        "enemy_database": cache_stat(_load_enemy_database),
+        "enemy_handbook": cache_stat(
+            _load_enemy_handbook, lambda r: len(r.get("enemyData") or {})
+        ),
+        "enemy_database": cache_stat(
+            _load_enemy_database, lambda r: len(r.get("_index") or {})
+        ),
         "enemy_name_to_id": cache_stat(_build_enemy_name_to_id),
         "enemy_search_records": cache_stat(_enemy_search_records),
     }

--- a/python/src/prts_mcp/data/images.py
+++ b/python/src/prts_mcp/data/images.py
@@ -168,7 +168,7 @@ register_activation_listener(clear_image_caches)
 # Label construction
 # ---------------------------------------------------------------------------
 
-_BASE_ILLUST_LABELS: Mapping[str, str] = {"1": "精英零立绘", "2": "精英二立绘"}
+BASE_ILLUST_LABELS: Mapping[str, str] = {"1": "精英零立绘", "2": "精英二立绘"}
 
 
 def build_artwork_label(
@@ -204,7 +204,7 @@ def build_artwork_label(
     suffix = skin_id.rsplit("#", 1)[-1] if "#" in skin_id else ""
     base_num = suffix.rstrip("+")
     plus = "+" in suffix
-    label = _BASE_ILLUST_LABELS.get(base_num)
+    label = BASE_ILLUST_LABELS.get(base_num)
     if label is None:
         label = f"立绘 {base_num}" if base_num else "立绘"
     if plus:

--- a/python/src/prts_mcp/data/images.py
+++ b/python/src/prts_mcp/data/images.py
@@ -14,6 +14,7 @@ from typing import Any, Mapping
 from prts_mcp.config import (
     Config,
     activation_aware_cache,
+    cache_stat,
     register_activation_listener,
 )
 from prts_mcp.data.stores import DirectoryStore
@@ -162,6 +163,13 @@ def clear_image_caches() -> None:
 
 
 register_activation_listener(clear_image_caches)
+
+
+def cache_stats() -> dict[str, dict]:
+    """Return ``{cache_name: {loaded, count}}`` for instrumentation (#104)."""
+    return {
+        "char_skins": cache_stat(load_char_skins),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/python/src/prts_mcp/data/item.py
+++ b/python/src/prts_mcp/data/item.py
@@ -4,7 +4,7 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
-from prts_mcp.config import Config, activation_aware_cache, register_activation_listener
+from prts_mcp.config import Config, activation_aware_cache, cache_stat, register_activation_listener
 from prts_mcp.data.stores import DirectoryStore
 
 
@@ -466,3 +466,12 @@ def _item_search_records() -> tuple[_ItemSearchRecord, ...]:
             search_text=f"{search_text} {item_id}",
         ))
     return tuple(records)
+
+
+def cache_stats() -> dict[str, dict]:
+    """Return ``{cache_name: {loaded, count}}`` for instrumentation (#104)."""
+    return {
+        "items": cache_stat(_load_items),
+        "item_lookup": cache_stat(_build_item_lookup),
+        "item_search_records": cache_stat(_item_search_records),
+    }

--- a/python/src/prts_mcp/data/operator.py
+++ b/python/src/prts_mcp/data/operator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from prts_mcp.config import Config, activation_aware_cache, register_activation_listener
+from prts_mcp.config import Config, activation_aware_cache, cache_stat, register_activation_listener
 from prts_mcp.data.stores import DirectoryStore
 from prts_mcp.utils.sanitizer import strip_wikitext
 
@@ -81,6 +81,16 @@ def _build_name_to_id() -> dict[str, str]:
 def resolve_char_id(name: str) -> str | None:
     mapping = _build_name_to_id()
     return mapping.get(name)
+
+
+def cache_stats() -> dict[str, dict]:
+    """Return ``{cache_name: {loaded, count}}`` for instrumentation (#104)."""
+    return {
+        "character_table": cache_stat(_load_character_table),
+        "handbook_table": cache_stat(_load_handbook_table),
+        "charword_table": cache_stat(_load_charword_table),
+        "name_to_id": cache_stat(_build_name_to_id),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/python/src/prts_mcp/data/operator.py
+++ b/python/src/prts_mcp/data/operator.py
@@ -87,8 +87,12 @@ def cache_stats() -> dict[str, dict]:
     """Return ``{cache_name: {loaded, count}}`` for instrumentation (#104)."""
     return {
         "character_table": cache_stat(_load_character_table),
-        "handbook_table": cache_stat(_load_handbook_table),
-        "charword_table": cache_stat(_load_charword_table),
+        "handbook_table": cache_stat(
+            _load_handbook_table, lambda r: len(r.get("handbookDict") or {})
+        ),
+        "charword_table": cache_stat(
+            _load_charword_table, lambda r: len(r.get("charWords") or {})
+        ),
         "name_to_id": cache_stat(_build_name_to_id),
     }
 

--- a/python/src/prts_mcp/data/search.py
+++ b/python/src/prts_mcp/data/search.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-from prts_mcp.config import Config, activation_aware_cache
+from prts_mcp.config import Config, activation_aware_cache, cache_stat
 from prts_mcp.data.operator import (
     _build_name_to_id,
     _load_character_table,
@@ -198,3 +198,10 @@ def _operator_search_records() -> tuple[_OperatorSearchRecord, ...]:
             ))
 
     return tuple(records)
+
+
+def cache_stats() -> dict[str, dict]:
+    """Return ``{cache_name: {loaded, count}}`` for instrumentation (#104)."""
+    return {
+        "search_records": cache_stat(_operator_search_records),
+    }

--- a/python/src/prts_mcp/data/stage.py
+++ b/python/src/prts_mcp/data/stage.py
@@ -7,6 +7,7 @@ from typing import Any
 from prts_mcp.config import (
     Config as _Config,
     activation_aware_cache as _activation_aware_cache,
+    cache_stat as _cache_stat,
     register_activation_listener,
 )
 from prts_mcp.data.item import get_item_name_by_id as _get_item_name_by_id
@@ -514,3 +515,12 @@ def _stage_search_records() -> tuple[_StageSearchRecord, ...]:
             search_text=search_text,
         ))
     return tuple(records)
+
+
+def cache_stats() -> dict[str, dict]:
+    """Return ``{cache_name: {loaded, count}}`` for instrumentation (#104)."""
+    return {
+        "stage_table": _cache_stat(_load_stage_table),
+        "zone_table": _cache_stat(_load_zone_table),
+        "stage_search_records": _cache_stat(_stage_search_records),
+    }

--- a/python/src/prts_mcp/data/stage_enemy.py
+++ b/python/src/prts_mcp/data/stage_enemy.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections import Counter
 from typing import Any
 
-from prts_mcp.config import Config, activation_aware_cache, register_activation_listener
+from prts_mcp.config import Config, activation_aware_cache, cache_stat, register_activation_listener
 from prts_mcp.data.stores import DirectoryStore
 
 
@@ -324,6 +324,17 @@ def _enemy_appearance_index() -> dict[str, list[tuple[str, int]]]:
         for enemy_id, count in _spawn_counts(level).items():
             appearances.setdefault(enemy_id, []).append((stage_id, count))
     return appearances
+
+
+def cache_stats() -> dict[str, dict]:
+    """Return ``{cache_name: {loaded, count}}`` for instrumentation (#104)."""
+    return {
+        "stage_table": cache_stat(_load_stage_table),
+        "enemy_handbook": cache_stat(_load_enemy_handbook),
+        "enemy_database": cache_stat(_load_enemy_database),
+        "enemy_name_to_id": cache_stat(_build_enemy_name_to_id),
+        "enemy_appearance_index": cache_stat(_enemy_appearance_index),
+    }
 
 
 def build_enemy_appearances(name: str, limit: int = 50, offset: int = 0) -> dict | str:

--- a/python/src/prts_mcp/data/story_search.py
+++ b/python/src/prts_mcp/data/story_search.py
@@ -50,8 +50,9 @@ class _StorySearchIndex:
     records: tuple[_StorySearchRecord, ...]
 
 
-# Instrumentation: chapters/records count of the last-built index (#104).
-_index_stats: dict[str, int] = {}
+# Instrumentation: last-built index for cache_stats() (#104).  Single source
+# of truth for both loaded and count, avoiding a parallel bookkeeping channel.
+_last_index: _StorySearchIndex | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -299,9 +300,8 @@ def story_search_index(store: JsonStore) -> _StorySearchIndex:
         index = _build_story_search_index(store)
     else:
         index = _cached_story_search_index(descriptor)
-    _index_stats.clear()
-    _index_stats["chapters"] = len(index.chapters)
-    _index_stats["records"] = len(index.records)
+    global _last_index  # noqa: PLW0603 — module-level instrumentation ref
+    _last_index = index
     return index
 
 
@@ -386,16 +386,13 @@ def _build_story_search_index(store: JsonStore) -> _StorySearchIndex:
 
 def clear_search_cache() -> None:
     """Clear the cached story search index."""
+    global _last_index  # noqa: PLW0603
     _cached_story_search_index.cache_clear()
-    _index_stats.clear()
+    _last_index = None
 
 
 def cache_stats() -> dict[str, dict]:
     """Return ``{cache_name: {loaded, count}}`` for instrumentation (#104)."""
-    loaded = _cached_story_search_index.cache_info().currsize > 0
-    return {
-        "story_search_index": {
-            "loaded": loaded,
-            "count": _index_stats.get("chapters", 0) if loaded else 0,
-        }
-    }
+    if _last_index is None:
+        return {"story_search_index": {"loaded": False, "count": 0}}
+    return {"story_search_index": {"loaded": True, "count": len(_last_index.chapters)}}

--- a/python/src/prts_mcp/data/story_search.py
+++ b/python/src/prts_mcp/data/story_search.py
@@ -50,6 +50,10 @@ class _StorySearchIndex:
     records: tuple[_StorySearchRecord, ...]
 
 
+# Instrumentation: chapters/records count of the last-built index (#104).
+_index_stats: dict[str, int] = {}
+
+
 # ---------------------------------------------------------------------------
 # Formatting
 # ---------------------------------------------------------------------------
@@ -292,8 +296,13 @@ def story_search_index(store: JsonStore) -> _StorySearchIndex:
     """
     descriptor = _story_store_descriptor(store)
     if descriptor is None:
-        return _build_story_search_index(store)
-    return _cached_story_search_index(descriptor)
+        index = _build_story_search_index(store)
+    else:
+        index = _cached_story_search_index(descriptor)
+    _index_stats.clear()
+    _index_stats["chapters"] = len(index.chapters)
+    _index_stats["records"] = len(index.records)
+    return index
 
 
 def _story_store_descriptor(store: JsonStore) -> tuple[str, str, int, int] | None:
@@ -378,3 +387,15 @@ def _build_story_search_index(store: JsonStore) -> _StorySearchIndex:
 def clear_search_cache() -> None:
     """Clear the cached story search index."""
     _cached_story_search_index.cache_clear()
+    _index_stats.clear()
+
+
+def cache_stats() -> dict[str, dict]:
+    """Return ``{cache_name: {loaded, count}}`` for instrumentation (#104)."""
+    loaded = _cached_story_search_index.cache_info().currsize > 0
+    return {
+        "story_search_index": {
+            "loaded": loaded,
+            "count": _index_stats.get("chapters", 0) if loaded else 0,
+        }
+    }

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -104,8 +104,32 @@ def _build_http_app():
     async def health(_request):
         return JSONResponse({"status": "ok"})
 
-    # Prepend /health so it is matched before any catch-all.
+    async def debug_cache(_request):
+        from prts_mcp.data.artwork_mediawiki import cache_stats as _am
+        from prts_mcp.data.enemy import cache_stats as _enemy
+        from prts_mcp.data.images import cache_stats as _images
+        from prts_mcp.data.item import cache_stats as _item
+        from prts_mcp.data.operator import cache_stats as _op
+        from prts_mcp.data.search import cache_stats as _search
+        from prts_mcp.data.stage import cache_stats as _stage
+        from prts_mcp.data.stage_enemy import cache_stats as _se
+        from prts_mcp.data.story_search import cache_stats as _ss
+
+        return JSONResponse({
+            "operator": _op(),
+            "enemy": _enemy(),
+            "stage": _stage(),
+            "stage_enemy": _se(),
+            "item": _item(),
+            "search": _search(),
+            "story_search": _ss(),
+            "images": _images(),
+            "artwork_mediawiki": _am(),
+        })
+
+    # Prepend /health and /debug/cache so they are matched before any catch-all.
     app.router.routes.insert(0, Route("/health", health))
+    app.router.routes.insert(0, Route("/debug/cache", debug_cache))
 
     return app
 

--- a/python/tests/test_e2e_http.py
+++ b/python/tests/test_e2e_http.py
@@ -146,6 +146,22 @@ def test_health(server):
     assert r.json() == {"status": "ok"}
 
 
+def test_debug_cache(server):
+    r = httpx.get(f"{server['origin']}/debug/cache", timeout=5.0)
+    assert r.status_code == 200
+    data = r.json()
+    expected_modules = {
+        "operator", "enemy", "stage", "stage_enemy", "item",
+        "search", "story_search", "images", "artwork_mediawiki",
+    }
+    assert set(data.keys()) == expected_modules
+    for module_name, caches in data.items():
+        assert isinstance(caches, dict)
+        for cache_name, stat in caches.items():
+            assert "loaded" in stat and isinstance(stat["loaded"], bool)
+            assert "count" in stat and isinstance(stat["count"], int)
+
+
 def test_initialize_and_tools_list(server):
     origin = server["origin"]
     status, payload, sid = _mcp_post(

--- a/python/tests/test_e2e_http.py
+++ b/python/tests/test_e2e_http.py
@@ -160,6 +160,9 @@ def test_debug_cache(server):
         for cache_name, stat in caches.items():
             assert "loaded" in stat and isinstance(stat["loaded"], bool)
             assert "count" in stat and isinstance(stat["count"], int)
+    # artwork_mediawiki.image_cache includes bytes
+    am = data["artwork_mediawiki"]["image_cache"]
+    assert "bytes" in am and isinstance(am["bytes"], int)
 
 
 def test_initialize_and_tools_list(server):

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Cache instrumentation (`/debug/cache` endpoint).** Each data module exports `getCacheStats()` returning per-cache `{loaded, count}` (and `bytes` for the image LRU). The read-only `/debug/cache` HTTP endpoint aggregates all 9 modules' stats for observability (#104).
+
+### Fixed
+
+- `Readable.fromWeb` cast in `imagesSync.ts` narrowed from bare `any` to the exact parameter type via `Parameters<typeof Readable.fromWeb>[0]` (#100).
+
+### Changed
+
+- Base illust label mapping (`BASE_ILLUST_LABELS`) consolidated to a single owner in `data/images.ts`; `data/artworkMediawiki.ts` imports it instead of maintaining a duplicate (#100).
+
 ## [2.5.1] - 2026-08-07
 
 ### Fixed

--- a/ts/src/data/artworkMediawiki.ts
+++ b/ts/src/data/artworkMediawiki.ts
@@ -45,6 +45,16 @@ export function imageCachePut(artworkId: string, variant: string, data: Buffer):
   }
 }
 
+export function getCacheStats(): Record<string, { loaded: boolean; count: number; bytes?: number }> {
+  return {
+    image_cache: {
+      loaded: _imageCache.size > 0,
+      count: _imageCache.size,
+      bytes: _imageCacheTotal,
+    },
+  };
+}
+
 function mediawikiBaseLabel(suffix: string): string {
   const base = suffix.replace(/\+$/, "");
   const plus = suffix.endsWith("+");

--- a/ts/src/data/artworkMediawiki.ts
+++ b/ts/src/data/artworkMediawiki.ts
@@ -6,14 +6,12 @@
  * matching the true-mode boundary (data/images.ts ↔ artworkTools.ts).
  */
 
+import { BASE_ILLUST_LABELS } from "./images.js";
+
 const IMAGE_CACHE_MAX_BYTES = 256 * 1024 * 1024; // 256 MiB (#85 §4.2)
 const _imageCache = new Map<string, Buffer>();
 let _imageCacheTotal = 0;
 
-const MEDIAWIKI_BASE_LABELS: Record<string, string> = {
-  "1": "精英零立绘",
-  "2": "精英二立绘",
-};
 export const VARIANT_WIDTH: Record<string, number> = { large: 1024, preview: 256 };
 
 function imageCacheKey(artworkId: string, variant: string): string {
@@ -50,7 +48,7 @@ export function imageCachePut(artworkId: string, variant: string, data: Buffer):
 function mediawikiBaseLabel(suffix: string): string {
   const base = suffix.replace(/\+$/, "");
   const plus = suffix.endsWith("+");
-  let label = MEDIAWIKI_BASE_LABELS[base];
+  let label = BASE_ILLUST_LABELS[base];
   if (label === undefined) label = base ? `立绘 ${base}` : "立绘";
   if (plus) label += "（变体）";
   return label;

--- a/ts/src/data/enemy.ts
+++ b/ts/src/data/enemy.ts
@@ -26,6 +26,15 @@ export function clearEnemyCaches(): void {
   _enemySearchRecords = null;
 }
 
+export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+  return {
+    enemy_handbook: { loaded: _handbook != null, count: _handbook ? Object.keys(_handbook.enemyData ?? {}).length : 0 },
+    enemy_database: { loaded: _dbIndex != null, count: _dbIndex ? Object.keys(_dbIndex).length : 0 },
+    enemy_name_to_id: { loaded: _nameToEnemyId != null, count: _nameToEnemyId ? _nameToEnemyId.size : 0 },
+    enemy_search_records: { loaded: _enemySearchRecords != null, count: _enemySearchRecords ? _enemySearchRecords.length : 0 },
+  };
+}
+
 registerActivationListener(clearEnemyCaches);
 
 // ---------------------------------------------------------------------------

--- a/ts/src/data/images.ts
+++ b/ts/src/data/images.ts
@@ -183,6 +183,12 @@ export function clearImageCaches(): void {
   _charSkins = null;
 }
 
+export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+  return {
+    char_skins: { loaded: _charSkins != null, count: _charSkins ? Object.keys(_charSkins).length : 0 },
+  };
+}
+
 registerActivationListener(clearImageCaches);
 
 // ---------------------------------------------------------------------------

--- a/ts/src/data/images.ts
+++ b/ts/src/data/images.ts
@@ -189,7 +189,7 @@ registerActivationListener(clearImageCaches);
 // Label construction
 // ---------------------------------------------------------------------------
 
-const BASE_ILLUST_LABELS: Record<string, string> = {
+export const BASE_ILLUST_LABELS: Record<string, string> = {
   "1": "精英零立绘",
   "2": "精英二立绘",
 };

--- a/ts/src/data/imagesSync.ts
+++ b/ts/src/data/imagesSync.ts
@@ -115,11 +115,15 @@ async function downloadLarge(url: string, dest: string, timeoutMs = 1_800_000): 
     // resident; mirrors python's httpx.stream chunked write. fetchCascading
     // returns a real Response at runtime but FetchResponse omits body to stay
     // decoupled from DOM, so narrow res via unknown instead of `any` (#100).
-    // Readable.fromWeb still needs a cast — Node 22's Uint8Array generic makes
-    // its parameter type incompatible at compile time (runtime is fine).
+    // Readable.fromWeb expects a DOM ReadableStream whose generic variance is
+    // incompatible with Node 22's global ReadableStream at compile time; derive
+    // the exact parameter type to avoid bare `any`.
     const body = (res as unknown as { body: ReadableStream | null }).body;
     if (body === null) throw new Error("download response body is null");
-    await pipeline(Readable.fromWeb(body as any), createWriteStream(tmp));
+    await pipeline(
+      Readable.fromWeb(body as unknown as Parameters<typeof Readable.fromWeb>[0]),
+      createWriteStream(tmp),
+    );
     await rename(tmp, dest);
   } finally {
     await unlink(tmp).catch(() => undefined);

--- a/ts/src/data/item.ts
+++ b/ts/src/data/item.ts
@@ -136,6 +136,14 @@ export function clearItemCaches(): void {
   itemSearchRecords = null;
 }
 
+export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+  return {
+    items: { loaded: itemTable != null, count: itemTable ? Object.keys(itemTable).length : 0 },
+    item_lookup: { loaded: itemLookup != null, count: itemLookup ? itemLookup.size : 0 },
+    item_search_records: { loaded: itemSearchRecords != null, count: itemSearchRecords ? itemSearchRecords.length : 0 },
+  };
+}
+
 registerActivationListener(clearItemCaches);
 
 function itemStore(): DirectoryStore {

--- a/ts/src/data/operator.ts
+++ b/ts/src/data/operator.ts
@@ -41,6 +41,15 @@ export function clearOperatorCaches(): void {
   clearSearchCaches();
 }
 
+export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+  return {
+    character_table: { loaded: _characterTable != null, count: _characterTable ? Object.keys(_characterTable).length : 0 },
+    handbook_table: { loaded: _handbookTable != null, count: _handbookTable ? Object.keys(_handbookTable).length : 0 },
+    charword_table: { loaded: _charwordTable != null, count: _charwordTable ? Object.keys(_charwordTable).length : 0 },
+    name_to_id: { loaded: _nameToId != null, count: _nameToId ? _nameToId.size : 0 },
+  };
+}
+
 registerActivationListener(clearOperatorCaches);
 
 // ---------------------------------------------------------------------------

--- a/ts/src/data/search.ts
+++ b/ts/src/data/search.ts
@@ -64,6 +64,12 @@ export function clearSearchCaches(): void {
   operatorSearchRecords = null;
 }
 
+export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+  return {
+    search_records: { loaded: operatorSearchRecords != null, count: operatorSearchRecords ? operatorSearchRecords.length : 0 },
+  };
+}
+
 export function searchOperatorData(pattern: string, maxResults = 30): string {
   const data = buildOperatorSearch(pattern, maxResults);
   if (typeof data === "string") return data;

--- a/ts/src/data/stage.ts
+++ b/ts/src/data/stage.ts
@@ -142,6 +142,14 @@ export function clearStageCaches(): void {
   _stageSearchRecords = null;
 }
 
+export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+  return {
+    stage_table: { loaded: _stageTable != null, count: _stageTable ? Object.keys(_stageTable).length : 0 },
+    zone_table: { loaded: _zoneTable != null, count: _zoneTable ? Object.keys(_zoneTable).length : 0 },
+    stage_search_records: { loaded: _stageSearchRecords != null, count: _stageSearchRecords ? _stageSearchRecords.length : 0 },
+  };
+}
+
 registerActivationListener(clearStageCaches);
 
 // ---------------------------------------------------------------------------

--- a/ts/src/data/stageEnemy.ts
+++ b/ts/src/data/stageEnemy.ts
@@ -111,6 +111,16 @@ export function clearStageEnemyCaches(): void {
   enemyAppearanceIndex = null;
 }
 
+export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+  return {
+    stage_table: { loaded: stageTable != null, count: stageTable ? Object.keys(stageTable).length : 0 },
+    enemy_handbook: { loaded: enemyHandbook != null, count: enemyHandbook ? Object.keys(enemyHandbook).length : 0 },
+    enemy_database: { loaded: enemyDatabase != null, count: enemyDatabase ? Object.keys(enemyDatabase).length : 0 },
+    enemy_name_to_id: { loaded: nameToEnemyId != null, count: nameToEnemyId ? nameToEnemyId.size : 0 },
+    enemy_appearance_index: { loaded: enemyAppearanceIndex != null, count: enemyAppearanceIndex ? enemyAppearanceIndex.size : 0 },
+  };
+}
+
 registerActivationListener(clearStageEnemyCaches);
 
 function excelStore(): DirectoryStore {

--- a/ts/src/data/storySearch.ts
+++ b/ts/src/data/storySearch.ts
@@ -78,6 +78,15 @@ export function clearSearchCache(): void {
   storySearchCache = null;
 }
 
+export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+  return {
+    story_search_index: {
+      loaded: storySearchCache !== null,
+      count: storySearchCache ? storySearchCache.index.chapters.length : 0,
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Formatting
 // ---------------------------------------------------------------------------

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -16,6 +16,15 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { startAutoSync } from "./startupSync.js";
 import { parseChannel, type OutputChannel } from "./output.js";
 import { createMcpServer, log, SERVER_VERSION } from "./server-core.js";
+import { getCacheStats as getOperatorCacheStats } from "./data/operator.js";
+import { getCacheStats as getEnemyCacheStats } from "./data/enemy.js";
+import { getCacheStats as getStageCacheStats } from "./data/stage.js";
+import { getCacheStats as getStageEnemyCacheStats } from "./data/stageEnemy.js";
+import { getCacheStats as getItemCacheStats } from "./data/item.js";
+import { getCacheStats as getSearchCacheStats } from "./data/search.js";
+import { getCacheStats as getStorySearchCacheStats } from "./data/storySearch.js";
+import { getCacheStats as getImagesCacheStats } from "./data/images.js";
+import { getCacheStats as getArtworkMediawikiCacheStats } from "./data/artworkMediawiki.js";
 
 function firstString(value: unknown): string | undefined {
   if (typeof value === "string") return value;
@@ -170,6 +179,20 @@ app.all("/mcp", async (req, res) => {
 
 app.get("/health", (_req, res) => {
   res.json({ status: "ok" });
+});
+
+app.get("/debug/cache", (_req, res) => {
+  res.json({
+    operator: getOperatorCacheStats(),
+    enemy: getEnemyCacheStats(),
+    stage: getStageCacheStats(),
+    stage_enemy: getStageEnemyCacheStats(),
+    item: getItemCacheStats(),
+    search: getSearchCacheStats(),
+    story_search: getStorySearchCacheStats(),
+    images: getImagesCacheStats(),
+    artwork_mediawiki: getArtworkMediawikiCacheStats(),
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -151,18 +151,20 @@ test("E2E", async (t) => {
   await t.test("debug cache returns expected modules", async () => {
     const res = await fetch(`${origin}/debug/cache`);
     assert.equal(res.status, 200);
-    const data = await res.json() as Record<string, Record<string, { loaded: boolean; count: number }>>;
-    const expectedModules = [
+    const data = await res.json() as Record<string, Record<string, { loaded: boolean; count: number; bytes?: number }>>;
+    const expectedModules = new Set([
       "operator", "enemy", "stage", "stage_enemy", "item",
       "search", "story_search", "images", "artwork_mediawiki",
-    ];
-    for (const mod of expectedModules) {
-      assert.ok(mod in data, `missing module: ${mod}`);
-      for (const [cacheName, stat] of Object.entries(data[mod])) {
+    ]);
+    assert.deepEqual(new Set(Object.keys(data)), expectedModules, "module set mismatch");
+    for (const [mod, caches] of Object.entries(data)) {
+      for (const [cacheName, stat] of Object.entries(caches)) {
         assert.equal(typeof stat.loaded, "boolean", `${mod}.${cacheName}.loaded should be boolean`);
         assert.equal(typeof stat.count, "number", `${mod}.${cacheName}.count should be number`);
       }
     }
+    // artwork_mediawiki.image_cache includes bytes
+    assert.equal(typeof data["artwork_mediawiki"]!["image_cache"]!.bytes, "number");
   });
 
   // --- protocol handshake ---

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -147,6 +147,24 @@ test("E2E", async (t) => {
 
   t.after(() => { child.kill(); });
 
+  // --- /debug/cache ---
+  await t.test("debug cache returns expected modules", async () => {
+    const res = await fetch(`${origin}/debug/cache`);
+    assert.equal(res.status, 200);
+    const data = await res.json() as Record<string, Record<string, { loaded: boolean; count: number }>>;
+    const expectedModules = [
+      "operator", "enemy", "stage", "stage_enemy", "item",
+      "search", "story_search", "images", "artwork_mediawiki",
+    ];
+    for (const mod of expectedModules) {
+      assert.ok(mod in data, `missing module: ${mod}`);
+      for (const [cacheName, stat] of Object.entries(data[mod])) {
+        assert.equal(typeof stat.loaded, "boolean", `${mod}.${cacheName}.loaded should be boolean`);
+        assert.equal(typeof stat.count, "number", `${mod}.${cacheName}.count should be number`);
+      }
+    }
+  });
+
   // --- protocol handshake ---
   let sessionId: string;
 


### PR DESCRIPTION
## Summary

Closes #100 (remaining items) and implements #104 (cache instrumentation).

**#100 remaining 2 items** (5 of 7 already shipped in 2.5.1):

- **Label mapping dedup** (`refactor(artwork)`): `BASE_ILLUST_LABELS` was duplicated in `images.py`/`images.ts` and `artwork_mediawiki.py`/`artworkMediawiki.ts`. Consolidated to a single owner; the consumer module imports it.
- **`as any` narrowing** (`fix(ts)`): `Readable.fromWeb(body as any)` in `imagesSync.ts` replaced with `body as unknown as Parameters<typeof Readable.fromWeb>[0]` to eliminate bare `any`.

**#104 cache instrumentation** (`feat(python)` + `feat(ts)`):

- `cache_stat()` helper in `config.py` reports `{loaded, count}` for `activation_aware_cache`-wrapped functions via `cache_info()` + `len()`.
- Each of the 9 data modules (operator, enemy, stage, stage_enemy, item, search, images, story_search, artwork_mediawiki) exports `cache_stats()` / `getCacheStats()` returning per-cache `{loaded, count}` (and `bytes` for the image LRU).
- `/debug/cache` HTTP endpoint aggregates all module stats into a read-only JSON payload (counts/bytes only, no data content). Structure is parity-matched between Python and TS.

## Test plan

- [x] Python: `uv run --directory python --locked python -m pytest tests -q` → 326 passed, 23 skipped
- [x] TS: `cd ts && npm run build && npm test && npm run typecheck` → 249 passed, 2 skipped
- [x] `test_debug_cache` (Python e2e_http): verifies `/debug/cache` returns all 9 module keys with valid `{loaded, count}` structure
- [x] `debug cache returns expected modules` (TS e2e): same structure assertions
- [x] `/debug/cache` response structure parity: both implementations return identical top-level keys and per-cache shape

## 未尽事宜

- #104 mentions cgroup `MemoryHigh=1024M` / `MemoryMax=1536M` deployment-side adjustment — not in this PR (deployment config, not code).
- `search` module was not in #104's explicit module list but was included as a data cache that contributes to memory.
- The `/debug/cache` endpoint is HTTP-only (not available on stdio transport), matching the `/health` pattern.