### PR TITLE
feat(ts): serve modern MCP requests alongside legacy

### DIFF
--- a/ts/src/server-stdio.ts
+++ b/ts/src/server-stdio.ts
@@ -11,7 +11,7 @@
  * Output channel is resolved purely from the PRTS_OUTPUT_CHANNEL env var
  * (stdio has no query string / headers); the default is "content".
  */
-import { StdioServerTransport } from "@modelcontextprotocol/server/stdio";
+import { serveStdio } from "@modelcontextprotocol/server/stdio";
 import { createMcpServer, log, SERVER_VERSION } from "./server-core.js";
 import { startAutoSync } from "./startupSync.js";
 import { parseChannel } from "./output.js";
@@ -24,9 +24,10 @@ async function main(): Promise<void> {
     warn,
   );
 
-  const server = createMcpServer(channel);
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
+  serveStdio(() => createMcpServer(channel), {
+    legacy: "serve",
+    onerror: (error) => log("ERROR", `stdio MCP request failed: ${error.message}`),
+  });
 
   log("INFO", `PRTS-MCP stdio server ${SERVER_VERSION} connected (channel=${channel})`);
 

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -12,7 +12,8 @@
 
 import { randomUUID } from "node:crypto";
 import express from "express";
-import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
+import { createMcpHandler, isLegacyRequest } from "@modelcontextprotocol/server";
+import { NodeStreamableHTTPServerTransport, toNodeHandler, toWebRequest } from "@modelcontextprotocol/node";
 import { startAutoSync } from "./startupSync.js";
 import { parseChannel, type OutputChannel } from "./output.js";
 import { createMcpServer, log, SERVER_VERSION } from "./server-core.js";
@@ -37,6 +38,16 @@ function resolveOutputChannel(req: express.Request): OutputChannel {
   return parseChannel(process.env["PRTS_OUTPUT_CHANNEL"], "PRTS_OUTPUT_CHANNEL", warn);
 }
 
+function resolveModernOutputChannel(request: Request | undefined): OutputChannel {
+  const url = request ? new URL(request.url) : undefined;
+  const queryValue = url?.searchParams.get("output_channel") ?? undefined;
+  const headerValue = request?.headers.get("x-prts-output-channel") ?? undefined;
+  const warn = (message: string) => log("WARN", message);
+  if (queryValue !== undefined) return parseChannel(queryValue, "output_channel", warn);
+  if (headerValue !== undefined) return parseChannel(headerValue, "x-prts-output-channel", warn);
+  return parseChannel(process.env["PRTS_OUTPUT_CHANNEL"], "PRTS_OUTPUT_CHANNEL", warn);
+}
+
 // ---------------------------------------------------------------------------
 // Express + StreamableHTTP
 // ---------------------------------------------------------------------------
@@ -48,6 +59,13 @@ app.use(express.json());
 const transports = new Map<string, NodeStreamableHTTPServerTransport>();
 const METRICS_ENABLED = process.env["PRTS_METRICS_ENABLED"] === "true";
 const runtimeMetrics = METRICS_ENABLED ? new RuntimeMetrics() : null;
+const modernHandler = createMcpHandler(
+  ({ requestInfo }) => createMcpServer(resolveModernOutputChannel(requestInfo)),
+  { legacy: "reject", onerror: (error) => log("ERROR", `Modern MCP request failed: ${error.message}`) },
+);
+const handleModernRequest = toNodeHandler(modernHandler, {
+  onerror: (error) => log("ERROR", `Modern MCP adapter failed: ${error.message}`),
+});
 
 const SESSION_IDLE_TIMEOUT_MS = (() => {
   const raw = process.env["SESSION_IDLE_TIMEOUT_MS"];
@@ -108,6 +126,15 @@ app.all("/mcp", async (req, res) => {
   const requestMetrics = runtimeMetrics?.beginRequest(req.body);
   const sessionId = req.headers["mcp-session-id"] as string | undefined;
   try {
+    // Keep the established sessionful legacy transport intact. SDK v2's
+    // classifier owns the era boundary so malformed modern claims never
+    // silently fall back to the legacy router.
+    const webRequest = await toWebRequest(req, req.body);
+    if (!await isLegacyRequest(webRequest, req.body)) {
+      await handleModernRequest(req, res, req.body);
+      return;
+    }
+
     let transport = sessionId ? transports.get(sessionId) : undefined;
 
     if (!transport) {

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -84,6 +84,43 @@ async function mcpPost(
   return { status: res.status, body: data as Record<string, unknown>, sessionId: sid };
 }
 
+const MODERN_VERSION = "2026-07-28";
+
+function modernBody(method: string, params: Record<string, unknown>, id: number): Record<string, unknown> {
+  return {
+    jsonrpc: "2.0",
+    method,
+    params: {
+      ...params,
+      _meta: {
+        "io.modelcontextprotocol/protocolVersion": MODERN_VERSION,
+        "io.modelcontextprotocol/clientInfo": { name: "e2e-modern", version: "1.0" },
+        "io.modelcontextprotocol/clientCapabilities": {},
+      },
+    },
+    id,
+  };
+}
+
+async function modernPost(origin: string, method: string, params: Record<string, unknown>, id: number): Promise<McpResponse> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+    "MCP-Protocol-Version": MODERN_VERSION,
+    "Mcp-Method": method,
+  };
+  if (method === "tools/call") headers["Mcp-Name"] = String(params["name"]);
+  const res = await fetch(`${origin}/mcp`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(modernBody(method, params, id)),
+  });
+  const raw = await res.text();
+  const sseMatch = raw.match(/^data:\s*(\{[\s\S]*\})/m);
+  const body = JSON.parse(sseMatch?.[1] ?? raw) as Record<string, unknown>;
+  return { status: res.status, body, sessionId: res.headers.get("mcp-session-id") };
+}
+
 function toolResultText(r: McpResponse): string {
   const content = (r.body?.result as Record<string, unknown>)?.content as Array<{ text: string }> | undefined;
   return content?.[0]?.text ?? "";
@@ -192,6 +229,39 @@ test("E2E", async (t) => {
     const serverInfo = (init.body?.result as { serverInfo?: { version?: string } })?.serverInfo;
     assert.equal(serverInfo?.version, EXPECTED_VERSION, "serverInfo.version should match package.json");
     assert.ok(init.body?.result, "initialize should have result");
+  });
+
+  await t.test("modern discover, list, and tool calls are stateless", async () => {
+    const discover = await modernPost(origin, "server/discover", {}, 100);
+    assert.equal(discover.status, 200);
+    assert.equal(discover.sessionId, null, "modern discover must not create a legacy session");
+    assert.ok(discover.body["result"], "discover should return a modern result");
+
+    const list = await modernPost(origin, "tools/list", {}, 101);
+    assert.equal(list.status, 200);
+    assert.equal(list.sessionId, null, "modern tools/list must stay stateless");
+    const tools = (list.body["result"] as { tools?: Array<{ name: string }> }).tools;
+    assert.equal(tools?.length, 24);
+
+    const call = await modernPost(origin, "tools/call", {
+      name: "get_operator_basic_info",
+      arguments: { name: "阿米娅" },
+    }, 102);
+    assert.equal(call.status, 200);
+    assert.equal(call.sessionId, null, "modern tools/call must not create a legacy session");
+    assert.match(toolResultText(call), /阿米娅/);
+
+    const malformed = await fetch(`${origin}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "MCP-Protocol-Version": MODERN_VERSION,
+        "Mcp-Method": "tools/list",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", params: {}, id: 103 }),
+    });
+    assert.equal(malformed.status, 400, "a modern header without its envelope must not fall back to legacy");
+    assert.equal(malformed.headers.get("mcp-session-id"), null);
   });
 
   // --- tools/list ---

--- a/ts/tests/e2eStdio.test.ts
+++ b/ts/tests/e2eStdio.test.ts
@@ -20,6 +20,23 @@ const GAMEDATA_PATH = join(REPO_ROOT, "data", "gamedata");
 const EXPECTED_VERSION = JSON.parse(
   readFileSync(join(REPO_ROOT, "ts", "package.json"), "utf-8"),
 ).version as string;
+const MODERN_VERSION = "2026-07-28";
+
+function modernMessage(method: string, params: Record<string, unknown>, id: number): Record<string, unknown> {
+  return {
+    jsonrpc: "2.0",
+    method,
+    id,
+    params: {
+      ...params,
+      _meta: {
+        "io.modelcontextprotocol/protocolVersion": MODERN_VERSION,
+        "io.modelcontextprotocol/clientInfo": { name: "stdio-test", version: "1.0" },
+        "io.modelcontextprotocol/clientCapabilities": {},
+      },
+    },
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -180,6 +197,24 @@ test("stdio: graceful error for unavailable data", async () => {
       text.includes("暂不可用") || text.includes("未就绪") || text.includes("仍在进行中"),
       `unexpected response: ${text.slice(0, 100)}`,
     );
+  } finally {
+    child.kill();
+  }
+});
+
+test("stdio: modern discovery and tools/list need no initialize", async () => {
+  const { child } = startServer();
+  try {
+    await send(child, modernMessage("server/discover", {}, 10));
+    const discover = await recv(child);
+    assert.equal(discover["id"], 10);
+    assert.ok(discover["result"]);
+
+    await send(child, modernMessage("tools/list", {}, 11));
+    const list = await recv(child);
+    assert.equal(list["id"], 11);
+    const tools = (list["result"] as { tools: Array<{ name: string }> }).tools;
+    assert.ok(tools.some((tool) => tool.name === "get_operator_basic_info"));
   } finally {
     child.kill();
   }


### PR DESCRIPTION
## Summary

- Route 2026-07-28 HTTP envelopes through the SDK v2 strict modern handler while retaining the existing sessionful legacy transport.
- Select stdio protocol era through SDK v2 serveStdio without changing legacy initialization.
- Add strict modern HTTP discover/list/call, no-session, malformed-envelope, and stdio discovery coverage.

## Test plan

- npm run typecheck
- npm test (263 passed, 2 skipped)
- npm run smoke:bun
- npm audit --omit=dev (0 vulnerabilities)

## Remaining work

Python v2 parity, #123 artwork aliases, #90 workload/ops assets, release and deployment remain separate PRs.