### PR TITLE
test(mcp): lock modern discover server identity

### DIFF
--- a/python/tests/test_e2e_http.py
+++ b/python/tests/test_e2e_http.py
@@ -18,6 +18,7 @@ import socket
 import subprocess
 import sys
 import time
+from importlib.metadata import version as _pkg_version
 from pathlib import Path
 
 import httpx
@@ -277,6 +278,11 @@ def test_modern_http_requests_are_stateless_and_strict(server):
     assert status == 200
     assert sid is None
     assert payload is not None and payload.get("result")
+    discover_result = payload["result"]
+    assert _MODERN_VERSION in discover_result["supportedVersions"]
+    server_info = discover_result["_meta"]["io.modelcontextprotocol/serverInfo"]
+    assert server_info["name"] == "PRTS_Wiki_Assistant"
+    assert server_info["version"] == _pkg_version("prts-mcp")
 
     status, payload, sid = _modern_post(origin, "tools/list", {}, 101)
     assert status == 200

--- a/python/tests/test_e2e_http.py
+++ b/python/tests/test_e2e_http.py
@@ -18,7 +18,7 @@ import socket
 import subprocess
 import sys
 import time
-from importlib.metadata import version as _pkg_version
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 from pathlib import Path
 
 import httpx
@@ -92,6 +92,10 @@ def _mcp_post(
 
 
 _MODERN_VERSION = "2026-07-28"
+try:
+    _EXPECTED_VERSION = _pkg_version("prts-mcp")
+except PackageNotFoundError:
+    _EXPECTED_VERSION = "0.0.0"
 
 
 def _modern_body(method: str, params: dict, request_id: int) -> dict:
@@ -282,7 +286,7 @@ def test_modern_http_requests_are_stateless_and_strict(server):
     assert _MODERN_VERSION in discover_result["supportedVersions"]
     server_info = discover_result["_meta"]["io.modelcontextprotocol/serverInfo"]
     assert server_info["name"] == "PRTS_Wiki_Assistant"
-    assert server_info["version"] == _pkg_version("prts-mcp")
+    assert server_info["version"] == _EXPECTED_VERSION
 
     status, payload, sid = _modern_post(origin, "tools/list", {}, 101)
     assert status == 200

--- a/ts/tests/e2e.test.ts
+++ b/ts/tests/e2e.test.ts
@@ -241,6 +241,16 @@ test("E2E", async (t) => {
     assert.equal(discover.status, 200);
     assert.equal(discover.sessionId, null, "modern discover must not create a legacy session");
     assert.ok(discover.body["result"], "discover should return a modern result");
+    const discoverResult = discover.body["result"] as {
+      supportedVersions?: string[];
+      _meta?: {
+        "io.modelcontextprotocol/serverInfo"?: { name?: string; version?: string };
+      };
+    };
+    assert.ok(discoverResult.supportedVersions?.includes(MODERN_VERSION));
+    const modernServerInfo = discoverResult._meta?.["io.modelcontextprotocol/serverInfo"];
+    assert.equal(modernServerInfo?.name, "PRTS_Wiki_Assistant");
+    assert.equal(modernServerInfo?.version, EXPECTED_VERSION);
 
     const list = await modernPost(origin, "tools/list", {}, 101);
     assert.equal(list.status, 200);


### PR DESCRIPTION
Closes #150

## Summary

- lock the final MCP 2026-07-28 `supportedVersions` discover contract in Python and TypeScript HTTP E2E tests
- assert the standard `_meta["io.modelcontextprotocol/serverInfo"]` identity stamp
- verify both implementations report `PRTS_Wiki_Assistant` and their runtime identity version (installed package metadata, or the Python server's documented `0.0.0` source-mode fallback)

No production protocol shim is added: the existing SDK 2.0.0 responses already match the final specification. Runtime consumption is fixed in companion QuickQuip PR 3aKHP/QuickQuip#112.

## Test plan

- `./scripts/check-runtime.sh --full`
  - Python: 355 passed, 23 skipped
  - TypeScript: 276 passed, 2 skipped
  - build, typecheck, Bun HTTP smoke, and cross-runtime shared-volume sync passed
- production read-only probe: `prts-mcp-ts@2.6.0` returned `PRTS_Wiki_Assistant 2.6.0` in the standard namespaced result metadata
- real cross-repo acceptance: QuickQuip #112 consumed the identity from a local PRTS-MCP 2.7.0-dev.0 server and listed 24 tools

## Outstanding

- merge QuickQuip #112 so chat-visible MCP status can display the standard identity