### PR TITLE
chore: resume v2.6.0 development

### DIFF
--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.6.0-alpha.2",
+  "version": "2.6.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.6.0-alpha.2",
+      "version": "2.6.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.6.0-alpha.2",
+  "version": "2.6.0-dev.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP + stdio)",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

- restore the TypeScript development version to 2.6.0-dev.0 after the alpha.2 tag
- keep the merged alpha.2 changelog entry and the TypeScript-only release scope unchanged

## Test plan

- package and lockfile version equality checked
- alpha.2 tag and published package remain immutable at 2.6.0-alpha.2