### PR TITLE
fix(wiki): normalize malformed template responses

### DIFF
--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -338,10 +338,13 @@ async def _render_template_batch(title: str, values: list[str]) -> list[str]:
     except httpx.HTTPError as exc:
         raise TemplateRenderError("模板字段渲染请求失败。") from exc
 
-    data = response.json()
+    try:
+        data = response.json()
+        rendered = _strip_html(data.get("parse", {}).get("text", {}).get("*", ""))
+    except Exception as exc:
+        raise TemplateRenderError("模板字段渲染请求失败。") from exc
     if data.get("error", {}).get("info"):
         raise TemplateRenderError("模板字段渲染请求失败。")
-    rendered = _strip_html(data.get("parse", {}).get("text", {}).get("*", ""))
     if not rendered:
         raise TemplateRenderError("模板字段渲染结果为空。")
 

--- a/python/tests/test_template_renderer.py
+++ b/python/tests/test_template_renderer.py
@@ -100,6 +100,27 @@ def test_template_renderer_skips_batch_render_for_plain_values() -> None:
     assert result == {"Test": {"数值": "12"}}
 
 
+def test_render_template_batch_converts_malformed_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _BadResponse:
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict:
+            raise ValueError("malformed json")
+
+    class _BadClient:
+        async def post(self, _url: str, *, data: dict) -> _BadResponse:
+            return _BadResponse()
+
+    monkeypatch.setattr(prts_wiki, "_get_client", lambda: _BadClient())
+    monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
+
+    with pytest.raises(TemplateRenderError, match="模板字段渲染请求失败"):
+        asyncio.run(prts_wiki._render_template_batch("测试", ["{{color|红}}"]))
+
+
 async def _unexpected_render(_title: str, _values: list[str]) -> list[str]:
     raise AssertionError("unsupported XML must not reach the renderer")
 


### PR DESCRIPTION
Follow-up for #125: convert malformed or structurally invalid MediaWiki template-render responses into TemplateRenderError so prts_page(action=template) preserves its content-only fallback contract. Adds a regression test.