### PR TITLE
chore(release): bump v2.6.0-alpha.1

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,8 +6,8 @@ _Last updated: 2026-08-07_
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 2.6.0.dev0 | Development |
-| TypeScript | 2.6.0-dev.0 | Development |
+| Python | 2.6.0a1 | Pre-release |
+| TypeScript | 2.6.0-alpha.1 | Pre-release |
 
 - 当前稳定发布：2.5.1（24 个 MCP 工具）
 - 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [2.6.0-alpha.1] - 2026-08-08
+
 ### Added
 
 - **Cache instrumentation (`/debug/cache` endpoint).** Each data module exports `cache_stats()` returning per-cache `{loaded, count}` (and `bytes` for the MediaWiki image LRU). The read-only `/debug/cache` HTTP endpoint aggregates all 9 modules' stats for observability (#104).

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.6.0.dev0"
+version = "2.6.0a1"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "prts-mcp"
-version = "2.6.0.dev0"
+version = "2.6.0a1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [2.6.0-alpha.1] - 2026-08-08
+
 ### Added
 
 - **Cache instrumentation (`/debug/cache` endpoint).** Each data module exports `getCacheStats()` returning per-cache `{loaded, count}` (and `bytes` for the image LRU). The read-only `/debug/cache` HTTP endpoint aggregates all 9 modules' stats for observability (#104).

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.6.0-dev.0",
+  "version": "2.6.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.6.0-dev.0",
+      "version": "2.6.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.6.0-dev.0",
+  "version": "2.6.0-alpha.1",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP + stdio)",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Path F pre-release: bump `develop` to `2.6.0-alpha.1` for the first preview release.

**Version changes:**
- `pyproject.toml`: `2.6.0.dev0` → `2.6.0a1` (PEP 440)
- `package.json`: `2.6.0-dev.0` → `2.6.0-alpha.1` (semver)
- `uv.lock` + `package-lock.json` synced
- CHANGELOGs: `[Unreleased]` → `[2.6.0-alpha.1] - 2026-08-08`

**Contents since 2.5.1:**
- #100 remaining items: base illust label mapping dedup, `Readable.fromWeb` `as any` narrowing
- #104 cache instrumentation: `cache_stats()`/`getCacheStats()` on 9 data modules + `/debug/cache` endpoint (dual implementation)
- CI/CD pre-release support: Path F documentation, branch scope verification in CD workflows

## Test plan

- [x] Python: 326 passed, 23 skipped
- [x] TS: 249 passed, 2 skipped, build + typecheck clean
- [ ] Bot CR

## Post-merge

After merge, tag the develop merge commit:
```bash
git tag python/v2.6.0-alpha.1 && git tag ts/v2.6.0-alpha.1
git push origin python/v2.6.0-alpha.1 ts/v2.6.0-alpha.1
```

Then bump back to `.dev0`/`-dev.0` via a `chore/v2.6.0-resume-dev` PR.