### PR TITLE
fix(wiki): preserve partial template results

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
+- Template rendering now preserves valid fields when another nested value renders empty, validates malformed MediaWiki response shapes, and keeps unexpected local processing errors observable.
 
 ## [2.6.0] - 2026-08-09
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
-- Template rendering now preserves valid fields when another nested value renders empty, validates malformed MediaWiki response shapes, and keeps unexpected local processing errors observable.
+- Template rendering now preserves valid fields when another nested value renders empty, validates malformed MediaWiki response shapes and marker boundaries, and keeps unexpected local processing errors observable.
 
 ## [2.6.0] - 2026-08-09
 

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -363,8 +363,11 @@ async def _render_template_batch(title: str, values: list[str]) -> list[str]:
     for begin, end in markers:
         if rendered.count(begin) != 1 or rendered.count(end) != 1:
             raise TemplateRenderError("模板字段渲染边界无效。")
-        start = rendered.index(begin) + len(begin)
-        finish = rendered.index(end, start)
+        begin_index = rendered.index(begin)
+        finish = rendered.index(end)
+        if finish < begin_index + len(begin):
+            raise TemplateRenderError("模板字段渲染边界无效。")
+        start = begin_index + len(begin)
         value = rendered[start:finish].strip()
         values_out.append(value)
     return values_out

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -345,9 +345,15 @@ async def _render_template_batch(title: str, values: list[str]) -> list[str]:
     if not isinstance(data, dict):
         raise TemplateRenderError("模板字段渲染响应格式无效。")
 
-    error = data.get("error")
-    if isinstance(error, dict) and error.get("info"):
-        raise TemplateRenderError("模板字段渲染请求失败。")
+    if "error" in data:
+        error = data["error"]
+        if not isinstance(error, dict) or "info" not in error:
+            raise TemplateRenderError("模板字段渲染响应格式无效。")
+        info = error["info"]
+        if not isinstance(info, str):
+            raise TemplateRenderError("模板字段渲染响应格式无效。")
+        if info:
+            raise TemplateRenderError("模板字段渲染请求失败。")
 
     parse = data.get("parse")
     text = parse.get("text") if isinstance(parse, dict) else None
@@ -360,13 +366,21 @@ async def _render_template_batch(title: str, values: list[str]) -> list[str]:
         raise TemplateRenderError("模板字段渲染结果为空。")
 
     values_out: list[str] = []
-    for begin, end in markers:
+    marker_positions: list[tuple[int, str, int]] = []
+    for index, (begin, end) in enumerate(markers):
         if rendered.count(begin) != 1 or rendered.count(end) != 1:
             raise TemplateRenderError("模板字段渲染边界无效。")
+        marker_positions.extend(
+            [(rendered.index(begin), "begin", index), (rendered.index(end), "end", index)]
+        )
+    expected_order = [(kind, index) for index in range(len(markers)) for kind in ("begin", "end")]
+    actual_order = [(kind, index) for _, kind, index in sorted(marker_positions)]
+    if actual_order != expected_order:
+        raise TemplateRenderError("模板字段渲染边界无效。")
+
+    for begin, end in markers:
         begin_index = rendered.index(begin)
         finish = rendered.index(end)
-        if finish < begin_index + len(begin):
-            raise TemplateRenderError("模板字段渲染边界无效。")
         start = begin_index + len(begin)
         value = rendered[start:finish].strip()
         values_out.append(value)

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -340,11 +340,22 @@ async def _render_template_batch(title: str, values: list[str]) -> list[str]:
 
     try:
         data = response.json()
-        rendered = _strip_html(data.get("parse", {}).get("text", {}).get("*", ""))
-    except Exception as exc:
+    except (TypeError, ValueError) as exc:
         raise TemplateRenderError("模板字段渲染请求失败。") from exc
-    if data.get("error", {}).get("info"):
+    if not isinstance(data, dict):
+        raise TemplateRenderError("模板字段渲染响应格式无效。")
+
+    error = data.get("error")
+    if isinstance(error, dict) and error.get("info"):
         raise TemplateRenderError("模板字段渲染请求失败。")
+
+    parse = data.get("parse")
+    text = parse.get("text") if isinstance(parse, dict) else None
+    html_text = text.get("*") if isinstance(text, dict) else None
+    if not isinstance(html_text, str):
+        raise TemplateRenderError("模板字段渲染响应格式无效。")
+
+    rendered = _strip_html(html_text)
     if not rendered:
         raise TemplateRenderError("模板字段渲染结果为空。")
 
@@ -355,8 +366,6 @@ async def _render_template_batch(title: str, values: list[str]) -> list[str]:
         start = rendered.index(begin) + len(begin)
         finish = rendered.index(end, start)
         value = rendered[start:finish].strip()
-        if not value:
-            raise TemplateRenderError("模板字段渲染结果为空。")
         values_out.append(value)
     return values_out
 

--- a/python/tests/test_template_renderer.py
+++ b/python/tests/test_template_renderer.py
@@ -163,6 +163,24 @@ def test_render_template_batch_keeps_other_fields_when_one_renders_empty(
     assert result == ["", "保留字段"]
 
 
+def test_render_template_batch_rejects_reversed_markers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _ReversedClient:
+        async def post(self, _url: str, *, data: dict) -> _Response:
+            match = re.search(r"(PRTSMCP_[0-9a-f]{32}_BEGIN_0_)", data["text"])
+            assert match is not None
+            begin = match.group(1)
+            end = begin.replace("_BEGIN_", "_END_")
+            return _Response({"parse": {"text": {"*": f"{end}\n{begin}\n错误"}}})
+
+    monkeypatch.setattr(prts_wiki, "_get_client", lambda: _ReversedClient())
+    monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
+
+    with pytest.raises(TemplateRenderError, match="模板字段渲染边界无效"):
+        asyncio.run(prts_wiki._render_template_batch("测试", ["{{color|红}}"]))
+
+
 def test_render_template_batch_does_not_mask_local_cleanup_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/python/tests/test_template_renderer.py
+++ b/python/tests/test_template_renderer.py
@@ -181,6 +181,27 @@ def test_render_template_batch_rejects_reversed_markers(
         asyncio.run(prts_wiki._render_template_batch("测试", ["{{color|红}}"]))
 
 
+def test_render_template_batch_rejects_interleaved_markers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _InterleavedClient:
+        async def post(self, _url: str, *, data: dict) -> _Response:
+            markers = list(re.finditer(r"(PRTSMCP_[0-9a-f]{32}_BEGIN_(\d+)_)", data["text"]))
+            assert len(markers) == 2
+            begin0 = markers[0].group(1)
+            end0 = begin0.replace("_BEGIN_", "_END_")
+            begin1 = markers[1].group(1)
+            end1 = begin1.replace("_BEGIN_", "_END_")
+            html = f"{begin0}\n{begin1}\n值0\n{end0}\n值1\n{end1}"
+            return _Response({"parse": {"text": {"*": html}}})
+
+    monkeypatch.setattr(prts_wiki, "_get_client", lambda: _InterleavedClient())
+    monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
+
+    with pytest.raises(TemplateRenderError, match="模板字段渲染边界无效"):
+        asyncio.run(prts_wiki._render_template_batch("测试", ["{{a}}", "{{b}}"]))
+
+
 def test_render_template_batch_does_not_mask_local_cleanup_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/python/tests/test_template_renderer.py
+++ b/python/tests/test_template_renderer.py
@@ -21,13 +21,13 @@ def _fixture() -> dict:
 
 
 class _Response:
-    def __init__(self, payload: dict) -> None:
+    def __init__(self, payload: object) -> None:
         self.payload = payload
 
     def raise_for_status(self) -> None:
         pass
 
-    def json(self) -> dict:
+    def json(self) -> object:
         return self.payload
 
 
@@ -118,6 +118,66 @@ def test_render_template_batch_converts_malformed_response(
     monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
 
     with pytest.raises(TemplateRenderError, match="模板字段渲染请求失败"):
+        asyncio.run(prts_wiki._render_template_batch("测试", ["{{color|红}}"]))
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [None, [], {"parse": []}, {"parse": {"text": {"*": None}}}],
+)
+def test_render_template_batch_rejects_invalid_response_shape(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: object,
+) -> None:
+    class _InvalidClient:
+        async def post(self, _url: str, *, data: dict) -> _Response:
+            return _Response(payload)
+
+    monkeypatch.setattr(prts_wiki, "_get_client", lambda: _InvalidClient())
+    monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
+
+    with pytest.raises(TemplateRenderError, match="模板字段渲染响应格式无效"):
+        asyncio.run(prts_wiki._render_template_batch("测试", ["{{color|红}}"]))
+
+
+def test_render_template_batch_keeps_other_fields_when_one_renders_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _PartialClient:
+        async def post(self, _url: str, *, data: dict) -> _Response:
+            text = data["text"]
+            markers = list(re.finditer(r"(PRTSMCP_[0-9a-f]{32}_BEGIN_(\d+)_)", text))
+            values = ["", "保留字段"]
+            html = []
+            for marker, value in zip(markers, values, strict=True):
+                begin = marker.group(1)
+                end = begin.replace("_BEGIN_", "_END_")
+                html.append(f"<p>{begin}\n{value}\n{end}</p>")
+            return _Response({"parse": {"text": {"*": "\n".join(html)}}})
+
+    monkeypatch.setattr(prts_wiki, "_get_client", lambda: _PartialClient())
+    monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
+
+    result = asyncio.run(prts_wiki._render_template_batch("测试", ["{{empty}}", "{{kept}}"]))
+
+    assert result == ["", "保留字段"]
+
+
+def test_render_template_batch_does_not_mask_local_cleanup_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _ValidClient:
+        async def post(self, _url: str, *, data: dict) -> _Response:
+            return _Response({"parse": {"text": {"*": "valid"}}})
+
+    def raise_cleanup_error(_text: str) -> str:
+        raise RuntimeError("bug")
+
+    monkeypatch.setattr(prts_wiki, "_get_client", lambda: _ValidClient())
+    monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
+    monkeypatch.setattr(prts_wiki, "_strip_html", raise_cleanup_error)
+
+    with pytest.raises(RuntimeError, match="bug"):
         asyncio.run(prts_wiki._render_template_batch("测试", ["{{color|红}}"]))
 
 

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
+- Template rendering now preserves valid fields when another nested value renders empty and normalizes malformed MediaWiki response shapes to the documented content-only fallback.
 
 ## [2.6.0] - 2026-08-09
 

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
-- Template rendering now preserves valid fields when another nested value renders empty and normalizes malformed MediaWiki response shapes to the documented content-only fallback.
+- Template rendering now preserves valid fields when another nested value renders empty and normalizes malformed MediaWiki response shapes and marker boundaries to the documented content-only fallback.
 
 ## [2.6.0] - 2026-08-09
 

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -381,21 +381,42 @@ async function renderTemplateBatch(title: string, values: string[]): Promise<str
     return `${begin}\n${value}\n${end}`;
   }).join("\n\n");
 
-  let data: { error?: { info?: string }; parse?: { text?: { "*"?: string } } };
+  let data: unknown;
   try {
-    data = (await prtsPost({
+    data = await prtsPost({
       action: "parse",
       title,
       text,
       prop: "text",
       format: "json",
-    })) as typeof data;
+    });
   } catch (error) {
     throw new TemplateRenderError("模板字段渲染请求失败。", { cause: error });
   }
-  if (data.error?.info) throw new TemplateRenderError("模板字段渲染请求失败。");
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    throw new TemplateRenderError("模板字段渲染响应格式无效。");
+  }
+  const response = data as { error?: unknown; parse?: unknown };
+  if (
+    typeof response.error === "object"
+    && response.error !== null
+    && !Array.isArray(response.error)
+    && "info" in response.error
+  ) {
+    throw new TemplateRenderError("模板字段渲染请求失败。");
+  }
 
-  const rendered = stripHtml(data.parse?.text?.["*"] ?? "");
+  const parse = typeof response.parse === "object" && response.parse !== null && !Array.isArray(response.parse)
+    ? response.parse as { text?: unknown }
+    : undefined;
+  const textNode = typeof parse?.text === "object" && parse.text !== null && !Array.isArray(parse.text)
+    ? parse.text as { "*"?: unknown }
+    : undefined;
+  if (typeof textNode?.["*"] !== "string") {
+    throw new TemplateRenderError("模板字段渲染响应格式无效。");
+  }
+
+  const rendered = stripHtml(textNode["*"]);
   if (!rendered) throw new TemplateRenderError("模板字段渲染结果为空。");
   return markers.map(([begin, end]) => {
     if (rendered.split(begin).length !== 2 || rendered.split(end).length !== 2) {
@@ -403,9 +424,7 @@ async function renderTemplateBatch(title: string, values: string[]): Promise<str
     }
     const start = rendered.indexOf(begin) + begin.length;
     const finish = rendered.indexOf(end, start);
-    const value = rendered.slice(start, finish).trim();
-    if (!value) throw new TemplateRenderError("模板字段渲染结果为空。");
-    return value;
+    return rendered.slice(start, finish).trim();
   });
 }
 

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -401,7 +401,8 @@ async function renderTemplateBatch(title: string, values: string[]): Promise<str
     typeof response.error === "object"
     && response.error !== null
     && !Array.isArray(response.error)
-    && "info" in response.error
+    && typeof (response.error as { info?: unknown }).info === "string"
+    && (response.error as { info: string }).info
   ) {
     throw new TemplateRenderError("模板字段渲染请求失败。");
   }
@@ -422,8 +423,12 @@ async function renderTemplateBatch(title: string, values: string[]): Promise<str
     if (rendered.split(begin).length !== 2 || rendered.split(end).length !== 2) {
       throw new TemplateRenderError("模板字段渲染边界无效。");
     }
-    const start = rendered.indexOf(begin) + begin.length;
-    const finish = rendered.indexOf(end, start);
+    const beginIndex = rendered.indexOf(begin);
+    const finish = rendered.indexOf(end);
+    if (finish < beginIndex + begin.length) {
+      throw new TemplateRenderError("模板字段渲染边界无效。");
+    }
+    const start = beginIndex + begin.length;
     return rendered.slice(start, finish).trim();
   });
 }

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -397,14 +397,15 @@ async function renderTemplateBatch(title: string, values: string[]): Promise<str
     throw new TemplateRenderError("模板字段渲染响应格式无效。");
   }
   const response = data as { error?: unknown; parse?: unknown };
-  if (
-    typeof response.error === "object"
-    && response.error !== null
-    && !Array.isArray(response.error)
-    && typeof (response.error as { info?: unknown }).info === "string"
-    && (response.error as { info: string }).info
-  ) {
-    throw new TemplateRenderError("模板字段渲染请求失败。");
+  if ("error" in response) {
+    if (typeof response.error !== "object" || response.error === null || Array.isArray(response.error)) {
+      throw new TemplateRenderError("模板字段渲染响应格式无效。");
+    }
+    const info = (response.error as { info?: unknown }).info;
+    if (typeof info !== "string") {
+      throw new TemplateRenderError("模板字段渲染响应格式无效。");
+    }
+    if (info) throw new TemplateRenderError("模板字段渲染请求失败。");
   }
 
   const parse = typeof response.parse === "object" && response.parse !== null && !Array.isArray(response.parse)
@@ -419,6 +420,21 @@ async function renderTemplateBatch(title: string, values: string[]): Promise<str
 
   const rendered = stripHtml(textNode["*"]);
   if (!rendered) throw new TemplateRenderError("模板字段渲染结果为空。");
+  const markerPositions = markers.flatMap(([begin, end], index) => [
+    { position: rendered.indexOf(begin), kind: "begin" as const, index },
+    { position: rendered.indexOf(end), kind: "end" as const, index },
+  ]);
+  const expectedOrder = markers.flatMap((_, index) => [
+    { kind: "begin" as const, index },
+    { kind: "end" as const, index },
+  ]);
+  const actualOrder = [...markerPositions]
+    .sort((left, right) => left.position - right.position)
+    .map(({ kind, index }) => ({ kind, index }));
+  if (JSON.stringify(actualOrder) !== JSON.stringify(expectedOrder)) {
+    throw new TemplateRenderError("模板字段渲染边界无效。");
+  }
+
   return markers.map(([begin, end]) => {
     if (rendered.split(begin).length !== 2 || rendered.split(end).length !== 2) {
       throw new TemplateRenderError("模板字段渲染边界无效。");

--- a/ts/tests/templateRenderer.test.ts
+++ b/ts/tests/templateRenderer.test.ts
@@ -140,3 +140,25 @@ test("getTemplateData normalizes invalid render response shapes", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+test("getTemplateData rejects reversed render markers", async () => {
+  const originalFetch = globalThis.fetch;
+  const parsetree = "<root><template><title>Test</title><part><name>字段</name><value><template><title>Nested</title></template></value></part></template></root>";
+  globalThis.fetch = (async (_input, init) => {
+    if (init?.method !== "POST") {
+      return new Response(JSON.stringify({ parse: { parsetree: { "*": parsetree } } }));
+    }
+    const form = new URLSearchParams(String(init.body));
+    const match = (form.get("text") ?? "").match(/(PRTSMCP_[0-9a-f]{32}_BEGIN_0_)/);
+    assert.ok(match);
+    const begin = match[1]!;
+    const end = begin.replace("_BEGIN_", "_END_");
+    return new Response(JSON.stringify({ parse: { text: { "*": `${end}\n${begin}\n错误` } } }));
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(getTemplateData("测试"), TemplateRenderError);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/ts/tests/templateRenderer.test.ts
+++ b/ts/tests/templateRenderer.test.ts
@@ -162,3 +162,49 @@ test("getTemplateData rejects reversed render markers", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+test("getTemplateData rejects interleaved render markers", async () => {
+  const originalFetch = globalThis.fetch;
+  const parsetree = [
+    "<root><template><title>Test</title>",
+    "<part><name>A</name><value><template><title>A</title></template></value></part>",
+    "<part><name>B</name><value><template><title>B</title></template></value></part>",
+    "</template></root>",
+  ].join("");
+  globalThis.fetch = (async (_input, init) => {
+    if (init?.method !== "POST") {
+      return new Response(JSON.stringify({ parse: { parsetree: { "*": parsetree } } }));
+    }
+    const form = new URLSearchParams(String(init.body));
+    const markers = [...(form.get("text") ?? "").matchAll(/(PRTSMCP_[0-9a-f]{32}_BEGIN_(\d+)_)/g)];
+    assert.equal(markers.length, 2);
+    const begin0 = markers[0]![1]!;
+    const end0 = begin0.replace("_BEGIN_", "_END_");
+    const begin1 = markers[1]![1]!;
+    const end1 = begin1.replace("_BEGIN_", "_END_");
+    return new Response(JSON.stringify({ parse: { text: { "*": `${begin0}\n${begin1}\n值0\n${end0}\n值1\n${end1}` } } }));
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(getTemplateData("测试"), TemplateRenderError);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getTemplateData rejects non-string MediaWiki error info", async () => {
+  const originalFetch = globalThis.fetch;
+  const parsetree = "<root><template><title>Test</title><part><name>字段</name><value><template><title>Nested</title></template></value></part></template></root>";
+  globalThis.fetch = (async (_input, init) => {
+    if (init?.method !== "POST") {
+      return new Response(JSON.stringify({ parse: { parsetree: { "*": parsetree } } }));
+    }
+    return new Response(JSON.stringify({ error: { info: 1 } }));
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(getTemplateData("测试"), TemplateRenderError);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/ts/tests/templateRenderer.test.ts
+++ b/ts/tests/templateRenderer.test.ts
@@ -89,3 +89,54 @@ test("renderTemplateData trims parsetree whitespace for plain values", async () 
 
   assert.deepEqual(result, { Test: { 字段: "阿米娅" } });
 });
+
+test("getTemplateData keeps other fields when one nested value renders empty", async () => {
+  const originalFetch = globalThis.fetch;
+  const parsetree = [
+    "<root><template><title>Test</title>",
+    "<part><name>空字段</name><value><template><title>Empty</title></template></value></part>",
+    "<part><name>保留字段</name><value><template><title>Kept</title></template></value></part>",
+    "</template></root>",
+  ].join("");
+  let requestCount = 0;
+  globalThis.fetch = (async (_input, init) => {
+    requestCount += 1;
+    if (init?.method !== "POST") {
+      return new Response(JSON.stringify({ parse: { parsetree: { "*": parsetree } } }));
+    }
+
+    const form = new URLSearchParams(String(init.body));
+    const markers = [...(form.get("text") ?? "").matchAll(/(PRTSMCP_[0-9a-f]{32}_BEGIN_(\d+)_)/g)];
+    const values = ["", "保留值"];
+    const html = markers.map((marker, index) => {
+      const begin = marker[1]!;
+      const end = begin.replace("_BEGIN_", "_END_");
+      return `<p>${begin}\n${values[index]}\n${end}</p>`;
+    }).join("\n");
+    return new Response(JSON.stringify({ parse: { text: { "*": html } } }));
+  }) as typeof fetch;
+
+  try {
+    assert.deepEqual(await getTemplateData("测试"), { Test: { 保留字段: "保留值" } });
+    assert.equal(requestCount, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getTemplateData normalizes invalid render response shapes", async () => {
+  const originalFetch = globalThis.fetch;
+  const parsetree = "<root><template><title>Test</title><part><name>字段</name><value><template><title>Nested</title></template></value></part></template></root>";
+  globalThis.fetch = (async (_input, init) => {
+    if (init?.method !== "POST") {
+      return new Response(JSON.stringify({ parse: { parsetree: { "*": parsetree } } }));
+    }
+    return new Response(JSON.stringify({ parse: { text: { "*": null } } }));
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(getTemplateData("测试"), TemplateRenderError);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Summary

- preserve valid `prts_page(action="template")` fields when another nested value renders empty
- validate malformed Python/TypeScript MediaWiki render response shapes before HTML cleanup
- keep unexpected Python local cleanup failures observable instead of relabeling them as request failures

## Test plan

- `./scripts/check-runtime.sh --full`
- Python: 353 passed, 23 skipped
- TypeScript: 273 passed, 2 skipped
- TypeScript build, typecheck, shared-volume sync, and Bun HTTP smoke passed

## Outstanding

- none; this resolves the release-readiness should-fix findings from PRs #138 and #139