### PR TITLE
feat(ops): add six-session memory canary gate

### DIFF
--- a/ops/prts-canary/README.md
+++ b/ops/prts-canary/README.md
@@ -1,0 +1,48 @@
+# PRTS-MCP 2.6.0 same-host canary
+
+This is a deliberately separate service for release acceptance. It is not a
+production replacement unit and it must not be enabled before the exact npm
+package has been published and verified.
+
+The unit starts the published package from
+`/opt/prts-mcp-canary/node_modules/prts-mcp-ts` on `127.0.0.1:5103`. It reads
+the existing GameData, StoryJson, and local image generation through explicit
+paths, which prevents the canary from becoming a second auto-sync publisher.
+`MemoryHigh=1G` (1 GiB) starts cgroup reclaim/throttling and
+`MemoryMax=1536M` (1.5 GiB) is the hard stop. The stable
+`prts-mcp-ts.service` remains unchanged throughout this phase.
+
+## Installation and rollback material
+
+1. Record the currently installed global package version and the active
+   `prts-mcp-ts.service` unit/drop-ins. Keep the known-good 2.5.2 package and
+   unit files available for rollback.
+2. Create `/opt/prts-mcp-canary` owned by `ubuntu`, install the exact
+   published package there with npm, and compare the downloaded tarball's
+   SHA-256 and size with the release manifest before `npm install`.
+3. Install `prts-mcp-ts-canary.service`, run `systemctl daemon-reload`, then
+   start only `prts-mcp-ts-canary.service`. Verify `/health` and
+   `/debug/metrics` directly on `127.0.0.1:5103`; never publish the metrics
+   endpoint through Nginx.
+4. Temporarily include `prts-canary.nginx.conf` in the existing MCP virtual
+   host, validate with root-owned `nginx -t`, and reload Nginx. The route uses
+   the existing authenticated `$mcp_auth` gate at `/prts-canary/mcp`.
+
+If any gate fails, remove the Nginx include, stop and disable the canary
+service, and retain its journal plus cgroup metrics for diagnosis. Do not
+modify the stable service during a failed canary.
+
+## Acceptance gates
+
+- strict-modern QuickQuip against the temporary route;
+- Prism Vesicle in strict-modern and auto-to-modern modes;
+- a real legacy session client against the stable route;
+- `PRTS_BENCH_ISOLATED=true` loopback benchmark with 6 mixed sessions;
+- cgroup `memory.current`, `memory.peak`, `memory.events`, and aggregate
+  `/debug/metrics` confirm no OOM/high-limit breach and bounded short-window
+  RSS growth.
+
+Only after all gates pass should the release owner update the stable service
+to the same verified package. Keep the 2.5.2 rollback package/unit material
+until the post-cutover legacy and modern checks complete, then remove the
+temporary Nginx route and canary unit.

--- a/ops/prts-canary/prts-canary.nginx.conf
+++ b/ops/prts-canary/prts-canary.nginx.conf
@@ -1,0 +1,17 @@
+# Include this location inside the existing mcp.4sljq.top server block only
+# while the 2.6.0 canary is under acceptance. It deliberately reuses the
+# established $mcp_auth gate and exposes no diagnostics route.
+location /prts-canary/mcp {
+    if ($mcp_auth = 0) { return 444; }
+    proxy_pass http://127.0.0.1:5103/mcp;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header Connection "";
+    proxy_buffering off;
+    proxy_request_buffering off;
+    proxy_read_timeout 3600;
+    proxy_send_timeout 3600;
+}

--- a/ops/prts-canary/prts-mcp-ts-canary.service
+++ b/ops/prts-canary/prts-mcp-ts-canary.service
@@ -1,0 +1,40 @@
+[Unit]
+Description=PRTS MCP Server 2.6.0 canary (TypeScript / Streamable HTTP)
+After=network.target
+
+[Service]
+Type=simple
+User=ubuntu
+Group=ubuntu
+WorkingDirectory=/opt/prts-mcp-canary
+ExecStart=/usr/bin/bun /opt/prts-mcp-canary/node_modules/prts-mcp-ts/dist/server-bun.js
+Restart=on-failure
+RestartSec=5s
+
+# Isolated loopback listener; the temporary authenticated Nginx location is
+# the only external ingress during acceptance.
+Environment=HOST=127.0.0.1
+Environment=PORT=5103
+Environment=PRTS_METRICS_ENABLED=true
+
+# Reuse the active production data read-only. Explicit GAMEDATA_PATH makes
+# the canary a consumer rather than a second auto-sync publisher.
+Environment=GAMEDATA_PATH=/home/ubuntu/.local/share/prts-mcp/gamedata
+Environment=STORYJSON_PATH=/home/ubuntu/.local/share/prts-mcp/storyjson/zh_CN.zip
+Environment=PRTS_IMAGE_DIR=/home/ubuntu/.local/share/prts-mcp/images
+Environment=IMAGES_ENABLED=true
+Environment=LOCAL_IMAGE=true
+Environment=ORIGINAL_IMAGE=true
+Environment=XDG_DATA_HOME=/home/ubuntu/.local/share
+
+# Start throttling before the hard cap. The main service remains untouched
+# until canary acceptance and the explicit cutover step.
+MemoryHigh=1G
+MemoryMax=1536M
+NoNewPrivileges=true
+PrivateTmp=true
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Six-session memory canary gate (#90).** The isolated loopback benchmark
+  now exercises archives, data search, story search, chapter/activity reads,
+  and an actual artwork image retrieval across six concurrent sessions. It
+  requires cache stability plus a quiescent request state and bounded RSS.
+  Version-controlled same-host canary assets add a separate loopback service,
+  authenticated temporary route, and cgroup limits of `MemoryHigh=1G` /
+  `MemoryMax=1536M` without modifying the stable service.
+
 ### Fixed
 
 - **Amiya artwork forms (#123).** `operator_artwork` now resolves

--- a/ts/README.md
+++ b/ts/README.md
@@ -164,7 +164,7 @@ docker run -d -p 3000:3000 -v prts-mcp-ts-data:/data/gamedata -v prts-mcp-ts-lev
 | `SESSION_IDLE_TIMEOUT_MS` | `86400000` | Streamable HTTP 会话空闲超时（毫秒）。设为非正数时禁用超时；会话活跃时间、有效值与淘汰计数可由已启用的 `/debug/metrics` 读取。`closed_total` 包含被空闲淘汰而关闭的会话，`evicted_total` 是其中的原因子集。 |
 | `PRTS_METRICS_ENABLED` | `false` | 设为严格的 `true` 才提供 `/debug/metrics`；响应只含进程、缓存、请求、工具和会话的聚合指标，不含 MCP 参数、结果或会话 ID。工具维度只接受内置工具名，避免把调用方输入变成指标标签。生产环境应保持服务仅监听 loopback，且不得为该路径配置公网反向代理。 |
 
-需要验证重复负载与并发会话时，只能在隔离的本机实例上执行 `PRTS_BENCH_ISOLATED=true PRTS_BENCH_ORIGIN=http://127.0.0.1:<port> npm run bench:memory`。脚本要求指标端点已启用，依次记录冷启动、同会话重复和三个并发会话的聚合快照，并在重复阶段新增缓存 miss 时失败；它拒绝非 loopback 目标，不得在生产服务器执行。
+需要验证重复负载与并发会话时，只能在隔离的本机实例上执行 `PRTS_BENCH_ISOLATED=true PRTS_BENCH_ORIGIN=http://127.0.0.1:<port> npm run bench:memory`。脚本要求指标端点和可读剧情/本地图片数据均已启用：它会先发现一个活动、章节和阿米娅立绘，然后以 **6 个并发会话** 执行档案、基础资料、数据搜索、剧情搜索、单章、活动分页和实际图片 get。除重复负载不能新增 cache miss 外，它还要求并发后至少 7 个会话仍在、请求已静止、RSS 不超过 1 GiB、相对冷缓存增长不超过 256 MiB（可用 `PRTS_BENCH_MAX_RSS_BYTES` / `PRTS_BENCH_MAX_RSS_GROWTH_BYTES` 调整）。它拒绝非 loopback 目标，不得在生产正式服务执行。
 
 ---
 

--- a/ts/scripts/bench-memory.mjs
+++ b/ts/scripts/bench-memory.mjs
@@ -9,6 +9,22 @@
  */
 
 const origin = requireIsolatedOrigin();
+const CONCURRENT_SESSIONS = 6;
+const MAX_RSS_BYTES = positiveEnv("PRTS_BENCH_MAX_RSS_BYTES", 1024 * 1024 * 1024);
+const MAX_RSS_GROWTH_BYTES = positiveEnv(
+  "PRTS_BENCH_MAX_RSS_GROWTH_BYTES",
+  256 * 1024 * 1024,
+);
+
+function positiveEnv(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer byte count`);
+  }
+  return parsed;
+}
 
 function requireIsolatedOrigin() {
   if (process.env.PRTS_BENCH_ISOLATED !== "true") {
@@ -34,10 +50,10 @@ async function readJson(res, label) {
   }
 }
 
-async function mcpPost(body, sessionId) {
+async function mcpPost(body, sessionId, query = "") {
   const headers = { "Content-Type": "application/json", Accept: "application/json, text/event-stream" };
   if (sessionId) headers["Mcp-Session-Id"] = sessionId;
-  const res = await fetch(`${origin}/mcp`, { method: "POST", headers, body: JSON.stringify(body) });
+  const res = await fetch(`${origin}/mcp${query}`, { method: "POST", headers, body: JSON.stringify(body) });
   const response = await readJson(res, "MCP request");
   if (response.error) throw new Error(`MCP protocol error: ${JSON.stringify(response.error)}`);
   if (!response.result) throw new Error("MCP response has no result");
@@ -70,25 +86,86 @@ async function startSession(id) {
       clientInfo: { name: "prts-memory-benchmark", version: "1" },
     },
     id,
-  });
+  }, undefined, "?output_channel=both");
   if (!initialized.sessionId) throw new Error("initialize did not return Mcp-Session-Id");
   await mcpNotify({ jsonrpc: "2.0", method: "notifications/initialized" }, initialized.sessionId);
   return initialized.sessionId;
 }
 
 async function callTool(sessionId, name, args, id) {
-  await mcpPost({
+  const { response } = await mcpPost({
     jsonrpc: "2.0",
     method: "tools/call",
     params: { name, arguments: args },
     id,
   }, sessionId);
+  const result = response.result;
+  if (!result || result.isError === true || !Array.isArray(result.content)) {
+    throw new Error(`${name} did not return a successful tool result`);
+  }
+  const hasText = result.content.some((block) => (
+    block && block.type === "text" && typeof block.text === "string" && block.text.length > 0
+  ));
+  if (!hasText) throw new Error(`${name} returned no text content`);
+  return result;
 }
 
-async function runWorkload(sessionId, idStart) {
+function requireStructured(result, toolName) {
+  if (!result.structuredContent || typeof result.structuredContent !== "object") {
+    throw new Error(`${toolName} did not return structuredContent; initialize must use output_channel=both`);
+  }
+  return result.structuredContent;
+}
+
+async function discoverWorkloadTargets(sessionId) {
+  const eventListing = requireStructured(
+    await callTool(sessionId, "list_story_events", {}, 2),
+    "list_story_events",
+  );
+  const events = Array.isArray(eventListing.events) ? eventListing.events : [];
+  const event = events.find((candidate) => (
+    candidate
+    && typeof candidate.event_id === "string"
+    && Number.isInteger(candidate.story_count)
+    && candidate.story_count > 0
+  ));
+  if (!event) throw new Error("list_story_events returned no readable event");
+
+  const storiesListing = requireStructured(
+    await callTool(sessionId, "list_stories", { event_id: event.event_id }, 3),
+    "list_stories",
+  );
+  const chapters = Array.isArray(storiesListing.chapters) ? storiesListing.chapters : [];
+  const chapter = chapters.find((candidate) => candidate && typeof candidate.story_key === "string");
+  if (!chapter) throw new Error(`list_stories returned no readable chapter for ${event.event_id}`);
+
+  const artworkListing = requireStructured(
+    await callTool(sessionId, "operator_artwork", { operator_name: "阿米娅", action: "list" }, 4),
+    "operator_artwork list",
+  );
+  const artworks = Array.isArray(artworkListing.artworks) ? artworkListing.artworks : [];
+  const artwork = artworks.find((candidate) => candidate && typeof candidate.artwork_id === "string");
+  if (!artwork) throw new Error("operator_artwork list returned no retrievable artwork");
+
+  return { eventId: event.event_id, storyKey: chapter.story_key, artworkId: artwork.artwork_id };
+}
+
+async function runWorkload(sessionId, idStart, targets) {
   await callTool(sessionId, "get_operator_archives", { name: "阿米娅" }, idStart);
   await callTool(sessionId, "get_operator_basic_info", { name: "阿米娅" }, idStart + 1);
   await callTool(sessionId, "search", { scope: "operators", pattern: "法术伤害", max_results: 20 }, idStart + 2);
+  await callTool(sessionId, "search_stories", {
+    pattern: "博士", context_lines: 1, max_results: 30,
+  }, idStart + 3);
+  await callTool(sessionId, "read_story", {
+    story_key: targets.storyKey, include_narration: true,
+  }, idStart + 4);
+  await callTool(sessionId, "read_activity", {
+    event_id: targets.eventId, include_narration: true, page: 1, page_size: 5,
+  }, idStart + 5);
+  await callTool(sessionId, "operator_artwork", {
+    operator_name: "阿米娅", action: "get", artwork_id: targets.artworkId, variant: "large",
+  }, idStart + 6);
 }
 
 function cacheMisses(cache) {
@@ -119,10 +196,11 @@ async function snapshot(label) {
 
 const before = await snapshot("before");
 const primarySession = await startSession(1);
-await runWorkload(primarySession, 10);
+const targets = await discoverWorkloadTargets(primarySession);
+await runWorkload(primarySession, 10, targets);
 const cold = await snapshot("cold");
 
-await runWorkload(primarySession, 20);
+await runWorkload(primarySession, 20, targets);
 const repeated = await snapshot("repeated");
 const coldMisses = cacheMisses(cold.cache);
 const repeatedMisses = cacheMisses(repeated.cache);
@@ -130,14 +208,43 @@ if (repeatedMisses !== coldMisses) {
   throw new Error(`repeat workload added cache misses (${coldMisses} -> ${repeatedMisses}); rerun only after confirming no activation invalidation occurred`);
 }
 
-const concurrentSessions = await Promise.all([startSession(100), startSession(200), startSession(300)]);
-await Promise.all(concurrentSessions.map((sessionId, index) => runWorkload(sessionId, 1_000 + index * 10)));
+const concurrentSessions = await Promise.all(
+  Array.from({ length: CONCURRENT_SESSIONS }, (_unused, index) => startSession(100 + index)),
+);
+await Promise.all(concurrentSessions.map((sessionId, index) => runWorkload(sessionId, 1_000 + index * 10, targets)));
 const concurrent = await snapshot("concurrent");
+const rssGrowthBytes = concurrent.process.rss_bytes - cold.process.rss_bytes;
+if (concurrent.sessions.active < CONCURRENT_SESSIONS + 1) {
+  throw new Error(`expected at least ${CONCURRENT_SESSIONS + 1} active sessions, got ${concurrent.sessions.active}`);
+}
+if (concurrent.requests.in_flight !== 0 || concurrent.tool_calls.in_flight !== 0) {
+  throw new Error("workload did not quiesce before the concurrent snapshot");
+}
+if (concurrent.process.rss_bytes > MAX_RSS_BYTES) {
+  throw new Error(`RSS exceeded budget (${concurrent.process.rss_bytes} > ${MAX_RSS_BYTES})`);
+}
+if (rssGrowthBytes > MAX_RSS_GROWTH_BYTES) {
+  throw new Error(`concurrent workload RSS growth exceeded budget (${rssGrowthBytes} > ${MAX_RSS_GROWTH_BYTES})`);
+}
 
 console.log(JSON.stringify({
   schema_version: "prts-mcp.memory-benchmark/v1",
   target: { origin, isolated: true },
-  assertions: { repeated_workload_added_no_cache_misses: true },
+  workload: {
+    concurrent_sessions: CONCURRENT_SESSIONS,
+    tools: [
+      "get_operator_archives", "get_operator_basic_info", "search", "search_stories",
+      "read_story", "read_activity", "operator_artwork",
+    ],
+  },
+  assertions: {
+    repeated_workload_added_no_cache_misses: true,
+    concurrent_sessions_remained_active: true,
+    post_workload_requests_quiesced: true,
+    max_rss_bytes: MAX_RSS_BYTES,
+    max_rss_growth_bytes: MAX_RSS_GROWTH_BYTES,
+    observed_rss_growth_bytes: rssGrowthBytes,
+  },
   snapshots: {
     before: compactSnapshot(before),
     cold: compactSnapshot(cold),


### PR DESCRIPTION
## Summary

- expand the isolated memory benchmark from three to six concurrent legacy sessions
- exercise archives, data search, story search, chapter/activity reads, and a real artwork image get
- require successful structured target discovery, cache stability, active-session coverage, a quiescent post-workload snapshot, and explicit RSS ceilings
- add version-controlled same-host canary assets for loopback port 5103, existing read-only data, temporary authenticated ingress, and `MemoryHigh=1G` / `MemoryMax=1536M`

## Verification

- `node --check ts/scripts/bench-memory.mjs`
- `cd ts && npm test` (264 passed, 2 skipped)
- `cd ts && npm run build`
- `cd ts && npm run smoke:bun`
- `./scripts/check-runtime.sh --full` (Python 337 passed, 23 skipped; TS 264 passed, 2 skipped)
- `git diff --check`

The full mixed workload is intentionally deferred to the release package canary; the script refuses non-loopback targets and never prints tool content or image data.

Closes #90.
