### PR TITLE
fix(ci): promote one exact release artifact

### DIFF
--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -111,13 +111,11 @@ jobs:
           "
           kill $SERVER_PID
 
-  publish-npm:
+  package:
     runs-on: ubuntu-latest
     needs: verify
-    environment: npm
     permissions:
       contents: read
-      id-token: write
 
     steps:
       - name: Checkout repository
@@ -127,7 +125,8 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version-file: 'ts/package.json'
-          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+          cache-dependency-path: 'ts/package-lock.json'
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -159,6 +158,49 @@ jobs:
       - name: Verify bundled package data
         run: python python/scripts/check_package_data.py --data-root ts/data
 
+      - name: Build and pack exact release artifact
+        id: pack
+        working-directory: ts
+        run: |
+          npm run build
+          npm pack --json > pack.json
+          TARBALL=$(node -e "const fs=require('fs'), path=require('path'); console.log(path.basename(JSON.parse(fs.readFileSync('pack.json','utf8'))[0].filename))")
+          test -f "$TARBALL"
+          tar -tzf "$TARBALL" | grep -q '^package/dist/server.js$'
+          echo "name=$TARBALL" >> "$GITHUB_OUTPUT"
+
+      - name: Upload exact release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ts-release-package
+          path: ts/${{ steps.pack.outputs.name }}
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-npm:
+    runs-on: ubuntu-latest
+    needs: package
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version-file: 'ts/package.json'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download exact release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ts-release-package
+          path: ts
+
       - name: Resolve npm dist-tag
         id: dist_tag
         run: |
@@ -171,8 +213,34 @@ jobs:
           fi
 
       - name: Publish to npm (Trusted Publishing)
-        run: npm publish --provenance --access public --tag "${{ steps.dist_tag.outputs.value }}"
+        run: |
+          TARBALL=$(find . -maxdepth 1 -name 'prts-mcp-ts-*.tgz' -type f -print -quit)
+          test -n "$TARBALL"
+          npm publish "$TARBALL" --provenance --access public --tag "${{ steps.dist_tag.outputs.value }}"
         working-directory: ts
+
+      - name: Verify npm published bytes
+        working-directory: ts
+        run: |
+          TARBALL=$(find . -maxdepth 1 -name 'prts-mcp-ts-*.tgz' -type f -print -quit)
+          EXPECTED=$(sha256sum "$TARBALL" | awk '{print $1}')
+          VERSION="${GITHUB_REF_NAME#ts/v}"
+          TMP=$(mktemp)
+          trap 'rm -f "$TMP"' EXIT
+          for attempt in $(seq 1 18); do
+            URL=$(npm view "prts-mcp-ts@${VERSION}" dist.tarball 2>/dev/null || true)
+            if [ -n "$URL" ] && curl -fsSL "$URL" -o "$TMP"; then
+              ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
+              if [ "$ACTUAL" = "$EXPECTED" ]; then
+                echo "npm tarball SHA-256 verified: $ACTUAL"
+                exit 0
+              fi
+            fi
+            echo "Waiting for npm tarball propagation (attempt $attempt/18)..."
+            sleep 10
+          done
+          echo "::error::Published npm tarball bytes differ from the exact release artifact"
+          exit 1
 
   github-release:
     runs-on: ubuntu-latest
@@ -189,39 +257,16 @@ jobs:
         with:
           node-version-file: 'ts/package.json'
 
-      - name: Install dependencies
-        run: npm ci
-        working-directory: ts
-
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
-      - name: Install Python package (for fetch_gamedata script)
-        run: python -m pip install -e python/
-
-      - name: Fetch bundled gamedata
-        run: python python/scripts/fetch_gamedata.py --output ts/data/gamedata
-
-      - name: Download bundled storyjson zip
-        run: |
-          mkdir -p ts/data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq '[.[] | select(.tagName | startswith("data-"))] | max_by(.createdAt) | .tagName')
-          gh release download "$DATA_TAG" \
-            --repo 3aKHP/arknights-data-pipeline \
-            --pattern "zh_CN.zip" \
-            --dir ts/data/storyjson/ \
-            --clobber
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Verify bundled package data
-        run: python python/scripts/check_package_data.py --data-root ts/data
-
-      - name: Pack npm tarball
-        run: npm pack
-        working-directory: ts
+      - name: Download exact release artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ts-release-package
+          path: ts
 
       - name: Extract version from tag
         id: version
@@ -262,5 +307,6 @@ jobs:
         with:
           body_path: release_notes.txt
           files: ts/prts-mcp-ts-*.tgz
+          fail_on_unmatched_files: true
           prerelease: ${{ steps.version.outputs.prerelease }}
           make_latest: ${{ steps.version.outputs.prerelease == 'true' && 'false' || 'true' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -222,7 +222,7 @@ jobs:
 
   github-release:
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: [build-and-push, publish-pypi]
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary

- Fix the TypeScript CD workflow to build and pack one exact tarball, then promote that artifact to npm and the GitHub Release.
- Verify the npm registry tarball SHA-256 matches the promoted artifact before creating the GitHub Release.
- Make the Python GitHub Release wait for the PyPI publish job to complete.

## Scope and safety

- This is a workflow-only HotFix; no application or package version changes.
- No new tag is created or pushed by this PR.
- This PR does not re-trigger the 2.6.1 npm, PyPI, GHCR, or GitHub Release workflows.
- No production configuration, service, deployment, or restart is performed.
- Issue #84 remains open; its observation gate is unchanged.

## Verification

- `actionlint .github/workflows/cd-ts.yml .github/workflows/cd.yml`
- `git diff --check`
- Local `npm publish <exact-tarball> --dry-run --provenance` confirmed the tarball is accepted and contains `dist/` (the command was expected to stop because 2.6.1 already exists).
