### PR TITLE
chore: reopen 2.7.0 development

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.6.1] - 2026-08-10
 
 ### Fixed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.6.1"
+version = "2.7.0.dev0"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "prts-mcp"
-version = "2.6.1"
+version = "2.7.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.6.1] - 2026-08-10
 
 ### Fixed

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.6.1",
+  "version": "2.7.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.6.1",
+      "version": "2.7.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "2.0.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.6.1",
+  "version": "2.7.0-dev.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP + stdio)",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
Reopen the 2.7.0 development line after the completed 2.6.1 release.

- Python version: 2.7.0.dev0
- TypeScript version: 2.7.0-dev.0
- uv.lock and package-lock.json synchronized
- Both changelogs restored with an empty [Unreleased] section
- Stable README/STATUS/ROADMAP remain on 2.6.1
- No production deployment, restart, or configuration change
- Issue #84 remains open for its separate observation gate