### PR TITLE
fix(ci): promote exact Python release artifacts

### DIFF
--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -78,7 +78,7 @@ jobs:
           # production runtime since 2.2.0) to verify the release artifact.
           bun dist/server-bun.js &
           SERVER_PID=$!
-          for i in $(seq 1 10); do
+          for _ in $(seq 1 10); do
             if curl -sf http://localhost:3000/health; then break; fi
             sleep 1
           done
@@ -207,9 +207,9 @@ jobs:
           VERSION="${GITHUB_REF_NAME#ts/v}"
           if [[ "${VERSION}" == *-* ]]; then
             PRERELEASE="${VERSION#*-}"
-            echo "value=${PRERELEASE%%.*}" >> $GITHUB_OUTPUT
+            echo "value=${PRERELEASE%%.*}" >> "$GITHUB_OUTPUT"
           else
-            echo "value=latest" >> $GITHUB_OUTPUT
+            echo "value=latest" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Publish to npm (Trusted Publishing)
@@ -272,11 +272,11 @@ jobs:
         id: version
         run: |
           VERSION="${GITHUB_REF_NAME#ts/v}"
-          echo "value=${VERSION}" >> $GITHUB_OUTPUT
+          echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
           if [[ "${VERSION}" == *-* ]]; then
-            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
-            echo "prerelease=false" >> $GITHUB_OUTPUT
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Extract changelog section
@@ -298,6 +298,8 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.value }}
         run: |
+          # Markdown code spans are intentionally literal.
+          # shellcheck disable=SC2016
           printf '\n---\n\n**Install**\n```bash\n# Run directly with npx (Node.js entrypoint, zero extra runtime install)\nnpx prts-mcp-ts\n\n# Or install globally\nnpm install -g prts-mcp-ts@%s\n\n# Bun runtime (default production runtime since 2.2.0)\nbunx --bun -p prts-mcp-ts@%s prts-mcp-ts-bun\n```\n\nThe default Docker image (`prts-mcp-ts:latest`) runs under Bun since 2.2.0;\n`ts/Dockerfile.node` provides the legacy Node.js image.\n\nMCP endpoint: `http://localhost:3000/mcp`\n' \
             "$VERSION" \
             "$VERSION" >> release_notes.txt

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -177,17 +177,17 @@ jobs:
         id: image
         run: |
           OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
-          echo "name=ghcr.io/${OWNER}/prts-mcp" >> $GITHUB_OUTPUT
+          echo "name=ghcr.io/${OWNER}/prts-mcp" >> "$GITHUB_OUTPUT"
 
       - name: Extract version from tag
         id: version
         run: |
           VERSION="${GITHUB_REF_NAME#python/v}"
-          echo "value=${VERSION}" >> $GITHUB_OUTPUT
+          echo "value=${VERSION}" >> "$GITHUB_OUTPUT"
           if [[ "${VERSION}" == *-* ]]; then
-            echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
-            echo "prerelease=false" >> $GITHUB_OUTPUT
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build Docker image
@@ -285,6 +285,8 @@ jobs:
           IMAGE: ${{ needs.build-and-push.outputs.image }}
           VERSION: ${{ needs.build-and-push.outputs.version }}
         run: |
+          # Markdown code fences are intentionally literal.
+          # shellcheck disable=SC2016
           printf '\n---\n\n**Install**\n```bash\npip install prts-mcp==%s\n```\n\n**Docker**\n```bash\ndocker pull %s:%s\n```\n' \
             "$VERSION" "$IMAGE" "$VERSION" >> release_notes.txt
 

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -84,6 +84,35 @@ jobs:
           print("Import/config verification passed.")
           PY
 
+  package:
+    runs-on: ubuntu-latest
+    needs: verify
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Build exact release artifacts
+        run: |
+          pip install build
+          python -m build python/
+          test "$(find python/dist -maxdepth 1 -type f | wc -l)" -eq 2
+
+      - name: Upload exact release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-release-package
+          path: python/dist/
+          if-no-files-found: error
+          retention-days: 7
+
   build-and-push:
     runs-on: ubuntu-latest
     needs: verify
@@ -222,7 +251,7 @@ jobs:
 
   github-release:
     runs-on: ubuntu-latest
-    needs: [build-and-push, publish-pypi]
+    needs: [build-and-push, package, publish-pypi]
     permissions:
       contents: write
 
@@ -230,15 +259,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Set up Python
-        uses: actions/setup-python@v7
+      - name: Download exact release artifacts
+        uses: actions/download-artifact@v4
         with:
-          python-version: "3.11"
-
-      - name: Build distribution
-        run: |
-          pip install build
-          python -m build python/
+          name: python-release-package
+          path: python/dist
 
       - name: Extract changelog section
         env:
@@ -268,30 +293,24 @@ jobs:
         with:
           body_path: release_notes.txt
           files: python/dist/*
+          fail_on_unmatched_files: true
           prerelease: ${{ needs.build-and-push.outputs.prerelease }}
           make_latest: ${{ needs.build-and-push.outputs.prerelease == 'true' && 'false' || 'true' }}
 
   publish-pypi:
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: [build-and-push, package]
     environment: pypi
     permissions:
       contents: read
       id-token: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v7
-
-      - name: Set up Python
-        uses: actions/setup-python@v7
+      - name: Download exact release artifacts
+        uses: actions/download-artifact@v4
         with:
-          python-version: "3.11"
-
-      - name: Build distribution
-        run: |
-          pip install build
-          python -m build python/
+          name: python-release-package
+          path: python/dist
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -101,8 +101,11 @@ jobs:
 
       - name: Build exact release artifacts
         run: |
-          pip install build
+          pip install build==1.3.0
           python -m build python/
+          find python/dist -maxdepth 1 -type f -printf '%f\n'
+          test "$(find python/dist -maxdepth 1 -type f -name '*.whl' | wc -l)" -eq 1
+          test "$(find python/dist -maxdepth 1 -type f -name '*.tar.gz' | wc -l)" -eq 1
           test "$(find python/dist -maxdepth 1 -type f | wc -l)" -eq 2
 
       - name: Upload exact release artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,24 @@ on:
       - '.github/workflows/cd-ts.yml'
 
 jobs:
+  workflow-lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25.x'
+          cache: false
+
+      - name: Lint GitHub Actions workflows
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
   # ---------------------------------------------------------------------------
   # Python implementation
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Build the Python wheel and sdist once in a dedicated package job.
- Promote the same exact files to PyPI and the GitHub Release.
- Keep the GitHub Release gated on both PyPI publication and the container publish job.
- Add a pinned, read-only `actionlint` CI job so release workflow PRs receive workflow-specific validation.

## Scope and safety

- Workflow-only HotFix; no application or package version changes.
- No tag is created or pushed, so no package/release/GHCR workflow is triggered.
- No production configuration, deployment, restart, or cutover.

## Test plan

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12`
- `git diff --check`
- Exact-head CI must pass before merge.
