### PR TITLE
chore: resume v2.6.0 development after alpha.1

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -6,8 +6,8 @@ _Last updated: 2026-08-07_
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 2.6.0a1 | Pre-release |
-| TypeScript | 2.6.0-alpha.1 | Pre-release |
+| Python | 2.6.0.dev0 | Development |
+| TypeScript | 2.6.0-dev.0 | Development |
 
 - 当前稳定发布：2.5.1（24 个 MCP 工具）
 - 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.6.0a1"
+version = "2.6.0.dev0"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "prts-mcp"
-version = "2.6.0a1"
+version = "2.6.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.6.0-alpha.1",
+  "version": "2.6.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.6.0-alpha.1",
+      "version": "2.6.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.6.0-alpha.1",
+  "version": "2.6.0-dev.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP + stdio)",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Path F step 8-9: bump versions back to development after `2.6.0-alpha.1` release.

- `pyproject.toml`: `2.6.0a1` → `2.6.0.dev0`
- `package.json`: `2.6.0-alpha.1` → `2.6.0-dev.0`
- `STATUS.md`: `Pre-release` → `Development`
- Lockfiles synced

**2.6.0-alpha.1 release artifacts (all verified):**
- PyPI: `prts-mcp==2.6.0a1` ✅
- npm: `prts-mcp-ts@2.6.0-alpha.1` (dist-tag `alpha`) ✅
- GitHub Releases: `python/v2.6.0-alpha.1` + `ts/v2.6.0-alpha.1` (pre-release) ✅
- Docker: `ghcr.io/3akhp/prts-mcp:2.6.0a1` (no `latest` update) ✅

## Test plan

- [x] Mechanical version bump; no code changes
- [ ] CI passes