### PR TITLE
ci: add pre-release tag support and branch scope verification

### DIFF
--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -14,6 +14,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Verify tag scope vs branch
+        run: |
+          git fetch --depth=200 origin main develop
+          VERSION="${GITHUB_REF_NAME#ts/v}"
+          if [[ "${VERSION}" != *-* ]]; then
+            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main 2>/dev/null; then
+              echo "::error::Stable tag (no -suffix) must be on main. Use -alpha.1 / -beta.1 / -rc.1 for pre-release tags on develop."
+              exit 1
+            fi
+          else
+            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/develop 2>/dev/null; then
+              echo "::error::Pre-release tag (-suffix) must be on develop."
+              exit 1
+            fi
+          fi
+          echo "Tag scope verification passed."
+
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:

--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -13,18 +13,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Verify tag scope vs branch
         run: |
-          git fetch --depth=200 origin main develop
           VERSION="${GITHUB_REF_NAME#ts/v}"
           if [[ "${VERSION}" != *-* ]]; then
-            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main 2>/dev/null; then
+            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
               echo "::error::Stable tag (no -suffix) must be on main. Use -alpha.1 / -beta.1 / -rc.1 for pre-release tags on develop."
               exit 1
             fi
           else
-            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/develop 2>/dev/null; then
+            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/develop; then
               echo "::error::Pre-release tag (-suffix) must be on develop."
               exit 1
             fi

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,18 +13,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Verify tag scope vs branch
         run: |
-          git fetch --depth=200 origin main develop
           VERSION="${GITHUB_REF_NAME#python/v}"
           if [[ "${VERSION}" != *-* ]]; then
-            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main 2>/dev/null; then
+            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
               echo "::error::Stable tag (no -suffix) must be on main. Use -alpha.1 / -beta.1 / -rc.1 for pre-release tags on develop."
               exit 1
             fi
           else
-            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/develop 2>/dev/null; then
+            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/develop; then
               echo "::error::Pre-release tag (-suffix) must be on develop."
               exit 1
             fi

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,6 +14,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Verify tag scope vs branch
+        run: |
+          git fetch --depth=200 origin main develop
+          VERSION="${GITHUB_REF_NAME#python/v}"
+          if [[ "${VERSION}" != *-* ]]; then
+            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main 2>/dev/null; then
+              echo "::error::Stable tag (no -suffix) must be on main. Use -alpha.1 / -beta.1 / -rc.1 for pre-release tags on develop."
+              exit 1
+            fi
+          else
+            if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/develop 2>/dev/null; then
+              echo "::error::Pre-release tag (-suffix) must be on develop."
+              exit 1
+            fi
+          fi
+          echo "Tag scope verification passed."
+
       - name: Set up Python
         uses: actions/setup-python@v7
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -324,3 +324,4 @@ git push origin python/v2.6.0-alpha.1 ts/v2.6.0-alpha.1
 - ArknightsStoryJson zip 内所有路径以 `zh_CN/` 为前缀
 - `GITHUB_MIRRORS` 配置的代理 URL 不要带尾部斜杠
 - Python 的 `httpx` 和 TS 的 `fetch` 行为不完全一致（重试、超时），sync 逻辑不要假设相同
+- **`pyproject.toml` 的预发布版本号必须用 PEP 440，不能用连字符**：写 `2.6.0a1`（不是 `2.6.0-alpha.1`）。`-alpha.1` 是 **git tag 和 `package.json`** 的格式；`pyproject.toml` 里写连字符形式会导致 `uv` / `pip` / PyPI 拒绝或误解析。CD 的 version check（`cd.yml`）会自动归一化 tag 的 `-alpha.` → PEP 440 `a` 再比对，但 `pyproject.toml` 本身必须原生合规

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,22 @@ fix/*（最新稳定 hotfix）────────→ main ──→ develop
 9. 从同一个 merge commit 创建并推送 `lts/1.7`
 10. 将同一个 release 分支通过双轨 CR 的 PR merge 回 `develop`，然后 bump 到 `2.0.0.dev0` 并重新打开空 `[Unreleased]`
 
+### 路径 F：预发布（→ develop）
+
+用于在 `develop` 上发布 alpha / beta / rc 版本供早期测试。预发布版本号约定：Python 用 PEP 440（`2.6.0a1`、`2.6.0b1`、`2.6.0rc1`），TypeScript 用 npm semver（`2.6.0-alpha.1`、`2.6.0-beta.1`、`2.6.0-rc.1`）。CD tag pattern `v*.*.*-*` 自动匹配两者。
+
+1. **拉分支**：从 `develop` 拉 `release/vX.Y.Z-alpha.N`（或 `-beta.N` / `-rc.N`）
+2. **bump 版本号**：`pyproject.toml` 从 `.dev0` 改为 `X.Y.ZaN`（如 `2.6.0a1`），`package.json` 从 `-dev.0` 改为 `X.Y.Z-alpha.N`（如 `2.6.0-alpha.1`）。运行 `uv lock --directory python` 同步 lockfile，同步 `ts/package-lock.json`
+3. **CHANGELOG**：`[Unreleased]` → `[X.Y.Z-alpha.N] - YYYY-MM-DD`
+4. **跑 `./scripts/check-runtime.sh --full`**
+5. **PR 到 `develop`**：双轨 CR → 人类 merge
+6. **在 `develop` 的 merge commit 上打 tag**：`git tag python/vX.Y.Z-alpha.N && git tag ts/vX.Y.Z-alpha.N && git push origin python/vX.Y.Z-alpha.N ts/vX.Y.Z-alpha.N`
+7. **CD 自动触发**：CI 验证 → PyPI 发布（`pip install` 默认不拉预发布，需 `pip install prts-mcp==X.Y.ZaN` 或 `--pre`）→ npm 发布（dist-tag 自动设为 `alpha`/`beta`/`rc`，`npm install prts-mcp-ts@alpha`）→ GitHub Release（标记为 pre-release，`make_latest: false`）→ Docker（仅版本 tag，不更新 `latest`）
+8. **bump 回开发版本**：从 `develop` 拉 `chore/vX.Y.Z-resume-dev`，`pyproject.toml` → `X.Y.Z.dev0`，`package.json` → `X.Y.Z-dev.0`，重新打开空 `[Unreleased]` 段
+9. **PR 到 `develop`**：双轨 CR → 人类 merge
+
+预发布累积到稳定发布时，按路径 D 走标准 release/* → main 流程；CHANGELOG 中多个预发布条目合并为一个稳定版条目。
+
 ## 验证矩阵
 
 按改动风险选最小的验证集（命令清单以"路径 A 步骤 4"为单一来源，本表只标层级）：
@@ -272,11 +288,16 @@ KHPilot 也可能在公开 Issue 中提供自动回复。这些回复只作为�
 
 涉及用户可见行为变化时，顺手更新 `README.md`。
 
-**打 tag 时使用实现级前缀**，CI 的 CD workflow 按前缀分发。Tag 必须打在 `main` 分支的 merge commit 上（不在 `develop` 打 tag）：
+**打 tag 时使用实现级前缀**，CI 的 CD workflow 按前缀分发。稳定版 tag（无 `-` 后缀）必须打在 `main` 分支的 merge commit 上；预发布 tag（`-alpha`/`-beta`/`-rc` 后缀）可以打在 `develop` 分支的 merge commit 上（见路径 F）。CD 的 `verify` job 会校验：稳定版 tag 的目标 commit 必须在 `main` 上，预发布 tag 的目标 commit 必须在 `develop` 上，不匹配则拒绝发布：
 
 ```bash
+# 稳定版（main merge commit）
 git tag python/v1.3.1 && git tag ts/v1.3.1
 git push origin python/v1.3.1 ts/v1.3.1
+
+# 预发布（develop merge commit）
+git tag python/v2.6.0a1 && git tag ts/v2.6.0-alpha.1
+git push origin python/v2.6.0a1 ts/v2.6.0-alpha.1
 ```
 
 - `python/v*` → PyPI 发布

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,9 @@ fix/*（最新稳定 hotfix）────────→ main ──→ develop
 
 ### 路径 F：预发布（→ develop）
 
-用于在 `develop` 上发布 alpha / beta / rc 版本供早期测试。预发布版本号约定：Python 用 PEP 440（`2.6.0a1`、`2.6.0b1`、`2.6.0rc1`），TypeScript 用 npm semver（`2.6.0-alpha.1`、`2.6.0-beta.1`、`2.6.0-rc.1`）。CD tag pattern `v*.*.*-*` 自动匹配两者。
+用于在 `develop` 上发布 alpha / beta / rc 版本供早期测试。
+
+**版本号约定**：tag 始终使用连字符后缀（`-alpha.N` / `-beta.N` / `-rc.N`），Python 和 TS 统一。`pyproject.toml` 内用 PEP 440（`2.6.0a1`），CD 的 version check 自动归一化 `-alpha.` → `a`；`package.json` 内用与 tag 相同的 semver 形式（`2.6.0-alpha.1`）。
 
 1. **拉分支**：从 `develop` 拉 `release/vX.Y.Z-alpha.N`（或 `-beta.N` / `-rc.N`）
 2. **bump 版本号**：`pyproject.toml` 从 `.dev0` 改为 `X.Y.ZaN`（如 `2.6.0a1`），`package.json` 从 `-dev.0` 改为 `X.Y.Z-alpha.N`（如 `2.6.0-alpha.1`）。运行 `uv lock --directory python` 同步 lockfile，同步 `ts/package-lock.json`
@@ -295,9 +297,9 @@ KHPilot 也可能在公开 Issue 中提供自动回复。这些回复只作为�
 git tag python/v1.3.1 && git tag ts/v1.3.1
 git push origin python/v1.3.1 ts/v1.3.1
 
-# 预发布（develop merge commit）
-git tag python/v2.6.0a1 && git tag ts/v2.6.0-alpha.1
-git push origin python/v2.6.0a1 ts/v2.6.0-alpha.1
+# 预发布（develop merge commit）— tag 始终用连字符后缀
+git tag python/v2.6.0-alpha.1 && git tag ts/v2.6.0-alpha.1
+git push origin python/v2.6.0-alpha.1 ts/v2.6.0-alpha.1
 ```
 
 - `python/v*` → PyPI 发布


### PR DESCRIPTION
## Summary

Enables alpha/beta/rc pre-release publishing from `develop`, with a safety guard against accidental stable releases.

**A — CLAUDE.md (policy)**:
- New **Path F**: documents the pre-release workflow (version bump → tag on develop merge commit → CD auto-publishes → bump back to `.dev0`)
- Updated tag policy: stable tags (`v*.*.*`) must be on `main`; pre-release tags (`v*.*.*-*`) allowed on `develop`
- Documents PyPI behavior (`pip install` skips pre-releases by default; `--pre` or explicit version opts in) and npm behavior (dist-tag `alpha`/`beta`/`rc`)

**B — cd.yml + cd-ts.yml (defense in depth)**:
- New "Verify tag scope vs branch" step in the `verify` job
- Stable tags (no `-` suffix): commit must be reachable from `origin/main`
- Pre-release tags (with `-` suffix): commit must be reachable from `origin/develop`
- Uses `git merge-base --is-ancestor` with `--depth=200` fetch

## Why no workflow changes for pre-release *publishing*?

The CD workflows already handle pre-releases correctly — tag patterns, prerelease detection, npm dist-tags, Docker `latest` skipping, and GitHub Release `prerelease`/`make_latest` flags were all already in place. The only gap was the lack of branch enforcement and the missing Path F documentation.

## Test plan

- [x] YAML syntax valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] CLAUDE.md Path F references existing version sync checklist and CD tag patterns
- [ ] CI passes on this PR (cd.yml / cd-ts.yml changes only affect tag-triggered CD, not CI)
- [ ] **Manual verification recommended before first use**: push a test pre-release tag to confirm the branch check passes on develop and the full CD pipeline runs

## 未尽事宜

- The `environment: pypi` / `environment: npm` GitHub Environment settings may have additional branch restrictions configured in repo settings — these are not visible from the workflow files and should be verified separately.
- Docker images for pre-releases get only a version tag (no `alpha`/`beta` channel tag). Users must pull `ghcr.io/.../prts-mcp:2.6.0a1` explicitly. A dedicated `alpha` Docker tag could be added in the future if needed.