### PR TITLE
fix(story): clarify out-of-range activity pages

### DIFF
--- a/python/src/prts_mcp/data/story_reader.py
+++ b/python/src/prts_mcp/data/story_reader.py
@@ -113,6 +113,7 @@ class ActivityResult:
     event_name: str
     total_chapters: int
     has_more: bool
+    page_out_of_range: bool
     chapters: list[StoryChapter]
 
 
@@ -508,9 +509,11 @@ def read_activity_from_store(
         end = start + page_size
         selected = summaries[start:end]
         has_more = end < total
+        page_out_of_range = total > 0 and start >= total
     else:
         selected = summaries
         has_more = False
+        page_out_of_range = False
 
     chapters = []
     event_name = ""
@@ -529,5 +532,6 @@ def read_activity_from_store(
         event_name=event_name,
         total_chapters=total,
         has_more=has_more,
+        page_out_of_range=page_out_of_range,
         chapters=chapters,
     )

--- a/python/src/prts_mcp/data/story_reader.py
+++ b/python/src/prts_mcp/data/story_reader.py
@@ -113,8 +113,8 @@ class ActivityResult:
     event_name: str
     total_chapters: int
     has_more: bool
-    page_out_of_range: bool
     chapters: list[StoryChapter]
+    page_out_of_range: bool = False
 
 
 @dataclass(frozen=True)
@@ -501,6 +501,9 @@ def read_activity_from_store(
     """Read all chapters of an activity in official story order using a JSON store."""
     summaries = list_stories_from_store(store, event_id)
     total = len(summaries)
+
+    if not 1 <= page_size <= 20:
+        raise ValueError("page_size 参数必须在 1 到 20 之间")
 
     if page is not None:
         if page < 1:

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -147,7 +147,7 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         event_id: Annotated[str, Field(description="活动 ID，如 \"act31side\"（可从 list_story_events 获取）。")],
         include_narration: Annotated[bool, Field(default=True, description="是否包含旁白，默认 True。")] = True,
         page: Annotated[int | None, Field(default=None, description="分页页码（从 1 开始）。不填则返回全部章节。")] = None,
-        page_size: Annotated[int, Field(default=5, description="每页章节数，默认 5。")] = 5,
+        page_size: Annotated[int, Field(default=5, ge=1, le=20, description="每页章节数，默认 5。")] = 5,
     ) -> object:
         """读取整个活动的完整剧情台词（按官方章节顺序合并）。
 

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -146,7 +146,10 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     def read_activity(
         event_id: Annotated[str, Field(description="活动 ID，如 \"act31side\"（可从 list_story_events 获取）。")],
         include_narration: Annotated[bool, Field(default=True, description="是否包含旁白，默认 True。")] = True,
-        page: Annotated[int | None, Field(default=None, description="分页页码（从 1 开始）。不填则返回全部章节。")] = None,
+        page: Annotated[
+            int | None,
+            Field(default=None, ge=1, description="分页页码（从 1 开始）。不填则返回全部章节。"),
+        ] = None,
         page_size: Annotated[int, Field(default=5, ge=1, le=20, description="每页章节数，默认 5。")] = 5,
     ) -> object:
         """读取整个活动的完整剧情台词（按官方章节顺序合并）。

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -177,6 +177,13 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         total = result.total_chapters
         has_more = result.has_more
 
+        if result.page_out_of_range:
+            total_pages = (total + page_size - 1) // page_size
+            return text_result(
+                f"页码超出范围：{event_id} 共 {total} 章，按 page_size={page_size} "
+                f"分页共 {total_pages} 页，请求的 page={page} 不存在。"
+            )
+
         header = f"【{result.event_name}】共 {total} 章"
         if page is not None:
             header += f"，当前第 {page} 页（{len(chapters)} 章）"

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -519,7 +519,7 @@ def test_read_activity_out_of_range_page_is_content_only(
     result = asyncio.run(
         app._tool_manager.call_tool(
             "read_activity",
-            {"event_id": "act_test", "page": 99, "page_size": 1},
+            {"event_id": "act_test", "page": 3, "page_size": 1},
             Context(mcp_server=app),
             convert_result=True,
         )
@@ -527,5 +527,5 @@ def test_read_activity_out_of_range_page_is_content_only(
 
     assert result.structured_content is None
     assert result.content[0].text == (
-        "页码超出范围：act_test 共 2 章，按 page_size=1 分页共 2 页，请求的 page=99 不存在。"
+        "页码超出范围：act_test 共 2 章，按 page_size=1 分页共 2 页，请求的 page=3 不存在。"
     )

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -529,3 +529,14 @@ def test_read_activity_out_of_range_page_is_content_only(
     assert result.content[0].text == (
         "页码超出范围：act_test 共 2 章，按 page_size=1 分页共 2 页，请求的 page=3 不存在。"
     )
+
+
+def test_read_activity_page_schema_requires_positive_integer() -> None:
+    app = MCPServer("story-test")
+    register_story_tools(app)
+
+    tools = asyncio.run(app.list_tools())
+    read_activity = next(tool for tool in tools if tool.name == "read_activity")
+    page_schema = read_activity.input_schema["properties"]["page"]
+
+    assert page_schema["anyOf"][0]["minimum"] == 1

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -506,3 +506,26 @@ def test_list_story_events_missing_zip_is_content_only(
         "剧情数据未就绪。请设置 STORYJSON_PATH 环境变量指向 zh_CN.zip，"
         "或等待服务器自动从 GitHub Release 下载完成后重试。"
     )
+
+
+def test_read_activity_out_of_range_page_is_content_only(
+    monkeypatch: pytest.MonkeyPatch,
+    story_zip: Path,
+) -> None:
+    monkeypatch.setenv("STORYJSON_PATH", str(story_zip))
+    app = MCPServer("story-test")
+    register_story_tools(app)
+
+    result = asyncio.run(
+        app._tool_manager.call_tool(
+            "read_activity",
+            {"event_id": "act_test", "page": 99, "page_size": 1},
+            Context(mcp_server=app),
+            convert_result=True,
+        )
+    )
+
+    assert result.structured_content is None
+    assert result.content[0].text == (
+        "页码超出范围：act_test 共 2 章，按 page_size=1 分页共 2 页，请求的 page=99 不存在。"
+    )

--- a/python/tests/test_story_reader_store.py
+++ b/python/tests/test_story_reader_store.py
@@ -143,10 +143,24 @@ def test_story_tools_read_from_store(tmp_path, store_kind):
     assert activity.page_out_of_range is False
     assert [chapter.story_key for chapter in activity.chapters] == [FIRST_STORY_KEY]
 
-    out_of_range = read_activity_from_store(store, "act_test", page=99, page_size=1)
+    out_of_range = read_activity_from_store(store, "act_test", page=3, page_size=1)
     assert out_of_range.total_chapters == 2
     assert out_of_range.chapters == []
     assert out_of_range.page_out_of_range is True
+
+    with pytest.raises(ValueError, match="page_size 参数必须在 1 到 20 之间"):
+        read_activity_from_store(store, "act_test", page=1, page_size=0)
+
+
+def test_unreadable_chapter_is_not_page_out_of_range(tmp_path: Path) -> None:
+    write_story_dir(tmp_path)
+    (tmp_path / story_path(FIRST_STORY_KEY)).unlink()
+
+    result = read_activity_from_store(DirectoryStore(tmp_path), "act_test", page=1, page_size=1)
+
+    assert result.total_chapters == 2
+    assert result.chapters == []
+    assert result.page_out_of_range is False
 
 
 def test_public_zip_path_api_still_reads_zip(tmp_path):

--- a/python/tests/test_story_reader_store.py
+++ b/python/tests/test_story_reader_store.py
@@ -140,7 +140,13 @@ def test_story_tools_read_from_store(tmp_path, store_kind):
     assert activity.event_name == "测试活动"
     assert activity.total_chapters == 2
     assert activity.has_more is True
+    assert activity.page_out_of_range is False
     assert [chapter.story_key for chapter in activity.chapters] == [FIRST_STORY_KEY]
+
+    out_of_range = read_activity_from_store(store, "act_test", page=99, page_size=1)
+    assert out_of_range.total_chapters == 2
+    assert out_of_range.chapters == []
+    assert out_of_range.page_out_of_range is True
 
 
 def test_public_zip_path_api_still_reads_zip(tmp_path):

--- a/ts/src/data/storyReader.ts
+++ b/ts/src/data/storyReader.ts
@@ -120,6 +120,7 @@ export interface ActivityResult {
   eventName: string;
   totalChapters: number;
   hasMore: boolean;
+  pageOutOfRange: boolean;
   chapters: StoryChapter[];
 }
 
@@ -524,15 +525,18 @@ export function readActivityFromStore(
 
   let selected: ChapterSummary[];
   let hasMore: boolean;
+  let pageOutOfRange: boolean;
   if (page !== undefined) {
     if (page < 1) throw new Error("page 参数必须 >= 1");
     const start = (page - 1) * pageSize;
     const end = start + pageSize;
     selected = summaries.slice(start, end);
     hasMore = end < total;
+    pageOutOfRange = total > 0 && start >= total;
   } else {
     selected = summaries;
     hasMore = false;
+    pageOutOfRange = false;
   }
 
   const chapters: StoryChapter[] = [];
@@ -549,5 +553,5 @@ export function readActivityFromStore(
     }
   }
 
-  return { eventId, eventName, totalChapters: total, hasMore, chapters };
+  return { eventId, eventName, totalChapters: total, hasMore, pageOutOfRange, chapters };
 }

--- a/ts/src/data/storyReader.ts
+++ b/ts/src/data/storyReader.ts
@@ -120,8 +120,8 @@ export interface ActivityResult {
   eventName: string;
   totalChapters: number;
   hasMore: boolean;
-  pageOutOfRange: boolean;
   chapters: StoryChapter[];
+  pageOutOfRange?: boolean;
 }
 
 export interface MemoirChapter {
@@ -522,6 +522,10 @@ export function readActivityFromStore(
 ): ActivityResult {
   const summaries = listStoriesFromStore(store, eventId);
   const total = summaries.length;
+
+  if (pageSize < 1 || pageSize > 20) {
+    throw new Error("page_size 参数必须在 1 到 20 之间");
+  }
 
   let selected: ChapterSummary[];
   let hasMore: boolean;

--- a/ts/src/tools/storyTools.ts
+++ b/ts/src/tools/storyTools.ts
@@ -213,6 +213,13 @@ export function registerStoryTools(server: McpServer, channel: OutputChannel = "
           page,
           page_size
         );
+        if (result.pageOutOfRange) {
+          const totalPages = Math.ceil(result.totalChapters / page_size);
+          return textResult(
+            `页码超出范围：${event_id} 共 ${result.totalChapters} 章，按 page_size=${page_size} `
+            + `分页共 ${totalPages} 页，请求的 page=${page} 不存在。`,
+          );
+        }
         const parts: string[] = [];
         if (result.eventName) {
           parts.push(

--- a/ts/tests/story.test.ts
+++ b/ts/tests/story.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import AdmZip from "adm-zip";
@@ -153,10 +153,15 @@ function assertStoryStore(store: JsonStore): void {
   assert.equal(activity.pageOutOfRange, false);
   assert.deepEqual(activity.chapters.map((chapter) => chapter.storyKey), [FIRST_STORY_KEY]);
 
-  const outOfRange = readActivityFromStore(store, "act_test", true, 99, 1);
+  const outOfRange = readActivityFromStore(store, "act_test", true, 3, 1);
   assert.equal(outOfRange.totalChapters, 2);
   assert.deepEqual(outOfRange.chapters, []);
   assert.equal(outOfRange.pageOutOfRange, true);
+
+  assert.throws(
+    () => readActivityFromStore(store, "act_test", true, 1, 0),
+    /page_size 参数必须在 1 到 20 之间/,
+  );
 }
 
 test("story tools read from DirectoryStore", () => {
@@ -217,17 +222,28 @@ test("read_activity reports an out-of-range page", async () => {
     const handler = server.handlers.get("read_activity");
     assert.ok(handler);
 
-    const result = await handler({ event_id: "act_test", page: 99, page_size: 1 }) as {
+    const result = await handler({ event_id: "act_test", page: 3, page_size: 1 }) as {
       content: Array<{ type: string; text?: string }>;
     };
     assert.equal(
       result.content[0]?.text,
-      "页码超出范围：act_test 共 2 章，按 page_size=1 分页共 2 页，请求的 page=99 不存在。",
+      "页码超出范围：act_test 共 2 章，按 page_size=1 分页共 2 页，请求的 page=3 不存在。",
     );
   } finally {
     if (previousStoryjsonPath === undefined) delete process.env["STORYJSON_PATH"];
     else process.env["STORYJSON_PATH"] = previousStoryjsonPath;
   }
+});
+
+test("unreadable chapter is not an out-of-range page", () => {
+  const root = tempRoot();
+  writeStoryDir(root);
+  unlinkSync(join(root, storyPath(FIRST_STORY_KEY)));
+
+  const result = readActivityFromStore(new DirectoryStore(root), "act_test", true, 1, 1);
+  assert.equal(result.totalChapters, 2);
+  assert.deepEqual(result.chapters, []);
+  assert.equal(result.pageOutOfRange, false);
 });
 
 test("missing story raises", () => {

--- a/ts/tests/story.test.ts
+++ b/ts/tests/story.test.ts
@@ -12,6 +12,7 @@ import {
   readStory,
   readStoryFromStore,
 } from "../src/data/story.ts";
+import { registerStoryTools } from "../src/tools/storyTools.ts";
 
 const STORY_REVIEW_PATH = "zh_CN/gamedata/excel/story_review_table.json";
 const FIRST_STORY_KEY = "activities/act_test/level_act_test_01_beg";
@@ -97,6 +98,16 @@ function writeStoryZip(path: string): void {
   zip.writeZip(path);
 }
 
+type ToolHandler = (args: Record<string, unknown>) => unknown | Promise<unknown>;
+
+class CapturingServer {
+  handlers = new Map<string, ToolHandler>();
+
+  registerTool(name: string, _config: unknown, handler: ToolHandler): void {
+    this.handlers.set(name, handler);
+  }
+}
+
 function assertStoryStore(store: JsonStore): void {
   const events = listStoryEventsFromStore(store, "activities");
   assert.deepEqual(
@@ -139,7 +150,13 @@ function assertStoryStore(store: JsonStore): void {
   assert.equal(activity.eventName, "测试活动");
   assert.equal(activity.totalChapters, 2);
   assert.equal(activity.hasMore, true);
+  assert.equal(activity.pageOutOfRange, false);
   assert.deepEqual(activity.chapters.map((chapter) => chapter.storyKey), [FIRST_STORY_KEY]);
+
+  const outOfRange = readActivityFromStore(store, "act_test", true, 99, 1);
+  assert.equal(outOfRange.totalChapters, 2);
+  assert.deepEqual(outOfRange.chapters, []);
+  assert.equal(outOfRange.pageOutOfRange, true);
 }
 
 test("story tools read from DirectoryStore", () => {
@@ -184,6 +201,32 @@ test("public zip path API closes transient store", () => {
     assert.deepEqual(closedPaths, [zipPath]);
   } finally {
     ZipStore.prototype.close = originalClose;
+  }
+});
+
+test("read_activity reports an out-of-range page", async () => {
+  const root = tempRoot();
+  const zipPath = join(root, "zh_CN.zip");
+  writeStoryZip(zipPath);
+  const previousStoryjsonPath = process.env["STORYJSON_PATH"];
+  process.env["STORYJSON_PATH"] = zipPath;
+
+  try {
+    const server = new CapturingServer();
+    registerStoryTools(server as never);
+    const handler = server.handlers.get("read_activity");
+    assert.ok(handler);
+
+    const result = await handler({ event_id: "act_test", page: 99, page_size: 1 }) as {
+      content: Array<{ type: string; text?: string }>;
+    };
+    assert.equal(
+      result.content[0]?.text,
+      "页码超出范围：act_test 共 2 章，按 page_size=1 分页共 2 页，请求的 page=99 不存在。",
+    );
+  } finally {
+    if (previousStoryjsonPath === undefined) delete process.env["STORYJSON_PATH"];
+    else process.env["STORYJSON_PATH"] = previousStoryjsonPath;
   }
 });
 


### PR DESCRIPTION
## Summary

- distinguish a page beyond an existing activity from an activity whose selected chapters cannot be read
- return the total chapters, page size, total pages, and requested page for read_activity page-overflow calls in both implementations
- add direct data-state and user-visible tool-result regression coverage

## Test plan

- ./scripts/check-runtime.sh --full
- git diff --check

## Open items

- None. This PR only addresses #124; #125 template parsing is intentionally excluded.