### PR TITLE
fix(artwork): resolve Amiya transformed forms

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Amiya artwork forms (#123).** `operator_artwork` now resolves
+  `阿米娅(近卫)` and `阿米娅(医疗)` to their distinct artwork char IDs without
+  changing name resolution for other tools. Opaque artwork tokens now require
+  an exact form match in both local and MediaWiki modes, so a base or sibling
+  form cannot retrieve another form's image.
+
 ### Changed
 
 - **MCP SDK v2 and dual-era serving (#84).** Migrated to the exact

--- a/python/src/prts_mcp/data/artwork_mediawiki.py
+++ b/python/src/prts_mcp/data/artwork_mediawiki.py
@@ -141,7 +141,6 @@ def artwork_belongs_to_operator(filename: str, operator_name: str) -> bool:
         return False
     requested = _normalized_operator_name(operator_name)
     actual = _normalized_operator_name(artwork_operator)
-    if requested == actual:
-        return True
-    base = actual.rsplit("(", 1)[0] if actual.endswith(")") and "(" in actual else actual
-    return requested == base
+    # artwork_id is opaque and list-scoped. A base-name request must not be
+    # able to retrieve a transformed form (or vice versa) by reusing a token.
+    return requested == actual

--- a/python/src/prts_mcp/tools_artwork.py
+++ b/python/src/prts_mcp/tools_artwork.py
@@ -37,6 +37,20 @@ from prts_mcp.data.operator import resolve_char_id
 from prts_mcp.output import render_image_result, render_result, text_result
 
 
+# These IDs represent forms that deliberately share the base character's
+# display name in the game table. Keep this resolver local to artwork: other
+# operator tools must retain their ordinary exact-name lookup contract.
+_ARTWORK_FORM_CHAR_IDS: Mapping[str, str] = {
+    "阿米娅(近卫)": "char_1001_amiya2",
+    "阿米娅(医疗)": "char_1037_amiya3",
+}
+
+
+def _resolve_artwork_char_id(operator_name: str) -> str | None:
+    """Resolve an artwork-only form alias without widening normal lookup."""
+    return _ARTWORK_FORM_CHAR_IDS.get(operator_name) or resolve_char_id(operator_name)
+
+
 def _images_generation() -> Path | None:
     """Return the active images generation directory, or None when unavailable."""
     cfg = Config.load()
@@ -188,7 +202,7 @@ async def _do_list(operator_name: str) -> object:
     if not cfg.local_image:
         return await _do_list_mediawiki(operator_name)
     try:
-        char_id = resolve_char_id(operator_name)
+        char_id = _resolve_artwork_char_id(operator_name)
     except (OSError, AssertionError):
         # gamedata not synced yet (effective_excel_path None or table missing).
         return _data_not_ready()
@@ -269,7 +283,7 @@ async def _do_get(
             f"找不到 artwork_id「{artwork_id}」。该 ID 不透明，请用 action=list 重新获取。"
         )
     try:
-        char_id = resolve_char_id(operator_name)
+        char_id = _resolve_artwork_char_id(operator_name)
     except (OSError, AssertionError):
         return _data_not_ready()
     if char_id is None:

--- a/python/tests/test_artwork_mediawiki.py
+++ b/python/tests/test_artwork_mediawiki.py
@@ -49,10 +49,12 @@ def test_label_rejects_non_png_and_malformed():
     assert label_from_filename("立绘阿米娅", _CHARINFO) is None  # no second underscore
 
 
-def test_artwork_filename_owner_accepts_exact_and_base_form_only():
+def test_artwork_filename_owner_requires_exact_form_match():
     assert operator_from_filename("立绘_阿米娅(近卫)_2.png") == "阿米娅(近卫)"
     assert artwork_belongs_to_operator("立绘_阿米娅(近卫)_2.png", "阿米娅(近卫)")
-    assert artwork_belongs_to_operator("立绘_阿米娅（近卫）_2.png", "阿米娅")
+    assert artwork_belongs_to_operator("立绘_阿米娅（近卫）_2.png", "阿米娅(近卫)")
+    assert not artwork_belongs_to_operator("立绘_阿米娅(近卫)_2.png", "阿米娅")
+    assert not artwork_belongs_to_operator("立绘_阿米娅(近卫)_2.png", "阿米娅(医疗)")
     assert not artwork_belongs_to_operator("立绘_阿米娅(近卫)_2.png", "阿米")
     assert not artwork_belongs_to_operator("立绘_斯卡蒂_2.png", "阿米娅")
     assert not artwork_belongs_to_operator("立绘_阿米娅_2b.png", "阿米娅")

--- a/python/tests/test_images.py
+++ b/python/tests/test_images.py
@@ -71,6 +71,25 @@ def _sample_index(include_foreign: bool = False) -> dict:
     return index
 
 
+def _add_amiya_form_artworks(index: dict) -> None:
+    artworks = index["artworks"]
+    for char_id, filename in (
+        ("char_1001_amiya2", "amiya_guard.large.png"),
+        ("char_1037_amiya3", "amiya_medic.large.png"),
+    ):
+        artworks[f"{char_id}#1"] = {
+            "kind": "base",
+            "shard": "chararts",
+            "large": {
+                "file": filename,
+                "w": 1024,
+                "h": 1100,
+                "bytes": 50,
+                "sha256": char_id,
+            },
+        }
+
+
 # ---------------------------------------------------------------------------
 # parse_index
 # ---------------------------------------------------------------------------
@@ -188,6 +207,40 @@ def test_list_unknown_operator(mock_images):
     result = asyncio.run(_do_list("不存在"))
     text = result.content[0].text
     assert "找不到" in text
+
+
+@pytest.mark.parametrize(
+    ("operator_name", "expected_char_id"),
+    [
+        ("阿米娅(近卫)", "char_1001_amiya2"),
+        ("阿米娅(医疗)", "char_1037_amiya3"),
+    ],
+)
+def test_list_resolves_amiya_artwork_form_aliases(
+    mock_images, operator_name, expected_char_id,
+):
+    index = _sample_index()
+    _add_amiya_form_artworks(index)
+    (mock_images / "index.json").write_text(json.dumps(index), "utf-8")
+
+    result = asyncio.run(_do_list(operator_name))
+
+    body = result.content[0].text
+    assert expected_char_id in body
+    assert "char_002_amiya#1" not in body
+
+
+def test_get_rejects_opaque_artwork_token_from_another_amiya_form(mock_images):
+    index = _sample_index()
+    _add_amiya_form_artworks(index)
+    (mock_images / "index.json").write_text(json.dumps(index), "utf-8")
+
+    result = asyncio.run(
+        _do_get("阿米娅(医疗)", "char_1001_amiya2#1", "large")
+    )
+
+    assert "不属于" in result.content[0].text
+    assert not any(block.type == "image" for block in result.content)
 
 
 def test_get_returns_image_content(mock_images):

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Amiya artwork forms (#123).** `operator_artwork` now resolves
+  `阿米娅(近卫)` and `阿米娅(医疗)` to their distinct artwork char IDs without
+  changing name resolution for other tools. Opaque artwork tokens now require
+  an exact form match in both local and MediaWiki modes, so a base or sibling
+  form cannot retrieve another form's image.
+
 ## [2.6.0-alpha.2] - 2026-08-08
 
 ### Added

--- a/ts/src/data/artworkMediawiki.ts
+++ b/ts/src/data/artworkMediawiki.ts
@@ -132,6 +132,7 @@ export function artworkBelongsToOperator(filename: string, operatorName: string)
   if (artworkOperator === null) return false;
   const requested = normalizedOperatorName(operatorName);
   const actual = normalizedOperatorName(artworkOperator);
-  if (requested === actual) return true;
-  return requested === actual.replace(/\([^()]*\)$/, "");
+  // artworkId is opaque and list-scoped. A base-name request must not be
+  // able to retrieve a transformed form (or vice versa) by reusing a token.
+  return requested === actual;
 }

--- a/ts/src/tools/artworkTools.ts
+++ b/ts/src/tools/artworkTools.ts
@@ -40,6 +40,18 @@ import { resolveCharId } from "../data/operator.js";
 import { renderImageResult, renderResult, textResult, type OutputChannel } from "../output.js";
 import { registerTool } from "./registerTool.js";
 
+// These IDs represent forms that deliberately share the base character's
+// display name in the game table. Keep this resolver local to artwork: other
+// operator tools retain their ordinary exact-name lookup contract.
+const ARTWORK_FORM_CHAR_IDS: Readonly<Record<string, string>> = {
+  "阿米娅(近卫)": "char_1001_amiya2",
+  "阿米娅(医疗)": "char_1037_amiya3",
+};
+
+function resolveArtworkCharId(operatorName: string): string | null {
+  return ARTWORK_FORM_CHAR_IDS[operatorName] ?? resolveCharId(operatorName);
+}
+
 // ---------------------------------------------------------------------------
 // Synchronous data access (runs inside withActivationSnapshot)
 // ---------------------------------------------------------------------------
@@ -200,7 +212,7 @@ async function doGetMediawiki(
 function doList(operatorName: string, channel: OutputChannel): CallToolResult {
   let charId: string | null;
   try {
-    charId = resolveCharId(operatorName);
+    charId = resolveArtworkCharId(operatorName);
   } catch {
     // gamedata not synced yet (effectiveExcelPath null or table missing).
     return dataNotReady();
@@ -277,7 +289,7 @@ function doGet(
   }
   let charId: string | null;
   try {
-    charId = resolveCharId(operatorName);
+    charId = resolveArtworkCharId(operatorName);
   } catch {
     return dataNotReady();
   }

--- a/ts/tests/artworkMediawiki.test.ts
+++ b/ts/tests/artworkMediawiki.test.ts
@@ -41,10 +41,12 @@ test("labelFromFilename: rejects non-png and malformed", () => {
   assert.equal(labelFromFilename("立绘阿米娅", CHARINFO), null);
 });
 
-test("artwork ownership accepts exact and base-form names only", () => {
+test("artwork ownership requires exact form match", () => {
   assert.equal(operatorFromFilename("立绘_阿米娅(近卫)_2.png"), "阿米娅(近卫)");
   assert.equal(artworkBelongsToOperator("立绘_阿米娅(近卫)_2.png", "阿米娅(近卫)"), true);
-  assert.equal(artworkBelongsToOperator("立绘_阿米娅（近卫）_2.png", "阿米娅"), true);
+  assert.equal(artworkBelongsToOperator("立绘_阿米娅（近卫）_2.png", "阿米娅(近卫)"), true);
+  assert.equal(artworkBelongsToOperator("立绘_阿米娅(近卫)_2.png", "阿米娅"), false);
+  assert.equal(artworkBelongsToOperator("立绘_阿米娅(近卫)_2.png", "阿米娅(医疗)"), false);
   assert.equal(artworkBelongsToOperator("立绘_阿米娅(近卫)_2.png", "阿米"), false);
   assert.equal(artworkBelongsToOperator("立绘_斯卡蒂_2.png", "阿米娅"), false);
   assert.equal(artworkBelongsToOperator("立绘_阿米娅_2b.png", "阿米娅"), false);

--- a/ts/tests/images.test.ts
+++ b/ts/tests/images.test.ts
@@ -174,3 +174,91 @@ test("operator_artwork rejects cross-operator tokens before local reads or Media
     clearOperatorCaches();
   }
 });
+
+test("operator_artwork resolves Amiya form aliases and rejects cross-form tokens", async () => {
+  const root = mkdtempSync(join(tmpdir(), "prts-artwork-amiya-forms-"));
+  const excel = join(root, "gamedata", "zh_CN", "gamedata", "excel");
+  const imageRoot = join(root, "images");
+  const generation = join(imageRoot, ".releases", "test");
+  mkdirSync(excel, { recursive: true });
+  mkdirSync(generation, { recursive: true });
+  for (const file of [
+    "handbook_info_table.json",
+    "charword_table.json",
+    "story_review_table.json",
+  ]) {
+    writeFileSync(join(excel, file), "{}", "utf-8");
+  }
+  // The production character table intentionally retains only the base name;
+  // the artwork-specific aliases must supply the two transformed char IDs.
+  writeFileSync(join(excel, "character_table.json"), JSON.stringify({
+    char_002_amiya: { name: "阿米娅" },
+  }), "utf-8");
+  writeFileSync(join(imageRoot, ".images_meta.json"), JSON.stringify({
+    generation_root: ".releases/test",
+  }), "utf-8");
+  writeFileSync(join(generation, "index.json"), JSON.stringify({
+    schemaVersion: SCHEMA_VERSION,
+    baselineVersion: "b1",
+    currentVersion: "c1",
+    shards: {},
+    artworks: {
+      "char_1001_amiya2#1": {
+        kind: "base",
+        shard: "chararts",
+        large: { file: "guard.png", w: 1, h: 1, bytes: 1, sha256: "guard" },
+      },
+      "char_1037_amiya3#1": {
+        kind: "base",
+        shard: "chararts",
+        large: { file: "medic.png", w: 1, h: 1, bytes: 1, sha256: "medic" },
+      },
+    },
+  }), "utf-8");
+
+  const savedEnv = {
+    gamedata: process.env["GAMEDATA_PATH"],
+    imageDir: process.env["PRTS_IMAGE_DIR"],
+    localImage: process.env["LOCAL_IMAGE"],
+  };
+  process.env["GAMEDATA_PATH"] = join(root, "gamedata");
+  process.env["PRTS_IMAGE_DIR"] = imageRoot;
+  process.env["LOCAL_IMAGE"] = "true";
+  clearOperatorCaches();
+
+  try {
+    const server = new CapturingServer();
+    registerArtworkTools(server as never);
+    assert.ok(server.handler);
+
+    for (const [operatorName, expectedId] of [
+      ["阿米娅(近卫)", "char_1001_amiya2#1"],
+      ["阿米娅(医疗)", "char_1037_amiya3#1"],
+    ]) {
+      const result = await server.handler({
+        operator_name: operatorName,
+        action: "list",
+      }) as { content: Array<{ type: string; text?: string }> };
+      assert.match(result.content[0]?.text ?? "", new RegExp(expectedId));
+    }
+
+    const crossForm = await server.handler({
+      operator_name: "阿米娅(医疗)",
+      action: "get",
+      artwork_id: "char_1001_amiya2#1",
+      variant: "large",
+    }) as { content: Array<{ type: string; text?: string }> };
+    assert.match(crossForm.content[0]?.text ?? "", /不属于/);
+    assert.equal(crossForm.content.some((block) => block.type === "image"), false);
+  } finally {
+    for (const [key, value] of Object.entries({
+      GAMEDATA_PATH: savedEnv.gamedata,
+      PRTS_IMAGE_DIR: savedEnv.imageDir,
+      LOCAL_IMAGE: savedEnv.localImage,
+    })) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    clearOperatorCaches();
+  }
+});


### PR DESCRIPTION
## Summary

- resolve `阿米娅(近卫)` and `阿米娅(医疗)` only within `operator_artwork` to their dedicated character IDs
- retain normal operator-name lookup for every other tool
- require an exact owner/form match for opaque artwork tokens in local and MediaWiki paths
- add focused Python and TypeScript regressions for both forms and sibling-form token rejection

## Verification

- `uv run --directory python --locked python -m pytest tests -q` (337 passed, 23 skipped)
- `cd ts && npm test` (264 passed, 2 skipped)
- `cd ts && npm run build`
- `cd ts && npm run smoke:bun`
- `git diff --check`

Closes #123.
