### PR TITLE
feat(ts): add aggregate runtime metrics

### DIFF
--- a/ops/prts-metrics/README.md
+++ b/ops/prts-metrics/README.md
@@ -1,0 +1,19 @@
+# PRTS-MCP production metrics sampler
+
+These files are the version-controlled source for the production-only sampler; they are not included in the npm package.
+
+Install after deploying a TS build that provides `/debug/metrics`:
+
+```bash
+install -m 0755 ops/prts-metrics/sample-metrics.sh /opt/prts-mcp/scripts/sample-metrics.sh
+install -m 0644 ops/prts-metrics/validate-sample.mjs /opt/prts-mcp/scripts/validate-sample.mjs
+install -m 0644 ops/prts-metrics/metrics.conf /etc/systemd/system/prts-mcp-ts.service.d/metrics.conf
+install -m 0644 ops/prts-metrics/prts-metrics-sampler.service /etc/systemd/system/
+install -m 0644 ops/prts-metrics/prts-metrics-sampler.timer /etc/systemd/system/
+install -m 0644 ops/prts-metrics/prts-metrics.logrotate /etc/logrotate.d/prts-mcp-metrics
+systemctl daemon-reload
+systemctl restart prts-mcp-ts.service
+systemctl enable --now prts-metrics-sampler.timer
+```
+
+The PRTS service must listen on loopback and no reverse-proxy route may expose `/debug/metrics`. The host needs Node.js available as `node` for schema validation (the production host's supported Node runtime satisfies this). Each successful timer run appends one schema-validated JSON object to `/var/log/prts-mcp/metrics-samples.jsonl`; a failed local probe fails the oneshot unit and writes no misleading empty sample.

--- a/ops/prts-metrics/metrics.conf
+++ b/ops/prts-metrics/metrics.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment=PRTS_METRICS_ENABLED=true

--- a/ops/prts-metrics/prts-metrics-sampler.service
+++ b/ops/prts-metrics/prts-metrics-sampler.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=PRTS-MCP aggregate metrics sampler
+After=prts-mcp-ts.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/prts-mcp/scripts/sample-metrics.sh
+User=root
+Group=root
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectHome=true

--- a/ops/prts-metrics/prts-metrics-sampler.timer
+++ b/ops/prts-metrics/prts-metrics-sampler.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=PRTS-MCP aggregate metrics sampler (every five minutes)
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=5s
+Unit=prts-metrics-sampler.service
+
+[Install]
+WantedBy=timers.target

--- a/ops/prts-metrics/prts-metrics.logrotate
+++ b/ops/prts-metrics/prts-metrics.logrotate
@@ -1,0 +1,8 @@
+/var/log/prts-mcp/metrics-samples.jsonl {
+    daily
+    rotate 14
+    compress
+    missingok
+    notifempty
+    create 0640 root root
+}

--- a/ops/prts-metrics/sample-metrics.sh
+++ b/ops/prts-metrics/sample-metrics.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Sample aggregate PRTS-MCP metrics and the owning systemd cgroup as JSONL.
+set -euo pipefail
+
+SERVICE="${PRTS_METRICS_SERVICE:-prts-mcp-ts.service}"
+METRICS_URL="${PRTS_METRICS_URL:-http://127.0.0.1:5102/debug/metrics}"
+LOG_DIR="${PRTS_METRICS_LOG_DIR:-/var/log/prts-mcp}"
+LOG_FILE="${LOG_DIR}/metrics-samples.jsonl"
+
+control_group="$(systemctl show "${SERVICE}" --property=ControlGroup --value)"
+main_pid="$(systemctl show "${SERVICE}" --property=MainPID --value)"
+if [[ ! "${control_group}" =~ ^/ ]] || [[ "${main_pid}" -le 0 ]]; then
+  echo "${SERVICE} has no running process or cgroup" >&2
+  exit 1
+fi
+
+cgroup_root="${PRTS_METRICS_CGROUP_ROOT:-/sys/fs/cgroup${control_group}}"
+proc_root="${PRTS_METRICS_PROC_ROOT:-/proc}"
+for required in memory.current memory.peak memory.events; do
+  if [[ ! -r "${cgroup_root}/${required}" ]]; then
+    echo "missing required cgroup file: ${cgroup_root}/${required}" >&2
+    exit 1
+  fi
+done
+
+metrics_json="$(curl --fail --silent --show-error --max-time 5 "${METRICS_URL}")"
+rss_kb="$(awk '/^VmRSS:/ {print $2; found=1} END {if (!found) exit 1}' "${proc_root}/${main_pid}/status")"
+memory_current="$(<"${cgroup_root}/memory.current")"
+memory_peak="$(<"${cgroup_root}/memory.peak")"
+memory_swap_current="null"
+if [[ -r "${cgroup_root}/memory.swap.current" ]]; then
+  memory_swap_current="$(<"${cgroup_root}/memory.swap.current")"
+fi
+
+mkdir -p "${LOG_DIR}"
+printf '%s' "${metrics_json}" | node "$(dirname "$0")/validate-sample.mjs" \
+  "$(date -Iseconds)" "${SERVICE}" "${main_pid}" "${rss_kb}" "${memory_current}" \
+  "${memory_peak}" "${memory_swap_current}" "${cgroup_root}/memory.events" >> "${LOG_FILE}"

--- a/ops/prts-metrics/validate-sample.mjs
+++ b/ops/prts-metrics/validate-sample.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/** Validate one local metrics probe and emit the JSONL record for storage. */
+import fs from "node:fs";
+
+const [ts, serviceName, pid, rssKb, memoryCurrent, memoryPeak, swapCurrent, eventsPath] = process.argv.slice(2);
+if ([ts, serviceName, pid, rssKb, memoryCurrent, memoryPeak, swapCurrent, eventsPath].some((value) => value === undefined)) {
+  throw new Error("expected timestamp, service identity, cgroup fields, and memory.events path");
+}
+
+const events = Object.fromEntries(
+  fs.readFileSync(eventsPath, "utf8").trim().split("\n").filter(Boolean).map((line) => {
+    const [key, value] = line.split(/\s+/, 2);
+    if (!key || !/^\d+$/.test(value ?? "")) throw new Error(`invalid memory.events line: ${line}`);
+    return [key, Number(value)];
+  }),
+);
+const metrics = JSON.parse(fs.readFileSync(0, "utf8"));
+if (metrics.schema_version !== "prts-mcp.metrics/v1") {
+  throw new Error(`unexpected metrics schema: ${metrics.schema_version}`);
+}
+for (const [label, value] of Object.entries({ pid, rssKb, memoryCurrent, memoryPeak })) {
+  if (!/^\d+$/.test(value)) throw new Error(`invalid ${label}: ${value}`);
+}
+if (swapCurrent !== "null" && !/^\d+$/.test(swapCurrent)) {
+  throw new Error(`invalid swapCurrent: ${swapCurrent}`);
+}
+
+process.stdout.write(`${JSON.stringify({
+  ts,
+  service: { name: serviceName, main_pid: Number(pid) },
+  process: { rss_kb: Number(rssKb) },
+  cgroup: {
+    memory_current_bytes: Number(memoryCurrent),
+    memory_peak_bytes: Number(memoryPeak),
+    memory_swap_current_bytes: swapCurrent === "null" ? null : Number(swapCurrent),
+    memory_events: events,
+  },
+  metrics,
+})}\n`);

--- a/ts/README.md
+++ b/ts/README.md
@@ -31,7 +31,7 @@ docker run -d -p 3000:3000 -v prts-mcp-ts-data:/data/gamedata -v prts-mcp-ts-lev
 docker build -f ts/Dockerfile.node -t prts-mcp-ts-node .
 ```
 
-服务启动后 MCP 端点为 `http://<host>:3000/mcp`，健康检查端点为 `http://<host>:3000/health`。
+服务启动后 MCP 端点为 `http://<host>:3000/mcp`，健康检查端点为 `http://<host>:3000/health`。部署诊断可在显式启用后使用仅聚合的 `/debug/metrics`；不要经公网代理该路径。
 
 ### 接入 MCP 客户端
 
@@ -161,6 +161,10 @@ docker run -d -p 3000:3000 -v prts-mcp-ts-data:/data/gamedata -v prts-mcp-ts-lev
 | `GITHUB_MIRRORS` | 空 | 逗号分隔的 ghproxy 风格代理前缀列表（如 `https://ghproxy.net`），依次在直连失败后尝试 |
 | `PRTS_AUTO_SYNC_INTERVAL_SECONDS` | `3600` | GitHub Release 周期检查间隔（秒）；有效范围 `60..604800`，`0` 表示只执行启动同步；非法值回落到默认值 |
 | `PRTS_OUTPUT_CHANNEL` | `content` | 2.0 输出通道：`content`（默认，仅 markdown，与 1.x 一致）/ `structured`（仅 structuredContent）/ `both`。也可经查询字符串 `?output_channel=` 或请求头 `x-prts-output-channel` 按请求覆盖。仅在客户端确认支持 `structuredContent` 时才用非默认值 |
+| `SESSION_IDLE_TIMEOUT_MS` | `86400000` | Streamable HTTP 会话空闲超时（毫秒）。设为非正数时禁用超时；会话活跃时间、有效值与淘汰计数可由已启用的 `/debug/metrics` 读取。`closed_total` 包含被空闲淘汰而关闭的会话，`evicted_total` 是其中的原因子集。 |
+| `PRTS_METRICS_ENABLED` | `false` | 设为严格的 `true` 才提供 `/debug/metrics`；响应只含进程、缓存、请求、工具和会话的聚合指标，不含 MCP 参数、结果或会话 ID。工具维度只接受内置工具名，避免把调用方输入变成指标标签。生产环境应保持服务仅监听 loopback，且不得为该路径配置公网反向代理。 |
+
+需要验证重复负载与并发会话时，只能在隔离的本机实例上执行 `PRTS_BENCH_ISOLATED=true PRTS_BENCH_ORIGIN=http://127.0.0.1:<port> npm run bench:memory`。脚本要求指标端点已启用，依次记录冷启动、同会话重复和三个并发会话的聚合快照，并在重复阶段新增缓存 miss 时失败；它拒绝非 loopback 目标，不得在生产服务器执行。
 
 ---
 

--- a/ts/package.json
+++ b/ts/package.json
@@ -32,6 +32,7 @@
     "smoke:http:fixture:node": "node scripts/smoke-http.mjs --fixture-data -- node dist/server.js",
     "smoke:bun": "bun run smoke:http:fixture",
     "smoke:bun:package": "bun scripts/smoke-package-bun.mjs",
+    "bench:memory": "node scripts/bench-memory.mjs",
     "test": "node --import tsx --test \"tests/**/*.test.ts\"",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "tsc"

--- a/ts/scripts/bench-memory.mjs
+++ b/ts/scripts/bench-memory.mjs
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+/**
+ * Run the repeat/concurrency memory probe against an explicitly isolated MCP
+ * instance. It never starts a server and refuses a non-loopback origin.
+ *
+ * Usage:
+ *   PRTS_BENCH_ISOLATED=true PRTS_BENCH_ORIGIN=http://127.0.0.1:3000 \
+ *     node scripts/bench-memory.mjs
+ */
+
+const origin = requireIsolatedOrigin();
+
+function requireIsolatedOrigin() {
+  if (process.env.PRTS_BENCH_ISOLATED !== "true") {
+    throw new Error("Set PRTS_BENCH_ISOLATED=true after confirming the target is an isolated instance");
+  }
+  const raw = process.env.PRTS_BENCH_ORIGIN;
+  if (!raw) throw new Error("Set PRTS_BENCH_ORIGIN to the isolated server origin");
+  const parsed = new URL(raw);
+  if (!["127.0.0.1", "localhost", "::1", "[::1]"].includes(parsed.hostname)) {
+    throw new Error("PRTS_BENCH_ORIGIN must use a loopback host; do not run this benchmark against production");
+  }
+  return parsed.origin;
+}
+
+async function readJson(res, label) {
+  const text = await res.text();
+  if (!res.ok) throw new Error(`${label} returned HTTP ${res.status}: ${text.slice(0, 500)}`);
+  const sseMatch = text.match(/^data:\s*(\{[\s\S]*\})/m);
+  try {
+    return JSON.parse(sseMatch ? sseMatch[1] : text);
+  } catch {
+    throw new Error(`${label} returned invalid JSON: ${text.slice(0, 500)}`);
+  }
+}
+
+async function mcpPost(body, sessionId) {
+  const headers = { "Content-Type": "application/json", Accept: "application/json, text/event-stream" };
+  if (sessionId) headers["Mcp-Session-Id"] = sessionId;
+  const res = await fetch(`${origin}/mcp`, { method: "POST", headers, body: JSON.stringify(body) });
+  const response = await readJson(res, "MCP request");
+  if (response.error) throw new Error(`MCP protocol error: ${JSON.stringify(response.error)}`);
+  if (!response.result) throw new Error("MCP response has no result");
+  return { response, sessionId: res.headers.get("mcp-session-id") };
+}
+
+async function mcpNotify(body, sessionId) {
+  const res = await fetch(`${origin}/mcp`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      "Mcp-Session-Id": sessionId,
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`MCP notification returned HTTP ${res.status}: ${text.slice(0, 500)}`);
+  }
+}
+
+async function startSession(id) {
+  const initialized = await mcpPost({
+    jsonrpc: "2.0",
+    method: "initialize",
+    params: {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "prts-memory-benchmark", version: "1" },
+    },
+    id,
+  });
+  if (!initialized.sessionId) throw new Error("initialize did not return Mcp-Session-Id");
+  await mcpNotify({ jsonrpc: "2.0", method: "notifications/initialized" }, initialized.sessionId);
+  return initialized.sessionId;
+}
+
+async function callTool(sessionId, name, args, id) {
+  await mcpPost({
+    jsonrpc: "2.0",
+    method: "tools/call",
+    params: { name, arguments: args },
+    id,
+  }, sessionId);
+}
+
+async function runWorkload(sessionId, idStart) {
+  await callTool(sessionId, "get_operator_archives", { name: "阿米娅" }, idStart);
+  await callTool(sessionId, "get_operator_basic_info", { name: "阿米娅" }, idStart + 1);
+  await callTool(sessionId, "search", { scope: "operators", pattern: "法术伤害", max_results: 20 }, idStart + 2);
+}
+
+function cacheMisses(cache) {
+  return Object.values(cache).reduce((total, domain) => total + Object.values(domain)
+    .reduce((domainTotal, stat) => domainTotal + Number(stat.misses ?? 0), 0), 0);
+}
+
+function compactSnapshot(snapshot) {
+  return {
+    server: snapshot.server,
+    process: snapshot.process,
+    requests: snapshot.requests,
+    tool_calls: snapshot.tool_calls,
+    sessions: snapshot.sessions,
+    cache_misses_total: cacheMisses(snapshot.cache),
+    cache: snapshot.cache,
+  };
+}
+
+async function snapshot(label) {
+  const res = await fetch(`${origin}/debug/metrics`);
+  const data = await readJson(res, `${label} metrics`);
+  if (data.schema_version !== "prts-mcp.metrics/v1") {
+    throw new Error(`${label} metrics endpoint is unavailable or has unexpected schema`);
+  }
+  return data;
+}
+
+const before = await snapshot("before");
+const primarySession = await startSession(1);
+await runWorkload(primarySession, 10);
+const cold = await snapshot("cold");
+
+await runWorkload(primarySession, 20);
+const repeated = await snapshot("repeated");
+const coldMisses = cacheMisses(cold.cache);
+const repeatedMisses = cacheMisses(repeated.cache);
+if (repeatedMisses !== coldMisses) {
+  throw new Error(`repeat workload added cache misses (${coldMisses} -> ${repeatedMisses}); rerun only after confirming no activation invalidation occurred`);
+}
+
+const concurrentSessions = await Promise.all([startSession(100), startSession(200), startSession(300)]);
+await Promise.all(concurrentSessions.map((sessionId, index) => runWorkload(sessionId, 1_000 + index * 10)));
+const concurrent = await snapshot("concurrent");
+
+console.log(JSON.stringify({
+  schema_version: "prts-mcp.memory-benchmark/v1",
+  target: { origin, isolated: true },
+  assertions: { repeated_workload_added_no_cache_misses: true },
+  snapshots: {
+    before: compactSnapshot(before),
+    cold: compactSnapshot(cold),
+    repeated: compactSnapshot(repeated),
+    concurrent: compactSnapshot(concurrent),
+  },
+}, null, 2));

--- a/ts/src/cacheStats.ts
+++ b/ts/src/cacheStats.ts
@@ -1,0 +1,38 @@
+/**
+ * Aggregate read-only cache instrumentation from each data domain.
+ */
+import { getCacheStats as getOperatorCacheStats } from "./data/operator.js";
+import { getCacheStats as getEnemyCacheStats } from "./data/enemy.js";
+import { getCacheStats as getStageCacheStats } from "./data/stage.js";
+import { getCacheStats as getStageEnemyCacheStats } from "./data/stageEnemy.js";
+import { getCacheStats as getItemCacheStats } from "./data/item.js";
+import { getCacheStats as getSearchCacheStats } from "./data/search.js";
+import { getCacheStats as getStorySearchCacheStats } from "./data/storySearch.js";
+import { getCacheStats as getImagesCacheStats } from "./data/images.js";
+import { getCacheStats as getArtworkMediawikiCacheStats } from "./data/artworkMediawiki.js";
+
+export interface CacheStat {
+  loaded: boolean;
+  count: number;
+  hits: number;
+  misses: number;
+  clears: number;
+  bytes?: number;
+}
+
+export type CacheStats = Record<string, Record<string, CacheStat>>;
+
+/** Return the stable nine-domain cache projection used by debug endpoints. */
+export function getCacheStats(): CacheStats {
+  return {
+    operator: getOperatorCacheStats(),
+    enemy: getEnemyCacheStats(),
+    stage: getStageCacheStats(),
+    stage_enemy: getStageEnemyCacheStats(),
+    item: getItemCacheStats(),
+    search: getSearchCacheStats(),
+    story_search: getStorySearchCacheStats(),
+    images: getImagesCacheStats(),
+    artwork_mediawiki: getArtworkMediawikiCacheStats(),
+  };
+}

--- a/ts/src/data/artworkMediawiki.ts
+++ b/ts/src/data/artworkMediawiki.ts
@@ -7,10 +7,13 @@
  */
 
 import { BASE_ILLUST_LABELS } from "./images.js";
+import { CacheMetrics } from "./cacheMetrics.js";
+import type { CacheStat } from "../cacheStats.js";
 
 const IMAGE_CACHE_MAX_BYTES = 256 * 1024 * 1024; // 256 MiB (#85 §4.2)
 const _imageCache = new Map<string, Buffer>();
 let _imageCacheTotal = 0;
+const imageCacheMetrics = new CacheMetrics();
 
 export const VARIANT_WIDTH: Record<string, number> = { large: 1024, preview: 256 };
 
@@ -21,6 +24,7 @@ function imageCacheKey(artworkId: string, variant: string): string {
 export function imageCacheGet(artworkId: string, variant: string): Buffer | null {
   const key = imageCacheKey(artworkId, variant);
   const v = _imageCache.get(key);
+  imageCacheMetrics.access(v !== undefined);
   if (v === undefined) return null;
   _imageCache.delete(key);
   _imageCache.set(key, v); // move to end (LRU)
@@ -45,13 +49,9 @@ export function imageCachePut(artworkId: string, variant: string, data: Buffer):
   }
 }
 
-export function getCacheStats(): Record<string, { loaded: boolean; count: number; bytes?: number }> {
+export function getCacheStats(): Record<string, CacheStat> {
   return {
-    image_cache: {
-      loaded: _imageCache.size > 0,
-      count: _imageCache.size,
-      bytes: _imageCacheTotal,
-    },
+    image_cache: imageCacheMetrics.snapshot(_imageCache.size > 0, _imageCache.size, _imageCacheTotal),
   };
 }
 

--- a/ts/src/data/cacheMetrics.ts
+++ b/ts/src/data/cacheMetrics.ts
@@ -1,0 +1,28 @@
+/** Lightweight per-cache counters for read-only observability. */
+import type { CacheStat } from "../cacheStats.js";
+
+export class CacheMetrics {
+  private hits = 0;
+  private misses = 0;
+  private clears = 0;
+
+  access(loaded: boolean): void {
+    if (loaded) this.hits += 1;
+    else this.misses += 1;
+  }
+
+  clear(): void {
+    this.clears += 1;
+  }
+
+  snapshot(loaded: boolean, count: number, bytes?: number): CacheStat {
+    return {
+      loaded,
+      count,
+      hits: this.hits,
+      misses: this.misses,
+      clears: this.clears,
+      ...(bytes === undefined ? {} : { bytes }),
+    };
+  }
+}

--- a/ts/src/data/enemy.ts
+++ b/ts/src/data/enemy.ts
@@ -6,6 +6,8 @@
 
 import { checkActivationChange, loadConfig, registerActivationListener } from "../config.js";
 import { DirectoryStore } from "./stores.js";
+import { CacheMetrics } from "./cacheMetrics.js";
+import type { CacheStat } from "../cacheStats.js";
 
 // ---------------------------------------------------------------------------
 // Module-level caches
@@ -15,23 +17,31 @@ let _handbook: EnemyHandbook | null = null;
 let _dbIndex: Record<string, EnemyDbEntry> | null = null;
 let _nameToEnemyId: Map<string, string> | null = null;
 let _enemySearchRecords: EnemySearchRecord[] | null = null;
+const handbookMetrics = new CacheMetrics();
+const databaseMetrics = new CacheMetrics();
+const nameToIdMetrics = new CacheMetrics();
+const searchRecordsMetrics = new CacheMetrics();
 
 const HANDBOOK_FILE = "enemy_handbook_table.json";
 const DATABASE_FILE = "enemy_database.json";
 
 export function clearEnemyCaches(): void {
+  handbookMetrics.clear();
+  databaseMetrics.clear();
+  nameToIdMetrics.clear();
+  searchRecordsMetrics.clear();
   _handbook = null;
   _dbIndex = null;
   _nameToEnemyId = null;
   _enemySearchRecords = null;
 }
 
-export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+export function getCacheStats(): Record<string, CacheStat> {
   return {
-    enemy_handbook: { loaded: _handbook != null, count: _handbook ? Object.keys(_handbook.enemyData ?? {}).length : 0 },
-    enemy_database: { loaded: _dbIndex != null, count: _dbIndex ? Object.keys(_dbIndex).length : 0 },
-    enemy_name_to_id: { loaded: _nameToEnemyId != null, count: _nameToEnemyId ? _nameToEnemyId.size : 0 },
-    enemy_search_records: { loaded: _enemySearchRecords != null, count: _enemySearchRecords ? _enemySearchRecords.length : 0 },
+    enemy_handbook: handbookMetrics.snapshot(_handbook != null, _handbook ? Object.keys(_handbook.enemyData ?? {}).length : 0),
+    enemy_database: databaseMetrics.snapshot(_dbIndex != null, _dbIndex ? Object.keys(_dbIndex).length : 0),
+    enemy_name_to_id: nameToIdMetrics.snapshot(_nameToEnemyId != null, _nameToEnemyId ? _nameToEnemyId.size : 0),
+    enemy_search_records: searchRecordsMetrics.snapshot(_enemySearchRecords != null, _enemySearchRecords ? _enemySearchRecords.length : 0),
   };
 }
 
@@ -215,6 +225,7 @@ function hasEnemyData(): boolean {
 
 function getHandbook(): EnemyHandbook {
   checkActivationChange();
+  handbookMetrics.access(_handbook !== null);
   if (_handbook === null) {
     const cfg = loadConfig();
     if (cfg.effectiveExcelPath === null) throw new Error("effectiveExcelPath is null");
@@ -239,6 +250,7 @@ function mValue<T>(obj: unknown, defaultValue?: T): T | undefined {
 
 function getDbIndex(): Record<string, EnemyDbEntry> {
   checkActivationChange();
+  databaseMetrics.access(_dbIndex !== null);
   if (_dbIndex === null) {
     const cfg = loadConfig();
     const lp = cfg.effectiveLevelsPath;
@@ -265,6 +277,7 @@ function join(...parts: (string | undefined | null)[]): string {
 
 function buildNameToEnemyId(): Map<string, string> {
   checkActivationChange();
+  nameToIdMetrics.access(_nameToEnemyId !== null);
   if (_nameToEnemyId === null) {
     const raw = getHandbook();
     const ed = raw.enemyData ?? {};
@@ -678,6 +691,7 @@ function renderEnemySearchCard(entry: EnemySearchPayload["results"][number]): st
 
 function getEnemySearchRecords(): EnemySearchRecord[] {
   checkActivationChange();
+  searchRecordsMetrics.access(_enemySearchRecords !== null);
   if (_enemySearchRecords !== null) return _enemySearchRecords;
   const ed = getHandbook().enemyData ?? {};
   _enemySearchRecords = Object.entries(ed)

--- a/ts/src/data/images.ts
+++ b/ts/src/data/images.ts
@@ -14,6 +14,8 @@ import {
   registerActivationListener,
 } from "../config.js";
 import { DirectoryStore } from "./stores.js";
+import { CacheMetrics } from "./cacheMetrics.js";
+import type { CacheStat } from "../cacheStats.js";
 
 export const SCHEMA_VERSION = "akdp-images/v1";
 export const VARIANT_ORDER = ["original", "large", "preview"] as const;
@@ -143,6 +145,7 @@ type CharSkinsCache = Record<string, CharSkinLike> | null;
 // null = not yet loaded; the cache is reset by clearImageCaches on activation
 // changes, mirroring operator.ts's lazy-cache pattern.
 let _charSkins: CharSkinsCache = null;
+const charSkinsMetrics = new CacheMetrics();
 
 /**
  * Load the ``charSkins`` mapping from ``skin_table.json``.
@@ -153,6 +156,7 @@ let _charSkins: CharSkinsCache = null;
  */
 export function getCharSkins(): Record<string, CharSkinLike> {
   checkActivationChange();
+  charSkinsMetrics.access(_charSkins !== null);
   if (_charSkins === null) {
     const ep = loadConfig().effectiveExcelPath;
     if (ep === null) {
@@ -180,12 +184,13 @@ export function getCharSkins(): Record<string, CharSkinLike> {
 }
 
 export function clearImageCaches(): void {
+  charSkinsMetrics.clear();
   _charSkins = null;
 }
 
-export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+export function getCacheStats(): Record<string, CacheStat> {
   return {
-    char_skins: { loaded: _charSkins != null, count: _charSkins ? Object.keys(_charSkins).length : 0 },
+    char_skins: charSkinsMetrics.snapshot(_charSkins != null, _charSkins ? Object.keys(_charSkins).length : 0),
   };
 }
 

--- a/ts/src/data/item.ts
+++ b/ts/src/data/item.ts
@@ -6,6 +6,8 @@
 
 import { checkActivationChange, loadConfig, registerActivationListener } from "../config.js";
 import { DirectoryStore } from "./stores.js";
+import { CacheMetrics } from "./cacheMetrics.js";
+import type { CacheStat } from "../cacheStats.js";
 
 const ITEM_FILE = "item_table.json";
 
@@ -129,18 +131,24 @@ export interface ItemSearchPayload {
 let itemTable: Record<string, ItemEntry> | null = null;
 let itemLookup: Map<string, string> | null = null;
 let itemSearchRecords: ItemSearchRecord[] | null = null;
+const itemTableMetrics = new CacheMetrics();
+const itemLookupMetrics = new CacheMetrics();
+const itemSearchRecordsMetrics = new CacheMetrics();
 
 export function clearItemCaches(): void {
+  itemTableMetrics.clear();
+  itemLookupMetrics.clear();
+  itemSearchRecordsMetrics.clear();
   itemTable = null;
   itemLookup = null;
   itemSearchRecords = null;
 }
 
-export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+export function getCacheStats(): Record<string, CacheStat> {
   return {
-    items: { loaded: itemTable != null, count: itemTable ? Object.keys(itemTable).length : 0 },
-    item_lookup: { loaded: itemLookup != null, count: itemLookup ? itemLookup.size : 0 },
-    item_search_records: { loaded: itemSearchRecords != null, count: itemSearchRecords ? itemSearchRecords.length : 0 },
+    items: itemTableMetrics.snapshot(itemTable != null, itemTable ? Object.keys(itemTable).length : 0),
+    item_lookup: itemLookupMetrics.snapshot(itemLookup != null, itemLookup ? itemLookup.size : 0),
+    item_search_records: itemSearchRecordsMetrics.snapshot(itemSearchRecords != null, itemSearchRecords ? itemSearchRecords.length : 0),
   };
 }
 
@@ -186,6 +194,7 @@ function shortText(text: string, limit = 80): string {
 
 function loadItems(): Record<string, ItemEntry> {
   checkActivationChange();
+  itemTableMetrics.access(itemTable !== null);
   if (itemTable === null) {
     const store = itemStore();
     if (!store.exists(ITEM_FILE)) {
@@ -202,6 +211,7 @@ function loadItems(): Record<string, ItemEntry> {
 
 function buildItemLookup(): Map<string, string> {
   checkActivationChange();
+  itemLookupMetrics.access(itemLookup !== null);
   if (itemLookup === null) {
     itemLookup = new Map<string, string>();
     for (const [itemId, info] of Object.entries(loadItems())) {
@@ -483,6 +493,7 @@ function itemSearchEntry(record: ItemSearchRecord): ItemSearchPayload["results"]
 
 function getItemSearchRecords(): ItemSearchRecord[] {
   checkActivationChange();
+  itemSearchRecordsMetrics.access(itemSearchRecords !== null);
   if (itemSearchRecords !== null) return itemSearchRecords;
   const entries = visibleItems();
   entries.sort((a, b) => {

--- a/ts/src/data/operator.ts
+++ b/ts/src/data/operator.ts
@@ -15,6 +15,8 @@ import {
 import { DirectoryStore } from "./stores.js";
 import { stripWikitext } from "../utils/sanitizer.js";
 import { clearSearchCaches } from "./search.js";
+import { CacheMetrics } from "./cacheMetrics.js";
+import type { CacheStat } from "../cacheStats.js";
 
 // ---------------------------------------------------------------------------
 // Module-level lazy caches
@@ -31,8 +33,16 @@ let _characterTable: TableCache<Record<string, CharacterEntry>> = null;
 let _handbookTable: TableCache<HandbookTable> = null;
 let _charwordTable: TableCache<CharwordTable> = null;
 let _nameToId: Map<string, string> | null = null;
+const characterTableMetrics = new CacheMetrics();
+const handbookTableMetrics = new CacheMetrics();
+const charwordTableMetrics = new CacheMetrics();
+const nameToIdMetrics = new CacheMetrics();
 
 export function clearOperatorCaches(): void {
+  characterTableMetrics.clear();
+  handbookTableMetrics.clear();
+  charwordTableMetrics.clear();
+  nameToIdMetrics.clear();
   _characterTable = null;
   _handbookTable = null;
   _charwordTable = null;
@@ -41,12 +51,12 @@ export function clearOperatorCaches(): void {
   clearSearchCaches();
 }
 
-export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+export function getCacheStats(): Record<string, CacheStat> {
   return {
-    character_table: { loaded: _characterTable != null, count: _characterTable ? Object.keys(_characterTable).length : 0 },
-    handbook_table: { loaded: _handbookTable != null, count: _handbookTable ? Object.keys(_handbookTable).length : 0 },
-    charword_table: { loaded: _charwordTable != null, count: _charwordTable ? Object.keys(_charwordTable).length : 0 },
-    name_to_id: { loaded: _nameToId != null, count: _nameToId ? _nameToId.size : 0 },
+    character_table: characterTableMetrics.snapshot(_characterTable != null, _characterTable ? Object.keys(_characterTable).length : 0),
+    handbook_table: handbookTableMetrics.snapshot(_handbookTable != null, _handbookTable ? Object.keys(_handbookTable).length : 0),
+    charword_table: charwordTableMetrics.snapshot(_charwordTable != null, _charwordTable ? Object.keys(_charwordTable).length : 0),
+    name_to_id: nameToIdMetrics.snapshot(_nameToId != null, _nameToId ? _nameToId.size : 0),
   };
 }
 
@@ -165,6 +175,7 @@ function operatorStore(): DirectoryStore {
 
 export function getCharacterTable(): Record<string, CharacterEntry> {
   checkActivationChange();
+  characterTableMetrics.access(_characterTable !== null);
   if (_characterTable === null) {
     _characterTable = loadJson<Record<string, CharacterEntry>>(
       "character_table.json"
@@ -176,6 +187,7 @@ export function getCharacterTable(): Record<string, CharacterEntry> {
 
 export function getHandbookTable(): HandbookTable {
   checkActivationChange();
+  handbookTableMetrics.access(_handbookTable !== null);
   if (_handbookTable === null) {
     _handbookTable = loadJson<HandbookTable>(
       "handbook_info_table.json"
@@ -187,6 +199,7 @@ export function getHandbookTable(): HandbookTable {
 
 export function getCharwordTable(): CharwordTable {
   checkActivationChange();
+  charwordTableMetrics.access(_charwordTable !== null);
   if (_charwordTable === null) {
     _charwordTable = loadJson<CharwordTable>("charword_table.json");
   }
@@ -196,6 +209,7 @@ export function getCharwordTable(): CharwordTable {
 
 export function resolveCharId(name: string): string | null {
   checkActivationChange();
+  nameToIdMetrics.access(_nameToId !== null);
   if (_nameToId === null) {
     const ct = getCharacterTable();
     _nameToId = new Map(

--- a/ts/src/data/search.ts
+++ b/ts/src/data/search.ts
@@ -10,6 +10,8 @@ import {
   getHandbookTable,
   getCharwordTable,
 } from "./operator.js";
+import { CacheMetrics } from "./cacheMetrics.js";
+import type { CacheStat } from "../cacheStats.js";
 import { buildEnemySearch, renderEnemySearch, type EnemySearchPayload } from "./enemy.js";
 import { buildStageSearch, renderStageSearch, type StageSearchPayload } from "./stage.js";
 import { buildItemSearch, renderItemSearch, type ItemSearchPayload } from "./item.js";
@@ -59,14 +61,16 @@ type SearchPayload =
   | ItemSearchPayload;
 
 let operatorSearchRecords: OperatorSearchEntry[] | null = null;
+const operatorSearchRecordsMetrics = new CacheMetrics();
 
 export function clearSearchCaches(): void {
+  operatorSearchRecordsMetrics.clear();
   operatorSearchRecords = null;
 }
 
-export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+export function getCacheStats(): Record<string, CacheStat> {
   return {
-    search_records: { loaded: operatorSearchRecords != null, count: operatorSearchRecords ? operatorSearchRecords.length : 0 },
+    search_records: operatorSearchRecordsMetrics.snapshot(operatorSearchRecords != null, operatorSearchRecords ? operatorSearchRecords.length : 0),
   };
 }
 
@@ -151,6 +155,7 @@ export function renderSearch(data: SearchPayload): string {
 
 function getOperatorSearchRecords(): OperatorSearchEntry[] {
   checkActivationChange();
+  operatorSearchRecordsMetrics.access(operatorSearchRecords !== null);
   if (operatorSearchRecords !== null) return operatorSearchRecords;
 
   const ct = getCharacterTable();

--- a/ts/src/data/stage.ts
+++ b/ts/src/data/stage.ts
@@ -1,6 +1,8 @@
 import { checkActivationChange, loadConfig, registerActivationListener } from "../config.js";
 import { DirectoryStore } from "./stores.js";
 import { getItemNameById } from "./item.js";
+import { CacheMetrics } from "./cacheMetrics.js";
+import type { CacheStat } from "../cacheStats.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -134,19 +136,25 @@ let _stageTable: StageTable | null = null;
 let _zoneTable: ZoneTable | null = null;
 let _zoneTableFailed = false;
 let _stageSearchRecords: StageSearchRecord[] | null = null;
+const stageTableMetrics = new CacheMetrics();
+const zoneTableMetrics = new CacheMetrics();
+const stageSearchRecordsMetrics = new CacheMetrics();
 
 export function clearStageCaches(): void {
+  stageTableMetrics.clear();
+  zoneTableMetrics.clear();
+  stageSearchRecordsMetrics.clear();
   _stageTable = null;
   _zoneTable = null;
   _zoneTableFailed = false;
   _stageSearchRecords = null;
 }
 
-export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+export function getCacheStats(): Record<string, CacheStat> {
   return {
-    stage_table: { loaded: _stageTable != null, count: _stageTable ? Object.keys(_stageTable).length : 0 },
-    zone_table: { loaded: _zoneTable != null, count: _zoneTable ? Object.keys(_zoneTable).length : 0 },
-    stage_search_records: { loaded: _stageSearchRecords != null, count: _stageSearchRecords ? _stageSearchRecords.length : 0 },
+    stage_table: stageTableMetrics.snapshot(_stageTable != null, _stageTable ? Object.keys(_stageTable).length : 0),
+    zone_table: zoneTableMetrics.snapshot(_zoneTable != null, _zoneTable ? Object.keys(_zoneTable).length : 0),
+    stage_search_records: stageSearchRecordsMetrics.snapshot(_stageSearchRecords != null, _stageSearchRecords ? _stageSearchRecords.length : 0),
   };
 }
 
@@ -205,6 +213,7 @@ function formatDrops(dropInfo: Record<string, unknown> | null | undefined): stri
 
 function getStageTable(): StageTable {
   checkActivationChange();
+  stageTableMetrics.access(_stageTable !== null);
   if (_stageTable === null) {
     const cfg = loadConfig();
     if (!cfg.effectiveExcelPath) {
@@ -225,6 +234,7 @@ function getStageTable(): StageTable {
 
 function getZoneTable(): ZoneTable | null {
   checkActivationChange();
+  zoneTableMetrics.access(_zoneTable !== null || _zoneTableFailed);
   if (_zoneTable === null && !_zoneTableFailed) {
     const cfg = loadConfig();
     if (!cfg.effectiveExcelPath) {
@@ -542,6 +552,7 @@ function stageSearchEntry(record: StageSearchRecord): StageSearchPayload["result
 
 function getStageSearchRecords(): StageSearchRecord[] {
   checkActivationChange();
+  stageSearchRecordsMetrics.access(_stageSearchRecords !== null);
   if (_stageSearchRecords !== null) return _stageSearchRecords;
   _stageSearchRecords = Object.entries(getStageTable())
     .sort(([a], [b]) => a.localeCompare(b))

--- a/ts/src/data/stageEnemy.ts
+++ b/ts/src/data/stageEnemy.ts
@@ -11,6 +11,8 @@ import {
   registerActivationListener,
 } from "../config.js";
 import { DirectoryStore } from "./stores.js";
+import { CacheMetrics } from "./cacheMetrics.js";
+import type { CacheStat } from "../cacheStats.js";
 
 const DATABASE_FILE = "enemydata/enemy_database.json";
 
@@ -102,8 +104,18 @@ let enemyHandbook: Record<string, EnemyHandbookEntry> | null = null;
 let enemyDatabase: Record<string, Record<number, EnemyData>> | null = null;
 let nameToEnemyId: Map<string, string> | null = null;
 let enemyAppearanceIndex: Map<string, Array<[string, number]>> | null = null;
+const stageTableMetrics = new CacheMetrics();
+const enemyHandbookMetrics = new CacheMetrics();
+const enemyDatabaseMetrics = new CacheMetrics();
+const nameToEnemyIdMetrics = new CacheMetrics();
+const enemyAppearanceIndexMetrics = new CacheMetrics();
 
 export function clearStageEnemyCaches(): void {
+  stageTableMetrics.clear();
+  enemyHandbookMetrics.clear();
+  enemyDatabaseMetrics.clear();
+  nameToEnemyIdMetrics.clear();
+  enemyAppearanceIndexMetrics.clear();
   stageTable = null;
   enemyHandbook = null;
   enemyDatabase = null;
@@ -111,13 +123,13 @@ export function clearStageEnemyCaches(): void {
   enemyAppearanceIndex = null;
 }
 
-export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+export function getCacheStats(): Record<string, CacheStat> {
   return {
-    stage_table: { loaded: stageTable != null, count: stageTable ? Object.keys(stageTable).length : 0 },
-    enemy_handbook: { loaded: enemyHandbook != null, count: enemyHandbook ? Object.keys(enemyHandbook).length : 0 },
-    enemy_database: { loaded: enemyDatabase != null, count: enemyDatabase ? Object.keys(enemyDatabase).length : 0 },
-    enemy_name_to_id: { loaded: nameToEnemyId != null, count: nameToEnemyId ? nameToEnemyId.size : 0 },
-    enemy_appearance_index: { loaded: enemyAppearanceIndex != null, count: enemyAppearanceIndex ? enemyAppearanceIndex.size : 0 },
+    stage_table: stageTableMetrics.snapshot(stageTable != null, stageTable ? Object.keys(stageTable).length : 0),
+    enemy_handbook: enemyHandbookMetrics.snapshot(enemyHandbook != null, enemyHandbook ? Object.keys(enemyHandbook).length : 0),
+    enemy_database: enemyDatabaseMetrics.snapshot(enemyDatabase != null, enemyDatabase ? Object.keys(enemyDatabase).length : 0),
+    enemy_name_to_id: nameToEnemyIdMetrics.snapshot(nameToEnemyId != null, nameToEnemyId ? nameToEnemyId.size : 0),
+    enemy_appearance_index: enemyAppearanceIndexMetrics.snapshot(enemyAppearanceIndex != null, enemyAppearanceIndex ? enemyAppearanceIndex.size : 0),
   };
 }
 
@@ -146,6 +158,7 @@ function missingLevelsMessage(): string {
 
 function loadStageTable(): Record<string, StageEntry> {
   checkActivationChange();
+  stageTableMetrics.access(stageTable !== null);
   if (stageTable === null) {
     const raw = excelStore().readJson<{ stages?: Record<string, StageEntry> }>("stage_table.json");
     if (!raw || typeof raw !== "object" || !raw.stages) {
@@ -158,6 +171,7 @@ function loadStageTable(): Record<string, StageEntry> {
 
 function loadEnemyHandbook(): Record<string, EnemyHandbookEntry> {
   checkActivationChange();
+  enemyHandbookMetrics.access(enemyHandbook !== null);
   if (enemyHandbook === null) {
     const raw = excelStore().readJson<{ enemyData?: Record<string, EnemyHandbookEntry> }>("enemy_handbook_table.json");
     if (!raw || typeof raw !== "object" || !raw.enemyData) {
@@ -170,6 +184,7 @@ function loadEnemyHandbook(): Record<string, EnemyHandbookEntry> {
 
 function loadEnemyDatabase(): Record<string, Record<number, EnemyData>> {
   checkActivationChange();
+  enemyDatabaseMetrics.access(enemyDatabase !== null);
   if (enemyDatabase === null) {
     const raw = levelsStore().readJson<{
       enemies?: Array<{ Key?: string; Value?: Array<{ level?: number | string; enemyData?: EnemyData }> }>;
@@ -190,6 +205,7 @@ function loadEnemyDatabase(): Record<string, Record<number, EnemyData>> {
 
 function buildNameToEnemyId(): Map<string, string> {
   checkActivationChange();
+  nameToEnemyIdMetrics.access(nameToEnemyId !== null);
   if (nameToEnemyId === null) {
     nameToEnemyId = new Map();
     for (const [enemyId, info] of Object.entries(loadEnemyHandbook())) {
@@ -402,6 +418,7 @@ function findEnemyAppearances(enemyId: string): Array<[string, number]> {
 
 function getEnemyAppearanceIndex(): Map<string, Array<[string, number]>> {
   checkActivationChange();
+  enemyAppearanceIndexMetrics.access(enemyAppearanceIndex !== null);
   if (enemyAppearanceIndex !== null) return enemyAppearanceIndex;
   const index = new Map<string, Array<[string, number]>>();
   const stages = loadStageTable();

--- a/ts/src/data/storySearch.ts
+++ b/ts/src/data/storySearch.ts
@@ -9,6 +9,8 @@
 
 import { statSync } from "node:fs";
 import { join } from "node:path";
+import type { CacheStat } from "../cacheStats.js";
+import { CacheMetrics } from "./cacheMetrics.js";
 import { DirectoryStore, type JsonStore, ZipStore } from "./stores.js";
 import {
   type StoryLine,
@@ -73,17 +75,19 @@ export interface StorySearchPayload {
 let storySearchCache:
   | { descriptor: string; index: StorySearchIndex }
   | null = null;
+const storySearchMetrics = new CacheMetrics();
 
 export function clearSearchCache(): void {
+  storySearchMetrics.clear();
   storySearchCache = null;
 }
 
-export function getCacheStats(): Record<string, { loaded: boolean; count: number }> {
+export function getCacheStats(): Record<string, CacheStat> {
   return {
-    story_search_index: {
-      loaded: storySearchCache !== null,
-      count: storySearchCache ? storySearchCache.index.chapters.length : 0,
-    },
+    story_search_index: storySearchMetrics.snapshot(
+      storySearchCache !== null,
+      storySearchCache ? storySearchCache.index.chapters.length : 0,
+    ),
   };
 }
 
@@ -284,7 +288,9 @@ export function renderStorySearch(data: StorySearchPayload): string {
 
 export function storySearchIndex(store: JsonStore): StorySearchIndex {
   const descriptor = storyStoreDescriptor(store);
-  if (descriptor !== null && storySearchCache?.descriptor === descriptor) {
+  const cached = descriptor !== null && storySearchCache?.descriptor === descriptor;
+  storySearchMetrics.access(cached);
+  if (cached && storySearchCache !== null) {
     return storySearchCache.index;
   }
   const index = buildStorySearchIndex(store);

--- a/ts/src/metrics.ts
+++ b/ts/src/metrics.ts
@@ -1,0 +1,200 @@
+/**
+ * Process-lifetime, aggregate-only HTTP and session instrumentation.
+ *
+ * This module deliberately stores no request payloads, tool results, client
+ * addresses, or session identifiers.
+ */
+import type { CacheStats } from "./cacheStats.js";
+
+interface MemoryUsage {
+  rss: number;
+  heapTotal: number;
+  heapUsed: number;
+  external: number;
+  arrayBuffers: number;
+}
+
+export interface SessionObservation {
+  createdAtMs: number;
+  lastActivityMs: number;
+}
+
+interface ToolCounters {
+  total: number;
+  inFlight: number;
+  durationMsTotal: number;
+  durationMsMax: number;
+  rssAfterMaxBytes: number;
+}
+
+interface RequestToken {
+  startedAtNs: bigint;
+  toolName?: string;
+}
+
+// Tool names are protocol input. Keep this allow-list fixed so an invalid
+// caller-supplied name cannot become a retained metric label or grow memory.
+const METRIC_TOOL_NAMES = new Set([
+  "search_prts",
+  "prts_page",
+  "get_operator_archives",
+  "get_operator_voicelines",
+  "get_operator_basic_info",
+  "list_story_events",
+  "list_stories",
+  "read_story",
+  "read_activity",
+  "search",
+  "search_stories",
+  "get_story_summary",
+  "list_enemies",
+  "get_enemy_info",
+  "get_stage_enemies",
+  "get_enemy_appearances",
+  "list_stages",
+  "get_stage_info",
+  "list_items",
+  "get_item_info",
+  "get_operator_memoirs",
+  "find_character_appearances",
+  "find_speakers_in",
+  "operator_artwork",
+]);
+
+function toolNameFromBody(body: unknown): string | undefined {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) return undefined;
+  const message = body as Record<string, unknown>;
+  if (message["method"] !== "tools/call") return undefined;
+  const params = message["params"];
+  if (typeof params !== "object" || params === null || Array.isArray(params)) return undefined;
+  const name = (params as Record<string, unknown>)["name"];
+  return typeof name === "string" && METRIC_TOOL_NAMES.has(name) ? name : undefined;
+}
+
+function durationMs(startedAtNs: bigint): number {
+  return Number(process.hrtime.bigint() - startedAtNs) / 1_000_000;
+}
+
+/** Collect aggregate metrics for the Streamable HTTP server lifetime. */
+export class RuntimeMetrics {
+  private readonly startedAtMs = Date.now();
+  private requestsInFlight = 0;
+  private requestsTotal = 0;
+  private httpErrorsTotal = 0;
+  private requestDurationMsTotal = 0;
+  private requestDurationMsMax = 0;
+  private rssHighWaterBytes = 0;
+  private sessionsInitializedTotal = 0;
+  private sessionsClosedTotal = 0;
+  private sessionsEvictedTotal = 0;
+  private readonly tools = new Map<string, ToolCounters>();
+
+  beginRequest(body: unknown): RequestToken {
+    this.requestsInFlight += 1;
+    const toolName = toolNameFromBody(body);
+    if (toolName !== undefined) {
+      const counters = this.toolCounters(toolName);
+      counters.inFlight += 1;
+    }
+    return { startedAtNs: process.hrtime.bigint(), toolName };
+  }
+
+  finishRequest(token: RequestToken, statusCode: number): void {
+    const elapsedMs = durationMs(token.startedAtNs);
+    this.requestsInFlight -= 1;
+    this.requestsTotal += 1;
+    this.requestDurationMsTotal += elapsedMs;
+    this.requestDurationMsMax = Math.max(this.requestDurationMsMax, elapsedMs);
+    if (statusCode >= 400) this.httpErrorsTotal += 1;
+
+    const memory = process.memoryUsage();
+    this.rssHighWaterBytes = Math.max(this.rssHighWaterBytes, memory.rss);
+    if (token.toolName !== undefined) {
+      const counters = this.toolCounters(token.toolName);
+      counters.inFlight -= 1;
+      counters.total += 1;
+      counters.durationMsTotal += elapsedMs;
+      counters.durationMsMax = Math.max(counters.durationMsMax, elapsedMs);
+      counters.rssAfterMaxBytes = Math.max(counters.rssAfterMaxBytes, memory.rss);
+    }
+  }
+
+  sessionInitialized(): void {
+    this.sessionsInitializedTotal += 1;
+  }
+
+  sessionClosed(): void {
+    this.sessionsClosedTotal += 1;
+  }
+
+  sessionEvicted(): void {
+    this.sessionsEvictedTotal += 1;
+  }
+
+  snapshot(
+    serverVersion: string,
+    idleTimeoutMs: number | null,
+    sessions: Iterable<SessionObservation>,
+    cache: CacheStats,
+  ): Record<string, unknown> {
+    const now = Date.now();
+    const memory = process.memoryUsage() as MemoryUsage;
+    this.rssHighWaterBytes = Math.max(this.rssHighWaterBytes, memory.rss);
+    const observedSessions = [...sessions];
+    const ages = observedSessions.map((session) => now - session.createdAtMs);
+    const idleAges = observedSessions.map((session) => now - session.lastActivityMs);
+
+    return {
+      schema_version: "prts-mcp.metrics/v1",
+      server: { version: serverVersion, uptime_ms: now - this.startedAtMs },
+      process: {
+        rss_bytes: memory.rss,
+        heap_total_bytes: memory.heapTotal,
+        heap_used_bytes: memory.heapUsed,
+        external_bytes: memory.external,
+        array_buffers_bytes: memory.arrayBuffers,
+        rss_high_water_bytes: this.rssHighWaterBytes,
+      },
+      requests: {
+        in_flight: this.requestsInFlight,
+        total: this.requestsTotal,
+        http_errors_total: this.httpErrorsTotal,
+        duration_ms_total: this.requestDurationMsTotal,
+        duration_ms_max: this.requestDurationMsMax,
+      },
+      tool_calls: {
+        in_flight: [...this.tools.values()].reduce((total, counters) => total + counters.inFlight, 0),
+        total: [...this.tools.values()].reduce((total, counters) => total + counters.total, 0),
+        by_name: Object.fromEntries(
+          [...this.tools.entries()].map(([name, counters]) => [name, {
+            total: counters.total,
+            in_flight: counters.inFlight,
+            duration_ms_total: counters.durationMsTotal,
+            duration_ms_max: counters.durationMsMax,
+            rss_after_max_bytes: counters.rssAfterMaxBytes,
+          }]),
+        ),
+      },
+      sessions: {
+        idle_timeout_ms: idleTimeoutMs,
+        active: observedSessions.length,
+        oldest_age_ms: ages.length === 0 ? 0 : Math.max(...ages),
+        max_idle_age_ms: idleAges.length === 0 ? 0 : Math.max(...idleAges),
+        initialized_total: this.sessionsInitializedTotal,
+        // Includes idle-evicted sessions; evicted_total is its reason subset.
+        closed_total: this.sessionsClosedTotal,
+        evicted_total: this.sessionsEvictedTotal,
+      },
+      cache,
+    };
+  }
+
+  private toolCounters(name: string): ToolCounters {
+    let counters = this.tools.get(name);
+    if (counters === undefined) {
+      counters = { total: 0, inFlight: 0, durationMsTotal: 0, durationMsMax: 0, rssAfterMaxBytes: 0 };
+      this.tools.set(name, counters);
+    }
+    return counters;
+  }
+}

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -16,15 +16,8 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { startAutoSync } from "./startupSync.js";
 import { parseChannel, type OutputChannel } from "./output.js";
 import { createMcpServer, log, SERVER_VERSION } from "./server-core.js";
-import { getCacheStats as getOperatorCacheStats } from "./data/operator.js";
-import { getCacheStats as getEnemyCacheStats } from "./data/enemy.js";
-import { getCacheStats as getStageCacheStats } from "./data/stage.js";
-import { getCacheStats as getStageEnemyCacheStats } from "./data/stageEnemy.js";
-import { getCacheStats as getItemCacheStats } from "./data/item.js";
-import { getCacheStats as getSearchCacheStats } from "./data/search.js";
-import { getCacheStats as getStorySearchCacheStats } from "./data/storySearch.js";
-import { getCacheStats as getImagesCacheStats } from "./data/images.js";
-import { getCacheStats as getArtworkMediawikiCacheStats } from "./data/artworkMediawiki.js";
+import { getCacheStats } from "./cacheStats.js";
+import { RuntimeMetrics } from "./metrics.js";
 
 function firstString(value: unknown): string | undefined {
   if (typeof value === "string") return value;
@@ -53,6 +46,8 @@ const app = express();
 app.use(express.json());
 
 const transports = new Map<string, StreamableHTTPServerTransport>();
+const METRICS_ENABLED = process.env["PRTS_METRICS_ENABLED"] === "true";
+const runtimeMetrics = METRICS_ENABLED ? new RuntimeMetrics() : null;
 
 const SESSION_IDLE_TIMEOUT_MS = (() => {
   const raw = process.env["SESSION_IDLE_TIMEOUT_MS"];
@@ -64,7 +59,9 @@ const SESSION_IDLE_TIMEOUT_MS = (() => {
 
 interface SessionMeta {
   transport: StreamableHTTPServerTransport;
+  createdAt: number;
   lastActivity: number;
+  closing?: boolean;
   timer?: ReturnType<typeof setTimeout>;
 }
 
@@ -90,9 +87,16 @@ function scheduleSessionTimeout(id: string): void {
     const idleMs = Date.now() - m.lastActivity;
     if (idleMs >= SESSION_IDLE_TIMEOUT_MS) {
       log("INFO", `Session ${id} idle for ${Math.round(idleMs / 1000)}s — evicting.`);
-      try { m.transport.close(); } catch { /* best-effort */ }
+      m.closing = true;
       transports.delete(id);
-      sessionMeta.delete(id);
+      runtimeMetrics?.sessionEvicted();
+      try {
+        m.transport.close();
+      } catch {
+        if (m.timer) clearTimeout(m.timer);
+        sessionMeta.delete(id);
+        runtimeMetrics?.sessionClosed();
+      }
     } else {
       scheduleSessionTimeout(id);
     }
@@ -101,80 +105,88 @@ function scheduleSessionTimeout(id: string): void {
 }
 
 app.all("/mcp", async (req, res) => {
+  const requestMetrics = runtimeMetrics?.beginRequest(req.body);
   const sessionId = req.headers["mcp-session-id"] as string | undefined;
-  let transport = sessionId ? transports.get(sessionId) : undefined;
+  try {
+    let transport = sessionId ? transports.get(sessionId) : undefined;
 
-  if (!transport) {
-    // Stale session ID: evicted by idle timeout or lost across restart.
-    // Per MCP Streamable HTTP spec §3.2, unrecognized session IDs MUST
-    // receive 404 regardless of request type.  We intentionally relax this
-    // for initialize requests: stripping the old ID and treating it as a
-    // fresh handshake gives broken/non-retrying clients (e.g. Chatbox) a
-    // zero-error recovery path.  Non-init requests get the spec-mandated
-    // 404 with an LLM-actionable message.
-    if (sessionId) {
-      const isInit =
-        req.method === "POST" &&
-        !Array.isArray(req.body) &&
-        req.body?.method === "initialize";
-      if (!isInit) {
-        log("INFO", `Session ${sessionId} not found; returning 404.`);
-        res.status(404).json({
-          jsonrpc: "2.0",
-          error: {
-            code: -32002,
-            message:
-              "MCP session lost (server may have restarted for data sync). " +
-              "Please ask the user to disconnect and reconnect the MCP server " +
-              "in the client settings — typically by toggling the MCP connection " +
-              "off and on, or restarting the client application.",
-          },
-          id: (req.body as Record<string, unknown> | undefined)?.id ?? null,
-        });
+    if (!transport) {
+      // Stale session ID: evicted by idle timeout or lost across restart.
+      // Per MCP Streamable HTTP spec §3.2, unrecognized session IDs MUST
+      // receive 404 regardless of request type.  We intentionally relax this
+      // for initialize requests: stripping the old ID and treating it as a
+      // fresh handshake gives broken/non-retrying clients (e.g. Chatbox) a
+      // zero-error recovery path.  Non-init requests get the spec-mandated
+      // 404 with an LLM-actionable message.
+      if (sessionId) {
+        const isInit =
+          req.method === "POST" &&
+          !Array.isArray(req.body) &&
+          req.body?.method === "initialize";
+        if (!isInit) {
+          log("INFO", `Session ${sessionId} not found; returning 404.`);
+          res.status(404).json({
+            jsonrpc: "2.0",
+            error: {
+              code: -32002,
+              message:
+                "MCP session lost (server may have restarted for data sync). " +
+                "Please ask the user to disconnect and reconnect the MCP server " +
+                "in the client settings — typically by toggling the MCP connection " +
+                "off and on, or restarting the client application.",
+            },
+            id: (req.body as Record<string, unknown> | undefined)?.id ?? null,
+          });
+          return;
+        }
+        delete req.headers["mcp-session-id"];
+        log("INFO", `Session ${sessionId} not found; allowing re-initialization.`);
+      }
+
+      const newTransport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (id) => {
+          const now = Date.now();
+          transports.set(id, newTransport);
+          sessionMeta.set(id, { transport: newTransport, createdAt: now, lastActivity: now });
+          runtimeMetrics?.sessionInitialized();
+          scheduleSessionTimeout(id);
+          log("INFO", `Session ${id} initialized.`);
+        },
+      });
+      newTransport.onclose = () => {
+        if (newTransport.sessionId) {
+          const meta = sessionMeta.get(newTransport.sessionId);
+          if (meta?.timer) clearTimeout(meta.timer);
+          transports.delete(newTransport.sessionId);
+          sessionMeta.delete(newTransport.sessionId);
+          runtimeMetrics?.sessionClosed();
+          log("INFO", `Session ${newTransport.sessionId} closed.`);
+        }
+      };
+      try {
+        const channel = resolveOutputChannel(req);
+        const server = createMcpServer(channel);
+        await server.connect(newTransport);
+      } catch (err) {
+        log("ERROR", `Failed to connect MCP server to transport: ${err instanceof Error ? err.message : String(err)}`);
+        res.status(500).json({ error: "Internal server error" });
         return;
       }
-      delete req.headers["mcp-session-id"];
-      log("INFO", `Session ${sessionId} not found; allowing re-initialization.`);
+      transport = newTransport;
     }
 
-    const newTransport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
-      onsessioninitialized: (id) => {
-        transports.set(id, newTransport);
-        sessionMeta.set(id, { transport: newTransport, lastActivity: Date.now() });
-        scheduleSessionTimeout(id);
-        log("INFO", `Session ${id} initialized.`);
-      },
-    });
-    newTransport.onclose = () => {
-      if (newTransport.sessionId) {
-        const meta = sessionMeta.get(newTransport.sessionId);
-        if (meta?.timer) clearTimeout(meta.timer);
-        transports.delete(newTransport.sessionId);
-        sessionMeta.delete(newTransport.sessionId);
-        log("INFO", `Session ${newTransport.sessionId} closed.`);
-      }
-    };
-    try {
-      const channel = resolveOutputChannel(req);
-      const server = createMcpServer(channel);
-      await server.connect(newTransport);
-    } catch (err) {
-      log("ERROR", `Failed to connect MCP server to transport: ${err instanceof Error ? err.message : String(err)}`);
-      res.status(500).json({ error: "Internal server error" });
-      return;
+    // Update idle timer on each request
+    if (sessionId) {
+      touchSession(sessionId);
     }
-    transport = newTransport;
-  }
 
-  // Update idle timer on each request
-  if (sessionId) {
-    touchSession(sessionId);
+    // Pass req.body explicitly so the transport uses the already-parsed body
+    // rather than attempting to re-read the consumed stream.
+    await transport.handleRequest(req, res, req.body);
+  } finally {
+    if (requestMetrics !== undefined) runtimeMetrics?.finishRequest(requestMetrics, res.statusCode);
   }
-
-  // Pass req.body explicitly so the transport uses the already-parsed body
-  // rather than attempting to re-read the consumed stream.
-  await transport.handleRequest(req, res, req.body);
 });
 
 app.get("/health", (_req, res) => {
@@ -182,17 +194,22 @@ app.get("/health", (_req, res) => {
 });
 
 app.get("/debug/cache", (_req, res) => {
-  res.json({
-    operator: getOperatorCacheStats(),
-    enemy: getEnemyCacheStats(),
-    stage: getStageCacheStats(),
-    stage_enemy: getStageEnemyCacheStats(),
-    item: getItemCacheStats(),
-    search: getSearchCacheStats(),
-    story_search: getStorySearchCacheStats(),
-    images: getImagesCacheStats(),
-    artwork_mediawiki: getArtworkMediawikiCacheStats(),
-  });
+  res.json(getCacheStats());
+});
+
+app.get("/debug/metrics", (_req, res) => {
+  if (runtimeMetrics === null) {
+    res.sendStatus(404);
+    return;
+  }
+  res.json(runtimeMetrics.snapshot(
+    SERVER_VERSION,
+    SESSION_IDLE_TIMEOUT_MS > 0 ? SESSION_IDLE_TIMEOUT_MS : null,
+    [...sessionMeta.values()]
+      .filter((session) => !session.closing)
+      .map(({ createdAt, lastActivity }) => ({ createdAtMs: createdAt, lastActivityMs: lastActivity })),
+    getCacheStats(),
+  ));
 });
 
 // ---------------------------------------------------------------------------

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -134,6 +134,7 @@ test("E2E", async (t) => {
         GITHUB_MIRRORS: "",
         IMAGES_ENABLED: "true",
         SESSION_IDLE_TIMEOUT_MS: "30000",
+        PRTS_METRICS_ENABLED: "true",
       },
       stdio: ["ignore", "pipe", "pipe"],
     },
@@ -151,7 +152,7 @@ test("E2E", async (t) => {
   await t.test("debug cache returns expected modules", async () => {
     const res = await fetch(`${origin}/debug/cache`);
     assert.equal(res.status, 200);
-    const data = await res.json() as Record<string, Record<string, { loaded: boolean; count: number; bytes?: number }>>;
+    const data = await res.json() as Record<string, Record<string, { loaded: boolean; count: number; hits: number; misses: number; clears: number; bytes?: number }>>;
     const expectedModules = new Set([
       "operator", "enemy", "stage", "stage_enemy", "item",
       "search", "story_search", "images", "artwork_mediawiki",
@@ -161,6 +162,9 @@ test("E2E", async (t) => {
       for (const [cacheName, stat] of Object.entries(caches)) {
         assert.equal(typeof stat.loaded, "boolean", `${mod}.${cacheName}.loaded should be boolean`);
         assert.equal(typeof stat.count, "number", `${mod}.${cacheName}.count should be number`);
+        assert.equal(typeof stat.hits, "number", `${mod}.${cacheName}.hits should be number`);
+        assert.equal(typeof stat.misses, "number", `${mod}.${cacheName}.misses should be number`);
+        assert.equal(typeof stat.clears, "number", `${mod}.${cacheName}.clears should be number`);
       }
     }
     // artwork_mediawiki.image_cache includes bytes
@@ -284,6 +288,27 @@ test("E2E", async (t) => {
     );
     assert.equal(r.status, 200);
     assert.ok(r.body?.result, "reused session should work");
+  });
+
+  await t.test("debug metrics exposes aggregate runtime state only", async () => {
+    const res = await fetch(`${origin}/debug/metrics`);
+    assert.equal(res.status, 200);
+    const data = await res.json() as Record<string, unknown>;
+    assert.equal(data.schema_version, "prts-mcp.metrics/v1");
+    const server = data.server as Record<string, unknown>;
+    const processMetrics = data.process as Record<string, unknown>;
+    const sessions = data.sessions as Record<string, unknown>;
+    const requests = data.requests as Record<string, unknown>;
+    const toolCalls = data.tool_calls as Record<string, unknown>;
+    assert.equal(server.version, EXPECTED_VERSION);
+    assert.equal(typeof processMetrics.rss_bytes, "number");
+    assert.equal(sessions.idle_timeout_ms, 30000);
+    assert.equal(sessions.active, 1);
+    assert.ok(Number(requests.total) >= 10);
+    const byName = toolCalls.by_name as Record<string, Record<string, unknown>>;
+    assert.ok(Number(byName.get_operator_basic_info?.total) >= 2);
+    assert.equal(typeof byName.get_operator_basic_info?.duration_ms_max, "number");
+    assert.equal(JSON.stringify(data).includes(sessionId), false, "metrics must not expose session IDs");
   });
 
   // --- PRTS API tools (opt-in) ---

--- a/ts/tests/metrics.test.ts
+++ b/ts/tests/metrics.test.ts
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { RuntimeMetrics } from "../src/metrics.js";
+import { CacheMetrics } from "../src/data/cacheMetrics.js";
+
+test("RuntimeMetrics records aggregate tool calls without retaining payloads", () => {
+  const metrics = new RuntimeMetrics();
+  const token = metrics.beginRequest({
+    jsonrpc: "2.0",
+    method: "tools/call",
+    params: { name: "get_operator_basic_info", arguments: { name: "阿米娅", secret: "must-not-leak" } },
+  });
+  metrics.finishRequest(token, 200);
+
+  const snapshot = metrics.snapshot("2.6.0-test", 86_400_000, [], {});
+  const text = JSON.stringify(snapshot);
+  const toolCalls = snapshot["tool_calls"] as Record<string, unknown>;
+  const byName = toolCalls["by_name"] as Record<string, Record<string, unknown>>;
+
+  assert.equal(toolCalls["total"], 1);
+  assert.equal(byName["get_operator_basic_info"]?.["total"], 1);
+  assert.equal(typeof byName["get_operator_basic_info"]?.["duration_ms_max"], "number");
+  assert.equal(text.includes("must-not-leak"), false);
+  assert.equal(text.includes("阿米娅"), false);
+  assert.equal(text.includes("arguments"), false);
+});
+
+test("RuntimeMetrics leaves batch requests out of ambiguous tool attribution", () => {
+  const metrics = new RuntimeMetrics();
+  const token = metrics.beginRequest([
+    { method: "tools/call", params: { name: "search", arguments: { pattern: "test" } } },
+  ]);
+  metrics.finishRequest(token, 404);
+
+  const snapshot = metrics.snapshot("2.6.0-test", null, [], {});
+  const requests = snapshot["requests"] as Record<string, unknown>;
+  const toolCalls = snapshot["tool_calls"] as Record<string, unknown>;
+
+  assert.equal(requests["total"], 1);
+  assert.equal(requests["http_errors_total"], 1);
+  assert.equal(toolCalls["total"], 0);
+});
+
+test("RuntimeMetrics does not retain an unrecognized caller-supplied tool name", () => {
+  const metrics = new RuntimeMetrics();
+  const toolName = "private-tool-name-must-not-be-retained";
+  const token = metrics.beginRequest({
+    jsonrpc: "2.0",
+    method: "tools/call",
+    params: { name: toolName, arguments: { secret: "must-not-leak" } },
+  });
+  metrics.finishRequest(token, 404);
+
+  const snapshot = metrics.snapshot("2.6.0-test", null, [], {});
+  const toolCalls = snapshot["tool_calls"] as Record<string, unknown>;
+  assert.equal(toolCalls["total"], 0);
+  assert.equal(JSON.stringify(snapshot).includes(toolName), false);
+});
+
+test("CacheMetrics reports cache-gate hits, misses, and invalidation attempts", () => {
+  const metrics = new CacheMetrics();
+  metrics.access(false);
+  metrics.access(true);
+  metrics.clear();
+
+  assert.deepEqual(metrics.snapshot(true, 3), {
+    loaded: true,
+    count: 3,
+    hits: 1,
+    misses: 1,
+    clears: 1,
+  });
+});

--- a/ts/tests/metricsSampler.test.ts
+++ b/ts/tests/metricsSampler.test.ts
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const validator = join(import.meta.dirname, "../../ops/prts-metrics/validate-sample.mjs");
+const metrics = JSON.stringify({ schema_version: "prts-mcp.metrics/v1", sessions: { active: 0 } });
+
+test("metrics sampler validator emits a schema-validated aggregate JSONL record", () => {
+  const directory = mkdtempSync(join(tmpdir(), "prts-metrics-sampler-"));
+  const events = join(directory, "memory.events");
+  writeFileSync(events, "low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\n", "utf8");
+
+  const result = spawnSync(process.execPath, [
+    validator,
+    "2026-08-08T00:00:00+00:00",
+    "prts-mcp-ts.service",
+    "123",
+    "456",
+    "789",
+    "1000",
+    "0",
+    events,
+  ], { input: metrics, encoding: "utf8" });
+
+  assert.equal(result.status, 0, result.stderr);
+  const sample = JSON.parse(result.stdout) as Record<string, unknown>;
+  assert.equal((sample.service as Record<string, unknown>).main_pid, 123);
+  assert.equal((sample.cgroup as Record<string, unknown>).memory_current_bytes, 789);
+  assert.equal((sample.metrics as Record<string, unknown>).schema_version, "prts-mcp.metrics/v1");
+});
+
+test("metrics sampler validator rejects an unexpected metrics schema", () => {
+  const directory = mkdtempSync(join(tmpdir(), "prts-metrics-sampler-"));
+  const events = join(directory, "memory.events");
+  writeFileSync(events, "low 0\n", "utf8");
+
+  const result = spawnSync(process.execPath, [
+    validator,
+    "2026-08-08T00:00:00+00:00",
+    "prts-mcp-ts.service",
+    "123",
+    "456",
+    "789",
+    "1000",
+    "0",
+    events,
+  ], { input: JSON.stringify({ schema_version: "wrong" }), encoding: "utf8" });
+
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /unexpected metrics schema/);
+});

--- a/ts/tests/serverOutputChannel.test.ts
+++ b/ts/tests/serverOutputChannel.test.ts
@@ -141,6 +141,8 @@ test("output_channel is resolved once per session by query/header/env priority",
   t.after(() => { child.kill(); });
 
   await waitForHealth(origin);
+  const metricsDisabled = await fetch(`${origin}/debug/metrics`);
+  assert.equal(metricsDisabled.status, 404, "metrics must be disabled unless explicitly enabled");
 
   let id = 1;
   const initialize = (query = "", headers: Record<string, string> = {}) =>

--- a/ts/tests/sessionIdleTimeout.test.ts
+++ b/ts/tests/sessionIdleTimeout.test.ts
@@ -61,6 +61,7 @@ test("idle sessions are evicted after timeout", async () => {
         GITHUB_MIRRORS: "",
         STORYJSON_PATH: join(dataHome, "storyjson", "missing.zip"),
         SESSION_IDLE_TIMEOUT_MS: "2000",
+        PRTS_METRICS_ENABLED: "true",
       },
       stdio: ["ignore", "ignore", "pipe"],
     },
@@ -71,6 +72,8 @@ test("idle sessions are evicted after timeout", async () => {
   try {
     const origin = "http://127.0.0.1:" + port;
     await waitForHealth(origin, 5000);
+    const metricsEnabled = await fetch(origin + "/debug/metrics");
+    assert.equal(metricsEnabled.status, 200, "metrics should be available when explicitly enabled");
 
     const initRes = await fetch(origin + "/mcp", {
       method: "POST",
@@ -88,6 +91,16 @@ test("idle sessions are evicted after timeout", async () => {
 
     // Wait for idle eviction (timeout is 2s, wait 4s)
     await new Promise((r) => setTimeout(r, 4000));
+
+    const metricsRes = await fetch(origin + "/debug/metrics");
+    assert.equal(metricsRes.status, 200);
+    const metricsText = await metricsRes.text();
+    const metrics = JSON.parse(metricsText) as { sessions: Record<string, unknown> };
+    assert.equal(metrics.sessions.active, 0, "an evicted session must not stay active in metrics");
+    assert.equal(metrics.sessions.initialized_total, 1);
+    assert.equal(metrics.sessions.evicted_total, 1);
+    assert.equal(metrics.sessions.closed_total, 1, "idle eviction closes the session");
+    assert.equal(metricsText.includes(sessionId), false, "metrics must not expose session IDs");
 
     // --- non-init request with stale session → 404 JSON-RPC error ---
     const reuseRes = await fetch(origin + "/mcp", {


### PR DESCRIPTION
## Summary

- Add opt-in aggregate-only runtime metrics for HTTP requests, built-in tools, sessions, process memory, and cache state.
- Instrument all nine cache domains and provide a production-only systemd cgroup sampler.
- Add an isolated loopback repeat/concurrency memory benchmark plus privacy and lifecycle coverage.

## Test plan

- Full repository runtime check passed.
- Bun packed-package HTTP MCP smoke passed.
- Staged systemd unit validation and logrotate dry run passed.
- Isolated loopback benchmark kept repeat cache misses at 5 to 5.

## Notes

- The metrics endpoint remains disabled unless PRTS_METRICS_ENABLED=true and must remain loopback-only.
- This PR intentionally does not bump the package version; alpha.2 packaging follows in a separate release PR.