### PR TITLE
chore: back-merge v2.6.1 release to develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Two release lines ship in parallel:
 
 | Line | Version | Tools | Status |
 |------|---------|-------|--------|
-| **2.6** (`main`) | `2.6.0` | 24 | MCP SDK v2 with opt-in modern protocol support while retaining legacy clients; Amiya artwork forms; isolated same-host memory canary. |
+| **2.6** (`main`) | `2.6.1` | 24 | Nested template rendering and malformed-response hardening; activity page-range validation. |
 | **1.7 LTS** (`lts/1.7`) | `1.7.0` | 32 | Stable maintenance line. 1.7.x accepts only compatibility, security, data-sync, and critical bug fixes. |
 
 The `main` and `develop` lines use the self-built `arknights-data-pipeline` Release exclusively for default Auto-Sync. The 1.7 LTS line retains its legacy upstream compatibility until a separate, backwards-compatible migration; changes to the new factory path must not be backported to LTS as an implicit source switch.
@@ -155,7 +155,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contribution workflow and [`doc
 
 | 版本线 | 版本 | 工具数 | 状态 |
 |--------|------|--------|------|
-| **2.6**（`main`） | `2.6.0` | 24 | MCP SDK v2，并以 opt-in 方式支持现代协议且保留 legacy 客户端；阿米娅形态立绘；隔离同机内存 canary。 |
+| **2.6**（`main`） | `2.6.1` | 24 | 模板嵌套字段安全渲染与 malformed-response 加固；活动剧情页码校验。 |
 | **1.7 LTS**（`lts/1.7`） | `1.7.0` | 32 | 稳定维护线。1.7.x 仅接受兼容性、安全性、数据同步和关键缺陷修复。 |
 
 | 范围 | Python | TypeScript |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,13 @@
 # PRTS-MCP Roadmap
 
-_Last updated: 2026-08-09_ · [中文版](ROADMAP.zh-CN.md)
+_Last updated: 2026-08-10_ · [中文版](ROADMAP.zh-CN.md)
 
 PRTS-MCP is past 1.0. Version 1.7.0 is the final 1.x feature release and the 1.7 LTS baseline. This document tracks **what comes next** — not what has shipped. For shipped features, see the Python and TypeScript CHANGELOGs.
 
 ## Current Release
 
-- Python: `2.6.0` _(latest stable)_
-- TypeScript: `2.6.0` _(latest stable)_
+- Python: `2.6.1` _(latest stable)_
+- TypeScript: `2.6.1` _(latest stable)_
 - `1.7.0` LTS remains the maintenance line — compatibility, security, data-sync, and critical fixes only.
 - 24 public MCP tools on the 2.x line (CI-enforced); 32 public MCP tools frozen on the 1.7 LTS line.
 - See [migration guide 0.x → 1.0](docs/migration-0.x-to-1.0.md) and [migration guide 1.x → 2.0](docs/migration-1.x-to-2.0.md).

--- a/ROADMAP.zh-CN.md
+++ b/ROADMAP.zh-CN.md
@@ -1,13 +1,13 @@
 # PRTS-MCP 路线图
 
-_最近更新：2026-08-09_ · [English](ROADMAP.md)
+_最近更新：2026-08-10_ · [English](ROADMAP.md)
 
 PRTS-MCP 已进入 1.x 稳定期。1.7.0 是最后一个 1.x 功能版本和 1.7 LTS 基线。本文档记录**接下来要做什么**——已发布的内容请查看 Python 和 TypeScript 各自的 CHANGELOG。
 
 ## 当前发布
 
-- Python：`2.6.0` _（最新稳定版）_
-- TypeScript：`2.6.0` _（最新稳定版）_
+- Python：`2.6.1` _（最新稳定版）_
+- TypeScript：`2.6.1` _（最新稳定版）_
 - `1.7.0` LTS 仍为维护线——仅兼容性、安全性、数据同步和关键缺陷修复。
 - 2.x 线为 24 个公共 MCP 工具（CI 强制检查）；1.7 LTS 线冻结 32 个公共 MCP 工具。
 - 迁移说明：[0.x → 1.0](docs/migration-0.x-to-1.0.md)、[1.x → 2.0](docs/migration-1.x-to-2.0.md)。

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,18 +1,19 @@
 # PRTS-MCP 项目状态
 
-_Last updated: 2026-08-09_
+_Last updated: 2026-08-10_
 
 ## 当前版本
 
 | 实现 | 版本 | 状态 |
 |------|------|------|
-| Python | 2.6.0 | Stable release |
-| TypeScript | 2.6.0 | Stable release |
+| Python | 2.6.1 | Stable release |
+| TypeScript | 2.6.1 | Stable release |
 
-- 当前稳定发布：2.6.0（24 个 MCP 工具）
+- 当前稳定发布：2.6.1（24 个 MCP 工具）
 - 当前 LTS 发布：1.7.0（32 个 MCP 工具，剧情角色追踪）
 - 下一开发目标：2.7.0（在 release branch 回合与开发版本重开后确定）
 - 当前稳定补丁线：2.6.x
+- 2.6.1 发布内容：`prts_page(action="template")` 的嵌套字段安全渲染与 malformed-response 边界；`read_activity` 页码输入和越界提示一致性。
 - 2.6.0 发布内容：MCP SDK v2 与 legacy/`2026-07-28` 双时代协议服务；`operator_artwork` 阿米娅近卫/医疗形态解析与精确 opaque token 归属；TS 聚合指标、六会话隔离内存基准及同机 canary 资产。
 - 2.5.0 发布内容：干员立绘工具 `operator_artwork`（list/get，默认 MediaWiki 在线获取 + 256 MiB LRU 缓存，`LOCAL_IMAGE=true` 时使用 AKDP 本地 PNG 资产）；数据源切换到自建 `arknights-data-pipeline` Release；TS stdio 不再泄漏 HTTP 监听器；TS JSON 空对象占位守卫。
 - 2.4.0 发布内容：常驻服务默认每小时同步 GameData excel、GameData levels 与 StoryJson；GameData 两类归档以同一代原子切换，并支持共享卷跨进程发布锁续租。
@@ -69,7 +70,7 @@ _Last updated: 2026-08-09_
 
 ## 当前分支
 
-- `main`：2.6.0（最新稳定发布线）
+- `main`：2.6.1（最新稳定发布线）
 - `lts/1.7`：1.7.x LTS 维护线（从 1.7.0 发布提交创建）
 - `develop`：release branch 回合后重开 2.7.0 开发线
 
@@ -228,6 +229,7 @@ PRTS-MCP/
 
 | 版本 | 日期 | 亮点 |
 |------|------|------|
+| 2.6.1 | 2026-08-10 | 模板嵌套字段安全渲染与 malformed-response 边界；活动剧情页码校验与越界提示 |
 | 2.6.0 | 2026-08-09 | MCP SDK v2 双时代协议；阿米娅形态立绘；聚合指标、六会话内存基准与同机 canary |
 | 2.5.2 | 2026-08-09 | npm 生产依赖安全更新；AKDP 直接敌人数据库；剧情标量 Decision；立绘 token 归属校验 |
 | 2.5.1 | 2026-08-07 | gamedata pair retry 修复；manifest 404 fail-open；image sha256 验证；CI Node 24 |

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.6.1] - 2026-08-10
 
 ### Fixed
 
 - `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
 - Template rendering now preserves valid fields when another nested value renders empty, validates malformed MediaWiki response shapes and marker boundaries, and keeps unexpected local processing errors observable.
+- `read_activity` now validates page inputs consistently and returns a clear content-only message when the requested page is beyond an existing activity's range (#137).
 
 ## [2.6.0] - 2026-08-09
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.7.0.dev0"
+version = "2.6.1"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "prts-mcp"
-version = "2.7.0.dev0"
+version = "2.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [2.6.1] - 2026-08-10
 
 ### Fixed
 
 - `prts_page(action="template")` now renders nested template fields to complete readable text instead of silently dropping text or returning parsetree XML fragments (#125).
 - Template rendering now preserves valid fields when another nested value renders empty and normalizes malformed MediaWiki response shapes and marker boundaries to the documented content-only fallback.
+- `read_activity` now validates page inputs consistently and returns a clear content-only message when the requested page is beyond an existing activity's range (#137).
 
 ## [2.6.0] - 2026-08-09
 

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.7.0-dev.0",
+  "version": "2.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.7.0-dev.0",
+      "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "2.0.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.7.0-dev.0",
+  "version": "2.6.1",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP + stdio)",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Back-merge the completed v2.6.1 release branch into develop with merge semantics.

- Release PR #141 merged to main at e6c74de.
- Public Python/TypeScript artifacts and GHCR 2.6.1 verified.
- No production deployment, restart, or configuration change.
- Keep Issue #84 open for its separate 48–72 hour observation gate.

After this merge, a separate PR will reopen 2.7.0 development metadata.