### PR TITLE
release: v2.5.2 security patch

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # PRTS-MCP 项目状态
 
-_Last updated: 2026-08-07_
+_Last updated: 2026-08-09_
 
 ## 当前版本
 
@@ -10,6 +10,7 @@ _Last updated: 2026-08-07_
 | TypeScript | 2.5.1 | Stable |
 
 - 当前稳定发布：2.5.1（24 个 MCP 工具）
+- 当前稳定补丁候选：2.5.2（24 个 MCP 工具，待合并/发布）
 - 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）
 - 下一开发目标：2.6.0（待规划）
 - 当前稳定补丁线：2.5.x
@@ -37,6 +38,16 @@ _Last updated: 2026-08-07_
   `search_prts` redirect/技术页面过滤修复。Bun 在 2.0.2 仍是可选候选路径。
 - 2.0 交付内容：工具面合并（32 → 23）+ output channel（structuredContent）；**双端协议同步（Python 上 HTTP / TS 上 stdio）已后置到 2.0 之后**。
 - 兼容性合约：1.7.x LTS 线既有 32 个工具名、必填参数、默认输出格式不变；仅接受兼容性、安全性、数据同步和关键缺陷修复
+
+## 2.5.2 待发布内容
+
+- [x] npm 生产依赖锁定图升级：`@modelcontextprotocol/sdk` 1.30、`adm-zip`
+  0.6 及其安全传递依赖；保持 MCP SDK v1。
+- [x] 当前 AKDP `enemy_database.json` 直接 ID 映射兼容：关卡敌人与敌人图鉴均能
+  读取战斗属性，并保留旧 wrapper 格式。
+- [x] 剧情 `Decision.options` 标量字符串按一整行 choice 返回。
+- [x] `operator_artwork(action=get)` 严格校验 artwork token 的干员归属，拒绝跨干员
+  token，且在本地读图或 MediaWiki 网络请求之前返回 text-only 错误。
 
 ## 2.5.1 发布内容
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.5.2] - 2026-08-09
+
+### Security
+
+- Updated the locked npm production dependency graph, including
+  `@modelcontextprotocol/sdk` 1.30 and `adm-zip` 0.6, resolving the audited
+  production advisories without a breaking SDK-major upgrade.
+
+### Fixed
+
+- **Current AKDP enemy databases.** `get_stage_enemies` and
+  `get_enemy_info` now read the direct enemy-ID mapping emitted by current
+  `zh_CN-levels.zip` releases, while retaining the legacy wrapper format.
+- **Scalar story decisions.** A `Decision.options` string is returned as one
+  complete choice line instead of being dropped or split into characters.
+- **Artwork token ownership.** `operator_artwork(action="get")` rejects an
+  artwork token belonging to another operator before reading local image data
+  or making a MediaWiki request.
+
 ## [2.5.1] - 2026-08-07
 
 ### Fixed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.5.1"
+version = "2.5.2"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/src/prts_mcp/data/artwork_mediawiki.py
+++ b/python/src/prts_mcp/data/artwork_mediawiki.py
@@ -103,3 +103,34 @@ def label_from_filename(
     if form:
         label += f"（{form}）"
     return label
+
+
+def operator_from_filename(filename: str) -> str | None:
+    """Return the declaring operator segment for a listable MediaWiki artwork."""
+    if not filename.endswith(".png") or not filename.startswith("立绘_"):
+        return None
+    if label_from_filename(filename, {}) is None:
+        return None
+    base = filename[:-4]
+    separator = base.find("_", len("立绘_"))
+    if separator < 0:
+        return None
+    operator_name = base[len("立绘_"):separator]
+    return operator_name or None
+
+
+def _normalized_operator_name(name: str) -> str:
+    return name.strip().replace("（", "(").replace("）", ")")
+
+
+def artwork_belongs_to_operator(filename: str, operator_name: str) -> bool:
+    """Check that a MediaWiki artwork belongs to its requested operator."""
+    artwork_operator = operator_from_filename(filename)
+    if artwork_operator is None:
+        return False
+    requested = _normalized_operator_name(operator_name)
+    actual = _normalized_operator_name(artwork_operator)
+    if requested == actual:
+        return True
+    base = actual.rsplit("(", 1)[0] if actual.endswith(")") and "(" in actual else actual
+    return requested == base

--- a/python/src/prts_mcp/data/enemy.py
+++ b/python/src/prts_mcp/data/enemy.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from prts_mcp.config import Config, activation_aware_cache, register_activation_listener
+from prts_mcp.data.enemy_database import normalize_enemy_database
 from prts_mcp.data.stores import DirectoryStore
 
 
@@ -99,14 +100,12 @@ def _load_enemy_database() -> dict[str, Any] | None:
     if not _has_database():
         return None
     store = _database_store()
-    raw = store.read_json(_DATABASE_FILE)
-    # Build enemyId → first-level-enemyData lookup
-    index: dict[str, dict] = {}
-    for entry in raw.get("enemies", []):
-        key = entry.get("Key", "")
-        values = entry.get("Value", [])
-        if values and key:
-            index[key] = values[0].get("enemyData", {})
+    levels = normalize_enemy_database(store.read_json(_DATABASE_FILE))
+    index = {
+        enemy_id: level_map.get(0) or next(iter(level_map.values()))
+        for enemy_id, level_map in levels.items()
+        if level_map
+    }
     return {"_index": index}
 
 

--- a/python/src/prts_mcp/data/enemy_database.py
+++ b/python/src/prts_mcp/data/enemy_database.py
@@ -1,0 +1,45 @@
+"""Normalize supported upstream ``enemy_database.json`` archive shapes."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_enemy_database(raw: Any) -> dict[str, dict[int, dict[str, Any]]]:
+    """Return an ``enemy ID -> level -> enemyData`` index for supported input."""
+    if not isinstance(raw, dict):
+        raise TypeError("enemy_database.json 格式异常：根节点必须是对象。")
+
+    index: dict[str, dict[int, dict[str, Any]]] = {}
+
+    def add_row(enemy_id: str, values: Any) -> None:
+        if not isinstance(values, list):
+            return
+        level_map: dict[int, dict[str, Any]] = {}
+        for value in values:
+            if not isinstance(value, dict):
+                continue
+            try:
+                level = int(value.get("level", 0))
+            except (TypeError, ValueError):
+                level = 0
+            enemy_data = value.get("enemyData")
+            if isinstance(enemy_data, dict):
+                level_map[level] = enemy_data
+        if level_map:
+            index[enemy_id] = level_map
+
+    legacy_rows = raw.get("enemies")
+    if isinstance(legacy_rows, list):
+        for row in legacy_rows:
+            if not isinstance(row, dict):
+                continue
+            key = row.get("Key")
+            if isinstance(key, str) and key:
+                add_row(key, row.get("Value"))
+        return index
+
+    for enemy_id, values in raw.items():
+        add_row(str(enemy_id), values)
+    if not index:
+        raise TypeError("enemy_database.json 格式异常：未找到敌人等级数据。")
+    return index

--- a/python/src/prts_mcp/data/stage_enemy.py
+++ b/python/src/prts_mcp/data/stage_enemy.py
@@ -4,6 +4,7 @@ from collections import Counter
 from typing import Any
 
 from prts_mcp.config import Config, activation_aware_cache, register_activation_listener
+from prts_mcp.data.enemy_database import normalize_enemy_database
 from prts_mcp.data.stores import DirectoryStore
 
 
@@ -68,26 +69,7 @@ def _load_enemy_handbook() -> dict[str, dict[str, Any]]:
 
 @activation_aware_cache(maxsize=1)
 def _load_enemy_database() -> dict[str, dict[int, dict[str, Any]]]:
-    raw = _levels_store().read_json(_DATABASE_FILE)
-    index: dict[str, dict[int, dict[str, Any]]] = {}
-    for row in raw.get("enemies", []):
-        key = row.get("Key")
-        values = row.get("Value") or []
-        if not key:
-            continue
-        level_map: dict[int, dict[str, Any]] = {}
-        for value in values:
-            if not isinstance(value, dict):
-                continue
-            try:
-                level = int(value.get("level", 0))
-            except (TypeError, ValueError):
-                level = 0
-            enemy_data = value.get("enemyData")
-            if isinstance(enemy_data, dict):
-                level_map[level] = enemy_data
-        index[str(key)] = level_map
-    return index
+    return normalize_enemy_database(_levels_store().read_json(_DATABASE_FILE))
 
 
 @activation_aware_cache(maxsize=1)
@@ -195,7 +177,7 @@ def _stage_specific_enemy_data(enemy_id: str, level: int, overwritten: Any = Non
 
 def _format_stats(enemy_data: dict[str, Any] | None) -> str:
     if not enemy_data:
-        return "战斗属性：无数据库记录"
+        return "无数据库记录"
     attrs = enemy_data.get("attributes") or {}
     hp = _m_value(attrs.get("maxHp"), 0)
     atk = _m_value(attrs.get("atk"), 0)

--- a/python/src/prts_mcp/data/story_reader.py
+++ b/python/src/prts_mcp/data/story_reader.py
@@ -201,10 +201,21 @@ def _parse_story_list(story_list: list[dict]) -> list[StoryLine]:
             if content:
                 lines.append(StoryLine(type="narration", role=None, text=_clean_text(content)))
         elif prop_lower == "decision":
-            options = attrs.get("options") or []
+            raw_options = attrs.get("options")
+            if isinstance(raw_options, str):
+                options = [raw_options]
+            elif isinstance(raw_options, list):
+                options = raw_options
+            else:
+                options = []
             for opt in options:
                 # options elements may be plain strings or dicts with a "text" key
-                text = opt if isinstance(opt, str) else (opt.get("text") or "")
+                if isinstance(opt, str):
+                    text = opt
+                elif isinstance(opt, dict):
+                    text = opt.get("text") or ""
+                else:
+                    text = ""
                 if text:
                     lines.append(StoryLine(type="choice", role=None, text=_clean_text(str(text))))
 

--- a/python/src/prts_mcp/tools_artwork.py
+++ b/python/src/prts_mcp/tools_artwork.py
@@ -27,6 +27,7 @@ from prts_mcp.data.images import (
 )
 from prts_mcp.data.artwork_mediawiki import (
     VARIANT_WIDTH,
+    artwork_belongs_to_operator,
     image_cache_get,
     image_cache_put,
     label_from_filename,
@@ -122,6 +123,11 @@ async def _do_get_mediawiki(
     """LOCAL_IMAGE=false get: MediaWiki imageinfo + safe download (+ LRU)."""
     if not artwork_id:
         return text_result("action=get 时必须提供 artwork_id。请先用 action=list 获取。")
+    if not artwork_belongs_to_operator(artwork_id, operator_name):
+        return text_result(
+            f"该 artwork_id 不属于干员「{operator_name}」。"
+            "artwork_id 为不透明 token，请用 action=list 重新获取。"
+        )
     if variant == "original":
         return text_result(
             "LOCAL_IMAGE=false 模式不提供 original 变体（PRTS 原图常超 1 MiB 安全上限）。"
@@ -261,6 +267,19 @@ async def _do_get(
     if entry is None:
         return text_result(
             f"找不到 artwork_id「{artwork_id}」。该 ID 不透明，请用 action=list 重新获取。"
+        )
+    try:
+        char_id = resolve_char_id(operator_name)
+    except (OSError, AssertionError):
+        return _data_not_ready()
+    if char_id is None:
+        return text_result(
+            f"找不到干员「{operator_name}」。建议先用 search_prts 确认准确的中文名称。"
+        )
+    if _char_id_of(artwork_id) != char_id:
+        return text_result(
+            f"该 artwork_id 不属于干员「{operator_name}」。"
+            "artwork_id 为不透明 token，请用 action=list 重新获取。"
         )
     variant_meta = entry.variant(chosen)
     if variant_meta is None:

--- a/python/tests/test_artwork_mediawiki.py
+++ b/python/tests/test_artwork_mediawiki.py
@@ -11,9 +11,11 @@ import pytest
 from prts_mcp.api.prts_wiki import _image_magic_ok, download_image_safe, list_allimages
 from prts_mcp.data.artwork_mediawiki import (
     _image_cache,
+    artwork_belongs_to_operator,
     image_cache_get,
     image_cache_put,
     label_from_filename,
+    operator_from_filename,
 )
 
 _CHARINFO = {"时装1名称": "报童", "时装2名称": "见习联结者", "时装3名称": "播种者"}
@@ -45,6 +47,15 @@ def test_label_fashion_fallback_without_charinfo():
 def test_label_rejects_non_png_and_malformed():
     assert label_from_filename("立绘_阿米娅_2.jpg", _CHARINFO) is None
     assert label_from_filename("立绘阿米娅", _CHARINFO) is None  # no second underscore
+
+
+def test_artwork_filename_owner_accepts_exact_and_base_form_only():
+    assert operator_from_filename("立绘_阿米娅(近卫)_2.png") == "阿米娅(近卫)"
+    assert artwork_belongs_to_operator("立绘_阿米娅(近卫)_2.png", "阿米娅(近卫)")
+    assert artwork_belongs_to_operator("立绘_阿米娅（近卫）_2.png", "阿米娅")
+    assert not artwork_belongs_to_operator("立绘_阿米娅(近卫)_2.png", "阿米")
+    assert not artwork_belongs_to_operator("立绘_斯卡蒂_2.png", "阿米娅")
+    assert not artwork_belongs_to_operator("立绘_阿米娅_2b.png", "阿米娅")
 
 
 def test_image_magic_ok():

--- a/python/tests/test_enemy.py
+++ b/python/tests/test_enemy.py
@@ -255,6 +255,30 @@ class TestGetEnemyInfo:
         assert "**最大生命**：25,000" in out
         assert "**免疫**：眩晕、冻结" in out
 
+    def test_reads_current_akdp_direct_map(self, gamedata):
+        db_path = (
+            gamedata / "zh_CN" / "gamedata" / "levels" / "enemydata"
+            / "enemy_database.json"
+        )
+        db_path.write_text(
+            json.dumps({
+                "enemy_1505_frstar": [{
+                    "level": 0,
+                    "enemyData": {
+                        "attributes": {
+                            "maxHp": {"m_defined": True, "m_value": 25000},
+                            "atk": {"m_defined": True, "m_value": 420},
+                            "def": {"m_defined": True, "m_value": 250},
+                            "magicResistance": {"m_defined": True, "m_value": 50},
+                        }
+                    },
+                }],
+            }, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        clear_enemy_caches()
+        assert "**最大生命**：25,000" in get_enemy_info("霜星")
+
     def test_handbook_only_when_no_db_entry(self, gamedata):
         # 源石虫 has no entry in our minimal database fixture
         out = get_enemy_info("源石虫")

--- a/python/tests/test_images.py
+++ b/python/tests/test_images.py
@@ -9,7 +9,7 @@ import pytest
 
 from prts_mcp.data.images import SCHEMA_VERSION, build_artwork_label, parse_index
 from prts_mcp.output import _channel_var
-from prts_mcp.tools_artwork import _do_get, _do_list
+from prts_mcp.tools_artwork import _do_get, _do_get_mediawiki, _do_list
 
 # A 1x1 transparent PNG used as a stand-in image payload.
 _SAMPLE_PNG_B64 = (
@@ -18,8 +18,8 @@ _SAMPLE_PNG_B64 = (
 )
 
 
-def _sample_index() -> dict:
-    return {
+def _sample_index(include_foreign: bool = False) -> dict:
+    index = {
         "schemaVersion": SCHEMA_VERSION,
         "baselineVersion": "b1",
         "currentVersion": "c1",
@@ -56,6 +56,19 @@ def _sample_index() -> dict:
             },
         },
     }
+    if include_foreign:
+        index["artworks"]["char_263_skadi#1"] = {
+            "kind": "base",
+            "shard": "chararts",
+            "large": {
+                "file": "amiya_1.large.png",
+                "w": 1024,
+                "h": 1100,
+                "bytes": 50,
+                "sha256": "h4",
+            },
+        }
+    return index
 
 
 # ---------------------------------------------------------------------------
@@ -196,6 +209,32 @@ def test_get_missing_artwork_id(mock_images):
     result = asyncio.run(_do_get("阿米娅", "char_999_nonexistent#1", "large"))
     text = result.content[0].text
     assert "找不到" in text
+    assert not any(c.type == "image" for c in result.content)
+
+
+def test_get_rejects_artwork_owned_by_another_operator(mock_images):
+    (mock_images / "index.json").write_text(
+        json.dumps(_sample_index(include_foreign=True)), "utf-8",
+    )
+    result = asyncio.run(_do_get("阿米娅", "char_263_skadi#1", "large"))
+    assert "不属于" in result.content[0].text
+    assert not any(c.type == "image" for c in result.content)
+
+
+def test_mediawiki_get_rejects_mismatched_filename_before_network(monkeypatch):
+    import prts_mcp.tools_artwork as artwork
+    from prts_mcp.config import Config
+
+    monkeypatch.setenv("LOCAL_IMAGE", "false")
+
+    async def unexpected_imageinfo(*_args, **_kwargs):
+        raise AssertionError("ownership validation must run before imageinfo")
+
+    monkeypatch.setattr(artwork, "_get_imageinfo", unexpected_imageinfo)
+    result = asyncio.run(_do_get_mediawiki(
+        "阿米娅", "立绘_斯卡蒂_2.png", "large", Config.load(),
+    ))
+    assert "不属于" in result.content[0].text
     assert not any(c.type == "image" for c in result.content)
 
 

--- a/python/tests/test_stage_enemy.py
+++ b/python/tests/test_stage_enemy.py
@@ -210,6 +210,33 @@ def test_get_stage_enemies_golden(gamedata: Path) -> None:
     assert render_stage_enemies(data) == get_stage_enemies("main_00-01")
 
 
+def test_get_stage_enemies_reads_current_akdp_direct_map(gamedata: Path) -> None:
+    db_path = (
+        gamedata / "gamedata-levels" / "zh_CN" / "gamedata" / "levels"
+        / "enemydata" / "enemy_database.json"
+    )
+    db_path.write_text(
+        json.dumps({
+            "enemy_1007_slime": [{
+                "level": 0,
+                "enemyData": {
+                    "attributes": {
+                        "maxHp": {"m_defined": True, "m_value": 550},
+                        "atk": {"m_defined": True, "m_value": 130},
+                        "def": {"m_defined": True, "m_value": 0},
+                        "magicResistance": {"m_defined": True, "m_value": 0},
+                    }
+                },
+            }],
+        }, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    clear_stage_enemy_caches()
+    out = get_stage_enemies("main_00-01")
+    assert "HP 550" in out
+    assert "无数据库记录" not in out
+
+
 def test_get_enemy_appearances_golden(gamedata: Path) -> None:
     # Golden: exact full markdown. Hardcoded (not tautology) — catches
     # build-layer field omissions and header/pagination regressions.

--- a/python/tests/test_story.py
+++ b/python/tests/test_story.py
@@ -89,6 +89,15 @@ class TestParseStoryList:
         lines = _parse_story_list(items)
         assert lines[0].text == "博士，你好"
 
+    def test_decision_scalar_option_is_one_complete_choice(self):
+        lines = _parse_story_list([{
+            "prop": "Decision",
+            "attributes": {"options": "我相信它们。相信你，凯尔希。", "values": "1"},
+        }])
+        assert lines == [
+            StoryLine(type="choice", role=None, text="我相信它们。相信你，凯尔希。"),
+        ]
+
     def test_mixed_items(self):
         items = [
             {"id": 1, "prop": "Background", "attributes": {}},

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -424,7 +424,7 @@ wheels = [
 
 [[package]]
 name = "prts-mcp"
-version = "2.5.1"
+version = "2.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.5.2] - 2026-08-09
+
+### Security
+
+- Updated the locked npm production dependency graph, including
+  `@modelcontextprotocol/sdk` 1.30 and `adm-zip` 0.6, resolving the audited
+  production advisories without a breaking SDK-major upgrade.
+
+### Fixed
+
+- **Current AKDP enemy databases.** `get_stage_enemies` and
+  `get_enemy_info` now read the direct enemy-ID mapping emitted by current
+  `zh_CN-levels.zip` releases, while retaining the legacy wrapper format.
+- **Scalar story decisions.** A `Decision.options` string is returned as one
+  complete choice line instead of being dropped or split into characters.
+- **Artwork token ownership.** `operator_artwork(action="get")` rejects an
+  artwork token belonging to another operator before reading local image data
+  or making a MediaWiki request.
+
 ## [2.5.1] - 2026-08-07
 
 ### Fixed

--- a/ts/bun.lock
+++ b/ts/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "prts-mcp-ts",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
-        "adm-zip": "^0.5.16",
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "adm-zip": "^0.6.0",
         "express": "^5.2.1",
         "undici": "^8.10.0",
       },
@@ -74,7 +74,7 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
     "@types/adm-zip": ["@types/adm-zip@0.5.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q=="],
 
@@ -100,7 +100,7 @@
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
-    "adm-zip": ["adm-zip@0.5.18", "", {}, "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng=="],
+    "adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
-        "adm-zip": "^0.5.16",
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "adm-zip": "^0.6.0",
         "express": "^5.2.1",
         "undici": "^8.10.0"
       },
@@ -473,24 +473,24 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.13",
-      "resolved": "https://registry.npmmirror.com/@hono/node-server/-/node-server-1.19.13.tgz",
-      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -646,12 +646,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmmirror.com/adm-zip/-/adm-zip-0.5.17.tgz",
-      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
       "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ajv": {
@@ -688,21 +688,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmmirror.com/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1051,9 +1064,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmmirror.com/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -1203,9 +1216,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.28",
-      "resolved": "https://registry.npmmirror.com/hono/-/hono-4.12.28.tgz",
-      "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -1254,9 +1267,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmmirror.com/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -1719,17 +1732,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/typescript": {

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP + stdio)",
   "type": "module",
   "main": "dist/server.js",
@@ -62,8 +62,8 @@
     "node": "24.14.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
-    "adm-zip": "^0.5.16",
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "adm-zip": "^0.6.0",
     "express": "^5.2.1",
     "undici": "^8.10.0"
   },

--- a/ts/src/data/artworkMediawiki.ts
+++ b/ts/src/data/artworkMediawiki.ts
@@ -102,3 +102,28 @@ export function labelFromFilename(
   if (form) label += `（${form}）`;
   return label;
 }
+
+/** Return the declaring operator segment for a listable MediaWiki artwork. */
+export function operatorFromFilename(filename: string): string | null {
+  if (!filename.endsWith(".png") || !filename.startsWith("立绘_")) return null;
+  if (labelFromFilename(filename, {}) === null) return null;
+  const base = filename.slice(0, -4);
+  const separator = base.indexOf("_", "立绘_".length);
+  if (separator < 0) return null;
+  const operatorName = base.slice("立绘_".length, separator);
+  return operatorName || null;
+}
+
+function normalizedOperatorName(name: string): string {
+  return name.trim().replaceAll("（", "(").replaceAll("）", ")");
+}
+
+/** Check that a MediaWiki artwork belongs to its requested operator. */
+export function artworkBelongsToOperator(filename: string, operatorName: string): boolean {
+  const artworkOperator = operatorFromFilename(filename);
+  if (artworkOperator === null) return false;
+  const requested = normalizedOperatorName(operatorName);
+  const actual = normalizedOperatorName(artworkOperator);
+  if (requested === actual) return true;
+  return requested === actual.replace(/\([^()]*\)$/, "");
+}

--- a/ts/src/data/enemy.ts
+++ b/ts/src/data/enemy.ts
@@ -6,6 +6,7 @@
 
 import { checkActivationChange, loadConfig, registerActivationListener } from "../config.js";
 import { DirectoryStore } from "./stores.js";
+import { normalizeEnemyDatabase } from "./enemyDatabase.js";
 
 // ---------------------------------------------------------------------------
 // Module-level caches
@@ -238,12 +239,11 @@ function getDbIndex(): Record<string, EnemyDbEntry> {
     // path handling
     const store = new DirectoryStore(dbRoot);
     if (!store.exists(DATABASE_FILE)) { _dbIndex = {}; return _dbIndex; }
-    const raw = store.readJson<EnemyDatabase>(DATABASE_FILE);
+    const levels = normalizeEnemyDatabase<EnemyDbEntry>(store.readJson(DATABASE_FILE));
     const index: Record<string, EnemyDbEntry> = {};
-    for (const row of Array.isArray(raw.enemies) ? raw.enemies : []) {
-      if (row.Key && row.Value && row.Value[0]?.enemyData) {
-        index[row.Key] = row.Value[0].enemyData;
-      }
+    for (const [enemyId, levelMap] of Object.entries(levels)) {
+      const first = levelMap[0] ?? Object.values(levelMap)[0];
+      if (first) index[enemyId] = first;
     }
     _dbIndex = index;
   }

--- a/ts/src/data/enemyDatabase.ts
+++ b/ts/src/data/enemyDatabase.ts
@@ -1,0 +1,62 @@
+/**
+ * Normalize enemy combat databases from supported upstream archive shapes.
+ *
+ * The legacy archive wraps rows in ``{ enemies: [{ Key, Value }] }`` while
+ * AKDP releases the equivalent ``{ enemyId: Value[] }`` mapping directly.
+ */
+
+interface EnemyDatabaseValue<T> {
+  level?: number | string;
+  enemyData?: T;
+}
+
+type LegacyEnemyDatabase<T> = {
+  enemies?: Array<{ Key?: string; Value?: EnemyDatabaseValue<T>[] }>;
+};
+
+function parseLevel(value: unknown): number {
+  const parsed = Number(value ?? 0);
+  return Number.isFinite(parsed) ? Math.trunc(parsed) : 0;
+}
+
+function addRow<T>(
+  index: Record<string, Record<number, T>>,
+  enemyId: string,
+  values: unknown,
+): void {
+  if (!Array.isArray(values)) return;
+  const levelMap: Record<number, T> = {};
+  for (const value of values) {
+    if (typeof value !== "object" || value === null) continue;
+    const row = value as EnemyDatabaseValue<T>;
+    if (row.enemyData && typeof row.enemyData === "object") {
+      levelMap[parseLevel(row.level)] = row.enemyData;
+    }
+  }
+  if (Object.keys(levelMap).length > 0) index[enemyId] = levelMap;
+}
+
+/** Normalize a supported enemy_database.json payload into an ID/level index. */
+export function normalizeEnemyDatabase<T>(raw: unknown): Record<string, Record<number, T>> {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new Error("enemy_database.json 格式异常：根节点必须是对象。");
+  }
+
+  const root = raw as LegacyEnemyDatabase<T> & Record<string, unknown>;
+  const index: Record<string, Record<number, T>> = {};
+  if (Array.isArray(root.enemies)) {
+    for (const row of root.enemies) {
+      if (!row?.Key) continue;
+      addRow(index, row.Key, row.Value);
+    }
+    return index;
+  }
+
+  for (const [enemyId, values] of Object.entries(root)) {
+    addRow(index, enemyId, values);
+  }
+  if (Object.keys(index).length === 0) {
+    throw new Error("enemy_database.json 格式异常：未找到敌人等级数据。");
+  }
+  return index;
+}

--- a/ts/src/data/stageEnemy.ts
+++ b/ts/src/data/stageEnemy.ts
@@ -11,6 +11,7 @@ import {
   registerActivationListener,
 } from "../config.js";
 import { DirectoryStore } from "./stores.js";
+import { normalizeEnemyDatabase } from "./enemyDatabase.js";
 
 const DATABASE_FILE = "enemydata/enemy_database.json";
 
@@ -161,19 +162,9 @@ function loadEnemyHandbook(): Record<string, EnemyHandbookEntry> {
 function loadEnemyDatabase(): Record<string, Record<number, EnemyData>> {
   checkActivationChange();
   if (enemyDatabase === null) {
-    const raw = levelsStore().readJson<{
-      enemies?: Array<{ Key?: string; Value?: Array<{ level?: number | string; enemyData?: EnemyData }> }>;
-    }>(DATABASE_FILE);
-    const index: Record<string, Record<number, EnemyData>> = {};
-    for (const row of Array.isArray(raw.enemies) ? raw.enemies : []) {
-      if (!row.Key) continue;
-      const levelMap: Record<number, EnemyData> = {};
-      for (const value of Array.isArray(row.Value) ? row.Value : []) {
-        if (value.enemyData) levelMap[parseLevel(value.level)] = value.enemyData;
-      }
-      index[row.Key] = levelMap;
-    }
-    enemyDatabase = index;
+    enemyDatabase = normalizeEnemyDatabase<EnemyData>(
+      levelsStore().readJson(DATABASE_FILE),
+    );
   }
   return enemyDatabase;
 }
@@ -296,7 +287,7 @@ function formatFloatLike(value: unknown): string {
 }
 
 function formatStats(enemyData: EnemyData | null): string {
-  if (!enemyData) return "战斗属性：无数据库记录";
+  if (!enemyData) return "无数据库记录";
   const attrs = enemyData.attributes ?? {};
   const hp = mValue(attrs.maxHp, 0);
   const atk = mValue(attrs.atk, 0);

--- a/ts/src/data/storyReader.ts
+++ b/ts/src/data/storyReader.ts
@@ -235,17 +235,18 @@ function parseStoryList(
         lines.push({ type: "narration", role: null, text: cleanText(content) });
       }
     } else if (prop === "decision") {
-      const options = attrs["options"];
-      if (Array.isArray(options)) {
-        for (const opt of options) {
-          let text = "";
-          if (typeof opt === "string") text = opt;
-          else if (opt !== null && typeof opt === "object") {
-            text = String((opt as Record<string, unknown>)["text"] ?? "");
-          }
-          if (text) {
-            lines.push({ type: "choice", role: null, text: cleanText(text) });
-          }
+      const rawOptions = attrs["options"];
+      const options = typeof rawOptions === "string"
+        ? [rawOptions]
+        : Array.isArray(rawOptions) ? rawOptions : [];
+      for (const opt of options) {
+        let text = "";
+        if (typeof opt === "string") text = opt;
+        else if (opt !== null && typeof opt === "object") {
+          text = String((opt as Record<string, unknown>)["text"] ?? "");
+        }
+        if (text) {
+          lines.push({ type: "choice", role: null, text: cleanText(text) });
         }
       }
     }

--- a/ts/src/tools/artworkTools.ts
+++ b/ts/src/tools/artworkTools.ts
@@ -24,6 +24,7 @@ import {
 } from "../data/images.js";
 import {
   VARIANT_WIDTH,
+  artworkBelongsToOperator,
   imageCacheGet,
   imageCachePut,
   labelFromFilename,
@@ -127,6 +128,11 @@ async function doGetMediawiki(
 ): Promise<CallToolResult> {
   if (!artworkId) {
     return textResult("action=get 时必须提供 artwork_id。请先用 action=list 获取。");
+  }
+  if (!artworkBelongsToOperator(artworkId, operatorName)) {
+    return textResult(
+      `该 artwork_id 不属于干员「${operatorName}」。artwork_id 为不透明 token，请用 action=list 重新获取。`,
+    );
   }
   if (variant === "original") {
     return textResult(
@@ -267,6 +273,22 @@ function doGet(
   if (entry === undefined) {
     return textResult(
       `找不到 artwork_id「${artworkId}」。该 ID 不透明，请用 action=list 重新获取。`,
+    );
+  }
+  let charId: string | null;
+  try {
+    charId = resolveCharId(operatorName);
+  } catch {
+    return dataNotReady();
+  }
+  if (charId === null) {
+    return textResult(
+      `找不到干员「${operatorName}」。建议先用 search_prts 确认准确的中文名称。`,
+    );
+  }
+  if (charIdOf(artworkId) !== charId) {
+    return textResult(
+      `该 artwork_id 不属于干员「${operatorName}」。artwork_id 为不透明 token，请用 action=list 重新获取。`,
     );
   }
   const variantMeta = entry.variants[chosen];

--- a/ts/tests/artworkMediawiki.test.ts
+++ b/ts/tests/artworkMediawiki.test.ts
@@ -1,7 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { labelFromFilename } from "../src/data/artworkMediawiki.ts";
+import {
+  artworkBelongsToOperator,
+  labelFromFilename,
+  operatorFromFilename,
+} from "../src/data/artworkMediawiki.ts";
 import { downloadImageSafe, imageMagicOk, listAllimages } from "../src/api/prtsWiki.ts";
 
 const CHARINFO: Record<string, unknown> = {
@@ -35,6 +39,15 @@ test("labelFromFilename: fashion fallback without CharinfoV2", () => {
 test("labelFromFilename: rejects non-png and malformed", () => {
   assert.equal(labelFromFilename("立绘_阿米娅_2.jpg", CHARINFO), null);
   assert.equal(labelFromFilename("立绘阿米娅", CHARINFO), null);
+});
+
+test("artwork ownership accepts exact and base-form names only", () => {
+  assert.equal(operatorFromFilename("立绘_阿米娅(近卫)_2.png"), "阿米娅(近卫)");
+  assert.equal(artworkBelongsToOperator("立绘_阿米娅(近卫)_2.png", "阿米娅(近卫)"), true);
+  assert.equal(artworkBelongsToOperator("立绘_阿米娅（近卫）_2.png", "阿米娅"), true);
+  assert.equal(artworkBelongsToOperator("立绘_阿米娅(近卫)_2.png", "阿米"), false);
+  assert.equal(artworkBelongsToOperator("立绘_斯卡蒂_2.png", "阿米娅"), false);
+  assert.equal(artworkBelongsToOperator("立绘_阿米娅_2b.png", "阿米娅"), false);
 });
 
 test("imageMagicOk: png/jpeg/webp signatures", () => {

--- a/ts/tests/enemy.test.ts
+++ b/ts/tests/enemy.test.ts
@@ -261,6 +261,31 @@ test("get_enemy_info reads database from sibling levels path", async () => {
   assert.match(out, /\*\*免疫\*\*：眩晕、冻结/);
 });
 
+test("get_enemy_info reads the direct-map enemy database from current AKDP releases", async () => {
+  const root = tempGamedataRoot();
+  process.env["GAMEDATA_PATH"] = root;
+  writeFixtures(root);
+  writeFileSync(
+    join(root, "zh_CN", "gamedata", "levels", "enemydata", "enemy_database.json"),
+    JSON.stringify({
+      enemy_1505_frstar: [{
+        level: 0,
+        enemyData: {
+          attributes: {
+            maxHp: { m_defined: true, m_value: 25000 },
+            atk: { m_defined: true, m_value: 420 },
+            def: { m_defined: true, m_value: 250 },
+            magicResistance: { m_defined: true, m_value: 50 },
+          },
+        },
+      }],
+    }),
+    "utf-8",
+  );
+  const enemy = await loadEnemyModule();
+  assert.match(enemy.getEnemyInfo("霜星"), /\*\*最大生命\*\*：25,000/);
+});
+
 test("get_enemy_info handbook-only when no database entry", async () => {
   const root = tempGamedataRoot();
   process.env["GAMEDATA_PATH"] = root;

--- a/ts/tests/images.test.ts
+++ b/ts/tests/images.test.ts
@@ -1,11 +1,26 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
+import { clearOperatorCaches } from "../src/data/operator.ts";
 import {
   SCHEMA_VERSION,
   parseIndex,
   buildArtworkLabel,
 } from "../src/data/images.ts";
+import { registerArtworkTools } from "../src/tools/artworkTools.ts";
+
+type ToolHandler = (args: Record<string, unknown>) => unknown | Promise<unknown>;
+
+class CapturingServer {
+  handler: ToolHandler | undefined;
+
+  tool(_name: string, _description: unknown, _schema: unknown, handler: ToolHandler): void {
+    this.handler = handler;
+  }
+}
 
 function sampleIndex(): unknown {
   return {
@@ -71,4 +86,91 @@ test("buildArtworkLabel covers base, plus, fashion and unknown shapes", () => {
   assert.equal(buildArtworkLabel("char_002_amiya@unknown#1", charSkins), "时装（unknown）");
   // Unknown base illust number gets a tolerant label.
   assert.equal(buildArtworkLabel("char_002_amiya#5", charSkins), "立绘 5");
+});
+
+test("operator_artwork rejects cross-operator tokens before local reads or MediaWiki requests", async () => {
+  const root = mkdtempSync(join(tmpdir(), "prts-artwork-owner-"));
+  const excel = join(root, "gamedata", "zh_CN", "gamedata", "excel");
+  const imageRoot = join(root, "images");
+  const generation = join(imageRoot, ".releases", "test");
+  mkdirSync(excel, { recursive: true });
+  mkdirSync(generation, { recursive: true });
+  for (const file of [
+    "handbook_info_table.json",
+    "charword_table.json",
+    "story_review_table.json",
+  ]) {
+    writeFileSync(join(excel, file), "{}", "utf-8");
+  }
+  writeFileSync(join(excel, "character_table.json"), JSON.stringify({
+    char_002_amiya: { name: "阿米娅" },
+  }), "utf-8");
+  writeFileSync(join(imageRoot, ".images_meta.json"), JSON.stringify({
+    generation_root: ".releases/test",
+  }), "utf-8");
+  writeFileSync(join(generation, "index.json"), JSON.stringify({
+    schemaVersion: SCHEMA_VERSION,
+    baselineVersion: "b1",
+    currentVersion: "c1",
+    shards: {},
+    artworks: {
+      "char_263_skadi#1": {
+        kind: "base",
+        shard: "chararts",
+        large: { file: "not-read.png", w: 1, h: 1, bytes: 1, sha256: "x" },
+      },
+    },
+  }), "utf-8");
+
+  const savedEnv = {
+    gamedata: process.env["GAMEDATA_PATH"],
+    imageDir: process.env["PRTS_IMAGE_DIR"],
+    localImage: process.env["LOCAL_IMAGE"],
+  };
+  const originalFetch = globalThis.fetch;
+  process.env["GAMEDATA_PATH"] = join(root, "gamedata");
+  process.env["PRTS_IMAGE_DIR"] = imageRoot;
+  process.env["LOCAL_IMAGE"] = "true";
+  clearOperatorCaches();
+
+  try {
+    const server = new CapturingServer();
+    registerArtworkTools(server as never);
+    assert.ok(server.handler);
+    const local = await server.handler({
+      operator_name: "阿米娅",
+      action: "get",
+      artwork_id: "char_263_skadi#1",
+      variant: "large",
+    }) as { content: Array<{ type: string; text?: string }> };
+    assert.match(local.content[0]?.text ?? "", /不属于/);
+    assert.equal(local.content.some((block) => block.type === "image"), false);
+
+    let fetched = false;
+    globalThis.fetch = (async () => {
+      fetched = true;
+      throw new Error("MediaWiki request must not be made");
+    }) as typeof fetch;
+    process.env["LOCAL_IMAGE"] = "false";
+    const mediawiki = await server.handler({
+      operator_name: "阿米娅",
+      action: "get",
+      artwork_id: "立绘_斯卡蒂_2.png",
+      variant: "large",
+    }) as { content: Array<{ type: string; text?: string }> };
+    assert.match(mediawiki.content[0]?.text ?? "", /不属于/);
+    assert.equal(mediawiki.content.some((block) => block.type === "image"), false);
+    assert.equal(fetched, false);
+  } finally {
+    globalThis.fetch = originalFetch;
+    for (const [key, value] of Object.entries({
+      GAMEDATA_PATH: savedEnv.gamedata,
+      PRTS_IMAGE_DIR: savedEnv.imageDir,
+      LOCAL_IMAGE: savedEnv.localImage,
+    })) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    clearOperatorCaches();
+  }
 });

--- a/ts/tests/stageEnemy.test.ts
+++ b/ts/tests/stageEnemy.test.ts
@@ -188,6 +188,32 @@ test("getStageEnemies uses spawn actions and overrides", async () => {
   assert.equal(mod.renderStageEnemies(data), out);
 });
 
+test("getStageEnemies reads the direct-map enemy database from current AKDP releases", async () => {
+  const root = tempRoot();
+  const gamedata = writeFixture(root);
+  writeJson(
+    join(root, "gamedata-levels", "zh_CN", "gamedata", "levels", "enemydata", "enemy_database.json"),
+    {
+      enemy_1007_slime: [{
+        level: 0,
+        enemyData: {
+          attributes: {
+            maxHp: { m_defined: true, m_value: 550 },
+            atk: { m_defined: true, m_value: 130 },
+            def: { m_defined: true, m_value: 0 },
+            magicResistance: { m_defined: true, m_value: 0 },
+          },
+        },
+      }],
+    },
+  );
+  process.env["GAMEDATA_PATH"] = gamedata;
+  const mod = await loadModule();
+  const out = mod.getStageEnemies("main_00-01");
+  assert.match(out, /HP 550/);
+  assert.doesNotMatch(out, /无数据库记录/);
+});
+
 test("getEnemyAppearances", async () => {
   const root = tempRoot();
   process.env["GAMEDATA_PATH"] = writeFixture(root);

--- a/ts/tests/story.test.ts
+++ b/ts/tests/story.test.ts
@@ -64,6 +64,7 @@ function storyFiles(): Record<string, unknown> {
         { prop: "name", attributes: { name: "阿米娅", content: "你好，{@nickname}。" } },
         { prop: "sticker", attributes: { content: "<b>场景描述</b>" } },
         { prop: "decision", attributes: { options: ["选项一"] } },
+        { prop: "decision", attributes: { options: "我相信它们。相信你，凯尔希。" } },
       ],
     },
     [storyPath(SECOND_STORY_KEY)]: {
@@ -128,10 +129,11 @@ function assertStoryStore(store: JsonStore): void {
     "你好，博士。",
     "场景描述",
     "选项一",
+    "我相信它们。相信你，凯尔希。",
   ]);
 
   const dialogsOnly = readStoryFromStore(store, FIRST_STORY_KEY, false);
-  assert.deepEqual(dialogsOnly.lines.map((line) => line.type), ["dialog", "choice"]);
+  assert.deepEqual(dialogsOnly.lines.map((line) => line.type), ["dialog", "choice", "choice"]);
 
   const activity = readActivityFromStore(store, "act_test", true, 1, 1);
   assert.equal(activity.eventName, "测试活动");


### PR DESCRIPTION
## Scope

- Updates the npm production dependency graph: MCP SDK 1.30, adm-zip 0.6, and audited compatible transitives. No MCP SDK major migration.
- Restores current AKDP direct-map enemy combat data for both stage and enemy queries.
- Parses scalar story Decision options as one complete choice.
- Enforces operator-artwork token ownership before local reads or MediaWiki network/cache operations.

## Verification

- `./scripts/check-runtime.sh --full`
  - Python: 331 passed, 23 fixture-dependent skips
  - TypeScript: 252 passed, 2 network-dependent skips
  - build, typecheck, cross-runtime shared-volume sync, and Bun HTTP MCP smoke passed
- `npm audit --omit=dev --json`: 0 vulnerabilities
- Current AKDP release fixture: both implementations normalize `enemy_10001_trslim` level 0 with HP 4500.

## Scope guard

Does not include #84 protocol migration, #90 architecture work, or #123–#125.

Closes #100
Closes #120
Closes #121
Closes #122