### PR TITLE
feat(python): migrate to MCP SDK v2

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **MCP SDK v2 and dual-era serving (#84).** Migrated to the exact
+  `mcp[cli]==2.0.0` dependency and `MCPServer` API. Legacy initialize/session
+  clients remain supported; a new stdio connection or HTTP request can instead
+  select the stateless `2026-07-28` envelope, including `server/discover`,
+  `tools/list`, and `tools/call` without initialize. Python result-model
+  construction now uses the SDK v2 snake_case API while preserving its
+  camelCase wire fields.
+
 ## [2.6.0-alpha.1] - 2026-08-08
 
 ### Added

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -39,7 +39,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "mcp[cli]>=1.28,<2",
+    "mcp[cli]==2.0.0",
     "httpx",
     "pydantic",
     # HTTP transport (PRTS_TRANSPORT=http). These are also transitively

--- a/python/src/prts_mcp/output.py
+++ b/python/src/prts_mcp/output.py
@@ -143,29 +143,29 @@ def render_result(
         # Error / missing-data path: text only, regardless of channel.
         return CallToolResult(
             content=[TextContent(type="text", text=markdown)],
-            structuredContent=None,
-            isError=False,
+            structured_content=None,
+            is_error=False,
         )
 
     if channel == "content":
         return CallToolResult(
             content=[TextContent(type="text", text=markdown)],
-            structuredContent=None,
-            isError=False,
+            structured_content=None,
+            is_error=False,
         )
 
     if channel == "both":
         return CallToolResult(
             content=[TextContent(type="text", text=markdown)],
-            structuredContent=data,
-            isError=False,
+            structured_content=data,
+            is_error=False,
         )
 
     # channel == "structured": minimal content summary + structured payload.
     return CallToolResult(
         content=[TextContent(type="text", text=_summarize(data, summary))],
-        structuredContent=data,
-        isError=False,
+        structured_content=data,
+        is_error=False,
     )
 
 
@@ -205,8 +205,8 @@ def text_result(markdown: str) -> CallToolResult:
     """
     return CallToolResult(
         content=[TextContent(type="text", text=markdown)],
-        structuredContent=None,
-        isError=False,
+        structured_content=None,
+        is_error=False,
     )
 
 
@@ -234,22 +234,22 @@ def render_image_result(
     """
     if channel is None:
         channel = get_output_channel()
-    image = ImageContent(type="image", data=image_data, mimeType=image_mimetype)
+    image = ImageContent(type="image", data=image_data, mime_type=image_mimetype)
     if data is None or channel == "content":
         return CallToolResult(
             content=[TextContent(type="text", text=markdown), image],
-            structuredContent=None,
-            isError=False,
+            structured_content=None,
+            is_error=False,
         )
     if channel == "both":
         return CallToolResult(
             content=[TextContent(type="text", text=markdown), image],
-            structuredContent=data,
-            isError=False,
+            structured_content=data,
+            is_error=False,
         )
     # structured: summary text + image, plus structured payload.
     return CallToolResult(
         content=[TextContent(type="text", text=_summarize(data, summary)), image],
-        structuredContent=data,
-        isError=False,
+        structured_content=data,
+        is_error=False,
     )

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -1,12 +1,12 @@
 """PRTS-MCP server entry point.
 
-Creates the FastMCP instance, delegates tool registration to focused
+Creates the MCPServer instance, delegates tool registration to focused
 modules (tools_prts / tools_gamedata / tools_story), and starts the
 background data-sync daemon before running the MCP transport.
 
 Supports two transports selected by the ``PRTS_TRANSPORT`` env var:
 
-- ``stdio`` (default) — FastMCP stdio, for local Claude Desktop / Code.
+- ``stdio`` (default) — MCP stdio, for local Claude Desktop / Code.
 - ``http`` — Streamable HTTP via Starlette + uvicorn, for self-hosted
   remote access. Mirrors the TypeScript implementation's HTTP surface
   (``/mcp`` endpoint, ``/health`` probe). output_channel is process-level
@@ -23,7 +23,7 @@ import sys
 import threading
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 # Re-export sync orchestration symbols for backward compatibility
 # (tests access these via server._sync_needs_retry etc.)
@@ -45,13 +45,11 @@ logging.basicConfig(
 )
 _logger = logging.getLogger("prts_mcp.server")
 
-mcp = FastMCP("PRTS_Wiki_Assistant")
-# FastMCP does not expose a version parameter; set it on the internal
-# MCPServer so initialize.serverInfo reports the product version.
+mcp = MCPServer("PRTS_Wiki_Assistant")
 try:
-    mcp._mcp_server.version = _pkg_version("prts-mcp")
+    mcp._lowlevel_server.version = _pkg_version("prts-mcp")
 except PackageNotFoundError:
-    mcp._mcp_server.version = "0.0.0"
+    mcp._lowlevel_server.version = "0.0.0"
 
 
 def _register_tools() -> None:

--- a/python/src/prts_mcp/tools_artwork.py
+++ b/python/src/prts_mcp/tools_artwork.py
@@ -339,7 +339,7 @@ def _render_list(operator_name: str, artworks: list[dict]) -> str:
 
 
 def register_artwork_tools(mcp) -> None:  # type: ignore[no-untyped-def]
-    """Register the ``operator_artwork`` tool on the given FastMCP instance."""
+    """Register the ``operator_artwork`` tool on the given MCPServer instance."""
 
     @mcp.tool()
     @activation_snapshot

--- a/python/src/prts_mcp/tools_gamedata.py
+++ b/python/src/prts_mcp/tools_gamedata.py
@@ -49,7 +49,7 @@ from prts_mcp.output import render_result, text_result
 
 
 def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
-    """Register the 12 GameData-backed tools on the given FastMCP instance."""
+    """Register the 12 GameData-backed tools on the given MCPServer instance."""
 
     @mcp.tool()
     @activation_snapshot
@@ -182,7 +182,7 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         limit: Annotated[int, Field(default=50, description="返回数量上限，默认 50。")] = 50,
         offset: Annotated[int, Field(default=0, description="分页偏移量，默认 0。")] = 0,
     ) -> object:
-        # Keep the return annotation as object: FastMCP auto-wraps -> str tools
+        # Keep the return annotation as object: MCPServer auto-wraps -> str tools
         # into outputSchema={result:string} plus duplicate structuredContent.
         # Explicit CallToolResult delivery requires bypassing that wrapper.
         """列出关卡列表，支持按章节和类型过滤。

--- a/python/src/prts_mcp/tools_prts.py
+++ b/python/src/prts_mcp/tools_prts.py
@@ -1,6 +1,6 @@
 """PRTS Wiki tool registrations — search, read, sections, categories, links, template.
 
-Split from server.py. Each register_* function receives the FastMCP instance
+Split from server.py. Each register_* function receives the MCPServer instance
 and attaches the tool handlers.
 """
 from __future__ import annotations
@@ -66,7 +66,7 @@ def _render_prts_search(data: dict) -> str:
 
 
 def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
-    """Register the 2 PRTS Wiki tools on the given FastMCP instance."""
+    """Register the 2 PRTS Wiki tools on the given MCPServer instance."""
 
     @mcp.tool()
     async def search_prts(

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -31,7 +31,7 @@ from prts_mcp.output import render_result, text_result
 
 
 def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
-    """Register the 9 story-backed tools on the given FastMCP instance."""
+    """Register the 9 story-backed tools on the given MCPServer instance."""
 
     @mcp.tool()
     def list_story_events(

--- a/python/tests/test_e2e.py
+++ b/python/tests/test_e2e.py
@@ -35,6 +35,7 @@ _has_operator_data = _op_table.is_file()
 
 _run_prts_api = os.environ.get("E2E_PRTS_API") == "1"
 _expected_version = _pkg_version("prts-mcp")
+_MODERN_VERSION = "2026-07-28"
 
 
 def _send(proc: subprocess.Popen, msg: dict) -> None:
@@ -74,6 +75,26 @@ def _tool_call(name: str, args: dict, id: int) -> dict:
         "jsonrpc": "2.0",
         "method": "tools/call",
         "params": {"name": name, "arguments": args},
+        "id": id,
+    }
+
+
+def _modern_message(method: str, params: dict, id: int) -> dict:
+    """Build a modern SDK v2 stdio request that needs no initialize step."""
+    return {
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": {
+            **params,
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": _MODERN_VERSION,
+                "io.modelcontextprotocol/clientInfo": {
+                    "name": "pytest-modern",
+                    "version": "1.0",
+                },
+                "io.modelcontextprotocol/clientCapabilities": {},
+            },
+        },
         "id": id,
     }
 
@@ -190,6 +211,54 @@ def test_tools_list(server: subprocess.Popen) -> None:
     assert len(names) == 24, f"Expected 24 tools, got {len(names)}: {sorted(names)}"
     for name in EXPECTED_TOOLS:
         assert name in names, f"Missing tool: {name}"
+
+
+def test_modern_stdio_discovery_list_and_call_need_no_initialize() -> None:
+    """A new stdio connection selects the modern era from its first request."""
+    env = os.environ.copy()
+    env["GAMEDATA_PATH"] = str(GAMEDATA_PATH)
+    env["GITHUB_MIRRORS"] = ""
+    env.setdefault("STORYJSON_PATH", str(GAMEDATA_PATH / "does-not-exist.zip"))
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+    proc = subprocess.Popen(
+        [sys.executable, "-c", "from prts_mcp.server import main; main()"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=env,
+    )
+    try:
+        _send(proc, _modern_message("server/discover", {}, 100))
+        discover = _recv(proc)
+        assert discover.get("id") == 100
+        assert discover.get("result")
+
+        _send(proc, _modern_message("tools/list", {}, 101))
+        listing = _recv(proc)
+        assert listing.get("id") == 101
+        names = {tool["name"] for tool in listing["result"]["tools"]}
+        assert "get_operator_basic_info" in names
+
+        if not _has_operator_data:
+            pytest.skip("No bundled operator data")
+        _send(
+            proc,
+            _modern_message(
+                "tools/call",
+                {"name": "get_operator_basic_info", "arguments": {"name": "阿米娅"}},
+                102,
+            ),
+        )
+        call = _recv(proc)
+        assert call.get("id") == 102
+        assert "阿米娅" in call["result"]["content"][0]["text"]
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
 
 
 @pytest.mark.skipif(not _has_operator_data, reason="No bundled operator data")

--- a/python/tests/test_e2e_http.py
+++ b/python/tests/test_e2e_http.py
@@ -89,6 +89,59 @@ def _mcp_post(
     return r.status_code, payload, sid
 
 
+_MODERN_VERSION = "2026-07-28"
+
+
+def _modern_body(method: str, params: dict, request_id: int) -> dict:
+    """Build the SDK v2 stateless-request envelope for the modern era."""
+    return {
+        "jsonrpc": "2.0",
+        "method": method,
+        "params": {
+            **params,
+            "_meta": {
+                "io.modelcontextprotocol/protocolVersion": _MODERN_VERSION,
+                "io.modelcontextprotocol/clientInfo": {
+                    "name": "pytest-modern",
+                    "version": "1.0",
+                },
+                "io.modelcontextprotocol/clientCapabilities": {},
+            },
+        },
+        "id": request_id,
+    }
+
+
+def _modern_post(
+    origin: str, method: str, params: dict, request_id: int
+) -> tuple[int, dict | None, str | None]:
+    """POST one strict modern request and decode JSON or SSE output."""
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+        "MCP-Protocol-Version": _MODERN_VERSION,
+        "Mcp-Method": method,
+    }
+    if method == "tools/call":
+        headers["Mcp-Name"] = str(params["name"])
+    response = httpx.post(
+        f"{origin}/mcp",
+        json=_modern_body(method, params, request_id),
+        headers=headers,
+        timeout=10.0,
+    )
+    payload: dict | None = None
+    if response.text:
+        try:
+            payload = _parse_sse(response.text)
+        except (ValueError, json.JSONDecodeError):
+            try:
+                payload = response.json()
+            except json.JSONDecodeError:
+                pass
+    return response.status_code, payload, response.headers.get("mcp-session-id")
+
+
 # ---------------------------------------------------------------------------
 # Server factory + fixtures
 # ---------------------------------------------------------------------------
@@ -210,6 +263,49 @@ def test_initialize_and_tools_list(server):
         "list_enemies",
     ]:
         assert required in names, f"missing tool {required}; got {sorted(names)[:10]}..."
+
+
+def test_modern_http_requests_are_stateless_and_strict(server):
+    """SDK v2 serves modern discovery/list/call without legacy sessions."""
+    origin = server["origin"]
+
+    status, payload, sid = _modern_post(origin, "server/discover", {}, 100)
+    assert status == 200
+    assert sid is None
+    assert payload is not None and payload.get("result")
+
+    status, payload, sid = _modern_post(origin, "tools/list", {}, 101)
+    assert status == 200
+    assert sid is None
+    assert payload is not None
+    names = {tool["name"] for tool in payload["result"]["tools"]}
+    assert "get_operator_basic_info" in names
+
+    if not (GAMEDATA_PATH / "zh_CN/gamedata/excel/character_table.json").is_file():
+        pytest.skip("GameData character_table not available; cannot verify modern tool call")
+    status, payload, sid = _modern_post(
+        origin,
+        "tools/call",
+        {"name": "get_operator_basic_info", "arguments": {"name": "阿米娅"}},
+        102,
+    )
+    assert status == 200
+    assert sid is None
+    assert payload is not None
+    assert "阿米娅" in payload["result"]["content"][0]["text"]
+
+    malformed = httpx.post(
+        f"{origin}/mcp",
+        headers={
+            "Content-Type": "application/json",
+            "MCP-Protocol-Version": _MODERN_VERSION,
+            "Mcp-Method": "tools/list",
+        },
+        json={"jsonrpc": "2.0", "method": "tools/list", "params": {}, "id": 103},
+        timeout=10.0,
+    )
+    assert malformed.status_code == 400
+    assert malformed.headers.get("mcp-session-id") is None
 
 
 def test_output_channel_env_governs_not_query():

--- a/python/tests/test_enemy.py
+++ b/python/tests/test_enemy.py
@@ -178,7 +178,7 @@ class TestListEnemies:
             f"offset=999 超出范围（总计 {data['total']} 条）。"
         )
         r = render_result(data, list_enemies(offset=999), channel="structured")
-        assert r.structuredContent == data
+        assert r.structured_content == data
 
     def test_filter_no_match_is_structured_no_empty_reason(self, gamedata):
         # Locks the current filter-no-match payload shape. Distinct from the
@@ -195,7 +195,7 @@ class TestListEnemies:
         assert "empty_reason" not in data
         assert list_enemies(threat_level="elite") == "# 敌人图鉴（共 0 个）"
         r = render_result(data, list_enemies(threat_level="elite"), channel="structured")
-        assert r.structuredContent == data
+        assert r.structured_content == data
 
     def test_threat_level_invalid_returns_error(self, gamedata):
         out = list_enemies(threat_level="INVALID")
@@ -348,7 +348,7 @@ class TestSearchEnemies:
         assert render_enemy_search(data) == expected
         assert search_enemies("整合运动") == expected
         r = render_result(data, expected, channel="both")
-        assert r.structuredContent == data
+        assert r.structured_content == data
 
     def test_no_match(self, gamedata):
         data = build_enemy_search("绝对不存在的关键词")
@@ -361,7 +361,7 @@ class TestSearchEnemies:
         assert render_enemy_search(data) == expected
         assert search_enemies("绝对不存在的关键词") == expected
         r = render_result(data, expected, channel="structured")
-        assert r.structuredContent == data
+        assert r.structured_content == data
 
     def test_invalid_regex(self, gamedata):
         out = search_enemies("[unclosed")

--- a/python/tests/test_images.py
+++ b/python/tests/test_images.py
@@ -8,7 +8,7 @@ import json
 import pytest
 
 from prts_mcp.data.images import SCHEMA_VERSION, build_artwork_label, parse_index
-from prts_mcp.output import _channel_var
+import prts_mcp.output as output_module
 from prts_mcp.tools_artwork import _do_get, _do_get_mediawiki, _do_list
 
 # A 1x1 transparent PNG used as a stand-in image payload.
@@ -153,8 +153,8 @@ def mock_images(monkeypatch, tmp_path):
 
 def test_list_returns_markdown_with_labels(mock_images):
     result = asyncio.run(_do_list("阿米娅"))
-    assert result.isError is False
-    assert result.structuredContent is None  # default channel = content
+    assert result.is_error is False
+    assert result.structured_content is None  # default channel = content
     text_blocks = [c for c in result.content if c.type == "text"]
     assert len(text_blocks) == 1
     body = text_blocks[0].text
@@ -166,12 +166,15 @@ def test_list_returns_markdown_with_labels(mock_images):
 
 
 def test_list_structured_channel(mock_images):
-    token = _channel_var.set("structured")
+    # test_output reloads the module when exercising import-time environment
+    # parsing, so access the current ContextVar through the module rather than
+    # retaining a stale imported instance.
+    token = output_module._channel_var.set("structured")
     try:
         result = asyncio.run(_do_list("阿米娅"))
     finally:
-        _channel_var.reset(token)
-    data = result.structuredContent
+        output_module._channel_var.reset(token)
+    data = result.structured_content
     assert data is not None
     assert data["operator_name"] == "阿米娅"
     assert data["char_id"] == "char_002_amiya"
@@ -189,10 +192,10 @@ def test_list_unknown_operator(mock_images):
 
 def test_get_returns_image_content(mock_images):
     result = asyncio.run(_do_get("阿米娅", "char_002_amiya#1", "large"))
-    assert result.isError is False
+    assert result.is_error is False
     image_blocks = [c for c in result.content if c.type == "image"]
     assert len(image_blocks) == 1
-    assert image_blocks[0].mimeType == "image/png"
+    assert image_blocks[0].mime_type == "image/png"
     # Pure base64 (no data: prefix) that decodes to the fixture PNG.
     assert image_blocks[0].data == _SAMPLE_PNG_B64
     text_blocks = [c for c in result.content if c.type == "text"]

--- a/python/tests/test_item.py
+++ b/python/tests/test_item.py
@@ -157,7 +157,7 @@ def test_list_items_empty_match_is_structured_not_error(gamedata: str) -> None:
     assert render_items_listing(data) == "没有匹配的物品（category=NONEXISTENT）。"
     # structured channel carries the empty payload
     r = render_result(data, list_items(category="NONEXISTENT"), channel="structured")
-    assert r.structuredContent == data
+    assert r.structured_content == data
 
 
 def test_get_item_info_golden(gamedata: str) -> None:
@@ -221,7 +221,7 @@ def test_search_items_structured_golden(gamedata: str) -> None:
     assert render_item_search(data) == expected
     assert search_items("公开渠道") == expected
     r = render_result(data, expected, channel="both")
-    assert r.structuredContent == data
+    assert r.structured_content == data
 
 
 def test_search_items_no_match_is_structured_empty(gamedata: str) -> None:
@@ -236,7 +236,7 @@ def test_search_items_no_match_is_structured_empty(gamedata: str) -> None:
     assert render_item_search(data) == expected
     assert search_items("绝对不存在的物品") == expected
     r = render_result(data, expected, channel="structured")
-    assert r.structuredContent == data
+    assert r.structured_content == data
     assert build_item_search("ZZZZNOMATCH") == _load_parity_fixture(
         "search_items_empty.json"
     )

--- a/python/tests/test_output.py
+++ b/python/tests/test_output.py
@@ -71,14 +71,14 @@ def test_content_channel_emits_markdown_only() -> None:
     r = render_result(_DATA, _MD, channel="content")
     assert isinstance(r, CallToolResult)
     assert [c.text for c in r.content] == [_MD]
-    assert r.structuredContent is None
-    assert r.isError is False
+    assert r.structured_content is None
+    assert r.is_error is False
 
 
 def test_both_channel_emits_markdown_and_structured() -> None:
     r = render_result(_DATA, _MD, channel="both")
     assert [c.text for c in r.content] == [_MD]
-    assert r.structuredContent == _DATA
+    assert r.structured_content == _DATA
 
 
 def test_structured_channel_emits_summary_and_structured() -> None:
@@ -86,7 +86,7 @@ def test_structured_channel_emits_summary_and_structured() -> None:
     # content is the minimal summary, NOT the full markdown.
     assert r.content[0].text != _MD
     assert "structuredContent" in r.content[0].text or "条" in r.content[0].text
-    assert r.structuredContent == _DATA
+    assert r.structured_content == _DATA
 
 
 def test_structured_summary_mentions_total_count() -> None:
@@ -105,13 +105,13 @@ def test_none_data_emits_markdown_only_regardless_of_channel() -> None:
     for ch in ("content", "structured", "both"):
         r = render_result(None, err, channel=ch)  # type: ignore[arg-type]
         assert [c.text for c in r.content] == [err], f"channel={ch}"
-        assert r.structuredContent is None, f"channel={ch}"
+        assert r.structured_content is None, f"channel={ch}"
 
 
 def test_structured_channel_without_total_falls_back_to_generic_summary() -> None:
     data = {"items": [1, 2, 3]}  # no "total" key
     r = render_result(data, _MD, channel="structured")
-    assert r.structuredContent == data
+    assert r.structured_content == data
     assert "structuredContent" in r.content[0].text
 
 
@@ -124,16 +124,16 @@ def test_text_result_is_content_only() -> None:
     r = text_result(_MD)
     assert isinstance(r, CallToolResult)
     assert [c.text for c in r.content] == [_MD]
-    assert r.structuredContent is None
-    assert r.isError is False
+    assert r.structured_content is None
+    assert r.is_error is False
 
 
 def test_text_result_carries_error_messages_verbatim() -> None:
     err = "未找到剧情章节：'nope'。请通过 list_stories 确认章节 key。"
     r = text_result(err)
     assert [c.text for c in r.content] == [err]
-    assert r.structuredContent is None
-    assert r.isError is False
+    assert r.structured_content is None
+    assert r.is_error is False
 
 
 # ---------------------------------------------------------------------------
@@ -146,7 +146,7 @@ def test_explicit_summary_used_in_structured_mode() -> None:
     data = {"name": "霜星", "id": "enemy_1505_frstar"}
     r = render_result(data, _MD, channel="structured", summary="敌人『霜星』的图鉴")
     assert r.content[0].text == "敌人『霜星』的图鉴"
-    assert r.structuredContent == data
+    assert r.structured_content == data
 
 
 def test_explicit_summary_ignored_in_content_and_both() -> None:

--- a/python/tests/test_search.py
+++ b/python/tests/test_search.py
@@ -159,7 +159,7 @@ class TestSearchOperatorData:
         assert render_operator_search(data) == expected
         assert search_operator_data("ZZZZZZZ") == expected
         result = render_result(data, expected, channel="structured")
-        assert result.structuredContent == data
+        assert result.structured_content == data
 
     def test_invalid_regex(self) -> None:
         result = search_operator_data("[")
@@ -195,7 +195,7 @@ class TestSearchOperatorData:
             "阿米娅的档案文本。"
         )
         result = render_result(data, render_operator_search(data), channel="both")
-        assert result.structuredContent == data
+        assert result.structured_content == data
 
     def test_unified_search_dispatch(self) -> None:
         data = build_search("operators", "阿米娅", max_results=1)
@@ -273,7 +273,7 @@ class TestSearchStories:
         assert render_story_search(data) == expected
         assert search_stories_from_store(store, "ZZZZZZ") == expected
         result = render_result(data, expected, channel="structured")
-        assert result.structuredContent == data
+        assert result.structured_content == data
 
     @pytest.mark.parametrize("store_kind", ["directory", "zip"])
     def test_invalid_regex(self, tmp_path: Path, store_kind: str) -> None:
@@ -326,4 +326,4 @@ class TestSearchStories:
         assert render_story_search(data) == expected
         assert search_stories_from_store(store, "你好") == expected
         result = render_result(data, expected, channel="both")
-        assert result.structuredContent == data
+        assert result.structured_content == data

--- a/python/tests/test_server_startup_sync.py
+++ b/python/tests/test_server_startup_sync.py
@@ -1,44 +1,5 @@
 from __future__ import annotations
 
-import sys
-import types
-
-
-class _FakeMcpServer:
-    def __init__(self) -> None:
-        self.version = "0.0.0"
-
-
-class FakeFastMCP:
-    def __init__(self, _name: str):
-        self._mcp_server = _FakeMcpServer()
-
-    def tool(self):
-        return lambda func: func
-
-    def run(self) -> None:
-        pass
-
-
-def _install_server_import_stubs() -> None:
-    mcp_module = types.ModuleType("mcp")
-    mcp_server_module = types.ModuleType("mcp.server")
-    fastmcp_module = types.ModuleType("mcp.server.fastmcp")
-    pydantic_module = types.ModuleType("pydantic")
-    fastmcp_module.FastMCP = FakeFastMCP
-    pydantic_module.Field = lambda *args, **kwargs: kwargs.get("default")
-    mcp_types_module = types.ModuleType("mcp.types")
-    for _name in ("CallToolResult", "ImageContent", "TextContent"):
-        setattr(mcp_types_module, _name, type(_name, (), {}))
-    sys.modules.setdefault("mcp", mcp_module)
-    sys.modules.setdefault("mcp.server", mcp_server_module)
-    sys.modules.setdefault("mcp.server.fastmcp", fastmcp_module)
-    sys.modules.setdefault("mcp.types", mcp_types_module)
-    sys.modules.setdefault("pydantic", pydantic_module)
-
-
-_install_server_import_stubs()
-
 from prts_mcp import server
 
 

--- a/python/tests/test_stage.py
+++ b/python/tests/test_stage.py
@@ -426,7 +426,7 @@ class TestSearchStages:
         assert render_stage_search(data) == expected
         assert search_stages("先锋") == expected
         r = render_result(data, expected, channel="both")
-        assert r.structuredContent == data
+        assert r.structured_content == data
 
     def test_by_code(self, gamedata: str) -> None:
         out = search_stages("AS-1")
@@ -454,7 +454,7 @@ class TestSearchStages:
         assert render_stage_search(data) == expected
         assert search_stages("ZZZZNOMATCH") == expected
         r = render_result(data, expected, channel="structured")
-        assert r.structuredContent == data
+        assert r.structured_content == data
 
     def test_invalid_regex(self, gamedata: str) -> None:
         out = search_stages("[invalid")

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -7,7 +7,8 @@ import zipfile
 from pathlib import Path
 
 import pytest
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
+from mcp.server.mcpserver import Context
 
 from prts_mcp.data.story import (
     build_character_appearances,
@@ -446,16 +447,17 @@ def test_search_prts_network_failure_is_content_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr("prts_mcp.tools_prts._search_prts", _raising_search_prts)
-    app = FastMCP("prts-test")
+    app = MCPServer("prts-test")
     register_prts_tools(app)
 
     result = asyncio.run(
         app._tool_manager.call_tool(
-            "search_prts", {"query": "阿米娅"}, convert_result=True,
+            "search_prts", {"query": "阿米娅"}, Context(mcp_server=app),
+            convert_result=True,
         )
     )
 
-    assert result.structuredContent is None
+    assert result.structured_content is None
     assert result.content[0].text == "搜索 PRTS 失败：network down"
 
 
@@ -464,16 +466,17 @@ def test_search_stories_missing_zip_is_content_only(
     tmp_path: Path,
 ) -> None:
     monkeypatch.setenv("STORYJSON_PATH", str(tmp_path / "missing.zip"))
-    app = FastMCP("story-test")
+    app = MCPServer("story-test")
     register_story_tools(app)
 
     result = asyncio.run(
         app._tool_manager.call_tool(
-            "search_stories", {"pattern": "博士"}, convert_result=True,
+            "search_stories", {"pattern": "博士"}, Context(mcp_server=app),
+            convert_result=True,
         )
     )
 
-    assert result.structuredContent is None
+    assert result.structured_content is None
     assert result.content[0].text == (
         "剧情数据未就绪。请设置 STORYJSON_PATH 环境变量指向 zh_CN.zip，"
         "或等待服务器自动从 GitHub Release 下载完成后重试。"
@@ -485,20 +488,20 @@ def test_list_story_events_missing_zip_is_content_only(
     tmp_path: Path,
 ) -> None:
     # Regression for #42: list_story_events returned a bare str on the
-    # missing-zip path, which FastMCP then wrapped into an automatic
+    # missing-zip path, which the MCP server then wrapped into an automatic
     # structuredContent={"result": ...}. The fix routes it through
     # text_result(...) so the missing-data message stays content-only.
     monkeypatch.setenv("STORYJSON_PATH", str(tmp_path / "missing.zip"))
-    app = FastMCP("story-test")
+    app = MCPServer("story-test")
     register_story_tools(app)
 
     result = asyncio.run(
         app._tool_manager.call_tool(
-            "list_story_events", {}, convert_result=True,
+            "list_story_events", {}, Context(mcp_server=app), convert_result=True,
         )
     )
 
-    assert result.structuredContent is None
+    assert result.structured_content is None
     assert result.content[0].text == (
         "剧情数据未就绪。请设置 STORYJSON_PATH 环境变量指向 zh_CN.zip，"
         "或等待服务器自动从 GitHub Release 下载完成后重试。"

--- a/python/tests/test_structured_passthrough.py
+++ b/python/tests/test_structured_passthrough.py
@@ -2,14 +2,14 @@
 
 The whole output-channel design rests on one assumption validated by the
 P1 spike: a tool that returns a hand-built ``CallToolResult`` reaches the
-client with ``content`` and ``structuredContent`` exactly as built — FastMCP
+client with ``content`` and ``structuredContent`` exactly as built — MCPServer
 does not rewrite content to JSON, drop structuredContent, or auto-derive
 an ``outputSchema``. That assumption lives in the SDK's ``convert_result``
 ``isinstance(result, CallToolResult)`` branch; if a future SDK version
 changes it, the failure is **silent** (structuredContent vanishes, or an
 extra serialized JSON block appears) and every other test stays green.
 
-These tests exercise the *real* FastMCP tool-call path
+These tests exercise the *real* MCPServer tool-call path
 (``ToolManager.call_tool(..., convert_result=True)`` — the same call the
 lowlevel server handler makes), not the ``render_result`` helper directly.
 A dedicated probe tool returns a fixed ``CallToolResult`` so the assertion
@@ -24,8 +24,9 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-from mcp.server.fastmcp.exceptions import ToolError
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
+from mcp.server.mcpserver import Context
+from mcp.server.mcpserver.exceptions import ToolError
 from mcp.types import CallToolResult
 
 from prts_mcp.output import render_result
@@ -34,14 +35,14 @@ _PROBE_DATA = {"total": 2, "stages": [{"stage_id": "main_00-01"}, {"stage_id": "
 _PROBE_MD = "# probe\n\n- main_00-01\n- main_00-02"
 
 
-def _build_probe_app(channel: str) -> FastMCP:
-    """FastMCP app with one probe tool returning render_result(...) for a channel.
+def _build_probe_app(channel: str) -> MCPServer:
+    """MCPServer app with one probe tool returning render_result(...) for a channel.
 
     The probe fixes its inputs so only the channel (and thus the SDK
     pass-through) varies — env parsing and the data layer are out of scope.
     """
 
-    app = FastMCP("probe")
+    app = MCPServer("probe")
 
     @app.tool()
     async def probe() -> object:  # returns a CallToolResult, not a str
@@ -51,10 +52,12 @@ def _build_probe_app(channel: str) -> FastMCP:
 
 
 def _call_probe(channel: str) -> CallToolResult:
-    """Drive the probe tool through the real FastMCP tool-call path."""
+    """Drive the probe tool through the real MCPServer tool-call path."""
     app = _build_probe_app(channel)
     result = asyncio.run(
-        app._tool_manager.call_tool("probe", {}, convert_result=True)
+        app._tool_manager.call_tool(
+            "probe", {}, Context(mcp_server=app), convert_result=True
+        )
     )
     return result  # type: ignore[return-value]
 
@@ -71,16 +74,16 @@ def test_sdk_passes_through_call_tool_result_verbatim(channel: str) -> None:
     )
 
     if channel == "content":
-        assert result.structuredContent is None
+        assert result.structured_content is None
         assert len(result.content) == 1
         assert result.content[0].text == _PROBE_MD
     elif channel == "both":
-        assert result.structuredContent == _PROBE_DATA
+        assert result.structured_content == _PROBE_DATA
         # Exactly one text block — no extra serialized-JSON block appended.
         assert len(result.content) == 1, "both channel appended an extra content block"
         assert result.content[0].text == _PROBE_MD
     else:  # structured
-        assert result.structuredContent == _PROBE_DATA
+        assert result.structured_content == _PROBE_DATA
         assert result.content[0].text != _PROBE_MD  # summary, not full markdown
         assert len(result.content) == 1
 
@@ -89,7 +92,7 @@ def test_no_output_schema_pollutes_the_manifest() -> None:
     app = _build_probe_app("both")
     tools = asyncio.run(app.list_tools())
     probe = next(t for t in tools if t.name == "probe")
-    assert probe.outputSchema is None, (
+    assert probe.output_schema is None, (
         "Returning a CallToolResult derived an outputSchema; this would eat the "
         "context budget the consolidation work is trying to save."
     )
@@ -98,12 +101,12 @@ def test_no_output_schema_pollutes_the_manifest() -> None:
 def test_str_annotation_rejects_explicit_call_tool_result() -> None:
     """Guard against forgetting -> object when migrating tools in P2.
 
-    FastMCP derives outputSchema from the return annotation. If a tool keeps
-    ``-> str`` but starts returning our explicit ``CallToolResult``, FastMCP
+    MCPServer derives outputSchema from the return annotation. If a tool keeps
+    ``-> str`` but starts returning our explicit ``CallToolResult``, MCPServer
     validates that object against ``{result: string}`` and the tool call fails.
     """
 
-    app = FastMCP("bad-probe")
+    app = MCPServer("bad-probe")
 
     @app.tool()
     async def bad_probe() -> str:
@@ -112,7 +115,11 @@ def test_str_annotation_rejects_explicit_call_tool_result() -> None:
         )
 
     with pytest.raises(ToolError) as excinfo:
-        asyncio.run(app._tool_manager.call_tool("bad_probe", {}, convert_result=True))
+        asyncio.run(
+            app._tool_manager.call_tool(
+                "bad_probe", {}, Context(mcp_server=app), convert_result=True
+            )
+        )
 
     message = str(excinfo.value)
     assert "validation error" in message

--- a/python/tests/test_tool_surface.py
+++ b/python/tests/test_tool_surface.py
@@ -4,7 +4,7 @@ import asyncio
 import ast
 from pathlib import Path
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 
 from prts_mcp.tools_gamedata import register_gamedata_tools
 from prts_mcp.tools_prts import register_prts_tools
@@ -41,8 +41,8 @@ EXPECTED_TOOL_SURFACE = {
 }
 
 
-def _build_registered_app() -> FastMCP:
-    app = FastMCP("tool-surface-test")
+def _build_registered_app() -> MCPServer:
+    app = MCPServer("tool-surface-test")
     register_prts_tools(app)
     register_gamedata_tools(app)
     register_story_tools(app)
@@ -90,7 +90,7 @@ def test_python_tool_functions_return_explicit_call_tool_results() -> None:
     for name in EXPECTED_TOOL_SURFACE:
         assert name in functions, f"Tool {name!r} not found in any tools_*.py module"
         assert _return_annotation(functions[name]) == "object", (
-            f"Tool {name!r} must stay annotated as -> object so FastMCP does "
+            f"Tool {name!r} must stay annotated as -> object so MCPServer does "
             "not derive an outputSchema that breaks explicit CallToolResult."
         )
 
@@ -107,4 +107,4 @@ def test_registered_tool_manifest_has_no_output_schema() -> None:
     assert set(tools) == expected_registered
 
     for name, tool in tools.items():
-        assert tool.outputSchema is None, f"{name} still has outputSchema"
+        assert tool.output_schema is None, f"{name} still has output_schema"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -283,6 +283,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
@@ -298,12 +311,19 @@ wheels = [
 ]
 
 [[package]]
-name = "httpx-sse"
-version = "0.4.3"
+name = "httpx2"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -366,15 +386,15 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.28.1"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
+    { name = "httpx2" },
     { name = "jsonschema" },
+    { name = "mcp-types" },
+    { name = "opentelemetry-api" },
     { name = "pydantic" },
-    { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "python-multipart" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
@@ -384,9 +404,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/33/32d4dff2c95bb5d897c3ef4c83649a08996b17b58f0a326d2495d4c81179/mcp-2.0.0.tar.gz", hash = "sha256:0f440e735c13ece8bb19bc62cf0b86f4313448432fbb77d35e14034f4e050728", size = 1662284, upload-time = "2026-07-28T13:45:32.346Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
+    { url = "https://files.pythonhosted.org/packages/67/72/7d7897418912c1d12e87556630dfb7bf0eac71160e9bef8b447960804ee3/mcp-2.0.0-py3-none-any.whl", hash = "sha256:1cb4c75d2d2c7b8c1d756355e5d82a39f2822cc7f13e22a2051d7ca3592349d6", size = 349980, upload-time = "2026-07-28T13:45:28.853Z" },
 ]
 
 [package.optional-dependencies]
@@ -396,12 +416,37 @@ cli = [
 ]
 
 [[package]]
+name = "mcp-types"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/56/9b8e1c152f61f6c6b07c4b5896c88c7d0ae90bac6ee6306f852fcc5c1eb0/mcp_types-2.0.0.tar.gz", hash = "sha256:d7d939b9285c9961ae8866ba75ef85da34d12bafe276efbf4eb6a131786d8379", size = 66632, upload-time = "2026-07-28T13:45:33.804Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/4c/c78d78c3d52b0ac594ad7cc8ef5972adfe070e3597a8a4c6ce0cd39196ea/mcp_types-2.0.0-py3-none-any.whl", hash = "sha256:6b2de797ca2797f568b79529e1b25948e34de511bcc0bd82fef1039a6d1b8eb0", size = 69649, upload-time = "2026-07-28T13:45:30.713Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -442,7 +487,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx" },
-    { name = "mcp", extras = ["cli"], specifier = ">=1.28,<2" },
+    { name = "mcp", extras = ["cli"], specifier = "==2.0.0" },
     { name = "pydantic" },
     { name = "starlette", specifier = ">=0.27" },
     { name = "uvicorn", specifier = ">=0.31" },
@@ -589,20 +634,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
-]
-
-[[package]]
-name = "pydantic-settings"
-version = "2.14.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/c1/6e422f34e569cf8e18df68d1939c81c099d2b61e4f7d9621c8a77560799c/pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440", size = 61715, upload-time = "2026-06-19T13:44:55.02Z" },
 ]
 
 [[package]]
@@ -1062,6 +1093,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- migrate Python from `FastMCP` / `mcp<2` to exact `mcp[cli]==2.0.0` and `MCPServer`
- preserve legacy HTTP session and stdio initialization behavior through the SDK v2 dual-era runner
- add black-box modern `2026-07-28` HTTP and stdio coverage, including strict malformed-envelope rejection
- update result-model construction and regression tests for SDK v2 snake_case fields

## Verification

- `./scripts/check-runtime.sh`
- `uv run --directory python --locked python -m pytest tests -q` (334 passed, 23 skipped)
- `git diff --check`

Closes #84 (Python portion only; TypeScript migration and modern routing already landed separately).
