### PR TITLE
chore(release): prepare v2.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Two release lines ship in parallel:
 
 | Line | Version | Tools | Status |
 |------|---------|-------|--------|
-| **2.6** (`main`) | `2.6.0` | 24 | MCP SDK v2 with opt-in modern protocol support while retaining legacy clients; Amiya artwork forms; isolated same-host memory canary. |
+| **2.6** (`main`) | `2.6.1` | 24 | Nested template rendering and malformed-response hardening; activity page-range validation. |
 | **1.7 LTS** (`lts/1.7`) | `1.7.0` | 32 | Stable maintenance line. 1.7.x accepts only compatibility, security, data-sync, and critical bug fixes. |
 
 The `main` and `develop` lines use the self-built `arknights-data-pipeline` Release exclusively for default Auto-Sync. The 1.7 LTS line retains its legacy upstream compatibility until a separate, backwards-compatible migration; changes to the new factory path must not be backported to LTS as an implicit source switch.
@@ -155,7 +155,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contribution workflow and [`doc
 
 | 版本线 | 版本 | 工具数 | 状态 |
 |--------|------|--------|------|
-| **2.6**（`main`） | `2.6.0` | 24 | MCP SDK v2，并以 opt-in 方式支持现代协议且保留 legacy 客户端；阿米娅形态立绘；隔离同机内存 canary。 |
+| **2.6**（`main`） | `2.6.1` | 24 | 模板嵌套字段安全渲染与 malformed-response 加固；活动剧情页码校验。 |
 | **1.7 LTS**（`lts/1.7`） | `1.7.0` | 32 | 稳定维护线。1.7.x 仅接受兼容性、安全性、数据同步和关键缺陷修复。 |
 
 | 范围 | Python | TypeScript |

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Both implementations expose the same tool set:
 | Tool | Description |
 |------|-------------|
 | `search_prts(query, limit)` | Search PRTS Wiki by keyword, returns matching article titles |
-| `prts_page(page_title, action, ...)` | Read a wiki page or its metadata; `action` ∈ read / sections / categories / links / template |
+| `prts_page(page_title, action, ...)` | Read a wiki page or metadata; `template` returns rendered fields from top-level templates |
 | `get_operator_archives(name)` | Retrieve operator archive records (Chinese name) |
 | `get_operator_voicelines(name)` | Retrieve operator voice lines (Chinese name) |
 | `get_operator_basic_info(name)` | Retrieve basic operator profile: class, rarity, faction, recruit tags, talents (Chinese name) |
@@ -186,7 +186,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contribution workflow and [`doc
 | 工具 | 说明 |
 |------|------|
 | `search_prts(query, limit)` | 关键词搜索 PRTS 维基词条，返回匹配标题列表 |
-| `prts_page(page_title, action, ...)` | 读取词条正文或元数据；`action` ∈ read / sections / categories / links / template |
+| `prts_page(page_title, action, ...)` | 读取词条正文或元数据；`template` 返回顶层模板的结构化、已渲染字段数据 |
 | `get_operator_archives(name)` | 获取干员档案资料（中文名） |
 | `get_operator_voicelines(name)` | 获取干员语音记录（中文名） |
 | `get_operator_basic_info(name)` | 获取干员基本信息：职业、稀有度、所属、招募标签、天赋（中文名） |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,13 @@
 # PRTS-MCP Roadmap
 
-_Last updated: 2026-08-09_ · [中文版](ROADMAP.zh-CN.md)
+_Last updated: 2026-08-10_ · [中文版](ROADMAP.zh-CN.md)
 
 PRTS-MCP is past 1.0. Version 1.7.0 is the final 1.x feature release and the 1.7 LTS baseline. This document tracks **what comes next** — not what has shipped. For shipped features, see the Python and TypeScript CHANGELOGs.
 
 ## Current Release
 
-- Python: `2.6.0` _(latest stable)_
-- TypeScript: `2.6.0` _(latest stable)_
+- Python: `2.6.1` _(latest stable)_
+- TypeScript: `2.6.1` _(latest stable)_
 - `1.7.0` LTS remains the maintenance line — compatibility, security, data-sync, and critical fixes only.
 - 24 public MCP tools on the 2.x line (CI-enforced); 32 public MCP tools frozen on the 1.7 LTS line.
 - See [migration guide 0.x → 1.0](docs/migration-0.x-to-1.0.md) and [migration guide 1.x → 2.0](docs/migration-1.x-to-2.0.md).

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -1,13 +1,13 @@
 # PRTS-MCP 路线图
 
-_最近更新：2026-08-09_ · [English](ROADMAP.md)
+_最近更新：2026-08-10_ · [English](ROADMAP.md)
 
 PRTS-MCP 已进入 1.x 稳定期。1.7.0 是最后一个 1.x 功能版本和 1.7 LTS 基线。本文档记录**接下来要做什么**——已发布的内容请查看 Python 和 TypeScript 各自的 CHANGELOG。
 
 ## 当前发布
 
-- Python：`2.6.0` _（最新稳定版）_
-- TypeScript：`2.6.0` _（最新稳定版）_
+- Python：`2.6.1` _（最新稳定版）_
+- TypeScript：`2.6.1` _（最新稳定版）_
 - `1.7.0` LTS 仍为维护线——仅兼容性、安全性、数据同步和关键缺陷修复。
 - 2.x 线为 24 个公共 MCP 工具（CI 强制检查）；1.7 LTS 线冻结 32 个公共 MCP 工具。
 - 迁移说明：[0.x → 1.0](docs/migration-0.x-to-1.0.md)、[1.x → 2.0](docs/migration-1.x-to-2.0.md)。

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,18 +1,19 @@
 # PRTS-MCP 项目状态
 
-_Last updated: 2026-08-09_
+_Last updated: 2026-08-10_
 
 ## 当前版本
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 2.6.0 | Stable release |
-| TypeScript | 2.6.0 | Stable release |
+| Python | 2.6.1 | Stable release |
+| TypeScript | 2.6.1 | Stable release |
 
-- 当前稳定发布：2.6.0（24 个 MCP 工具）
+- 当前稳定发布：2.6.1（24 个 MCP 工具）
 - 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）
 - 下一开发目标：2.7.0（在 release branch 回合与开发版本重开后确定）
 - 当前稳定补丁线：2.6.x
+- 2.6.1 发布内容：`prts_page(action="template")` 的嵌套字段安全渲染与 malformed-response 边界；`read_activity` 页码输入和越界提示一致性。
 - 2.6.0 发布内容：MCP SDK v2 与 legacy/`2026-07-28` 双时代协议服务；`operator_artwork` 阿米娅近卫/医疗形态解析与精确 opaque token 归属；TS 聚合指标、六会话隔离内存基准及同机 canary 资产。
 - 2.5.0 发布内容：干员立绘工具 `operator_artwork`（list/get，默认 MediaWiki 在线获取 + 256 MiB LRU 缓存，`LOCAL_IMAGE=true` 时使用 AKDP 本地 PNG 资产）；数据源切换到自建 `arknights-data-pipeline` Release；TS stdio 不再泄漏 HTTP 监听器；TS JSON 空对象占位守卫。
 - 2.4.0 发布内容：常驻服务默认每小时同步 GameData excel、GameData levels 与 StoryJson；GameData 两类归档以同一代原子切换，并支持共享卷跨进程发布锁续租。
@@ -69,7 +70,7 @@ _Last updated: 2026-08-09_
 
 ## 当前分支
 
-- `main`：2.6.0（最新稳定发布线）
+- `main`：2.6.1（最新稳定发布线）
 - `lts/1.7`：1.7.x LTS 维护线（从 1.7.0 发布提交创建）
 - `develop`：release branch 回合后重开 2.7.0 开发线
 
@@ -228,6 +229,7 @@ PRTS-MCP/
 
 | 版本 | 日期 | 亮点 |
 |------|------|------|
+| 2.6.1 | 2026-08-10 | 模板嵌套字段安全渲染与 malformed-response 边界；活动剧情页码校验与越界提示 |
 | 2.6.0 | 2026-08-09 | MCP SDK v2 双时代协议；阿米娅形态立绘；聚合指标、六会话内存基准与同机 canary |
 | 2.5.2 | 2026-08-09 | npm 生产依赖安全更新；AKDP 直接敌人数据库；剧情标量 Decision；立绘 token 归属校验 |
 | 2.5.1 | 2026-08-07 | gamedata pair retry 修复；manifest 404 fail-open；image sha256 验证；CI Node 24 |

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
+
 ## [2.6.0] - 2026-08-09
 
 ### Added

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
+- Template rendering now preserves valid fields when another nested value renders empty, validates malformed MediaWiki response shapes, and keeps unexpected local processing errors observable.
 
 ## [2.6.0] - 2026-08-09
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
-- Template rendering now preserves valid fields when another nested value renders empty, validates malformed MediaWiki response shapes, and keeps unexpected local processing errors observable.
+- Template rendering now preserves valid fields when another nested value renders empty, validates malformed MediaWiki response shapes and marker boundaries, and keeps unexpected local processing errors observable.
 
 ## [2.6.0] - 2026-08-09
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.6.0] - 2026-08-09
 
 ### Added

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.6.1] - 2026-08-10
 
 ### Fixed
 
 - `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
 - Template rendering now preserves valid fields when another nested value renders empty, validates malformed MediaWiki response shapes and marker boundaries, and keeps unexpected local processing errors observable.
+- `read_activity` now validates page inputs consistently and returns a clear content-only message when the requested page is beyond an existing activity's range (#137).
 
 ## [2.6.0] - 2026-08-09
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.7.0.dev0"
+version = "2.6.1"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.6.0"
+version = "2.7.0.dev0"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -4,11 +4,11 @@ import asyncio
 import html as _html
 import logging
 import re
-
-import xml.etree.ElementTree as ET
+import secrets
 
 import httpx
 
+from prts_mcp.api.template_renderer import TemplateRenderError, render_template_data
 from prts_mcp.config import PRTS_API_ENDPOINT, USER_AGENT, RATE_LIMIT_INTERVAL
 from prts_mcp.utils.sanitizer import strip_wikitext
 
@@ -307,20 +307,59 @@ async def get_links(
     }
 
 
+async def _render_template_batch(title: str, values: list[str]) -> list[str]:
+    """Render nested template values in one MediaWiki POST request."""
+    if not values:
+        return []
+
+    prefix = f"PRTSMCP_{secrets.token_hex(16)}"
+    markers = [
+        (f"{prefix}_BEGIN_{index}_", f"{prefix}_END_{index}_")
+        for index in range(len(values))
+    ]
+    text = "\n\n".join(
+        f"{begin}\n{value}\n{end}"
+        for value, (begin, end) in zip(values, markers, strict=True)
+    )
+
+    await _rate_limit()
+    try:
+        response = await _get_client().post(
+            PRTS_API_ENDPOINT,
+            data={
+                "action": "parse",
+                "title": title,
+                "text": text,
+                "prop": "text",
+                "format": "json",
+            },
+        )
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        raise TemplateRenderError("模板字段渲染请求失败。") from exc
+
+    data = response.json()
+    if data.get("error", {}).get("info"):
+        raise TemplateRenderError("模板字段渲染请求失败。")
+    rendered = _strip_html(data.get("parse", {}).get("text", {}).get("*", ""))
+    if not rendered:
+        raise TemplateRenderError("模板字段渲染结果为空。")
+
+    values_out: list[str] = []
+    for begin, end in markers:
+        if rendered.count(begin) != 1 or rendered.count(end) != 1:
+            raise TemplateRenderError("模板字段渲染边界无效。")
+        start = rendered.index(begin) + len(begin)
+        finish = rendered.index(end, start)
+        value = rendered[start:finish].strip()
+        if not value:
+            raise TemplateRenderError("模板字段渲染结果为空。")
+        values_out.append(value)
+    return values_out
+
+
 async def get_template_data(title: str) -> dict:
-    """Return structured key-value data from template calls on a wiki page.
-
-    Fetches the page's parsetree via action=parse&prop=parsetree and extracts
-    key=value parts from every TOP-LEVEL template that uses the <name>kv</name>
-    pattern (e.g. {{CharinfoV2}}, {{敌人信息/common2}}, {{道具信息}}).
-
-    Nested templates inside a value (e.g. {{color|...}} inside CharinfoV2's
-    特性 field) are stripped from the value text — they are NOT yielded as
-    separate top-level entries. This matches the TS implementation.
-
-    Named-positional (index) templates like {{Navigator}} or {{参阅}} are
-    included as positional fields in the dict value.
-    """
+    """Return top-level structured template data with readable nested values."""
     await _rate_limit()
     params = {
         "action": "parse",
@@ -340,64 +379,7 @@ async def get_template_data(title: str) -> dict:
     if not xml_str:
         raise RuntimeError(f"页面 '{title}' 无 parsetree 数据。")
 
-    root = ET.fromstring(xml_str)
-    templates: dict[str, dict] = {}
-
-    # Only iterate top-level <template> children of <root>, not nested ones.
-    for elem in root.findall("template"):
-        t_title_elem = elem.find("title")
-        if t_title_elem is None:
-            continue
-        # Strip nested <comment> tags out of title before extracting text.
-        comment_text = ""
-        for sub in list(t_title_elem):
-            if sub.tag == "comment":
-                if sub.text:
-                    comment_text = sub.text.strip()
-                if sub.tail:
-                    t_title_elem.text = (t_title_elem.text or "") + sub.tail
-                t_title_elem.remove(sub)
-        t_name = (t_title_elem.text or "").strip()
-        if not t_name:
-            continue
-
-        kv: dict[str, str] = {}
-        positional: list[str] = []
-
-        for part in elem.findall("part"):
-            name_el = part.find("name")
-            value_el = part.find("value")
-            if value_el is None:
-                continue
-
-            # Get full text of <value>, stripping any nested <template> children.
-            for nested in list(value_el.findall("template")):
-                if nested.tail:
-                    value_el.text = (value_el.text or "") + nested.tail
-                value_el.remove(nested)
-            val = (value_el.text or "").strip()
-            if not val:
-                continue
-
-            if name_el is not None and "index" in name_el.attrib:
-                positional.append(val)
-            elif name_el is not None and name_el.text:
-                key = name_el.text.strip()
-                if key:
-                    kv[key] = val
-
-        entry: dict = {}
-        if kv:
-            entry.update(kv)
-        if positional:
-            entry["_positional"] = positional
-        if comment_text:
-            entry["_comment"] = comment_text
-
-        if entry:
-            templates[t_name] = entry
-
-    return templates
+    return await render_template_data(title, xml_str, _render_template_batch)
 
 
 def _clean_snippet(snippet: str) -> str:

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -363,8 +363,11 @@ async def _render_template_batch(title: str, values: list[str]) -> list[str]:
     for begin, end in markers:
         if rendered.count(begin) != 1 or rendered.count(end) != 1:
             raise TemplateRenderError("模板字段渲染边界无效。")
-        start = rendered.index(begin) + len(begin)
-        finish = rendered.index(end, start)
+        begin_index = rendered.index(begin)
+        finish = rendered.index(end)
+        if finish < begin_index + len(begin):
+            raise TemplateRenderError("模板字段渲染边界无效。")
+        start = begin_index + len(begin)
         value = rendered[start:finish].strip()
         values_out.append(value)
     return values_out

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -345,9 +345,15 @@ async def _render_template_batch(title: str, values: list[str]) -> list[str]:
     if not isinstance(data, dict):
         raise TemplateRenderError("模板字段渲染响应格式无效。")
 
-    error = data.get("error")
-    if isinstance(error, dict) and error.get("info"):
-        raise TemplateRenderError("模板字段渲染请求失败。")
+    if "error" in data:
+        error = data["error"]
+        if not isinstance(error, dict) or "info" not in error:
+            raise TemplateRenderError("模板字段渲染响应格式无效。")
+        info = error["info"]
+        if not isinstance(info, str):
+            raise TemplateRenderError("模板字段渲染响应格式无效。")
+        if info:
+            raise TemplateRenderError("模板字段渲染请求失败。")
 
     parse = data.get("parse")
     text = parse.get("text") if isinstance(parse, dict) else None
@@ -360,13 +366,21 @@ async def _render_template_batch(title: str, values: list[str]) -> list[str]:
         raise TemplateRenderError("模板字段渲染结果为空。")
 
     values_out: list[str] = []
-    for begin, end in markers:
+    marker_positions: list[tuple[int, str, int]] = []
+    for index, (begin, end) in enumerate(markers):
         if rendered.count(begin) != 1 or rendered.count(end) != 1:
             raise TemplateRenderError("模板字段渲染边界无效。")
+        marker_positions.extend(
+            [(rendered.index(begin), "begin", index), (rendered.index(end), "end", index)]
+        )
+    expected_order = [(kind, index) for index in range(len(markers)) for kind in ("begin", "end")]
+    actual_order = [(kind, index) for _, kind, index in sorted(marker_positions)]
+    if actual_order != expected_order:
+        raise TemplateRenderError("模板字段渲染边界无效。")
+
+    for begin, end in markers:
         begin_index = rendered.index(begin)
         finish = rendered.index(end)
-        if finish < begin_index + len(begin):
-            raise TemplateRenderError("模板字段渲染边界无效。")
         start = begin_index + len(begin)
         value = rendered[start:finish].strip()
         values_out.append(value)

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -340,11 +340,22 @@ async def _render_template_batch(title: str, values: list[str]) -> list[str]:
 
     try:
         data = response.json()
-        rendered = _strip_html(data.get("parse", {}).get("text", {}).get("*", ""))
-    except Exception as exc:
+    except (TypeError, ValueError) as exc:
         raise TemplateRenderError("模板字段渲染请求失败。") from exc
-    if data.get("error", {}).get("info"):
+    if not isinstance(data, dict):
+        raise TemplateRenderError("模板字段渲染响应格式无效。")
+
+    error = data.get("error")
+    if isinstance(error, dict) and error.get("info"):
         raise TemplateRenderError("模板字段渲染请求失败。")
+
+    parse = data.get("parse")
+    text = parse.get("text") if isinstance(parse, dict) else None
+    html_text = text.get("*") if isinstance(text, dict) else None
+    if not isinstance(html_text, str):
+        raise TemplateRenderError("模板字段渲染响应格式无效。")
+
+    rendered = _strip_html(html_text)
     if not rendered:
         raise TemplateRenderError("模板字段渲染结果为空。")
 
@@ -355,8 +366,6 @@ async def _render_template_batch(title: str, values: list[str]) -> list[str]:
         start = rendered.index(begin) + len(begin)
         finish = rendered.index(end, start)
         value = rendered[start:finish].strip()
-        if not value:
-            raise TemplateRenderError("模板字段渲染结果为空。")
         values_out.append(value)
     return values_out
 

--- a/python/src/prts_mcp/api/prts_wiki.py
+++ b/python/src/prts_mcp/api/prts_wiki.py
@@ -338,10 +338,13 @@ async def _render_template_batch(title: str, values: list[str]) -> list[str]:
     except httpx.HTTPError as exc:
         raise TemplateRenderError("模板字段渲染请求失败。") from exc
 
-    data = response.json()
+    try:
+        data = response.json()
+        rendered = _strip_html(data.get("parse", {}).get("text", {}).get("*", ""))
+    except Exception as exc:
+        raise TemplateRenderError("模板字段渲染请求失败。") from exc
     if data.get("error", {}).get("info"):
         raise TemplateRenderError("模板字段渲染请求失败。")
-    rendered = _strip_html(data.get("parse", {}).get("text", {}).get("*", ""))
     if not rendered:
         raise TemplateRenderError("模板字段渲染结果为空。")
 

--- a/python/src/prts_mcp/api/template_renderer.py
+++ b/python/src/prts_mcp/api/template_renderer.py
@@ -1,0 +1,170 @@
+"""Parse and render top-level MediaWiki template data safely."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable
+import xml.etree.ElementTree as ET
+
+
+class TemplateRenderError(RuntimeError):
+    """Raised when structured template fields cannot be rendered completely."""
+
+
+@dataclass
+class _Part:
+    name: str | None
+    value: str
+    needs_render: bool
+
+
+@dataclass
+class _Template:
+    name: str
+    parts: list[_Part]
+    comment: str
+
+
+def _text_without_comments(elem: ET.Element) -> str:
+    pieces = [elem.text or ""]
+    for child in elem:
+        if child.tag != "comment":
+            pieces.append("".join(child.itertext()))
+        pieces.append(child.tail or "")
+    return "".join(pieces)
+
+
+def _content_to_wikitext(elem: ET.Element) -> str:
+    pieces = [elem.text or ""]
+    for child in elem:
+        if child.tag == "comment":
+            pieces.append(f"<!--{child.text or ''}-->")
+        else:
+            pieces.append(_node_to_wikitext(child))
+        pieces.append(child.tail or "")
+    return "".join(pieces)
+
+
+def _part_to_wikitext(part: ET.Element) -> str:
+    value = part.find("value")
+    if value is None:
+        raise TemplateRenderError("模板字段缺少 value 节点。")
+    name = part.find("name")
+    rendered_value = _content_to_wikitext(value)
+    if name is None or "index" in name.attrib:
+        return f"|{rendered_value}"
+    rendered_name = _text_without_comments(name).strip()
+    return f"|{rendered_name}={rendered_value}" if rendered_name else f"|{rendered_value}"
+
+
+def _node_to_wikitext(elem: ET.Element) -> str:
+    if elem.tag == "template":
+        title = elem.find("title")
+        if title is None:
+            raise TemplateRenderError("嵌套模板缺少 title 节点。")
+        name = _text_without_comments(title).strip()
+        if not name:
+            raise TemplateRenderError("嵌套模板 title 为空。")
+        return "{{" + name + "".join(_part_to_wikitext(part) for part in elem.findall("part")) + "}}"
+
+    if elem.tag == "tplarg":
+        name = elem.find("title")
+        if name is None:
+            raise TemplateRenderError("模板参数缺少 title 节点。")
+        title = _text_without_comments(name).strip()
+        if not title:
+            raise TemplateRenderError("模板参数 title 为空。")
+        return "{{{" + title + "".join(_part_to_wikitext(part) for part in elem.findall("part")) + "}}}"
+
+    if elem.tag == "link":
+        target = elem.find("target")
+        if target is None:
+            raise TemplateRenderError("链接缺少 target 节点。")
+        target_text = _content_to_wikitext(target).strip()
+        if not target_text:
+            raise TemplateRenderError("链接 target 为空。")
+        parts = "".join(_part_to_wikitext(part) for part in elem.findall("part"))
+        return f"[[{target_text}{parts}]]"
+
+    if elem.tag == "comment":
+        return f"<!--{elem.text or ''}-->"
+
+    raise TemplateRenderError(f"不支持的模板字段节点：{elem.tag}。")
+
+
+def _parse_templates(xml: str) -> list[_Template]:
+    try:
+        root = ET.fromstring(xml)
+    except ET.ParseError as exc:
+        raise TemplateRenderError("页面模板数据格式无效。") from exc
+
+    templates: list[_Template] = []
+    for elem in root.findall("template"):
+        title = elem.find("title")
+        if title is None:
+            continue
+        name = _text_without_comments(title).strip()
+        if not name:
+            continue
+
+        comment = ""
+        for child in title.findall("comment"):
+            if child.text:
+                comment = child.text.strip()
+
+        parts: list[_Part] = []
+        for part in elem.findall("part"):
+            value = part.find("value")
+            if value is None:
+                continue
+            name_elem = part.find("name")
+            part_name = None
+            if name_elem is not None and "index" not in name_elem.attrib:
+                candidate = _text_without_comments(name_elem).strip()
+                part_name = candidate or None
+
+            meaningful_children = [child for child in value if child.tag != "comment"]
+            if meaningful_children:
+                source = _content_to_wikitext(value)
+                if source.strip():
+                    parts.append(_Part(part_name, source, True))
+                continue
+
+            plain = _text_without_comments(value).strip()
+            if plain:
+                parts.append(_Part(part_name, plain, False))
+        templates.append(_Template(name, parts, comment))
+    return templates
+
+
+async def render_template_data(
+    title: str,
+    xml: str,
+    render_batch: Callable[[str, list[str]], Awaitable[list[str]]],
+) -> dict[str, dict[str, Any]]:
+    """Return top-level template fields with nested syntax rendered to text."""
+    templates = _parse_templates(xml)
+    render_sources = [part.value for template in templates for part in template.parts if part.needs_render]
+    rendered_values = await render_batch(title, render_sources) if render_sources else []
+    if len(rendered_values) != len(render_sources):
+        raise TemplateRenderError("模板字段渲染结果数量不匹配。")
+
+    rendered_iter = iter(rendered_values)
+    result: dict[str, dict[str, Any]] = {}
+    for template in templates:
+        entry: dict[str, Any] = {}
+        positional: list[str] = []
+        for part in template.parts:
+            value = next(rendered_iter) if part.needs_render else part.value
+            if not value:
+                continue
+            if part.name is None:
+                positional.append(value)
+            else:
+                entry[part.name] = value
+        if positional:
+            entry["_positional"] = positional
+        if template.comment:
+            entry["_comment"] = template.comment
+        if entry:
+            result[template.name] = entry
+    return result

--- a/python/src/prts_mcp/data/story_reader.py
+++ b/python/src/prts_mcp/data/story_reader.py
@@ -114,6 +114,7 @@ class ActivityResult:
     total_chapters: int
     has_more: bool
     chapters: list[StoryChapter]
+    page_out_of_range: bool = False
 
 
 @dataclass(frozen=True)
@@ -501,6 +502,9 @@ def read_activity_from_store(
     summaries = list_stories_from_store(store, event_id)
     total = len(summaries)
 
+    if not 1 <= page_size <= 20:
+        raise ValueError("page_size 参数必须在 1 到 20 之间")
+
     if page is not None:
         if page < 1:
             raise ValueError("page 参数必须 >= 1")
@@ -508,9 +512,11 @@ def read_activity_from_store(
         end = start + page_size
         selected = summaries[start:end]
         has_more = end < total
+        page_out_of_range = total > 0 and start >= total
     else:
         selected = summaries
         has_more = False
+        page_out_of_range = False
 
     chapters = []
     event_name = ""
@@ -529,5 +535,6 @@ def read_activity_from_store(
         event_name=event_name,
         total_chapters=total,
         has_more=has_more,
+        page_out_of_range=page_out_of_range,
         chapters=chapters,
     )

--- a/python/src/prts_mcp/tools_prts.py
+++ b/python/src/prts_mcp/tools_prts.py
@@ -11,6 +11,7 @@ from typing import Annotated, Literal
 
 from pydantic import Field
 
+from prts_mcp.api.template_renderer import TemplateRenderError
 from prts_mcp.api.prts_wiki import (
     search_prts as _search_prts,
     read_page as _read_page,
@@ -96,7 +97,7 @@ def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     @mcp.tool()
     async def prts_page(
         page_title: Annotated[str, Field(description="词条标题，需与维基页面标题完全一致，如「阿米娅」。建议先用 search_prts 获取准确标题。")],
-        action: Annotated[Literal["read", "sections", "categories", "links", "template"], Field(description="操作（必填）：read=读取正文 / sections=章节目录 / categories=分类标签 / links=相关链接 / template=结构化模板数据。")],
+        action: Annotated[Literal["read", "sections", "categories", "links", "template"], Field(description="操作（必填）：read=读取正文 / sections=章节目录 / categories=分类标签 / links=相关链接 / template=顶层模板的结构化、已渲染字段数据。")],
         section_index: Annotated[int | None, Field(default=None, description="仅 action=read 生效：章节编号（从 action=sections 获取）。不填返回整页。")] = None,
         direction: Annotated[Literal["outbound", "inbound"], Field(default="outbound", description="仅 action=links 生效：outbound（出链，默认）或 inbound（入站）。")] = "outbound",
         limit: Annotated[int, Field(default=30, ge=1, le=100, description="仅 action=links 生效：返回链接数量上限，默认 30。")] = 30,
@@ -106,7 +107,7 @@ def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         推荐流程：先用 action="sections" 看目录（每行 `[编号] L层级 标题`，T- 前缀表示模板
         嵌入的节），再用 action="read" + section_index 读特定章节，避免整页过载。其余 action：
         categories 返回分类标签；links 返回相关链接（outbound 出链 / inbound 反向链接）；
-        template 返回结构化模板数据（如干员 CharinfoV2、敌人 敌人信息/common2、物品 道具信息）。
+        template 返回顶层模板的结构化、已渲染字段数据（如干员 CharinfoV2、敌人 敌人信息/common2、物品 道具信息）。
         """
         try:
             if action == "read":
@@ -139,6 +140,8 @@ def register_prts_tools(mcp) -> None:  # type: ignore[no-untyped-def]
             if not templates:
                 return text_result(f"页面 '{page_title}' 未找到可提取的模板数据。")
             return text_result(json.dumps(templates, ensure_ascii=False, indent=2))
+        except TemplateRenderError:
+            return text_result('模板字段渲染失败。请改用 action="read" 获取正文。')
         except RuntimeError as e:
             return text_result(str(e))
         except Exception as e:

--- a/python/src/prts_mcp/tools_story.py
+++ b/python/src/prts_mcp/tools_story.py
@@ -146,8 +146,11 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     def read_activity(
         event_id: Annotated[str, Field(description="活动 ID，如 \"act31side\"（可从 list_story_events 获取）。")],
         include_narration: Annotated[bool, Field(default=True, description="是否包含旁白，默认 True。")] = True,
-        page: Annotated[int | None, Field(default=None, description="分页页码（从 1 开始）。不填则返回全部章节。")] = None,
-        page_size: Annotated[int, Field(default=5, description="每页章节数，默认 5。")] = 5,
+        page: Annotated[
+            int | None,
+            Field(default=None, ge=1, description="分页页码（从 1 开始）。不填则返回全部章节。"),
+        ] = None,
+        page_size: Annotated[int, Field(default=5, ge=1, le=20, description="每页章节数，默认 5。")] = 5,
     ) -> object:
         """读取整个活动的完整剧情台词（按官方章节顺序合并）。
 
@@ -176,6 +179,13 @@ def register_story_tools(mcp) -> None:  # type: ignore[no-untyped-def]
         chapters = result.chapters
         total = result.total_chapters
         has_more = result.has_more
+
+        if result.page_out_of_range:
+            total_pages = (total + page_size - 1) // page_size
+            return text_result(
+                f"页码超出范围：{event_id} 共 {total} 章，按 page_size={page_size} "
+                f"分页共 {total_pages} 页，请求的 page={page} 不存在。"
+            )
 
         header = f"【{result.event_name}】共 {total} 章"
         if page is not None:

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -506,3 +506,37 @@ def test_list_story_events_missing_zip_is_content_only(
         "剧情数据未就绪。请设置 STORYJSON_PATH 环境变量指向 zh_CN.zip，"
         "或等待服务器自动从 GitHub Release 下载完成后重试。"
     )
+
+
+def test_read_activity_out_of_range_page_is_content_only(
+    monkeypatch: pytest.MonkeyPatch,
+    story_zip: Path,
+) -> None:
+    monkeypatch.setenv("STORYJSON_PATH", str(story_zip))
+    app = MCPServer("story-test")
+    register_story_tools(app)
+
+    result = asyncio.run(
+        app._tool_manager.call_tool(
+            "read_activity",
+            {"event_id": "act_test", "page": 3, "page_size": 1},
+            Context(mcp_server=app),
+            convert_result=True,
+        )
+    )
+
+    assert result.structured_content is None
+    assert result.content[0].text == (
+        "页码超出范围：act_test 共 2 章，按 page_size=1 分页共 2 页，请求的 page=3 不存在。"
+    )
+
+
+def test_read_activity_page_schema_requires_positive_integer() -> None:
+    app = MCPServer("story-test")
+    register_story_tools(app)
+
+    tools = asyncio.run(app.list_tools())
+    read_activity = next(tool for tool in tools if tool.name == "read_activity")
+    page_schema = read_activity.input_schema["properties"]["page"]
+
+    assert page_schema["anyOf"][0]["minimum"] == 1

--- a/python/tests/test_story_reader_store.py
+++ b/python/tests/test_story_reader_store.py
@@ -140,7 +140,27 @@ def test_story_tools_read_from_store(tmp_path, store_kind):
     assert activity.event_name == "测试活动"
     assert activity.total_chapters == 2
     assert activity.has_more is True
+    assert activity.page_out_of_range is False
     assert [chapter.story_key for chapter in activity.chapters] == [FIRST_STORY_KEY]
+
+    out_of_range = read_activity_from_store(store, "act_test", page=3, page_size=1)
+    assert out_of_range.total_chapters == 2
+    assert out_of_range.chapters == []
+    assert out_of_range.page_out_of_range is True
+
+    with pytest.raises(ValueError, match="page_size 参数必须在 1 到 20 之间"):
+        read_activity_from_store(store, "act_test", page=1, page_size=0)
+
+
+def test_unreadable_chapter_is_not_page_out_of_range(tmp_path: Path) -> None:
+    write_story_dir(tmp_path)
+    (tmp_path / story_path(FIRST_STORY_KEY)).unlink()
+
+    result = read_activity_from_store(DirectoryStore(tmp_path), "act_test", page=1, page_size=1)
+
+    assert result.total_chapters == 2
+    assert result.chapters == []
+    assert result.page_out_of_range is False
 
 
 def test_public_zip_path_api_still_reads_zip(tmp_path):

--- a/python/tests/test_template_renderer.py
+++ b/python/tests/test_template_renderer.py
@@ -1,0 +1,127 @@
+"""Regression coverage for rendered PRTS template fields (#125)."""
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from pathlib import Path
+
+import pytest
+from mcp.server import MCPServer
+from mcp.server.mcpserver import Context
+
+import prts_mcp.api.prts_wiki as prts_wiki
+from prts_mcp.api.template_renderer import TemplateRenderError, render_template_data
+from prts_mcp.tools_prts import register_prts_tools
+
+
+def _fixture() -> dict:
+    path = Path(__file__).parents[2] / "tests" / "parity-fixtures" / "template_nested_rendering.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+class _Response:
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self) -> dict:
+        return self.payload
+
+
+class _TemplateClient:
+    def __init__(self, fixture: dict) -> None:
+        self.fixture = fixture
+        self.get_params: dict | None = None
+        self.post_data: dict | None = None
+
+    async def get(self, _url: str, *, params: dict) -> _Response:
+        self.get_params = params
+        return _Response({"parse": {"parsetree": {"*": self.fixture["parsetree"]}}})
+
+    async def post(self, _url: str, *, data: dict) -> _Response:
+        self.post_data = data
+        text = data["text"]
+        markers = list(re.finditer(r"(PRTSMCP_[0-9a-f]{32}_BEGIN_(\d+)_)", text))
+        assert len(markers) == len(self.fixture["rendered_values"])
+        html = []
+        for marker, value in zip(markers, self.fixture["rendered_values"], strict=True):
+            begin = marker.group(1)
+            end = begin.replace("_BEGIN_", "_END_")
+            html.append(f"<p>{begin}\n{value}\n{end}</p>")
+        return _Response({"parse": {"text": {"*": "\n".join(html)}}})
+
+
+async def _no_rate_limit() -> None:
+    pass
+
+
+def test_get_template_data_renders_nested_fields_in_one_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixture = _fixture()
+    client = _TemplateClient(fixture)
+    monkeypatch.setattr(prts_wiki, "_get_client", lambda: client)
+    monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
+
+    result = asyncio.run(prts_wiki.get_template_data(fixture["title"]))
+
+    assert result == fixture["expected"]
+    assert client.get_params == {
+        "action": "parse",
+        "page": fixture["title"],
+        "prop": "parsetree",
+        "format": "json",
+    }
+    assert client.post_data is not None
+    assert client.post_data["action"] == "parse"
+    assert client.post_data["title"] == fixture["title"]
+    assert client.post_data["prop"] == "text"
+    assert "攻击造成{{color|#00B0FF|法术伤害}}。" in client.post_data["text"]
+    assert "攻击力{{*|100%}}" in client.post_data["text"]
+    assert "查看[[阿米娅|阿米娅]]" in client.post_data["text"]
+    assert "数值" not in client.post_data["text"]
+
+
+def test_template_renderer_rejects_unknown_nested_node() -> None:
+    xml = "<root><template><title>Test</title><part><name>字段</name><value><h>标题</h></value></part></template></root>"
+
+    with pytest.raises(TemplateRenderError, match="不支持的模板字段节点：h"):
+        asyncio.run(render_template_data("测试", xml, _unexpected_render))
+
+
+def test_template_renderer_skips_batch_render_for_plain_values() -> None:
+    xml = "<root><template><title>Test</title><part><name>数值</name><value>12</value></part></template></root>"
+
+    result = asyncio.run(render_template_data("测试", xml, _unexpected_render))
+
+    assert result == {"Test": {"数值": "12"}}
+
+
+async def _unexpected_render(_title: str, _values: list[str]) -> list[str]:
+    raise AssertionError("unsupported XML must not reach the renderer")
+
+
+def test_prts_page_returns_content_only_template_render_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fail_template(_title: str) -> dict:
+        raise TemplateRenderError('模板字段渲染失败。请改用 action="read" 获取正文。')
+
+    monkeypatch.setattr("prts_mcp.tools_prts._get_template_data", fail_template)
+    app = MCPServer("template-renderer-test")
+    register_prts_tools(app)
+
+    result = asyncio.run(
+        app._tool_manager.call_tool(
+            "prts_page",
+            {"page_title": "阿米娅", "action": "template"},
+            Context(mcp_server=app),
+            convert_result=True,
+        )
+    )
+
+    assert result.structured_content is None
+    assert result.content[0].text == '模板字段渲染失败。请改用 action="read" 获取正文。'

--- a/python/tests/test_template_renderer.py
+++ b/python/tests/test_template_renderer.py
@@ -100,6 +100,27 @@ def test_template_renderer_skips_batch_render_for_plain_values() -> None:
     assert result == {"Test": {"数值": "12"}}
 
 
+def test_render_template_batch_converts_malformed_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _BadResponse:
+        def raise_for_status(self) -> None:
+            pass
+
+        def json(self) -> dict:
+            raise ValueError("malformed json")
+
+    class _BadClient:
+        async def post(self, _url: str, *, data: dict) -> _BadResponse:
+            return _BadResponse()
+
+    monkeypatch.setattr(prts_wiki, "_get_client", lambda: _BadClient())
+    monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
+
+    with pytest.raises(TemplateRenderError, match="模板字段渲染请求失败"):
+        asyncio.run(prts_wiki._render_template_batch("测试", ["{{color|红}}"]))
+
+
 async def _unexpected_render(_title: str, _values: list[str]) -> list[str]:
     raise AssertionError("unsupported XML must not reach the renderer")
 

--- a/python/tests/test_template_renderer.py
+++ b/python/tests/test_template_renderer.py
@@ -163,6 +163,24 @@ def test_render_template_batch_keeps_other_fields_when_one_renders_empty(
     assert result == ["", "保留字段"]
 
 
+def test_render_template_batch_rejects_reversed_markers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _ReversedClient:
+        async def post(self, _url: str, *, data: dict) -> _Response:
+            match = re.search(r"(PRTSMCP_[0-9a-f]{32}_BEGIN_0_)", data["text"])
+            assert match is not None
+            begin = match.group(1)
+            end = begin.replace("_BEGIN_", "_END_")
+            return _Response({"parse": {"text": {"*": f"{end}\n{begin}\n错误"}}})
+
+    monkeypatch.setattr(prts_wiki, "_get_client", lambda: _ReversedClient())
+    monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
+
+    with pytest.raises(TemplateRenderError, match="模板字段渲染边界无效"):
+        asyncio.run(prts_wiki._render_template_batch("测试", ["{{color|红}}"]))
+
+
 def test_render_template_batch_does_not_mask_local_cleanup_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/python/tests/test_template_renderer.py
+++ b/python/tests/test_template_renderer.py
@@ -181,6 +181,27 @@ def test_render_template_batch_rejects_reversed_markers(
         asyncio.run(prts_wiki._render_template_batch("测试", ["{{color|红}}"]))
 
 
+def test_render_template_batch_rejects_interleaved_markers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _InterleavedClient:
+        async def post(self, _url: str, *, data: dict) -> _Response:
+            markers = list(re.finditer(r"(PRTSMCP_[0-9a-f]{32}_BEGIN_(\d+)_)", data["text"]))
+            assert len(markers) == 2
+            begin0 = markers[0].group(1)
+            end0 = begin0.replace("_BEGIN_", "_END_")
+            begin1 = markers[1].group(1)
+            end1 = begin1.replace("_BEGIN_", "_END_")
+            html = f"{begin0}\n{begin1}\n值0\n{end0}\n值1\n{end1}"
+            return _Response({"parse": {"text": {"*": html}}})
+
+    monkeypatch.setattr(prts_wiki, "_get_client", lambda: _InterleavedClient())
+    monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
+
+    with pytest.raises(TemplateRenderError, match="模板字段渲染边界无效"):
+        asyncio.run(prts_wiki._render_template_batch("测试", ["{{a}}", "{{b}}"]))
+
+
 def test_render_template_batch_does_not_mask_local_cleanup_errors(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/python/tests/test_template_renderer.py
+++ b/python/tests/test_template_renderer.py
@@ -21,13 +21,13 @@ def _fixture() -> dict:
 
 
 class _Response:
-    def __init__(self, payload: dict) -> None:
+    def __init__(self, payload: object) -> None:
         self.payload = payload
 
     def raise_for_status(self) -> None:
         pass
 
-    def json(self) -> dict:
+    def json(self) -> object:
         return self.payload
 
 
@@ -118,6 +118,66 @@ def test_render_template_batch_converts_malformed_response(
     monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
 
     with pytest.raises(TemplateRenderError, match="模板字段渲染请求失败"):
+        asyncio.run(prts_wiki._render_template_batch("测试", ["{{color|红}}"]))
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [None, [], {"parse": []}, {"parse": {"text": {"*": None}}}],
+)
+def test_render_template_batch_rejects_invalid_response_shape(
+    monkeypatch: pytest.MonkeyPatch,
+    payload: object,
+) -> None:
+    class _InvalidClient:
+        async def post(self, _url: str, *, data: dict) -> _Response:
+            return _Response(payload)
+
+    monkeypatch.setattr(prts_wiki, "_get_client", lambda: _InvalidClient())
+    monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
+
+    with pytest.raises(TemplateRenderError, match="模板字段渲染响应格式无效"):
+        asyncio.run(prts_wiki._render_template_batch("测试", ["{{color|红}}"]))
+
+
+def test_render_template_batch_keeps_other_fields_when_one_renders_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _PartialClient:
+        async def post(self, _url: str, *, data: dict) -> _Response:
+            text = data["text"]
+            markers = list(re.finditer(r"(PRTSMCP_[0-9a-f]{32}_BEGIN_(\d+)_)", text))
+            values = ["", "保留字段"]
+            html = []
+            for marker, value in zip(markers, values, strict=True):
+                begin = marker.group(1)
+                end = begin.replace("_BEGIN_", "_END_")
+                html.append(f"<p>{begin}\n{value}\n{end}</p>")
+            return _Response({"parse": {"text": {"*": "\n".join(html)}}})
+
+    monkeypatch.setattr(prts_wiki, "_get_client", lambda: _PartialClient())
+    monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
+
+    result = asyncio.run(prts_wiki._render_template_batch("测试", ["{{empty}}", "{{kept}}"]))
+
+    assert result == ["", "保留字段"]
+
+
+def test_render_template_batch_does_not_mask_local_cleanup_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _ValidClient:
+        async def post(self, _url: str, *, data: dict) -> _Response:
+            return _Response({"parse": {"text": {"*": "valid"}}})
+
+    def raise_cleanup_error(_text: str) -> str:
+        raise RuntimeError("bug")
+
+    monkeypatch.setattr(prts_wiki, "_get_client", lambda: _ValidClient())
+    monkeypatch.setattr(prts_wiki, "_rate_limit", _no_rate_limit)
+    monkeypatch.setattr(prts_wiki, "_strip_html", raise_cleanup_error)
+
+    with pytest.raises(RuntimeError, match="bug"):
         asyncio.run(prts_wiki._render_template_batch("测试", ["{{color|红}}"]))
 
 

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "prts-mcp"
-version = "2.7.0.dev0"
+version = "2.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "prts-mcp"
-version = "2.6.0"
+version = "2.7.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/tests/parity-fixtures/template_nested_rendering.json
+++ b/tests/parity-fixtures/template_nested_rendering.json
@@ -1,0 +1,23 @@
+{
+  "title": "阿米娅",
+  "parsetree": "<root><template><title>CharinfoV2<comment>主模板</comment></title><part><name>特性</name><value>攻击造成<template><title>color</title><part><name index=\"1\"/><value>#00B0FF</value></part><part><name index=\"2\"/><value>法术伤害</value></part></template>。</value></part><part><name>技能1描述</name><value>攻击力<template><title>*</title><part><name index=\"1\"/><value>100%</value></part></template></value></part><part><name>数值</name><value>12</value></part><part><name index=\"1\"/><value>导航</value></part></template><template><title>Links</title><part><name>链接</name><value>查看<link><target>阿米娅</target><part><value>阿米娅</value></part></link></value></part></template></root>",
+  "rendered_values": [
+    "攻击造成法术伤害。",
+    "攻击力100%",
+    "查看阿米娅"
+  ],
+  "expected": {
+    "CharinfoV2": {
+      "特性": "攻击造成法术伤害。",
+      "技能1描述": "攻击力100%",
+      "数值": "12",
+      "_positional": [
+        "导航"
+      ],
+      "_comment": "主模板"
+    },
+    "Links": {
+      "链接": "查看阿米娅"
+    }
+  }
+}

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
+
 ## [2.6.0] - 2026-08-09
 
 ### Added

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
+- Template rendering now preserves valid fields when another nested value renders empty and normalizes malformed MediaWiki response shapes to the documented content-only fallback.
 
 ## [2.6.0] - 2026-08-09
 

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.6.0] - 2026-08-09
 
 ### Added

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.6.1] - 2026-08-10
 
 ### Fixed
 
 - `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
 - Template rendering now preserves valid fields when another nested value renders empty and normalizes malformed MediaWiki response shapes and marker boundaries to the documented content-only fallback.
+- `read_activity` now validates page inputs consistently and returns a clear content-only message when the requested page is beyond an existing activity's range (#137).
 
 ## [2.6.0] - 2026-08-09
 

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
-- Template rendering now preserves valid fields when another nested value renders empty and normalizes malformed MediaWiki response shapes to the documented content-only fallback.
+- Template rendering now preserves valid fields when another nested value renders empty and normalizes malformed MediaWiki response shapes and marker boundaries to the documented content-only fallback.
 
 ## [2.6.0] - 2026-08-09
 

--- a/ts/bun.lock
+++ b/ts/bun.lock
@@ -9,6 +9,7 @@
         "@modelcontextprotocol/server": "2.0.0",
         "adm-zip": "^0.6.0",
         "express": "^5.2.1",
+        "fast-xml-parser": "5.10.1",
         "undici": "^8.10.0",
         "zod": "4.3.6",
       },
@@ -85,6 +86,8 @@
 
     "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0", "", { "dependencies": { "@modelcontextprotocol/core": "2.0.0", "zod": "^4.2.0" } }, "sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw=="],
 
+    "@nodable/entities": ["@nodable/entities@3.0.0", "", {}, "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw=="],
+
     "@types/adm-zip": ["@types/adm-zip@0.5.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q=="],
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
@@ -110,6 +113,8 @@
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "adm-zip": ["adm-zip@0.6.0", "", {}, "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg=="],
+
+    "anynum": ["anynum@1.0.1", "", {}, "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A=="],
 
     "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
 
@@ -151,6 +156,10 @@
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
+    "fast-xml-builder": ["fast-xml-builder@1.3.0", "", { "dependencies": { "path-expression-matcher": "^1.6.2", "xml-naming": "^0.3.0" } }, "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.10.1", "", { "dependencies": { "@nodable/entities": "^3.0.0", "fast-xml-builder": "^1.2.0", "is-unsafe": "^2.0.0", "path-expression-matcher": "^1.6.2", "strnum": "^2.4.1", "xml-naming": "^0.3.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw=="],
+
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
@@ -183,6 +192,8 @@
 
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
+    "is-unsafe": ["is-unsafe@2.0.0", "", {}, "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
@@ -204,6 +215,8 @@
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-expression-matcher": ["path-expression-matcher@1.6.2", "", {}, "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ=="],
 
     "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
@@ -235,6 +248,8 @@
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
+    "strnum": ["strnum@2.4.1", "", { "dependencies": { "anynum": "^1.0.1" } }, "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg=="],
+
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "tsx": ["tsx@4.23.0", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w=="],
@@ -252,6 +267,8 @@
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "xml-naming": ["xml-naming@0.3.0", "", {}, "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ=="],
 
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -13,6 +13,7 @@
         "@modelcontextprotocol/server": "2.0.0",
         "adm-zip": "^0.6.0",
         "express": "^5.2.1",
+        "fast-xml-parser": "5.10.1",
         "undici": "^8.10.0",
         "zod": "4.3.6"
       },
@@ -532,6 +533,18 @@
         "node": ">=20"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@types/adm-zip": {
       "version": "0.5.8",
       "resolved": "https://registry.npmmirror.com/@types/adm-zip/-/adm-zip-0.5.8.tgz",
@@ -661,6 +674,18 @@
       "engines": {
         "node": ">=14.0"
       }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.3.0",
@@ -962,6 +987,45 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmmirror.com/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -1165,6 +1229,18 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -1275,6 +1351,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-to-regexp": {
@@ -1494,6 +1585,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1606,6 +1712,21 @@
       "resolved": "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/zod": {
       "version": "4.3.6",

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.6.0",
+  "version": "2.7.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.6.0",
+      "version": "2.7.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "2.0.0",

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.7.0-dev.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.7.0-dev.0",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "2.0.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.6.0",
+  "version": "2.7.0-dev.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP + stdio)",
   "type": "module",
   "main": "dist/server.js",

--- a/ts/package.json
+++ b/ts/package.json
@@ -67,6 +67,7 @@
     "@modelcontextprotocol/server": "2.0.0",
     "adm-zip": "^0.6.0",
     "express": "^5.2.1",
+    "fast-xml-parser": "5.10.1",
     "undici": "^8.10.0",
     "zod": "4.3.6"
   },

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.7.0-dev.0",
+  "version": "2.6.1",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP + stdio)",
   "type": "module",
   "main": "dist/server.js",

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -381,21 +381,42 @@ async function renderTemplateBatch(title: string, values: string[]): Promise<str
     return `${begin}\n${value}\n${end}`;
   }).join("\n\n");
 
-  let data: { error?: { info?: string }; parse?: { text?: { "*"?: string } } };
+  let data: unknown;
   try {
-    data = (await prtsPost({
+    data = await prtsPost({
       action: "parse",
       title,
       text,
       prop: "text",
       format: "json",
-    })) as typeof data;
+    });
   } catch (error) {
     throw new TemplateRenderError("模板字段渲染请求失败。", { cause: error });
   }
-  if (data.error?.info) throw new TemplateRenderError("模板字段渲染请求失败。");
+  if (typeof data !== "object" || data === null || Array.isArray(data)) {
+    throw new TemplateRenderError("模板字段渲染响应格式无效。");
+  }
+  const response = data as { error?: unknown; parse?: unknown };
+  if (
+    typeof response.error === "object"
+    && response.error !== null
+    && !Array.isArray(response.error)
+    && "info" in response.error
+  ) {
+    throw new TemplateRenderError("模板字段渲染请求失败。");
+  }
 
-  const rendered = stripHtml(data.parse?.text?.["*"] ?? "");
+  const parse = typeof response.parse === "object" && response.parse !== null && !Array.isArray(response.parse)
+    ? response.parse as { text?: unknown }
+    : undefined;
+  const textNode = typeof parse?.text === "object" && parse.text !== null && !Array.isArray(parse.text)
+    ? parse.text as { "*"?: unknown }
+    : undefined;
+  if (typeof textNode?.["*"] !== "string") {
+    throw new TemplateRenderError("模板字段渲染响应格式无效。");
+  }
+
+  const rendered = stripHtml(textNode["*"]);
   if (!rendered) throw new TemplateRenderError("模板字段渲染结果为空。");
   return markers.map(([begin, end]) => {
     if (rendered.split(begin).length !== 2 || rendered.split(end).length !== 2) {
@@ -403,9 +424,7 @@ async function renderTemplateBatch(title: string, values: string[]): Promise<str
     }
     const start = rendered.indexOf(begin) + begin.length;
     const finish = rendered.indexOf(end, start);
-    const value = rendered.slice(start, finish).trim();
-    if (!value) throw new TemplateRenderError("模板字段渲染结果为空。");
-    return value;
+    return rendered.slice(start, finish).trim();
   });
 }
 

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -3,12 +3,15 @@
  * Mirrors python/src/prts_mcp/api/prts_wiki.py.
  */
 
+import { randomUUID } from "node:crypto";
+
 import {
   PRTS_API_ENDPOINT,
   RATE_LIMIT_INTERVAL,
   USER_AGENT,
 } from "../config.js";
 import { stripWikitext } from "../utils/sanitizer.js";
+import { renderTemplateData, TemplateRenderError } from "./templateRenderer.js";
 
 // ---------------------------------------------------------------------------
 // Rate limiter
@@ -44,6 +47,18 @@ async function prtsGet(params: Record<string, string | number>): Promise<unknown
   }
   const res = await fetch(url.toString(), {
     headers: DEFAULT_HEADERS,
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) throw new Error(`PRTS API error: HTTP ${res.status}`);
+  return res.json();
+}
+
+async function prtsPost(params: Record<string, string | number>): Promise<unknown> {
+  await rateLimit();
+  const res = await fetch(PRTS_API_ENDPOINT, {
+    method: "POST",
+    headers: { ...DEFAULT_HEADERS, "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(Object.entries(params).map(([key, value]) => [key, String(value)])),
     signal: AbortSignal.timeout(15_000),
   });
   if (!res.ok) throw new Error(`PRTS API error: HTTP ${res.status}`);
@@ -270,104 +285,6 @@ export async function listSections(
   }));
 }
 
-// ---------------------------------------------------------------------------
-// Parsetree XML parser
-// ---------------------------------------------------------------------------
-
-function* splitTopLevelTags(xml: string, tag: string): Generator<string> {
-  const open = `<${tag}`;
-  const close = `</${tag}>`;
-
-  let depth = 0;
-  let start = 0;
-
-  for (let i = 0; i < xml.length; ) {
-    if (xml.startsWith(open, i)) {
-      if (depth === 0) start = i;
-      depth++;
-      i += open.length;
-    } else if (xml.startsWith(close, i)) {
-      depth--;
-      if (depth === 0) {
-        yield xml.substring(start, i + close.length);
-      }
-      i += close.length;
-    } else {
-      i++;
-    }
-  }
-}
-
-function stripComments(xml: string): string {
-  return xml.replace(/<comment>[\s\S]*?<\/comment>/g, "");
-}
-
-const PART_RE = /<part>([\s\S]*?)<\/part>/g;
-const NAME_RE = /<name[^>]*>([\s\S]*?)<\/name>/;
-const VALUE_RE = /<value>([\s\S]*?)<\/value>/;
-const INDEX_RE = /\bindex\s*=/;
-
-function parsePart(partXml: string): { key?: string; value: string } | null {
-  const nameMatch = partXml.match(NAME_RE);
-  const valueMatch = partXml.match(VALUE_RE);
-  if (!valueMatch?.[1]) return null;
-  // Strip nested template tags from the value
-  const raw = valueMatch[1].replace(/<template[\s\S]*?<\/template>/g, "");
-  const value = raw.trim();
-  if (!value) return null;
-  if (nameMatch) {
-    const nameText = nameMatch[1].replace(/<[^>]+>/g, "").trim();
-    if (!nameText && INDEX_RE.test(partXml)) return { value }; // positional (name index=N)
-    if (nameText) return { key: nameText, value };
-  }
-  return { value };
-}
-
-function parseParsetreeXml(xml: string): Record<string, Record<string, unknown>> {
-  const templates: Record<string, Record<string, unknown>> = {};
-
-  for (const tXml of splitTopLevelTags(xml, "template")) {
-    const titleMatch = tXml.match(/<title>([\s\S]*?)<\/title>/);
-    if (!titleMatch) continue;
-
-    const title = stripComments(titleMatch[1]).replace(/\n/g, "").trim();
-    if (!title) continue;
-
-    const commentMatch = tXml.match(/<comment>([\s\S]*?)<\/comment>/);
-    const comment = commentMatch?.[1]?.trim() ?? "";
-
-    const kv: Record<string, string> = {};
-    const positional: string[] = [];
-
-    let pMatch: RegExpExecArray | null;
-    PART_RE.lastIndex = 0;
-    while ((pMatch = PART_RE.exec(tXml)) !== null) {
-      const parsed = parsePart(pMatch[1]);
-      if (!parsed) continue;
-      if (parsed.key) {
-        kv[parsed.key] = parsed.value;
-      } else {
-        positional.push(parsed.value);
-      }
-    }
-
-    const entry: Record<string, unknown> = {};
-    if (Object.keys(kv).length > 0) Object.assign(entry, kv);
-    if (positional.length > 0) entry._positional = positional;
-    if (comment) entry._comment = comment;
-
-    if (Object.keys(entry).length > 0) {
-      templates[title] = entry;
-    }
-  }
-
-  return templates;
-}
-
-// ---------------------------------------------------------------------------
-// Public API (continued)
-// ---------------------------------------------------------------------------
-
 /** Mirrors prts_wiki.get_categories(). */
 export async function getCategories(title: string): Promise<string[]> {
   const data = (await prtsGet({
@@ -451,6 +368,47 @@ export async function getLinks(
   };
 }
 
+async function renderTemplateBatch(title: string, values: string[]): Promise<string[]> {
+  if (values.length === 0) return [];
+
+  const prefix = `PRTSMCP_${randomUUID().replaceAll("-", "")}`;
+  const markers = values.map((_, index) => [
+    `${prefix}_BEGIN_${index}_`,
+    `${prefix}_END_${index}_`,
+  ] as const);
+  const text = values.map((value, index) => {
+    const [begin, end] = markers[index]!;
+    return `${begin}\n${value}\n${end}`;
+  }).join("\n\n");
+
+  let data: { error?: { info?: string }; parse?: { text?: { "*"?: string } } };
+  try {
+    data = (await prtsPost({
+      action: "parse",
+      title,
+      text,
+      prop: "text",
+      format: "json",
+    })) as typeof data;
+  } catch (error) {
+    throw new TemplateRenderError("模板字段渲染请求失败。", { cause: error });
+  }
+  if (data.error?.info) throw new TemplateRenderError("模板字段渲染请求失败。");
+
+  const rendered = stripHtml(data.parse?.text?.["*"] ?? "");
+  if (!rendered) throw new TemplateRenderError("模板字段渲染结果为空。");
+  return markers.map(([begin, end]) => {
+    if (rendered.split(begin).length !== 2 || rendered.split(end).length !== 2) {
+      throw new TemplateRenderError("模板字段渲染边界无效。");
+    }
+    const start = rendered.indexOf(begin) + begin.length;
+    const finish = rendered.indexOf(end, start);
+    const value = rendered.slice(start, finish).trim();
+    if (!value) throw new TemplateRenderError("模板字段渲染结果为空。");
+    return value;
+  });
+}
+
 /** Mirrors prts_wiki.get_template_data(). */
 export async function getTemplateData(
   title: string,
@@ -474,7 +432,7 @@ export async function getTemplateData(
     throw new Error(`页面 '${title}' 无 parsetree 数据。`);
   }
 
-  return parseParsetreeXml(xml);
+  return renderTemplateData(title, xml, renderTemplateBatch);
 }
 
 // ---------------------------------------------------------------------------

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -401,7 +401,8 @@ async function renderTemplateBatch(title: string, values: string[]): Promise<str
     typeof response.error === "object"
     && response.error !== null
     && !Array.isArray(response.error)
-    && "info" in response.error
+    && typeof (response.error as { info?: unknown }).info === "string"
+    && (response.error as { info: string }).info
   ) {
     throw new TemplateRenderError("模板字段渲染请求失败。");
   }
@@ -422,8 +423,12 @@ async function renderTemplateBatch(title: string, values: string[]): Promise<str
     if (rendered.split(begin).length !== 2 || rendered.split(end).length !== 2) {
       throw new TemplateRenderError("模板字段渲染边界无效。");
     }
-    const start = rendered.indexOf(begin) + begin.length;
-    const finish = rendered.indexOf(end, start);
+    const beginIndex = rendered.indexOf(begin);
+    const finish = rendered.indexOf(end);
+    if (finish < beginIndex + begin.length) {
+      throw new TemplateRenderError("模板字段渲染边界无效。");
+    }
+    const start = beginIndex + begin.length;
     return rendered.slice(start, finish).trim();
   });
 }

--- a/ts/src/api/prtsWiki.ts
+++ b/ts/src/api/prtsWiki.ts
@@ -397,14 +397,15 @@ async function renderTemplateBatch(title: string, values: string[]): Promise<str
     throw new TemplateRenderError("模板字段渲染响应格式无效。");
   }
   const response = data as { error?: unknown; parse?: unknown };
-  if (
-    typeof response.error === "object"
-    && response.error !== null
-    && !Array.isArray(response.error)
-    && typeof (response.error as { info?: unknown }).info === "string"
-    && (response.error as { info: string }).info
-  ) {
-    throw new TemplateRenderError("模板字段渲染请求失败。");
+  if ("error" in response) {
+    if (typeof response.error !== "object" || response.error === null || Array.isArray(response.error)) {
+      throw new TemplateRenderError("模板字段渲染响应格式无效。");
+    }
+    const info = (response.error as { info?: unknown }).info;
+    if (typeof info !== "string") {
+      throw new TemplateRenderError("模板字段渲染响应格式无效。");
+    }
+    if (info) throw new TemplateRenderError("模板字段渲染请求失败。");
   }
 
   const parse = typeof response.parse === "object" && response.parse !== null && !Array.isArray(response.parse)
@@ -419,6 +420,21 @@ async function renderTemplateBatch(title: string, values: string[]): Promise<str
 
   const rendered = stripHtml(textNode["*"]);
   if (!rendered) throw new TemplateRenderError("模板字段渲染结果为空。");
+  const markerPositions = markers.flatMap(([begin, end], index) => [
+    { position: rendered.indexOf(begin), kind: "begin" as const, index },
+    { position: rendered.indexOf(end), kind: "end" as const, index },
+  ]);
+  const expectedOrder = markers.flatMap((_, index) => [
+    { kind: "begin" as const, index },
+    { kind: "end" as const, index },
+  ]);
+  const actualOrder = [...markerPositions]
+    .sort((left, right) => left.position - right.position)
+    .map(({ kind, index }) => ({ kind, index }));
+  if (JSON.stringify(actualOrder) !== JSON.stringify(expectedOrder)) {
+    throw new TemplateRenderError("模板字段渲染边界无效。");
+  }
+
   return markers.map(([begin, end]) => {
     if (rendered.split(begin).length !== 2 || rendered.split(end).length !== 2) {
       throw new TemplateRenderError("模板字段渲染边界无效。");

--- a/ts/src/api/templateRenderer.ts
+++ b/ts/src/api/templateRenderer.ts
@@ -1,0 +1,190 @@
+import { XMLParser } from "fast-xml-parser";
+
+export class TemplateRenderError extends Error {}
+
+type XmlEntry = Record<string, unknown>;
+type XmlContent = XmlEntry[];
+
+interface XmlElement {
+  content: XmlContent;
+  attrs: Record<string, string>;
+}
+
+interface TemplatePart {
+  name?: string;
+  value: string;
+  needsRender: boolean;
+}
+
+interface TemplateEntry {
+  name: string;
+  parts: TemplatePart[];
+  comment: string;
+}
+
+const xmlParser = new XMLParser({
+  preserveOrder: true,
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  commentPropName: "#comment",
+  parseTagValue: false,
+  trimValues: false,
+});
+
+function isRecord(value: unknown): value is XmlEntry {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asContent(value: unknown): XmlContent {
+  return Array.isArray(value) && value.every(isRecord) ? value : [];
+}
+
+function attributes(entry: XmlEntry): Record<string, string> {
+  const attrs = entry[":@"];
+  if (!isRecord(attrs)) return {};
+  return Object.fromEntries(
+    Object.entries(attrs).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  );
+}
+
+function elements(content: XmlContent, tag: string): XmlElement[] {
+  return content.flatMap((entry) => {
+    const children = entry[tag];
+    if (!Array.isArray(children)) return [];
+    return [{ content: asContent(children), attrs: attributes(entry) }];
+  });
+}
+
+function firstElement(content: XmlContent, tag: string): XmlElement | undefined {
+  return elements(content, tag)[0];
+}
+
+function textWithoutComments(content: XmlContent): string {
+  let text = "";
+  for (const entry of content) {
+    if (typeof entry["#text"] === "string") text += entry["#text"];
+    for (const [tag, value] of Object.entries(entry)) {
+      if (tag === "#text" || tag === "#comment" || tag === "comment" || tag === ":@" || !Array.isArray(value)) continue;
+      text += textWithoutComments(asContent(value));
+    }
+  }
+  return text;
+}
+
+function partToWikitext(part: XmlElement): string {
+  const value = firstElement(part.content, "value");
+  if (!value) throw new TemplateRenderError("模板字段缺少 value 节点。");
+  const name = firstElement(part.content, "name");
+  const renderedValue = contentToWikitext(value.content);
+  if (!name || "@_index" in name.attrs) return `|${renderedValue}`;
+  const renderedName = textWithoutComments(name.content).trim();
+  return renderedName ? `|${renderedName}=${renderedValue}` : `|${renderedValue}`;
+}
+
+function elementToWikitext(tag: string, element: XmlElement): string {
+  if (tag === "template") {
+    const title = firstElement(element.content, "title");
+    const name = title ? textWithoutComments(title.content).trim() : "";
+    if (!name) throw new TemplateRenderError("嵌套模板缺少 title 节点。");
+    return `{{${name}${elements(element.content, "part").map(partToWikitext).join("")}}}`;
+  }
+
+  if (tag === "tplarg") {
+    const title = firstElement(element.content, "title");
+    const name = title ? textWithoutComments(title.content).trim() : "";
+    if (!name) throw new TemplateRenderError("模板参数缺少 title 节点。");
+    return `{{{${name}${elements(element.content, "part").map(partToWikitext).join("")}}}`;
+  }
+
+  if (tag === "link") {
+    const target = firstElement(element.content, "target");
+    const targetText = target ? contentToWikitext(target.content).trim() : "";
+    if (!targetText) throw new TemplateRenderError("链接缺少 target 节点。");
+    return `[[${targetText}${elements(element.content, "part").map(partToWikitext).join("")}]]`;
+  }
+
+  throw new TemplateRenderError(`不支持的模板字段节点：${tag}。`);
+}
+
+function contentToWikitext(content: XmlContent): string {
+  let text = "";
+  for (const entry of content) {
+    if (typeof entry["#text"] === "string") text += entry["#text"];
+    if (typeof entry["#comment"] === "string") text += `<!--${entry["#comment"]}-->`;
+    for (const [tag, value] of Object.entries(entry)) {
+      if (tag === "#text" || tag === "#comment" || tag === ":@" || !Array.isArray(value)) continue;
+      if (tag === "comment") {
+        text += `<!--${textWithoutComments(asContent(value))}-->`;
+      } else {
+        text += elementToWikitext(tag, { content: asContent(value), attrs: attributes(entry) });
+      }
+    }
+  }
+  return text;
+}
+
+function parseTemplates(xml: string): TemplateEntry[] {
+  let parsed: XmlContent;
+  try {
+    parsed = asContent(xmlParser.parse(xml));
+  } catch (error) {
+    throw new TemplateRenderError("页面模板数据格式无效。", { cause: error });
+  }
+  const root = firstElement(parsed, "root");
+  if (!root) throw new TemplateRenderError("页面模板数据格式无效。");
+
+  return elements(root.content, "template").flatMap((template) => {
+    const title = firstElement(template.content, "title");
+    const name = title ? textWithoutComments(title.content).trim() : "";
+    if (!name) return [];
+    const commentElement = title ? firstElement(title.content, "comment") : undefined;
+    const comment = commentElement ? textWithoutComments(commentElement.content).trim() : "";
+    const parts = elements(template.content, "part").flatMap((part) => {
+      const value = firstElement(part.content, "value");
+      if (!value) return [];
+      const nameElement = firstElement(part.content, "name");
+      const partName = nameElement && !("@_index" in nameElement.attrs)
+        ? textWithoutComments(nameElement.content).trim() || undefined
+        : undefined;
+      const needsRender = value.content.some((entry) => Object.keys(entry).some(
+        (key) => key !== "#text" && key !== "#comment" && key !== "comment" && key !== ":@",
+      ));
+      const rawValue = needsRender ? contentToWikitext(value.content) : textWithoutComments(value.content);
+      const normalizedValue = rawValue.trim();
+      return normalizedValue ? [{ name: partName, value: normalizedValue, needsRender }] : [];
+    });
+    return [{ name, parts, comment }];
+  });
+}
+
+export async function renderTemplateData(
+  title: string,
+  xml: string,
+  renderBatch: (title: string, values: string[]) => Promise<string[]>,
+): Promise<Record<string, Record<string, unknown>>> {
+  const templates = parseTemplates(xml);
+  const sources = templates.flatMap((template) => template.parts
+    .filter((part) => part.needsRender)
+    .map((part) => part.value));
+  const rendered = sources.length > 0 ? await renderBatch(title, sources) : [];
+  if (rendered.length !== sources.length) {
+    throw new TemplateRenderError("模板字段渲染结果数量不匹配。");
+  }
+
+  const iterator = rendered.values();
+  const result: Record<string, Record<string, unknown>> = {};
+  for (const template of templates) {
+    const entry: Record<string, unknown> = {};
+    const positional: string[] = [];
+    for (const part of template.parts) {
+      const value = part.needsRender ? iterator.next().value : part.value;
+      if (!value) continue;
+      if (part.name) entry[part.name] = value;
+      else positional.push(value);
+    }
+    if (positional.length > 0) entry._positional = positional;
+    if (template.comment) entry._comment = template.comment;
+    if (Object.keys(entry).length > 0) result[template.name] = entry;
+  }
+  return result;
+}

--- a/ts/src/data/storyReader.ts
+++ b/ts/src/data/storyReader.ts
@@ -121,6 +121,7 @@ export interface ActivityResult {
   totalChapters: number;
   hasMore: boolean;
   chapters: StoryChapter[];
+  pageOutOfRange?: boolean;
 }
 
 export interface MemoirChapter {
@@ -522,17 +523,24 @@ export function readActivityFromStore(
   const summaries = listStoriesFromStore(store, eventId);
   const total = summaries.length;
 
+  if (pageSize < 1 || pageSize > 20) {
+    throw new Error("page_size 参数必须在 1 到 20 之间");
+  }
+
   let selected: ChapterSummary[];
   let hasMore: boolean;
+  let pageOutOfRange: boolean;
   if (page !== undefined) {
     if (page < 1) throw new Error("page 参数必须 >= 1");
     const start = (page - 1) * pageSize;
     const end = start + pageSize;
     selected = summaries.slice(start, end);
     hasMore = end < total;
+    pageOutOfRange = total > 0 && start >= total;
   } else {
     selected = summaries;
     hasMore = false;
+    pageOutOfRange = false;
   }
 
   const chapters: StoryChapter[] = [];
@@ -549,5 +557,5 @@ export function readActivityFromStore(
     }
   }
 
-  return { eventId, eventName, totalChapters: total, hasMore, chapters };
+  return { eventId, eventName, totalChapters: total, hasMore, pageOutOfRange, chapters };
 }

--- a/ts/src/tools/prtsTools.ts
+++ b/ts/src/tools/prtsTools.ts
@@ -15,6 +15,7 @@ import {
   getLinks,
   getTemplateData,
 } from "../api/prtsWiki.js";
+import { TemplateRenderError } from "../api/templateRenderer.js";
 import { renderResult, textResult, type OutputChannel } from "../output.js";
 import { registerTool } from "./registerTool.js";
 
@@ -96,11 +97,11 @@ export function registerPrtsTools(server: McpServer, channel: OutputChannel = "c
     [
       "读取 PRTS 维基页面的正文或元数据，按 action 分派。",
       "推荐流程：先用 action=\"sections\" 看目录（每行 `[编号] L层级 标题`，T- 前缀表示模板嵌入的节），再用 action=\"read\" + section_index 读特定章节，避免整页过载。",
-      "其余 action：categories 返回分类标签；links 返回相关链接（outbound 出链 / inbound 反向链接）；template 返回结构化模板数据（如干员 CharinfoV2、敌人 敌人信息/common2、物品 道具信息）。",
+      "其余 action：categories 返回分类标签；links 返回相关链接（outbound 出链 / inbound 反向链接）；template 返回顶层模板的结构化、已渲染字段数据（如干员 CharinfoV2、敌人 敌人信息/common2、物品 道具信息）。",
     ].join(" "),
     {
       page_title: z.string().describe("词条标题，需与维基页面标题完全一致，如「阿米娅」。建议先用 search_prts 获取准确标题。"),
-      action: z.enum(["read", "sections", "categories", "links", "template"]).describe("操作（必填）：read=读取正文 / sections=章节目录 / categories=分类标签 / links=相关链接 / template=结构化模板数据。"),
+      action: z.enum(["read", "sections", "categories", "links", "template"]).describe("操作（必填）：read=读取正文 / sections=章节目录 / categories=分类标签 / links=相关链接 / template=顶层模板的结构化、已渲染字段数据。"),
       section_index: z.number().int().optional().describe("仅 action=read 生效：章节编号（从 action=sections 获取）。不填返回整页。"),
       direction: z.enum(["outbound", "inbound"]).default("outbound").describe("仅 action=links 生效：outbound（出链，默认）或 inbound（入链）。"),
       limit: z.number().int().min(1).max(100).default(30).describe("仅 action=links 生效：返回链接数量上限，默认 30。"),
@@ -143,6 +144,9 @@ export function registerPrtsTools(server: McpServer, channel: OutputChannel = "c
         }
         return textResult(JSON.stringify(templates, null, 2));
       } catch (e) {
+        if (e instanceof TemplateRenderError) {
+          return textResult('模板字段渲染失败。请改用 action="read" 获取正文。');
+        }
         return textResult(e instanceof Error ? e.message : String(e));
       }
     }

--- a/ts/src/tools/storyTools.ts
+++ b/ts/src/tools/storyTools.ts
@@ -213,6 +213,13 @@ export function registerStoryTools(server: McpServer, channel: OutputChannel = "
           page,
           page_size
         );
+        if (result.pageOutOfRange) {
+          const totalPages = Math.ceil(result.totalChapters / page_size);
+          return textResult(
+            `页码超出范围：${event_id} 共 ${result.totalChapters} 章，按 page_size=${page_size} `
+            + `分页共 ${totalPages} 页，请求的 page=${page} 不存在。`,
+          );
+        }
         const parts: string[] = [];
         if (result.eventName) {
           parts.push(

--- a/ts/tests/story.test.ts
+++ b/ts/tests/story.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import AdmZip from "adm-zip";
@@ -12,6 +12,7 @@ import {
   readStory,
   readStoryFromStore,
 } from "../src/data/story.ts";
+import { registerStoryTools } from "../src/tools/storyTools.ts";
 
 const STORY_REVIEW_PATH = "zh_CN/gamedata/excel/story_review_table.json";
 const FIRST_STORY_KEY = "activities/act_test/level_act_test_01_beg";
@@ -97,6 +98,16 @@ function writeStoryZip(path: string): void {
   zip.writeZip(path);
 }
 
+type ToolHandler = (args: Record<string, unknown>) => unknown | Promise<unknown>;
+
+class CapturingServer {
+  handlers = new Map<string, ToolHandler>();
+
+  registerTool(name: string, _config: unknown, handler: ToolHandler): void {
+    this.handlers.set(name, handler);
+  }
+}
+
 function assertStoryStore(store: JsonStore): void {
   const events = listStoryEventsFromStore(store, "activities");
   assert.deepEqual(
@@ -139,7 +150,18 @@ function assertStoryStore(store: JsonStore): void {
   assert.equal(activity.eventName, "测试活动");
   assert.equal(activity.totalChapters, 2);
   assert.equal(activity.hasMore, true);
+  assert.equal(activity.pageOutOfRange, false);
   assert.deepEqual(activity.chapters.map((chapter) => chapter.storyKey), [FIRST_STORY_KEY]);
+
+  const outOfRange = readActivityFromStore(store, "act_test", true, 3, 1);
+  assert.equal(outOfRange.totalChapters, 2);
+  assert.deepEqual(outOfRange.chapters, []);
+  assert.equal(outOfRange.pageOutOfRange, true);
+
+  assert.throws(
+    () => readActivityFromStore(store, "act_test", true, 1, 0),
+    /page_size 参数必须在 1 到 20 之间/,
+  );
 }
 
 test("story tools read from DirectoryStore", () => {
@@ -185,6 +207,43 @@ test("public zip path API closes transient store", () => {
   } finally {
     ZipStore.prototype.close = originalClose;
   }
+});
+
+test("read_activity reports an out-of-range page", async () => {
+  const root = tempRoot();
+  const zipPath = join(root, "zh_CN.zip");
+  writeStoryZip(zipPath);
+  const previousStoryjsonPath = process.env["STORYJSON_PATH"];
+  process.env["STORYJSON_PATH"] = zipPath;
+
+  try {
+    const server = new CapturingServer();
+    registerStoryTools(server as never);
+    const handler = server.handlers.get("read_activity");
+    assert.ok(handler);
+
+    const result = await handler({ event_id: "act_test", page: 3, page_size: 1 }) as {
+      content: Array<{ type: string; text?: string }>;
+    };
+    assert.equal(
+      result.content[0]?.text,
+      "页码超出范围：act_test 共 2 章，按 page_size=1 分页共 2 页，请求的 page=3 不存在。",
+    );
+  } finally {
+    if (previousStoryjsonPath === undefined) delete process.env["STORYJSON_PATH"];
+    else process.env["STORYJSON_PATH"] = previousStoryjsonPath;
+  }
+});
+
+test("unreadable chapter is not an out-of-range page", () => {
+  const root = tempRoot();
+  writeStoryDir(root);
+  unlinkSync(join(root, storyPath(FIRST_STORY_KEY)));
+
+  const result = readActivityFromStore(new DirectoryStore(root), "act_test", true, 1, 1);
+  assert.equal(result.totalChapters, 2);
+  assert.deepEqual(result.chapters, []);
+  assert.equal(result.pageOutOfRange, false);
 });
 
 test("missing story raises", () => {

--- a/ts/tests/templateRenderer.test.ts
+++ b/ts/tests/templateRenderer.test.ts
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getTemplateData } from "../src/api/prtsWiki.ts";
+import { TemplateRenderError, renderTemplateData } from "../src/api/templateRenderer.ts";
+
+interface Fixture {
+  title: string;
+  parsetree: string;
+  rendered_values: string[];
+  expected: Record<string, Record<string, unknown>>;
+}
+
+function fixture(): Fixture {
+  return JSON.parse(
+    readFileSync(join(import.meta.dirname, "..", "..", "tests", "parity-fixtures", "template_nested_rendering.json"), "utf-8"),
+  ) as Fixture;
+}
+
+test("getTemplateData renders nested fields in one POST", async () => {
+  const data = fixture();
+  const originalFetch = globalThis.fetch;
+  const calls: Array<{ input: string; init?: RequestInit }> = [];
+  globalThis.fetch = (async (input, init) => {
+    calls.push({ input: String(input), init });
+    if (init?.method !== "POST") {
+      return new Response(JSON.stringify({ parse: { parsetree: { "*": data.parsetree } } }));
+    }
+
+    const form = new URLSearchParams(String(init.body));
+    const text = form.get("text") ?? "";
+    const markers = [...text.matchAll(/(PRTSMCP_[0-9a-f]{32}_BEGIN_(\d+)_)/g)];
+    assert.equal(markers.length, data.rendered_values.length);
+    const html = markers.map((marker, index) => {
+      const begin = marker[1]!;
+      const end = begin.replace("_BEGIN_", "_END_");
+      return `<p>${begin}\n${data.rendered_values[index]}\n${end}</p>`;
+    }).join("\n");
+    return new Response(JSON.stringify({ parse: { text: { "*": html } } }));
+  }) as typeof fetch;
+
+  try {
+    assert.deepEqual(await getTemplateData(data.title), data.expected);
+    assert.equal(calls.length, 2);
+    assert.equal(new URL(calls[0]!.input).searchParams.get("prop"), "parsetree");
+    const form = new URLSearchParams(String(calls[1]!.init?.body));
+    assert.equal(calls[1]!.init?.method, "POST");
+    assert.equal(form.get("action"), "parse");
+    assert.equal(form.get("title"), data.title);
+    assert.equal(form.get("prop"), "text");
+    assert.match(form.get("text") ?? "", /攻击造成\{\{color\|#00B0FF\|法术伤害\}\}。/);
+    assert.match(form.get("text") ?? "", /攻击力\{\{\*\|100%\}\}/);
+    assert.match(form.get("text") ?? "", /查看\[\[阿米娅\|阿米娅\]\]/);
+    assert.doesNotMatch(form.get("text") ?? "", /数值/);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("renderTemplateData rejects unsupported nested nodes", async () => {
+  const xml = "<root><template><title>Test</title><part><name>字段</name><value><h>标题</h></value></part></template></root>";
+
+  await assert.rejects(
+    renderTemplateData("测试", xml, async () => {
+      throw new Error("renderer should not be called");
+    }),
+    TemplateRenderError,
+  );
+});
+
+test("renderTemplateData skips batch rendering for plain values", async () => {
+  const xml = "<root><template><title>Test</title><part><name>数值</name><value>12</value></part></template></root>";
+
+  const result = await renderTemplateData("测试", xml, async () => {
+    throw new Error("plain values must not reach the renderer");
+  });
+
+  assert.deepEqual(result, { Test: { 数值: "12" } });
+});
+
+test("renderTemplateData trims parsetree whitespace for plain values", async () => {
+  const xml = "<root><template><title>Test</title><part><name>字段</name><value>\n  阿米娅  \n</value></part></template></root>";
+
+  const result = await renderTemplateData("测试", xml, async () => {
+    throw new Error("plain values must not reach the renderer");
+  });
+
+  assert.deepEqual(result, { Test: { 字段: "阿米娅" } });
+});

--- a/ts/tests/templateRenderer.test.ts
+++ b/ts/tests/templateRenderer.test.ts
@@ -140,3 +140,25 @@ test("getTemplateData normalizes invalid render response shapes", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+test("getTemplateData rejects reversed render markers", async () => {
+  const originalFetch = globalThis.fetch;
+  const parsetree = "<root><template><title>Test</title><part><name>字段</name><value><template><title>Nested</title></template></value></part></template></root>";
+  globalThis.fetch = (async (_input, init) => {
+    if (init?.method !== "POST") {
+      return new Response(JSON.stringify({ parse: { parsetree: { "*": parsetree } } }));
+    }
+    const form = new URLSearchParams(String(init.body));
+    const match = (form.get("text") ?? "").match(/(PRTSMCP_[0-9a-f]{32}_BEGIN_0_)/);
+    assert.ok(match);
+    const begin = match[1]!;
+    const end = begin.replace("_BEGIN_", "_END_");
+    return new Response(JSON.stringify({ parse: { text: { "*": `${end}\n${begin}\n错误` } } }));
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(getTemplateData("测试"), TemplateRenderError);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/ts/tests/templateRenderer.test.ts
+++ b/ts/tests/templateRenderer.test.ts
@@ -162,3 +162,49 @@ test("getTemplateData rejects reversed render markers", async () => {
     globalThis.fetch = originalFetch;
   }
 });
+
+test("getTemplateData rejects interleaved render markers", async () => {
+  const originalFetch = globalThis.fetch;
+  const parsetree = [
+    "<root><template><title>Test</title>",
+    "<part><name>A</name><value><template><title>A</title></template></value></part>",
+    "<part><name>B</name><value><template><title>B</title></template></value></part>",
+    "</template></root>",
+  ].join("");
+  globalThis.fetch = (async (_input, init) => {
+    if (init?.method !== "POST") {
+      return new Response(JSON.stringify({ parse: { parsetree: { "*": parsetree } } }));
+    }
+    const form = new URLSearchParams(String(init.body));
+    const markers = [...(form.get("text") ?? "").matchAll(/(PRTSMCP_[0-9a-f]{32}_BEGIN_(\d+)_)/g)];
+    assert.equal(markers.length, 2);
+    const begin0 = markers[0]![1]!;
+    const end0 = begin0.replace("_BEGIN_", "_END_");
+    const begin1 = markers[1]![1]!;
+    const end1 = begin1.replace("_BEGIN_", "_END_");
+    return new Response(JSON.stringify({ parse: { text: { "*": `${begin0}\n${begin1}\n值0\n${end0}\n值1\n${end1}` } } }));
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(getTemplateData("测试"), TemplateRenderError);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getTemplateData rejects non-string MediaWiki error info", async () => {
+  const originalFetch = globalThis.fetch;
+  const parsetree = "<root><template><title>Test</title><part><name>字段</name><value><template><title>Nested</title></template></value></part></template></root>";
+  globalThis.fetch = (async (_input, init) => {
+    if (init?.method !== "POST") {
+      return new Response(JSON.stringify({ parse: { parsetree: { "*": parsetree } } }));
+    }
+    return new Response(JSON.stringify({ error: { info: 1 } }));
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(getTemplateData("测试"), TemplateRenderError);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/ts/tests/templateRenderer.test.ts
+++ b/ts/tests/templateRenderer.test.ts
@@ -89,3 +89,54 @@ test("renderTemplateData trims parsetree whitespace for plain values", async () 
 
   assert.deepEqual(result, { Test: { 字段: "阿米娅" } });
 });
+
+test("getTemplateData keeps other fields when one nested value renders empty", async () => {
+  const originalFetch = globalThis.fetch;
+  const parsetree = [
+    "<root><template><title>Test</title>",
+    "<part><name>空字段</name><value><template><title>Empty</title></template></value></part>",
+    "<part><name>保留字段</name><value><template><title>Kept</title></template></value></part>",
+    "</template></root>",
+  ].join("");
+  let requestCount = 0;
+  globalThis.fetch = (async (_input, init) => {
+    requestCount += 1;
+    if (init?.method !== "POST") {
+      return new Response(JSON.stringify({ parse: { parsetree: { "*": parsetree } } }));
+    }
+
+    const form = new URLSearchParams(String(init.body));
+    const markers = [...(form.get("text") ?? "").matchAll(/(PRTSMCP_[0-9a-f]{32}_BEGIN_(\d+)_)/g)];
+    const values = ["", "保留值"];
+    const html = markers.map((marker, index) => {
+      const begin = marker[1]!;
+      const end = begin.replace("_BEGIN_", "_END_");
+      return `<p>${begin}\n${values[index]}\n${end}</p>`;
+    }).join("\n");
+    return new Response(JSON.stringify({ parse: { text: { "*": html } } }));
+  }) as typeof fetch;
+
+  try {
+    assert.deepEqual(await getTemplateData("测试"), { Test: { 保留字段: "保留值" } });
+    assert.equal(requestCount, 2);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getTemplateData normalizes invalid render response shapes", async () => {
+  const originalFetch = globalThis.fetch;
+  const parsetree = "<root><template><title>Test</title><part><name>字段</name><value><template><title>Nested</title></template></value></part></template></root>";
+  globalThis.fetch = (async (_input, init) => {
+    if (init?.method !== "POST") {
+      return new Response(JSON.stringify({ parse: { parsetree: { "*": parsetree } } }));
+    }
+    return new Response(JSON.stringify({ parse: { text: { "*": null } } }));
+  }) as typeof fetch;
+
+  try {
+    await assert.rejects(getTemplateData("测试"), TemplateRenderError);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/ts/tests/toolSurface.test.ts
+++ b/ts/tests/toolSurface.test.ts
@@ -89,6 +89,28 @@ test("SDK v2 tool registrations publish object input schemas", () => {
   }
 });
 
+test("prts_page keeps template render failures content-only", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(JSON.stringify({
+    parse: {
+      parsetree: {
+        "*": "<root><template><title>Test</title><part><name>字段</name><value><h>标题</h></value></part></template></root>",
+      },
+    },
+  }))) as typeof fetch;
+
+  try {
+    const server = new CapturingServer();
+    registerPrtsTools(server as never);
+    const result = await callTool(server, "prts_page", { page_title: "测试", action: "template" });
+    const content = result["content"] as Array<{ text?: string }>;
+    assert.equal(content[0]?.text, '模板字段渲染失败。请改用 action="read" 获取正文。');
+    assert.equal(result["structuredContent"], undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 function writeJson(path: string, data: unknown): void {
   writeFileSync(path, JSON.stringify(data), "utf-8");
 }


### PR DESCRIPTION
## Summary

- release Python and TypeScript implementations as 2.6.1 from the current develop baseline
- include #137 activity page-range validation and #125 nested template rendering plus malformed-response hardening
- synchronize changelogs, STATUS, ROADMAP, README, Python uv.lock, and npm package-lock metadata

## Test plan

- `./scripts/check-runtime.sh --full` (Python 355 passed, 23 skipped; TypeScript 276 passed, 2 skipped)
- `uv lock --check --directory python`
- `npm ci --ignore-scripts` (0 vulnerabilities)
- exact-head develop CI on 0764557 passed before release preparation

## Production boundary

- This release publication intentionally does not deploy, restart, or modify production.
- Issue #84 48–72-hour observation remains open and is not closed by this PR.

## Follow-up

- After merge/tag and artifact verification, merge this release branch back to develop and reopen 2.7.0 development metadata.