### PR TITLE
chore(release): merge v2.6.0 back to develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ Two release lines ship in parallel:
 
 | Line | Version | Tools | Status |
 |------|---------|-------|--------|
-| **2.5** (`main`) | `2.5.2` | 24 | Operator artwork tool (`operator_artwork`); MediaWiki on-demand image delivery by default; data source switched to self-hosted `arknights-data-pipeline`. |
+| **2.6** (`main`) | `2.6.0` | 24 | MCP SDK v2 with opt-in modern protocol support while retaining legacy clients; Amiya artwork forms; isolated same-host memory canary. |
 | **1.7 LTS** (`lts/1.7`) | `1.7.0` | 32 | Stable maintenance line. 1.7.x accepts only compatibility, security, data-sync, and critical bug fixes. |
 
 The `main` and `develop` lines use the self-built `arknights-data-pipeline` Release exclusively for default Auto-Sync. The 1.7 LTS line retains its legacy upstream compatibility until a separate, backwards-compatible migration; changes to the new factory path must not be backported to LTS as an implicit source switch.
 
 | Area | Python | TypeScript |
 |------|--------|------------|
-| MCP tools | Same 24 public tool names and required parameters (2.5) / 32 on 1.7 LTS | Same 24 (2.5) / 32 on 1.7 LTS |
+| MCP tools | Same 24 public tool names and required parameters (2.x) / 32 on 1.7 LTS | Same 24 (2.x) / 32 on 1.7 LTS |
 | GameData | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` | `GAMEDATA_PATH` or auto-synced `zh_CN-excel.zip` |
 | Level data | Auto-synced `zh_CN-levels.zip` beside GameData | Auto-synced `zh_CN-levels.zip` beside GameData |
 | Story data | `STORYJSON_PATH` or auto-synced `zh_CN.zip` | `STORYJSON_PATH` or auto-synced `zh_CN.zip` |
@@ -50,6 +50,10 @@ Both implementations consume the self-built [`arknights-data-pipeline`](https://
 `GITHUB_MIRRORS` is an explicit fallback for GitHub URL access. In Node deployments, standard `HTTP_PROXY`/`HTTPS_PROXY` (including lowercase spellings) are honored via Undici; Bun keeps its native `fetch` path. Proxy support does not weaken manifest or ZIP validation.
 
 See [`docs/migration-1.x-to-2.0.md`](docs/migration-1.x-to-2.0.md) for the 1.x → 2.0 breaking changes (tool consolidation, `operator_name` → `name`, output channel), and [`docs/migration-0.x-to-1.0.md`](docs/migration-0.x-to-1.0.md) for the 0.x → 1.0 transition.
+
+### MCP protocol compatibility
+
+2.6.0 retains the established initialize/session flow for legacy MCP clients and adds opt-in support for the `2026-07-28` protocol era. Modern HTTP requests use the modern envelope and are stateless; they do not send `Mcp-Session-Id`. For stdio, the first request on a connection selects the era, so open a separate connection when changing protocol modes. See [the 2.5 → 2.6 migration guide](docs/migration-2.5-to-2.6.md) before switching a client to modern mode.
 
 ### Tools
 
@@ -151,12 +155,12 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contribution workflow and [`doc
 
 | 版本线 | 版本 | 工具数 | 状态 |
 |--------|------|--------|------|
-| **2.5**（`main`） | `2.5.2` | 24 | 干员立绘工具（`operator_artwork`）；默认 MediaWiki 按需获取图片；数据源切换到自建 `arknights-data-pipeline`。 |
+| **2.6**（`main`） | `2.6.0` | 24 | MCP SDK v2，并以 opt-in 方式支持现代协议且保留 legacy 客户端；阿米娅形态立绘；隔离同机内存 canary。 |
 | **1.7 LTS**（`lts/1.7`） | `1.7.0` | 32 | 稳定维护线。1.7.x 仅接受兼容性、安全性、数据同步和关键缺陷修复。 |
 
 | 范围 | Python | TypeScript |
 |------|--------|------------|
-| MCP 工具 | 相同的 24 个工具名和必填参数（2.5）/ 1.7 LTS 为 32 个 | 相同的 24 个（2.5）/ 1.7 LTS 为 32 个 |
+| MCP 工具 | 相同的 24 个工具名和必填参数（2.x）/ 1.7 LTS 为 32 个 | 相同的 24 个（2.x）/ 1.7 LTS 为 32 个 |
 | 干员数据 | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` | `GAMEDATA_PATH` 或自动同步 `zh_CN-excel.zip` |
 | 关卡战斗数据 | 自动同步与 GameData 并列的 `zh_CN-levels.zip` | 自动同步与 GameData 并列的 `zh_CN-levels.zip` |
 | 剧情数据 | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` | `STORYJSON_PATH` 或自动同步 `zh_CN.zip` |
@@ -170,6 +174,10 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contribution workflow and [`doc
 `GITHUB_MIRRORS` 是显式的 GitHub 访问备用路径；Node 部署会通过 Undici 使用标准 `HTTP_PROXY`/`HTTPS_PROXY`（也识别小写变量），Bun 保持原生 `fetch` 路径。代理不会绕过 manifest 或 ZIP 校验。
 
 1.x → 2.0 的破坏性变更（工具面合并、`operator_name` → `name`、output channel）见 [`docs/migration-1.x-to-2.0.md`](docs/migration-1.x-to-2.0.md)；0.x → 1.0 迁移见 [`docs/migration-0.x-to-1.0.md`](docs/migration-0.x-to-1.0.md)。
+
+### MCP 协议兼容性
+
+2.6.0 保留既有 initialize/session 的 legacy MCP 客户端流程，并新增 opt-in 的 `2026-07-28` 协议时代支持。现代 HTTP 请求使用现代 envelope 且无状态，不发送 `Mcp-Session-Id`；stdio 由连接上的第一条请求选择协议时代，切换协议模式时请新建连接。把客户端切换到 modern 前，请先阅读 [2.5 → 2.6 迁移指南](docs/migration-2.5-to-2.6.md)。
 
 ### 工具集
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,16 +1,17 @@
 # PRTS-MCP Roadmap
 
-_Last updated: 2026-08-07_ · [中文版](ROADMAP.zh-CN.md)
+_Last updated: 2026-08-09_ · [中文版](ROADMAP.zh-CN.md)
 
 PRTS-MCP is past 1.0. Version 1.7.0 is the final 1.x feature release and the 1.7 LTS baseline. This document tracks **what comes next** — not what has shipped. For shipped features, see the Python and TypeScript CHANGELOGs.
 
 ## Current Release
 
-- Python: `2.5.1` _(latest stable)_
-- TypeScript: `2.5.1` _(latest stable)_
+- Python: `2.6.0` _(latest stable)_
+- TypeScript: `2.6.0` _(latest stable)_
 - `1.7.0` LTS remains the maintenance line — compatibility, security, data-sync, and critical fixes only.
 - 24 public MCP tools on the 2.x line (CI-enforced); 32 public MCP tools frozen on the 1.7 LTS line.
 - See [migration guide 0.x → 1.0](docs/migration-0.x-to-1.0.md) and [migration guide 1.x → 2.0](docs/migration-1.x-to-2.0.md).
+- 2.6.0 retains legacy MCP clients while adding opt-in `2026-07-28` support; see [2.5 → 2.6](docs/migration-2.5-to-2.6.md) before changing client protocol configuration.
 
 ## 1.x Compatibility Contract
 

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -1,16 +1,17 @@
 # PRTS-MCP 路线图
 
-_最近更新：2026-08-07_ · [English](ROADMAP.md)
+_最近更新：2026-08-09_ · [English](ROADMAP.md)
 
 PRTS-MCP 已进入 1.x 稳定期。1.7.0 是最后一个 1.x 功能版本和 1.7 LTS 基线。本文档记录**接下来要做什么**——已发布的内容请查看 Python 和 TypeScript 各自的 CHANGELOG。
 
 ## 当前发布
 
-- Python：`2.5.1` _（最新稳定版）_
-- TypeScript：`2.5.1` _（最新稳定版）_
+- Python：`2.6.0` _（最新稳定版）_
+- TypeScript：`2.6.0` _（最新稳定版）_
 - `1.7.0` LTS 仍为维护线——仅兼容性、安全性、数据同步和关键缺陷修复。
 - 2.x 线为 24 个公共 MCP 工具（CI 强制检查）；1.7 LTS 线冻结 32 个公共 MCP 工具。
 - 迁移说明：[0.x → 1.0](docs/migration-0.x-to-1.0.md)、[1.x → 2.0](docs/migration-1.x-to-2.0.md)。
+- 2.6.0 在保留 legacy MCP 客户端的同时新增 opt-in `2026-07-28` 支持；变更客户端协议配置前请阅读 [2.5 → 2.6](docs/migration-2.5-to-2.6.md)。
 
 ## 1.x 兼容合约
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,13 +6,14 @@ _Last updated: 2026-08-09_
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 2.6.0.dev0 | Development |
-| TypeScript | 2.6.0-dev.0 | Development |
+| Python | 2.6.0 | Stable release |
+| TypeScript | 2.6.0 | Stable release |
 
-- 当前稳定发布：2.5.2（24 个 MCP 工具）
+- 当前稳定发布：2.6.0（24 个 MCP 工具）
 - 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）
-- 下一开发目标：2.6.0（待规划）
-- 当前稳定补丁线：2.5.x
+- 下一开发目标：2.7.0（在 release branch 回合与开发版本重开后确定）
+- 当前稳定补丁线：2.6.x
+- 2.6.0 发布内容：MCP SDK v2 与 legacy/`2026-07-28` 双时代协议服务；`operator_artwork` 阿米娅近卫/医疗形态解析与精确 opaque token 归属；TS 聚合指标、六会话隔离内存基准及同机 canary 资产。
 - 2.5.0 发布内容：干员立绘工具 `operator_artwork`（list/get，默认 MediaWiki 在线获取 + 256 MiB LRU 缓存，`LOCAL_IMAGE=true` 时使用 AKDP 本地 PNG 资产）；数据源切换到自建 `arknights-data-pipeline` Release；TS stdio 不再泄漏 HTTP 监听器；TS JSON 空对象占位守卫。
 - 2.4.0 发布内容：常驻服务默认每小时同步 GameData excel、GameData levels 与 StoryJson；GameData 两类归档以同一代原子切换，并支持共享卷跨进程发布锁续租。
 - 2.3.1 发布内容：TypeScript 生产依赖安全更新，并同步 `prts-mcp-ts-stdio` 的 npm 锁文件 bin 元数据；不改变 MCP 工具面或传输行为。
@@ -22,6 +23,14 @@ _Last updated: 2026-08-09_
 - 2.0.2 补丁集：TS HTTP MCP smoke harness、TS Bun 候选运行路径、 `search_prts` redirect/技术页面过滤修复。Bun 在 2.0.2 仍是可选候选路径。
 - 2.0 交付内容：工具面合并（32 → 23）+ output channel（structuredContent）；**双端协议同步（Python 上 HTTP / TS 上 stdio）已后置到 2.0 之后**。
 - 兼容性合约：1.7.x LTS 线既有 32 个工具名、必填参数、默认输出格式不变；仅接受兼容性、安全性、数据同步和关键缺陷修复
+
+## 2.6.0 发布内容
+
+- [x] Python 迁移到精确锁定的 `mcp[cli]==2.0.0` 和 `MCPServer` API；SDK v2 内部 snake_case 字段保持正确的 camelCase wire 结果。
+- [x] Python 与 TypeScript 同时保留 legacy initialize/session 流程，并支持 opt-in 的 `2026-07-28` 现代协议：HTTP 现代请求无状态且无需 `Mcp-Session-Id`；stdio 由连接上的第一条请求选择协议时代。
+- [x] `operator_artwork` 仅为 `阿米娅(近卫)` / `阿米娅(医疗)` 解析各自 char ID，不改变其他工具的通用干员解析；本地与 MediaWiki opaque artwork token 都必须与请求的精确形态匹配。
+- [x] TS 的 `/debug/metrics` 仅在显式启用时提供聚合进程、缓存、请求、工具和会话指标，不保留 MCP 参数、结果或会话标识；生产反向代理不得公开该路径。
+- [x] 隔离 loopback 的六会话基准覆盖档案、数据/剧情搜索、单章/活动读取及真实立绘 get，要求缓存稳定、请求静止和 RSS 上限；同机 canary 使用独立服务、临时认证路由及 `MemoryHigh=1G` / `MemoryMax=1536M`，不触碰稳定服务。
 
 ## 2.5.2 发布内容
 
@@ -60,9 +69,9 @@ _Last updated: 2026-08-09_
 
 ## 当前分支
 
-- `main`：2.5.2（最新稳定发布线）
+- `main`：2.6.0（最新稳定发布线）
 - `lts/1.7`：1.7.x LTS 维护线（从 1.7.0 发布提交创建）
-- `develop`：2.6.0 开发线（待规划）
+- `develop`：release branch 回合后重开 2.7.0 开发线
 
 1.7.0 是最后一个 1.x 功能版本和 LTS 基线。它将 server.py/server.ts 和 story.py/story.ts 单体文件拆分为聚焦子模块，保留向后兼容垫片（shim），并新增剧情角色追踪工具：`find_character_appearances`、`find_speakers_in`。后续功能开发转向 2.0；1.7.x 仅做兼容性、安全性、数据同步和关键缺陷修复。
 
@@ -219,6 +228,7 @@ PRTS-MCP/
 
 | 版本 | 日期 | 亮点 |
 |------|------|------|
+| 2.6.0 | 2026-08-09 | MCP SDK v2 双时代协议；阿米娅形态立绘；聚合指标、六会话内存基准与同机 canary |
 | 2.5.2 | 2026-08-09 | npm 生产依赖安全更新；AKDP 直接敌人数据库；剧情标量 Decision；立绘 token 归属校验 |
 | 2.5.1 | 2026-08-07 | gamedata pair retry 修复；manifest 404 fail-open；image sha256 验证；CI Node 24 |
 | 2.5.0 | 2026-08-07 | 干员立绘工具 `operator_artwork`；数据源切换到自建 arknights-data-pipeline；TS stdio HTTP 泄漏修复 |

--- a/STATUS.md
+++ b/STATUS.md
@@ -28,8 +28,8 @@ _Last updated: 2026-08-09_
 
 - [x] Python 迁移到精确锁定的 `mcp[cli]==2.0.0` 和 `MCPServer` API；SDK v2 内部 snake_case 字段保持正确的 camelCase wire 结果。
 - [x] Python 与 TypeScript 同时保留 legacy initialize/session 流程，并支持 opt-in 的 `2026-07-28` 现代协议：HTTP 现代请求无状态且无需 `Mcp-Session-Id`；stdio 由连接上的第一条请求选择协议时代。
-- [x] `operator_artwork` 仅为 `阿米娅(近卫)` / `阿米娅(医疗)` 解析各自 char ID，不改变其他工具的通用干员解析；本地与 MediaWiki opaque artwork token 都必须与请求的精确形态匹配。
-- [x] TS 的 `/debug/metrics` 仅在显式启用时提供聚合进程、缓存、请求、工具和会话指标，不保留 MCP 参数、结果或会话标识；生产反向代理不得公开该路径。
+- [x] `operator_artwork` 仅为 `阿米娅(近卫)` / `阿米娅(医疗)` 的全角或半角括号拼写解析各自 char ID，不改变其他工具的通用干员解析；本地与 MediaWiki opaque artwork token 都必须与请求的精确形态匹配。
+- [x] `/debug/cache` 与 TS 的 `/debug/metrics` 仅在配置 `PRTS_DEBUG_TOKEN` 且 Bearer token 匹配时可用；metrics 还需显式启用，不保留 MCP 参数、结果或会话标识，生产反向代理不得公开这两个路径。
 - [x] 隔离 loopback 的六会话基准覆盖档案、数据/剧情搜索、单章/活动读取及真实立绘 get，要求缓存稳定、请求静止和 RSS 上限；同机 canary 使用独立服务、临时认证路由及 `MemoryHigh=1G` / `MemoryMax=1536M`，不触碰稳定服务。
 
 ## 2.5.2 发布内容

--- a/docs/migration-1.x-to-2.0.md
+++ b/docs/migration-1.x-to-2.0.md
@@ -9,7 +9,7 @@ PRTS-MCP 2.0 consolidates the 1.x tool surface (32 tools in 1.7.0 LTS) down to *
 - Tool surface: **32 → 23** (net reduction of 9). Eleven legacy tool names are removed/folded into three unified entry points; nothing is lost.
 - One required parameter is renamed: `operator_name` → `name` on four operator tools.
 - Output stays markdown by default. A new **connection-level** output channel can additionally emit MCP-native `structuredContent`; it is **not** a per-call `output_format` parameter and does **not** flip the default to JSON.
-- Transport roles are unchanged in 2.0: Python = stdio, TypeScript = Streamable HTTP. Cross-transport parity (Python HTTP / TS stdio) is deferred beyond 2.0.
+- At the 2.0.0 release, transport roles remained Python = stdio and TypeScript = Streamable HTTP. Cross-transport parity shipped later in 2.3.0; current protocol-era guidance is in [the 2.5 → 2.6 migration guide](migration-2.5-to-2.6.md).
 
 ## Breaking Changes
 
@@ -122,7 +122,7 @@ These are unchanged from 1.x and require no migration:
 - **Markdown content text.** The default `content` output stays markdown, and most tools preserve their 1.7.x rendering. The notable exception is `list_stories(include_summaries=true)`, which now prepends the event-level overview (see breaking change #3 above); tools reached via the new unified entry points (`search`, `prts_page`) render the same cards as their 1.x counterparts. The TS story empty-result wording was aligned to Python.
 - **Environment variable semantics.** `GAMEDATA_PATH`, `STORYJSON_PATH`, `GITHUB_TOKEN`, `GITHUB_MIRRORS`, and the auto-sync behavior are unchanged.
 - **Data sources and sync.** The three Release archives (`zh_CN-excel.zip`, `zh_CN-levels.zip`, story `zh_CN.zip`) and the PRTS Wiki API are unchanged.
-- **Transport roles.** Python remains stdio (FastMCP); TypeScript remains Streamable HTTP (Express). Docker and `npm install -g` deployment paths are unchanged.
+- **2.0 transport semantics.** The original 2.0 release did not require a transport change. Since 2.3.0 both implementations support stdio and Streamable HTTP; Docker and `npm install -g` deployment paths remain compatible.
 
 ## Upgrade Notes
 
@@ -132,8 +132,8 @@ These are unchanged from 1.x and require no migration:
 4. No environment variable changes are required. To opt into structured output, set `PRTS_OUTPUT_CHANNEL=structured` (or `both`) only if your client is confirmed to consume `structuredContent`.
 5. For Docker deployments, no volume or compose changes are needed.
 
-## Deferred Beyond 2.0
+## Later delivery
 
-- **Cross-transport parity.** Both implementations supporting both stdio and Streamable HTTP (Python gaining HTTP, TypeScript gaining stdio) was an original 2.0 boundary goal but is deferred to a later release. 2.0 ships with the same de-facto transport split as 1.x.
+- **Cross-transport parity.** Both implementations gained stdio and Streamable HTTP support in 2.3.0. This guide preserves the 2.0 breaking-change boundary; see [the 2.5 → 2.6 migration guide](migration-2.5-to-2.6.md) for the current dual-era protocol boundary.
 
 For the 0.x → 1.0 transition, see [`migration-0.x-to-1.0.md`](migration-0.x-to-1.0.md).

--- a/docs/migration-2.5-to-2.6.md
+++ b/docs/migration-2.5-to-2.6.md
@@ -18,13 +18,13 @@ The wire field names remain MCP-standard camelCase, including `structuredContent
 
 ## Artwork form handling
 
-`operator_artwork` now recognizes `阿米娅(近卫)` and `阿米娅(医疗)` as artwork-specific form aliases. This is deliberately limited to this tool: general operator lookup behaviour has not changed. An opaque `artwork_id` returned by `operator_artwork(action="list")` belongs to one exact normalized operator form. Pass it only back to `get` for that same form; the base form and sibling form are rejected before any local image read or MediaWiki request.
+`operator_artwork` now recognizes `阿米娅(近卫)` / `阿米娅(医疗)` and their full-width-parenthesis spellings as artwork-specific form aliases. This is deliberately limited to this tool: general operator lookup behaviour has not changed. An opaque `artwork_id` returned by `operator_artwork(action="list")` belongs to one exact normalized operator form. Pass it only back to `get` for that same form; the base form and sibling form are rejected before any local image read or MediaWiki request.
 
 ## Operations and observability
 
-The TypeScript server's `/debug/metrics` endpoint remains opt-in (`PRTS_METRICS_ENABLED=true`) and exposes aggregate process, cache, request, tool, and session counters only. Do not reverse-proxy it publicly. It must never expose MCP arguments, results, authorization material, session IDs, image base64, or resource bodies.
+`/debug/cache` and the TypeScript server's opt-in `/debug/metrics` endpoint require a configured `PRTS_DEBUG_TOKEN` and a matching `Authorization: Bearer` request header. The metrics endpoint additionally requires `PRTS_METRICS_ENABLED=true`. They expose aggregate process, cache, request, tool, and session counters only; do not reverse-proxy either route publicly. They must never expose MCP arguments, results, authorization material, session IDs, image base64, or resource bodies.
 
-Run the six-session memory benchmark only against an isolated loopback canary, never the stable production service. The documented canary assets set a soft cgroup pressure limit of 1 GiB and a hard limit of 1.5 GiB; a failed benchmark or consumer acceptance gate means remove the temporary route and stop the canary while leaving the stable service untouched.
+Run the six-session memory benchmark only against an isolated loopback canary, with that canary's `PRTS_DEBUG_TOKEN`, never the stable production service. The documented canary assets set a soft cgroup pressure limit of 1 GiB and a hard limit of 1.5 GiB; a failed benchmark or consumer acceptance gate means remove the temporary route and stop the canary while leaving the stable service untouched.
 
 ## Removal horizon
 

--- a/docs/migration-2.5-to-2.6.md
+++ b/docs/migration-2.5-to-2.6.md
@@ -1,0 +1,31 @@
+# Migrating from 2.5 to 2.6
+
+PRTS-MCP 2.6.0 upgrades both implementations to MCP SDK v2 and adds support for the `2026-07-28` protocol era. It does not remove the established legacy protocol path. Existing 2.5 clients can continue using their current initialize/session behaviour without configuration changes.
+
+## Choose one protocol era per connection
+
+Legacy clients continue to send `initialize`, receive and reuse `Mcp-Session-Id` on Streamable HTTP, then use the normal tools protocol. This is the compatibility path and remains supported throughout the 2.x line.
+
+Modern clients may opt into the `2026-07-28` envelope. On HTTP this path is stateless: use the modern request envelope for `server/discover`, `tools/list`, and `tools/call`; do not send `Mcp-Session-Id`, and do not rely on an initialize handshake. A request that claims the modern protocol but omits its required modern envelope is rejected instead of being silently routed as legacy.
+
+For stdio, the first request on a process connection selects the protocol era. Start a separate stdio process when switching between legacy and modern modes; do not attempt to change eras later on the same connection.
+
+## Client rollout
+
+Keep current clients on legacy first. Enable a strict-modern client only after it successfully discovers the server, lists tools, and performs an ordinary tool call against the intended endpoint. An auto-negotiating client should be verified both in its normal mode and with its modern mode forced, because protocol autodetection is a client behaviour rather than a server guarantee.
+
+The wire field names remain MCP-standard camelCase, including `structuredContent`, `isError`, and `mimeType`. The Python SDK v2 API uses snake_case while constructing these results internally; this is not a client-side schema change.
+
+## Artwork form handling
+
+`operator_artwork` now recognizes `阿米娅(近卫)` and `阿米娅(医疗)` as artwork-specific form aliases. This is deliberately limited to this tool: general operator lookup behaviour has not changed. An opaque `artwork_id` returned by `operator_artwork(action="list")` belongs to one exact normalized operator form. Pass it only back to `get` for that same form; the base form and sibling form are rejected before any local image read or MediaWiki request.
+
+## Operations and observability
+
+The TypeScript server's `/debug/metrics` endpoint remains opt-in (`PRTS_METRICS_ENABLED=true`) and exposes aggregate process, cache, request, tool, and session counters only. Do not reverse-proxy it publicly. It must never expose MCP arguments, results, authorization material, session IDs, image base64, or resource bodies.
+
+Run the six-session memory benchmark only against an isolated loopback canary, never the stable production service. The documented canary assets set a soft cgroup pressure limit of 1 GiB and a hard limit of 1.5 GiB; a failed benchmark or consumer acceptance gate means remove the temporary route and stop the canary while leaving the stable service untouched.
+
+## Removal horizon
+
+2.x retains the legacy protocol path. Any 3.x removal decision requires a documented deprecation period, telemetry that demonstrates client migration, and successful real-consumer modern acceptance. Version 2.6.0 is an additive compatibility release, not a forced protocol cutover.

--- a/ops/prts-canary/README.md
+++ b/ops/prts-canary/README.md
@@ -20,10 +20,12 @@ paths, which prevents the canary from becoming a second auto-sync publisher.
 2. Create `/opt/prts-mcp-canary` owned by `ubuntu`, install the exact
    published package there with npm, and compare the downloaded tarball's
    SHA-256 and size with the release manifest before `npm install`.
-3. Install `prts-mcp-ts-canary.service`, run `systemctl daemon-reload`, then
-   start only `prts-mcp-ts-canary.service`. Verify `/health` and
-   `/debug/metrics` directly on `127.0.0.1:5103`; never publish the metrics
-   endpoint through Nginx.
+3. Create `/etc/prts-mcp-canary/debug.env` with a unique `PRTS_DEBUG_TOKEN`,
+   readable only by the canary operator, then install
+   `prts-mcp-ts-canary.service`, run `systemctl daemon-reload`, and start only
+   `prts-mcp-ts-canary.service`. Verify `/health` and `/debug/metrics`
+   directly on `127.0.0.1:5103`, supplying `Authorization: Bearer` with that
+   token; never publish the metrics endpoint through Nginx.
 4. Temporarily include `prts-canary.nginx.conf` in the existing MCP virtual
    host, validate with root-owned `nginx -t`, and reload Nginx. The route uses
    the existing authenticated `$mcp_auth` gate at `/prts-canary/mcp`.
@@ -37,7 +39,7 @@ modify the stable service during a failed canary.
 - strict-modern QuickQuip against the temporary route;
 - Prism Vesicle in strict-modern and auto-to-modern modes;
 - a real legacy session client against the stable route;
-- `PRTS_BENCH_ISOLATED=true` loopback benchmark with 6 mixed sessions;
+- `PRTS_BENCH_ISOLATED=true PRTS_DEBUG_TOKEN=...` loopback benchmark with 6 mixed sessions;
 - cgroup `memory.current`, `memory.peak`, `memory.events`, and aggregate
   `/debug/metrics` confirm no OOM/high-limit breach and bounded short-window
   RSS growth.

--- a/ops/prts-canary/prts-mcp-ts-canary.service
+++ b/ops/prts-canary/prts-mcp-ts-canary.service
@@ -16,6 +16,7 @@ RestartSec=5s
 Environment=HOST=127.0.0.1
 Environment=PORT=5103
 Environment=PRTS_METRICS_ENABLED=true
+EnvironmentFile=/etc/prts-mcp-canary/debug.env
 
 # Reuse the active production data read-only. Explicit GAMEDATA_PATH makes
 # the canary a consumer rather than a second auto-sync publisher.

--- a/ops/prts-metrics/README.md
+++ b/ops/prts-metrics/README.md
@@ -16,4 +16,4 @@ systemctl restart prts-mcp-ts.service
 systemctl enable --now prts-metrics-sampler.timer
 ```
 
-The PRTS service must listen on loopback and no reverse-proxy route may expose `/debug/metrics`. The host needs Node.js available as `node` for schema validation (the production host's supported Node runtime satisfies this). Each successful timer run appends one schema-validated JSON object to `/var/log/prts-mcp/metrics-samples.jsonl`; a failed local probe fails the oneshot unit and writes no misleading empty sample.
+Before reloading systemd, create `/etc/prts-mcp/debug.env` with a unique `PRTS_DEBUG_TOKEN` and restrict it to the service operator. Both the server and sampler load this file; the sampler keeps the bearer token out of its process arguments. The PRTS service must listen on loopback and no reverse-proxy route may expose `/debug/metrics`. The host needs Node.js available as `node` for schema validation (the production host's supported Node runtime satisfies this). Each successful timer run appends one schema-validated JSON object to `/var/log/prts-mcp/metrics-samples.jsonl`; a failed local probe fails the oneshot unit and writes no misleading empty sample.

--- a/ops/prts-metrics/metrics.conf
+++ b/ops/prts-metrics/metrics.conf
@@ -1,2 +1,3 @@
 [Service]
 Environment=PRTS_METRICS_ENABLED=true
+EnvironmentFile=/etc/prts-mcp/debug.env

--- a/ops/prts-metrics/prts-metrics-sampler.service
+++ b/ops/prts-metrics/prts-metrics-sampler.service
@@ -7,6 +7,7 @@ Type=oneshot
 ExecStart=/opt/prts-mcp/scripts/sample-metrics.sh
 User=root
 Group=root
+EnvironmentFile=/etc/prts-mcp/debug.env
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectHome=true

--- a/ops/prts-metrics/sample-metrics.sh
+++ b/ops/prts-metrics/sample-metrics.sh
@@ -7,6 +7,11 @@ METRICS_URL="${PRTS_METRICS_URL:-http://127.0.0.1:5102/debug/metrics}"
 LOG_DIR="${PRTS_METRICS_LOG_DIR:-/var/log/prts-mcp}"
 LOG_FILE="${LOG_DIR}/metrics-samples.jsonl"
 
+if [[ -z "${PRTS_DEBUG_TOKEN:-}" ]]; then
+  echo "PRTS_DEBUG_TOKEN is required for the local metrics probe" >&2
+  exit 1
+fi
+
 control_group="$(systemctl show "${SERVICE}" --property=ControlGroup --value)"
 main_pid="$(systemctl show "${SERVICE}" --property=MainPID --value)"
 if [[ ! "${control_group}" =~ ^/ ]] || [[ "${main_pid}" -le 0 ]]; then
@@ -23,7 +28,7 @@ for required in memory.current memory.peak memory.events; do
   fi
 done
 
-metrics_json="$(curl --fail --silent --show-error --max-time 5 "${METRICS_URL}")"
+metrics_json="$(printf '%s\n' "header = \"Authorization: Bearer ${PRTS_DEBUG_TOKEN}\"" | curl --config - --fail --silent --show-error --max-time 5 "${METRICS_URL}")"
 rss_kb="$(awk '/^VmRSS:/ {print $2; found=1} END {if (!found) exit 1}' "${proc_root}/${main_pid}/status")"
 memory_current="$(<"${cgroup_root}/memory.current")"
 memory_peak="$(<"${cgroup_root}/memory.peak")"

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,35 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
-
-### Fixed
-
-- **Amiya artwork forms (#123).** `operator_artwork` now resolves
-  `阿米娅(近卫)` and `阿米娅(医疗)` to their distinct artwork char IDs without
-  changing name resolution for other tools. Opaque artwork tokens now require
-  an exact form match in both local and MediaWiki modes, so a base or sibling
-  form cannot retrieve another form's image.
-
-### Changed
-
-- **MCP SDK v2 and dual-era serving (#84).** Migrated to the exact
-  `mcp[cli]==2.0.0` dependency and `MCPServer` API. Legacy initialize/session
-  clients remain supported; a new stdio connection or HTTP request can instead
-  select the stateless `2026-07-28` envelope, including `server/discover`,
-  `tools/list`, and `tools/call` without initialize. Python result-model
-  construction now uses the SDK v2 snake_case API while preserving its
-  camelCase wire fields.
-
-## [2.6.0-alpha.1] - 2026-08-08
+## [2.6.0] - 2026-08-09
 
 ### Added
 
-- **Cache instrumentation (`/debug/cache` endpoint).** Each data module exports `cache_stats()` returning per-cache `{loaded, count}` (and `bytes` for the MediaWiki image LRU). The read-only `/debug/cache` HTTP endpoint aggregates all 9 modules' stats for observability (#104).
+- **Cache instrumentation (`/debug/cache` endpoint).** Each data module exports `cache_stats()` returning per-cache `{loaded, count}` (and `bytes` for the MediaWiki image LRU). The read-only `/debug/cache` HTTP endpoint aggregates all nine modules for observability (#104).
+
+### Fixed
+
+- **Amiya artwork forms (#123).** `operator_artwork` resolves `阿米娅(近卫)` and `阿米娅(医疗)` to their distinct artwork char IDs without changing name resolution for other tools. Opaque artwork tokens require an exact form match in both local and MediaWiki modes, so a base or sibling form cannot retrieve another form's image.
 
 ### Changed
 
 - Base illust label mapping (`BASE_ILLUST_LABELS`) consolidated to a single owner in `data/images.py`; `data/artwork_mediawiki.py` imports it instead of maintaining a duplicate (#100).
+- **MCP SDK v2 and dual-era serving (#84).** Migrated to the exact `mcp[cli]==2.0.0` dependency and `MCPServer` API. Legacy initialize/session clients remain supported; a new stdio connection or HTTP request can instead select the stateless `2026-07-28` envelope, including `server/discover`, `tools/list`, and `tools/call` without initialize. Python result-model construction uses the SDK v2 snake_case API while preserving its camelCase wire fields.
 
 ## [2.5.2] - 2026-08-09
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Fixed
 
-- **Amiya artwork forms (#123).** `operator_artwork` resolves `阿米娅(近卫)` and `阿米娅(医疗)` to their distinct artwork char IDs without changing name resolution for other tools. Opaque artwork tokens require an exact form match in both local and MediaWiki modes, so a base or sibling form cannot retrieve another form's image.
+- **Artwork form and diagnostics boundaries (#123).** `operator_artwork` resolves the half-width and full-width-parenthesis spellings of `阿米娅(近卫)` and `阿米娅(医疗)` to their distinct artwork char IDs without changing name resolution for other tools. Opaque artwork tokens require an exact form match in both local and MediaWiki modes. `/debug/cache` now requires `PRTS_DEBUG_TOKEN` Bearer authentication and otherwise returns 404.
 
 ### Changed
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.6.0.dev0"
+version = "2.6.0"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/src/prts_mcp/server.py
+++ b/python/src/prts_mcp/server.py
@@ -21,6 +21,7 @@ import logging
 import os
 import sys
 import threading
+from secrets import compare_digest
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
 from mcp.server import MCPServer
@@ -94,7 +95,7 @@ def _build_http_app():
     because it resolves the channel at session-creation time and injects
     it into ``createMcpServer(channel)``.
     """
-    from starlette.responses import JSONResponse
+    from starlette.responses import JSONResponse, Response
     from starlette.routing import Route
 
     app = mcp.streamable_http_app()
@@ -102,7 +103,15 @@ def _build_http_app():
     async def health(_request):
         return JSONResponse({"status": "ok"})
 
-    async def debug_cache(_request):
+    def debug_authorized(request) -> bool:
+        token = os.environ.get("PRTS_DEBUG_TOKEN")
+        authorization = request.headers.get("authorization")
+        expected = f"Bearer {token}" if token else None
+        return bool(expected and authorization and compare_digest(authorization, expected))
+
+    async def debug_cache(request):
+        if not debug_authorized(request):
+            return Response(status_code=404)
         from prts_mcp.data.artwork_mediawiki import cache_stats as _am
         from prts_mcp.data.enemy import cache_stats as _enemy
         from prts_mcp.data.images import cache_stats as _images

--- a/python/src/prts_mcp/tools_artwork.py
+++ b/python/src/prts_mcp/tools_artwork.py
@@ -46,9 +46,15 @@ _ARTWORK_FORM_CHAR_IDS: Mapping[str, str] = {
 }
 
 
+def _normalized_artwork_form_name(operator_name: str) -> str:
+    """Normalize only the punctuation accepted by artwork form aliases."""
+    return operator_name.strip().replace("（", "(").replace("）", ")")
+
+
 def _resolve_artwork_char_id(operator_name: str) -> str | None:
     """Resolve an artwork-only form alias without widening normal lookup."""
-    return _ARTWORK_FORM_CHAR_IDS.get(operator_name) or resolve_char_id(operator_name)
+    normalized = _normalized_artwork_form_name(operator_name)
+    return _ARTWORK_FORM_CHAR_IDS.get(normalized) or resolve_char_id(operator_name)
 
 
 def _images_generation() -> Path | None:
@@ -88,10 +94,11 @@ def _data_not_ready() -> object:
 
 async def _do_list_mediawiki(operator_name: str) -> object:
     """LOCAL_IMAGE=false list: discover PRTS File: titles + CharinfoV2 labels."""
-    prefix = f"立绘_{operator_name}_"
+    normalized_name = _normalized_artwork_form_name(operator_name)
+    prefix = f"立绘_{normalized_name}_"
     try:
         files = await _list_allimages(prefix)
-        templates = await _get_template_data(operator_name)
+        templates = await _get_template_data(normalized_name)
     except Exception as exc:  # noqa: BLE001
         return text_result(f"查询 PRTS 立绘失败：{exc}")
     charinfo = templates.get("CharinfoV2")

--- a/python/tests/test_e2e_http.py
+++ b/python/tests/test_e2e_http.py
@@ -29,6 +29,7 @@ import pytest
 
 GAMEDATA_PATH = Path(__file__).resolve().parents[2] / "data" / "gamedata"
 GAMEDATA_PATH = GAMEDATA_PATH.resolve()
+_DEBUG_HEADERS = {"Authorization": "Bearer test-debug-token"}
 
 
 def _free_port() -> int:
@@ -157,6 +158,7 @@ def _start_server(extra_env: dict | None = None) -> dict:
     env["HOST"] = "127.0.0.1"
     env["GAMEDATA_PATH"] = str(GAMEDATA_PATH)
     env["GITHUB_MIRRORS"] = ""
+    env["PRTS_DEBUG_TOKEN"] = "test-debug-token"
     env.setdefault("STORYJSON_PATH", str(GAMEDATA_PATH / "does-not-exist.zip"))
     if extra_env:
         env.update(extra_env)
@@ -200,7 +202,9 @@ def test_health(server):
 
 
 def test_debug_cache(server):
-    r = httpx.get(f"{server['origin']}/debug/cache", timeout=5.0)
+    unauthenticated = httpx.get(f"{server['origin']}/debug/cache", timeout=5.0)
+    assert unauthenticated.status_code == 404
+    r = httpx.get(f"{server['origin']}/debug/cache", headers=_DEBUG_HEADERS, timeout=5.0)
     assert r.status_code == 200
     data = r.json()
     expected_modules = {

--- a/python/tests/test_images.py
+++ b/python/tests/test_images.py
@@ -214,6 +214,8 @@ def test_list_unknown_operator(mock_images):
     [
         ("阿米娅(近卫)", "char_1001_amiya2"),
         ("阿米娅(医疗)", "char_1037_amiya3"),
+        ("阿米娅（近卫）", "char_1001_amiya2"),
+        ("阿米娅（医疗）", "char_1037_amiya3"),
     ],
 )
 def test_list_resolves_amiya_artwork_form_aliases(

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "prts-mcp"
-version = "2.6.0.dev0"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - `Readable.fromWeb` cast is narrowed from bare `any` to the exact parameter type via `Parameters<typeof Readable.fromWeb>[0]` (#100).
-- **Amiya artwork forms (#123).** `operator_artwork` resolves `阿米娅(近卫)` and `阿米娅(医疗)` to their distinct artwork char IDs without changing name resolution for other tools. Opaque artwork tokens require an exact form match in both local and MediaWiki modes, so a base or sibling form cannot retrieve another form's image.
+- **Artwork form and diagnostics boundaries (#123).** `operator_artwork` resolves the half-width and full-width-parenthesis spellings of `阿米娅(近卫)` and `阿米娅(医疗)` to their distinct artwork char IDs without changing name resolution for other tools. Opaque artwork tokens require an exact form match in both local and MediaWiki modes. `/debug/cache` and `/debug/metrics` now require `PRTS_DEBUG_TOKEN` Bearer authentication and otherwise return 404.
 
 ## [2.5.2] - 2026-08-09
 

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,51 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.6.0] - 2026-08-09
 
 ### Added
 
-- **Six-session memory canary gate (#90).** The isolated loopback benchmark
-  now exercises archives, data search, story search, chapter/activity reads,
-  and an actual artwork image retrieval across six concurrent sessions. It
-  requires cache stability plus a quiescent request state and bounded RSS.
-  Version-controlled same-host canary assets add a separate loopback service,
-  authenticated temporary route, and cgroup limits of `MemoryHigh=1G` /
-  `MemoryMax=1536M` without modifying the stable service.
-
-### Fixed
-
-- **Amiya artwork forms (#123).** `operator_artwork` now resolves
-  `阿米娅(近卫)` and `阿米娅(医疗)` to their distinct artwork char IDs without
-  changing name resolution for other tools. Opaque artwork tokens now require
-  an exact form match in both local and MediaWiki modes, so a base or sibling
-  form cannot retrieve another form's image.
-
-## [2.6.0-alpha.2] - 2026-08-08
-
-### Added
-
-- **Aggregate runtime metrics for Issue #90.** The TypeScript Streamable HTTP server now provides an opt-in `/debug/metrics` endpoint with process memory high-water, request/tool duration and error totals, session age/idle-timeout/lifecycle totals, and nine-domain cache hit/miss/invalidation counters. Metrics are aggregate-only and retain neither MCP arguments/results nor session identifiers.
+- **Cache instrumentation (`/debug/cache` endpoint).** Each data module exports `getCacheStats()` returning per-cache `{loaded, count}` (and `bytes` for the image LRU). The read-only endpoint aggregates all nine modules (#104).
+- **Aggregate runtime metrics for Issue #90.** The TypeScript Streamable HTTP server provides an opt-in `/debug/metrics` endpoint with process memory high-water, request/tool duration and error totals, session age/idle-timeout/lifecycle totals, and nine-domain cache hit/miss/invalidation counters. Metrics are aggregate-only and retain neither MCP arguments/results nor session identifiers.
 - **Production cgroup sampler.** Added a systemd timer template that resolves the PRTS service cgroup dynamically and appends validated five-minute memory and runtime-metrics samples to JSONL, with log rotation and no public reverse-proxy route.
-- **Isolated memory benchmark.** Added a loopback-only repeat/concurrency probe that fails when an unchanged workload produces new cache misses, providing a reproducible input for Issue #90's bounded-growth decision.
+- **Six-session memory canary gate (#90).** The isolated loopback benchmark exercises archives, data search, story search, chapter/activity reads, and an actual artwork image retrieval across six concurrent sessions. It requires cache stability plus a quiescent request state and bounded RSS. Version-controlled same-host canary assets add a separate loopback service, authenticated temporary route, and cgroup limits of `MemoryHigh=1G` / `MemoryMax=1536M` without modifying the stable service.
 
 ### Changed
 
 - Cache debug projections now include process-lifetime `hits`, `misses`, and `clears` fields while preserving the existing nine-domain shape.
-
-## [2.6.0-alpha.1] - 2026-08-08
-
-### Added
-
-- **Cache instrumentation (`/debug/cache` endpoint).** Each data module exports `getCacheStats()` returning per-cache `{loaded, count}` (and `bytes` for the image LRU). The read-only `/debug/cache` HTTP endpoint aggregates all 9 modules' stats for observability (#104).
+- **MCP SDK v2 and dual-era serving (#84).** Migrated to SDK v2. Legacy initialize/session clients remain supported; HTTP clients can opt into the stateless `2026-07-28` envelope for `server/discover`, `tools/list`, and `tools/call` without initialize or `Mcp-Session-Id`.
+- Base illust label mapping (`BASE_ILLUST_LABELS`) is consolidated to a single owner in `data/images.ts`; `data/artworkMediawiki.ts` imports it instead of maintaining a duplicate (#100).
 
 ### Fixed
 
-- `Readable.fromWeb` cast in `imagesSync.ts` narrowed from bare `any` to the exact parameter type via `Parameters<typeof Readable.fromWeb>[0]` (#100).
-
-### Changed
-
-- Base illust label mapping (`BASE_ILLUST_LABELS`) consolidated to a single owner in `data/images.ts`; `data/artworkMediawiki.ts` imports it instead of maintaining a duplicate (#100).
+- `Readable.fromWeb` cast is narrowed from bare `any` to the exact parameter type via `Parameters<typeof Readable.fromWeb>[0]` (#100).
+- **Amiya artwork forms (#123).** `operator_artwork` resolves `阿米娅(近卫)` and `阿米娅(医疗)` to their distinct artwork char IDs without changing name resolution for other tools. Opaque artwork tokens require an exact form match in both local and MediaWiki modes, so a base or sibling form cannot retrieve another form's image.
 
 ## [2.5.2] - 2026-08-09
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -162,9 +162,10 @@ docker run -d -p 3000:3000 -v prts-mcp-ts-data:/data/gamedata -v prts-mcp-ts-lev
 | `PRTS_AUTO_SYNC_INTERVAL_SECONDS` | `3600` | GitHub Release 周期检查间隔（秒）；有效范围 `60..604800`，`0` 表示只执行启动同步；非法值回落到默认值 |
 | `PRTS_OUTPUT_CHANNEL` | `content` | 2.0 输出通道：`content`（默认，仅 markdown，与 1.x 一致）/ `structured`（仅 structuredContent）/ `both`。也可经查询字符串 `?output_channel=` 或请求头 `x-prts-output-channel` 按请求覆盖。仅在客户端确认支持 `structuredContent` 时才用非默认值 |
 | `SESSION_IDLE_TIMEOUT_MS` | `86400000` | Streamable HTTP 会话空闲超时（毫秒）。设为非正数时禁用超时；会话活跃时间、有效值与淘汰计数可由已启用的 `/debug/metrics` 读取。`closed_total` 包含被空闲淘汰而关闭的会话，`evicted_total` 是其中的原因子集。 |
-| `PRTS_METRICS_ENABLED` | `false` | 设为严格的 `true` 才提供 `/debug/metrics`；响应只含进程、缓存、请求、工具和会话的聚合指标，不含 MCP 参数、结果或会话 ID。工具维度只接受内置工具名，避免把调用方输入变成指标标签。生产环境应保持服务仅监听 loopback，且不得为该路径配置公网反向代理。 |
+| `PRTS_METRICS_ENABLED` | `false` | 设为严格的 `true` 才启用 `/debug/metrics`；仍需有效的 `PRTS_DEBUG_TOKEN` Bearer 请求头。响应只含进程、缓存、请求、工具和会话的聚合指标，不含 MCP 参数、结果或会话 ID。工具维度只接受内置工具名，避免把调用方输入变成指标标签。 |
+| `PRTS_DEBUG_TOKEN` | 未设置 | `/debug/cache` 和 `/debug/metrics` 的必需 Bearer token；未设置或不匹配时返回 404。不要公开反向代理这两个路径，也不要把 token 写入日志、请求正文或客户端配置。 |
 
-需要验证重复负载与并发会话时，只能在隔离的本机实例上执行 `PRTS_BENCH_ISOLATED=true PRTS_BENCH_ORIGIN=http://127.0.0.1:<port> npm run bench:memory`。脚本要求指标端点和可读剧情/本地图片数据均已启用：它会先发现一个活动、章节和阿米娅立绘，然后以 **6 个并发会话** 执行档案、基础资料、数据搜索、剧情搜索、单章、活动分页和实际图片 get。除重复负载不能新增 cache miss 外，它还要求并发后至少 7 个会话仍在、请求已静止、RSS 不超过 1 GiB、相对冷缓存增长不超过 256 MiB（可用 `PRTS_BENCH_MAX_RSS_BYTES` / `PRTS_BENCH_MAX_RSS_GROWTH_BYTES` 调整）。它拒绝非 loopback 目标，不得在生产正式服务执行。
+需要验证重复负载与并发会话时，只能在隔离的本机实例上执行 `PRTS_BENCH_ISOLATED=true PRTS_BENCH_ORIGIN=http://127.0.0.1:<port> PRTS_DEBUG_TOKEN=... npm run bench:memory`。脚本要求指标端点、有效诊断 token 和可读剧情/本地图片数据均已启用：它会先发现一个活动、章节和阿米娅立绘，然后以 **6 个并发会话** 执行档案、基础资料、数据搜索、剧情搜索、单章、活动分页和实际图片 get。除重复负载不能新增 cache miss 外，它还要求并发后至少 7 个会话仍在、请求已静止、RSS 不超过 1 GiB、相对冷缓存增长不超过 256 MiB（可用 `PRTS_BENCH_MAX_RSS_BYTES` / `PRTS_BENCH_MAX_RSS_GROWTH_BYTES` 调整）。它拒绝非 loopback 目标，不得在生产正式服务执行。
 
 ---
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.6.0-dev.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.6.0-dev.0",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "2.0.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.6.0-dev.0",
+  "version": "2.6.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP + stdio)",
   "type": "module",
   "main": "dist/server.js",

--- a/ts/scripts/bench-memory.mjs
+++ b/ts/scripts/bench-memory.mjs
@@ -9,6 +9,7 @@
  */
 
 const origin = requireIsolatedOrigin();
+const debugToken = requireDebugToken();
 const CONCURRENT_SESSIONS = 6;
 const MAX_RSS_BYTES = positiveEnv("PRTS_BENCH_MAX_RSS_BYTES", 1024 * 1024 * 1024);
 const MAX_RSS_GROWTH_BYTES = positiveEnv(
@@ -37,6 +38,12 @@ function requireIsolatedOrigin() {
     throw new Error("PRTS_BENCH_ORIGIN must use a loopback host; do not run this benchmark against production");
   }
   return parsed.origin;
+}
+
+function requireDebugToken() {
+  const token = process.env.PRTS_DEBUG_TOKEN;
+  if (!token) throw new Error("PRTS_DEBUG_TOKEN is required for the isolated benchmark");
+  return token;
 }
 
 async function readJson(res, label) {
@@ -186,7 +193,9 @@ function compactSnapshot(snapshot) {
 }
 
 async function snapshot(label) {
-  const res = await fetch(`${origin}/debug/metrics`);
+  const res = await fetch(`${origin}/debug/metrics`, {
+    headers: { Authorization: `Bearer ${debugToken}` },
+  });
   const data = await readJson(res, `${label} metrics`);
   if (data.schema_version !== "prts-mcp.metrics/v1") {
     throw new Error(`${label} metrics endpoint is unavailable or has unexpected schema`);

--- a/ts/src/server.ts
+++ b/ts/src/server.ts
@@ -10,7 +10,7 @@
  * as a background task before the server starts listening.
  */
 
-import { randomUUID } from "node:crypto";
+import { randomUUID, timingSafeEqual } from "node:crypto";
 import express from "express";
 import { createMcpHandler, isLegacyRequest } from "@modelcontextprotocol/server";
 import { NodeStreamableHTTPServerTransport, toNodeHandler, toWebRequest } from "@modelcontextprotocol/node";
@@ -58,7 +58,19 @@ app.use(express.json());
 
 const transports = new Map<string, NodeStreamableHTTPServerTransport>();
 const METRICS_ENABLED = process.env["PRTS_METRICS_ENABLED"] === "true";
+const DEBUG_TOKEN = process.env["PRTS_DEBUG_TOKEN"];
 const runtimeMetrics = METRICS_ENABLED ? new RuntimeMetrics() : null;
+
+function debugAuthorized(req: express.Request): boolean {
+  if (!DEBUG_TOKEN) return false;
+  const authorization = req.get("authorization");
+  const expected = `Bearer ${DEBUG_TOKEN}`;
+  if (authorization === undefined) return false;
+  const actualBytes = Buffer.from(authorization);
+  const expectedBytes = Buffer.from(expected);
+  if (actualBytes.byteLength !== expectedBytes.byteLength) return false;
+  return timingSafeEqual(actualBytes, expectedBytes);
+}
 const modernHandler = createMcpHandler(
   ({ requestInfo }) => createMcpServer(resolveModernOutputChannel(requestInfo)),
   { legacy: "reject", onerror: (error) => log("ERROR", `Modern MCP request failed: ${error.message}`) },
@@ -220,12 +232,16 @@ app.get("/health", (_req, res) => {
   res.json({ status: "ok" });
 });
 
-app.get("/debug/cache", (_req, res) => {
+app.get("/debug/cache", (req, res) => {
+  if (!debugAuthorized(req)) {
+    res.sendStatus(404);
+    return;
+  }
   res.json(getCacheStats());
 });
 
-app.get("/debug/metrics", (_req, res) => {
-  if (runtimeMetrics === null) {
+app.get("/debug/metrics", (req, res) => {
+  if (runtimeMetrics === null || !debugAuthorized(req)) {
     res.sendStatus(404);
     return;
   }

--- a/ts/src/tools/artworkTools.ts
+++ b/ts/src/tools/artworkTools.ts
@@ -48,8 +48,12 @@ const ARTWORK_FORM_CHAR_IDS: Readonly<Record<string, string>> = {
   "阿米娅(医疗)": "char_1037_amiya3",
 };
 
+function normalizedArtworkFormName(operatorName: string): string {
+  return operatorName.trim().replaceAll("（", "(").replaceAll("）", ")");
+}
+
 function resolveArtworkCharId(operatorName: string): string | null {
-  return ARTWORK_FORM_CHAR_IDS[operatorName] ?? resolveCharId(operatorName);
+  return ARTWORK_FORM_CHAR_IDS[normalizedArtworkFormName(operatorName)] ?? resolveCharId(operatorName);
 }
 
 // ---------------------------------------------------------------------------
@@ -83,12 +87,13 @@ async function doListMediawiki(
   operatorName: string,
   channel: OutputChannel,
 ): Promise<CallToolResult> {
-  const prefix = `立绘_${operatorName}_`;
+  const normalizedName = normalizedArtworkFormName(operatorName);
+  const prefix = `立绘_${normalizedName}_`;
   let files: { name: string; size: number; mime: string }[];
   let templates: Record<string, Record<string, unknown>>;
   try {
     files = await listAllimages(prefix);
-    templates = await getTemplateData(operatorName);
+    templates = await getTemplateData(normalizedName);
   } catch (err) {
     return textResult(`查询 PRTS 立绘失败：${err instanceof Error ? err.message : String(err)}`);
   }

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -85,6 +85,8 @@ async function mcpPost(
 }
 
 const MODERN_VERSION = "2026-07-28";
+const DEBUG_TOKEN = "e2e-debug-token";
+const DEBUG_HEADERS = { Authorization: `Bearer ${DEBUG_TOKEN}` };
 
 function modernBody(method: string, params: Record<string, unknown>, id: number): Record<string, unknown> {
   return {
@@ -172,6 +174,7 @@ test("E2E", async (t) => {
         IMAGES_ENABLED: "true",
         SESSION_IDLE_TIMEOUT_MS: "30000",
         PRTS_METRICS_ENABLED: "true",
+        PRTS_DEBUG_TOKEN: DEBUG_TOKEN,
       },
       stdio: ["ignore", "pipe", "pipe"],
     },
@@ -187,7 +190,9 @@ test("E2E", async (t) => {
 
   // --- /debug/cache ---
   await t.test("debug cache returns expected modules", async () => {
-    const res = await fetch(`${origin}/debug/cache`);
+    const unauthenticated = await fetch(`${origin}/debug/cache`);
+    assert.equal(unauthenticated.status, 404);
+    const res = await fetch(`${origin}/debug/cache`, { headers: DEBUG_HEADERS });
     assert.equal(res.status, 200);
     const data = await res.json() as Record<string, Record<string, { loaded: boolean; count: number; hits: number; misses: number; clears: number; bytes?: number }>>;
     const expectedModules = new Set([
@@ -361,7 +366,9 @@ test("E2E", async (t) => {
   });
 
   await t.test("debug metrics exposes aggregate runtime state only", async () => {
-    const res = await fetch(`${origin}/debug/metrics`);
+    const unauthenticated = await fetch(`${origin}/debug/metrics`);
+    assert.equal(unauthenticated.status, 404);
+    const res = await fetch(`${origin}/debug/metrics`, { headers: DEBUG_HEADERS });
     assert.equal(res.status, 200);
     const data = await res.json() as Record<string, unknown>;
     assert.equal(data.schema_version, "prts-mcp.metrics/v1");

--- a/ts/tests/images.test.ts
+++ b/ts/tests/images.test.ts
@@ -234,6 +234,8 @@ test("operator_artwork resolves Amiya form aliases and rejects cross-form tokens
     for (const [operatorName, expectedId] of [
       ["阿米娅(近卫)", "char_1001_amiya2#1"],
       ["阿米娅(医疗)", "char_1037_amiya3#1"],
+      ["阿米娅（近卫）", "char_1001_amiya2#1"],
+      ["阿米娅（医疗）", "char_1037_amiya3#1"],
     ]) {
       const result = await server.handler({
         operator_name: operatorName,

--- a/ts/tests/sessionIdleTimeout.test.ts
+++ b/ts/tests/sessionIdleTimeout.test.ts
@@ -42,6 +42,8 @@ function collectStderr(child: ChildProcess): string[] {
 }
 
 test("idle sessions are evicted after timeout", async () => {
+  const debugToken = "session-idle-debug-token";
+  const debugHeaders = { Authorization: `Bearer ${debugToken}` };
   const port = await getFreePort();
   const dataHome = mkdtempSync(join(tmpdir(), "prts-session-idle-"));
   const localAppData = join(dataHome, "LocalAppData");
@@ -62,6 +64,7 @@ test("idle sessions are evicted after timeout", async () => {
         STORYJSON_PATH: join(dataHome, "storyjson", "missing.zip"),
         SESSION_IDLE_TIMEOUT_MS: "2000",
         PRTS_METRICS_ENABLED: "true",
+        PRTS_DEBUG_TOKEN: debugToken,
       },
       stdio: ["ignore", "ignore", "pipe"],
     },
@@ -72,7 +75,7 @@ test("idle sessions are evicted after timeout", async () => {
   try {
     const origin = "http://127.0.0.1:" + port;
     await waitForHealth(origin, 5000);
-    const metricsEnabled = await fetch(origin + "/debug/metrics");
+    const metricsEnabled = await fetch(origin + "/debug/metrics", { headers: debugHeaders });
     assert.equal(metricsEnabled.status, 200, "metrics should be available when explicitly enabled");
 
     const initRes = await fetch(origin + "/mcp", {
@@ -92,7 +95,7 @@ test("idle sessions are evicted after timeout", async () => {
     // Wait for idle eviction (timeout is 2s, wait 4s)
     await new Promise((r) => setTimeout(r, 4000));
 
-    const metricsRes = await fetch(origin + "/debug/metrics");
+    const metricsRes = await fetch(origin + "/debug/metrics", { headers: debugHeaders });
     assert.equal(metricsRes.status, 200);
     const metricsText = await metricsRes.text();
     const metrics = JSON.parse(metricsText) as { sessions: Record<string, unknown> };


### PR DESCRIPTION
GitFlow back-merge for the released 2.6.0 line.

- Main release: #134 / `b402e00`
- Published: PyPI `prts-mcp==2.6.0`, npm `prts-mcp-ts@2.6.0`
- Production canary and stable cutover passed legacy, modern, consumer, memory, and Nginx acceptance.

This PR deliberately preserves the release branch history; no squash.