### PR TITLE
fix(ci): run checks for release workflow changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,16 @@ on:
       - 'ts/**'
       - 'scripts/test-shared-volume-sync.sh'
       - '.github/workflows/ci.yml'
+      - '.github/workflows/cd.yml'
+      - '.github/workflows/cd-ts.yml'
   pull_request:
     paths:
       - 'python/**'
       - 'ts/**'
       - 'scripts/test-shared-volume-sync.sh'
       - '.github/workflows/ci.yml'
+      - '.github/workflows/cd.yml'
+      - '.github/workflows/cd-ts.yml'
 
 jobs:
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Include `cd.yml` and `cd-ts.yml` in CI path filters so workflow-only changes receive PR checks.

## Scope and safety

- CI trigger configuration only; no application or package version changes.
- No tag, package publish, GitHub Release, GHCR push, or production operation.

## Test plan

- `actionlint .github/workflows/ci.yml .github/workflows/cd-ts.yml .github/workflows/cd.yml`
- `git diff --check`
