### PR TITLE
merge: forward-port CI trigger HotFix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,16 @@ on:
       - 'ts/**'
       - 'scripts/test-shared-volume-sync.sh'
       - '.github/workflows/ci.yml'
+      - '.github/workflows/cd.yml'
+      - '.github/workflows/cd-ts.yml'
   pull_request:
     paths:
       - 'python/**'
       - 'ts/**'
       - 'scripts/test-shared-volume-sync.sh'
       - '.github/workflows/ci.yml'
+      - '.github/workflows/cd.yml'
+      - '.github/workflows/cd-ts.yml'
 
 jobs:
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Forward-port the merged CI path-filter HotFix from `main` to `develop`.
- Ensure future release workflow changes on either long-lived branch receive PR CI.

## Scope and safety

- CI trigger configuration only; no version bump or application changes.
- No tag, package publish, release, GHCR push, deployment, or production operation.

## Test plan

- Exact-head PR #146 checks all passed.
- `actionlint` and `git diff --check` passed.
