### PR TITLE
fix(sync): forward-port GameData pair idempotency

### DIFF
--- a/python/src/prts_mcp/data/sync.py
+++ b/python/src/prts_mcp/data/sync.py
@@ -939,9 +939,10 @@ def _load_gamedata_pair(
     levels_spec: ReleaseArchiveSpec,
 ) -> tuple[str, Path, Path] | None:
     try:
-        value = json.loads(
-            _gamedata_pair_path(excel_spec, levels_spec).read_text(encoding="utf-8")
-        )
+        path = _gamedata_pair_path(excel_spec, levels_spec)
+        if not path.is_file() or path.is_symlink():
+            return None
+        value = json.loads(path.read_text(encoding="utf-8"))
         commit_sha = value.get("commit_sha")
         excel_data_root = value.get("excel_data_root")
         levels_data_root = value.get("levels_data_root")
@@ -973,6 +974,13 @@ def _save_gamedata_pair(
     levels_root: Path,
 ) -> None:
     path = _gamedata_pair_path(excel_spec, levels_spec)
+    current = (
+        _load_gamedata_pair(excel_spec, levels_spec)
+        if path.is_file() and not path.is_symlink()
+        else None
+    )
+    if current == (commit_sha, excel_root.resolve(), levels_root.resolve()):
+        return
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
     tmp.write_text(
@@ -1001,17 +1009,24 @@ def _initialize_gamedata_pair(
         return
     excel_meta = _load_extract_meta(excel_spec)
     levels_meta = _load_extract_meta(levels_spec)
-    excel_root = excel_meta[1] if excel_meta is not None else excel_spec.local_root
-    levels_root = levels_meta[1] if levels_meta is not None else levels_spec.local_root
+    if excel_meta is None and levels_meta is None:
+        commit_sha = "legacy"
+        excel_root = excel_spec.local_root
+        levels_root = levels_spec.local_root
+    elif (
+        excel_meta is not None
+        and levels_meta is not None
+        and excel_meta[0] == levels_meta[0]
+    ):
+        commit_sha = excel_meta[0]
+        excel_root = excel_meta[1]
+        levels_root = levels_meta[1]
+    else:
+        return
     if not all((excel_root / path).is_file() for path in excel_spec.required_files):
         return
     if not all((levels_root / path).is_file() for path in levels_spec.required_files):
         return
-    sha_parts = (
-        excel_meta[0] if excel_meta is not None else "legacy",
-        levels_meta[0] if levels_meta is not None else "legacy",
-    )
-    commit_sha = sha_parts[0] if sha_parts[0] == sha_parts[1] else "legacy-pair"
     _save_gamedata_pair(
         excel_spec,
         levels_spec,

--- a/python/tests/test_sync_release.py
+++ b/python/tests/test_sync_release.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import prts_mcp.config as config_module
 from prts_mcp.data.sync import (
     ReleaseSpec,
     ReleaseArchiveSpec,
@@ -434,6 +435,182 @@ class TestSyncRelease:
 # ---------------------------------------------------------------------------
 
 class TestSyncReleaseArchive:
+    @staticmethod
+    def _activate_pair_generation(
+        excel_spec: ReleaseArchiveSpec,
+        levels_spec: ReleaseArchiveSpec,
+        generation: str,
+    ) -> None:
+        for spec in (excel_spec, levels_spec):
+            required = spec.required_files[0]
+            root = spec.local_root / ".releases" / generation
+            path = root / required
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(generation, encoding="utf-8")
+            spec.local_zip.parent.mkdir(parents=True, exist_ok=True)
+            with zipfile.ZipFile(spec.local_zip, "w") as zf:
+                zf.writestr(required, generation)
+            (spec.local_zip.parent / "release_meta.json").write_text(
+                json.dumps({
+                    "repo": f"{spec.owner}/{spec.repo}",
+                    "branch": "releases",
+                    "commit_sha": generation,
+                    "fetched_at": "2099-01-01T00:00:00Z",
+                    "files": [spec.asset_name],
+                }),
+                encoding="utf-8",
+            )
+            (spec.local_zip.parent / "extract_meta.json").write_text(
+                json.dumps({
+                    "commit_sha": generation,
+                    "data_root": f".releases/{generation}",
+                }),
+                encoding="utf-8",
+            )
+
+    @staticmethod
+    def _pair_specs(tmp_path: Path) -> tuple[ReleaseArchiveSpec, ReleaseArchiveSpec]:
+        return (
+            ReleaseArchiveSpec(
+                owner="3aKHP",
+                repo="arknights-data-pipeline",
+                asset_name="zh_CN-excel.zip",
+                local_zip=tmp_path / "gamedata" / "archives" / "zh_CN-excel.zip",
+                local_root=tmp_path / "gamedata",
+                required_files=("zh_CN/gamedata/excel/character_table.json",),
+            ),
+            ReleaseArchiveSpec(
+                owner="3aKHP",
+                repo="arknights-data-pipeline",
+                asset_name="zh_CN-levels.zip",
+                local_zip=tmp_path / "gamedata-levels" / "archives" / "zh_CN-levels.zip",
+                local_root=tmp_path / "gamedata-levels",
+                required_files=(
+                    "zh_CN/gamedata/levels/enemydata/enemy_database.json",
+                ),
+            ),
+        )
+
+    def test_pair_manifest_is_stable_until_generation_changes(self, tmp_path):
+        excel_spec, levels_spec = self._pair_specs(tmp_path)
+        self._activate_pair_generation(excel_spec, levels_spec, "same")
+        pair_path = tmp_path / ".gamedata_pair.json"
+
+        with (
+            patch.dict(os.environ, {"GAMEDATA_PATH": str(excel_spec.local_root)}),
+            patch.object(config_module, "_activation_signature", None),
+            patch.object(config_module, "_activation_listeners", []),
+        ):
+            first = sync_release_archive_pair(excel_spec, levels_spec)
+            assert [result.status for result in first] == ["up_to_date", "up_to_date"]
+            config_module.check_activation_change()
+            clears = 0
+
+            def record_clear() -> None:
+                nonlocal clears
+                clears += 1
+
+            config_module.register_activation_listener(record_clear)
+            before = pair_path.stat()
+            second = sync_release_archive_pair(excel_spec, levels_spec)
+            after = pair_path.stat()
+            config_module.check_activation_change()
+
+            assert [result.status for result in second] == ["up_to_date", "up_to_date"]
+            assert (after.st_ino, after.st_mtime_ns, after.st_ctime_ns) == (
+                before.st_ino,
+                before.st_mtime_ns,
+                before.st_ctime_ns,
+            )
+            assert clears == 0
+
+            self._activate_pair_generation(excel_spec, levels_spec, "next")
+            sync_release_archive_pair(excel_spec, levels_spec)
+            changed = pair_path.stat()
+            config_module.check_activation_change()
+
+            assert json.loads(pair_path.read_text(encoding="utf-8"))["commit_sha"] == "next"
+            assert changed.st_ino != after.st_ino
+            assert clears == 1
+
+    def test_pair_manifest_is_rebuilt_when_missing_or_invalid(self, tmp_path):
+        excel_spec, levels_spec = self._pair_specs(tmp_path)
+        self._activate_pair_generation(excel_spec, levels_spec, "same")
+        pair_path = tmp_path / ".gamedata_pair.json"
+
+        sync_release_archive_pair(excel_spec, levels_spec)
+        pair_path.unlink()
+        sync_release_archive_pair(excel_spec, levels_spec)
+        assert json.loads(pair_path.read_text(encoding="utf-8"))["commit_sha"] == "same"
+
+        pair_path.write_text("not json", encoding="utf-8")
+        sync_release_archive_pair(excel_spec, levels_spec)
+        assert json.loads(pair_path.read_text(encoding="utf-8"))["commit_sha"] == "same"
+
+    def test_pair_manifest_rebuild_rejects_mixed_generations(self, tmp_path):
+        excel_spec, levels_spec = self._pair_specs(tmp_path)
+        self._activate_pair_generation(excel_spec, levels_spec, "old")
+        excel_root = excel_spec.local_root / ".releases" / "new"
+        excel_file = excel_root / excel_spec.required_files[0]
+        excel_file.parent.mkdir(parents=True)
+        excel_file.write_text("new", encoding="utf-8")
+        (excel_spec.local_zip.parent / "extract_meta.json").write_text(
+            json.dumps({
+                "commit_sha": "new",
+                "data_root": ".releases/new",
+            }),
+            encoding="utf-8",
+        )
+        pair_path = tmp_path / ".gamedata_pair.json"
+
+        fallback = lambda spec: SyncResult(spec, "offline_fallback", None, "offline")
+        with patch(
+            "prts_mcp.data.sync.sync_release_archive",
+            side_effect=lambda spec, force_check=False: fallback(spec),
+        ):
+            sync_release_archive_pair(excel_spec, levels_spec)
+
+        assert not pair_path.exists()
+
+    def test_pair_manifest_symlink_is_replaced(self, tmp_path):
+        excel_spec, levels_spec = self._pair_specs(tmp_path)
+        for spec in (excel_spec, levels_spec):
+            required = spec.local_root / spec.required_files[0]
+            required.parent.mkdir(parents=True)
+            required.write_text("legacy", encoding="utf-8")
+        pair_path = tmp_path / ".gamedata_pair.json"
+        external = tmp_path / "external-pair.json"
+        external.write_text(
+            json.dumps({
+                "commit_sha": "legacy",
+                "excel_data_root": ".",
+                "levels_data_root": ".",
+            }),
+            encoding="utf-8",
+        )
+        pair_path.symlink_to(external)
+
+        with patch(
+            "prts_mcp.data.sync.sync_release_archive",
+            side_effect=lambda spec, force_check=False: SyncResult(
+                spec,
+                "offline_fallback",
+                None,
+                "offline",
+            ),
+        ):
+            results = sync_release_archive_pair(excel_spec, levels_spec)
+
+        assert [result.status for result in results] == [
+            "offline_fallback",
+            "offline_fallback",
+        ]
+        assert pair_path.is_file()
+        assert not pair_path.is_symlink()
+        assert json.loads(external.read_text(encoding="utf-8")) == json.loads(
+            pair_path.read_text(encoding="utf-8")
+        )
+
     def test_reclaims_abandoned_ownerless_lock(self, tmp_path):
         archive_dir = tmp_path / "archives"
         archive_dir.mkdir()

--- a/scripts/test-shared-volume-sync.sh
+++ b/scripts/test-shared-volume-sync.sh
@@ -131,6 +131,81 @@ if [[ ! (
   exit 1
 fi
 
+PAIR_PATH="${SHARED_ROOT}/.gamedata_pair.json"
+PAIR_IDENTITY_BEFORE="$(stat -c '%i:%s:%Y:%Z' "${PAIR_PATH}")"
+
+uv run --directory "${REPO_ROOT}/python" --frozen --no-sync python - \
+  "${EXCEL_ROOT}" "${LEVELS_ROOT}" "${EXCEL_ARCHIVE}" "${LEVELS_ARCHIVE}" \
+  "${EXCEL_REQUIRED}" "${LEVELS_REQUIRED}" <<'PY'
+import sys
+from pathlib import Path
+
+from prts_mcp.data.sync import ReleaseArchiveSpec, sync_release_archive_pair
+
+results = sync_release_archive_pair(
+    ReleaseArchiveSpec(
+        owner="3aKHP",
+        repo="arknights-data-pipeline",
+        asset_name=Path(sys.argv[3]).name,
+        local_zip=Path(sys.argv[3]),
+        local_root=Path(sys.argv[1]),
+        required_files=(sys.argv[5],),
+    ),
+    ReleaseArchiveSpec(
+        owner="3aKHP",
+        repo="arknights-data-pipeline",
+        asset_name=Path(sys.argv[4]).name,
+        local_zip=Path(sys.argv[4]),
+        local_root=Path(sys.argv[2]),
+        required_files=(sys.argv[6],),
+    ),
+)
+assert [result.status for result in results] == ["up_to_date", "up_to_date"]
+PY
+
+PAIR_IDENTITY_AFTER_PYTHON="$(stat -c '%i:%s:%Y:%Z' "${PAIR_PATH}")"
+if [[ "${PAIR_IDENTITY_AFTER_PYTHON}" != "${PAIR_IDENTITY_BEFORE}" ]]; then
+  echo "Python rewrote unchanged TypeScript-compatible pair metadata" >&2
+  exit 1
+fi
+
+(cd "${REPO_ROOT}/ts" && node --import tsx \
+  --input-type=module - \
+  "${EXCEL_ROOT}" "${LEVELS_ROOT}" "${EXCEL_ARCHIVE}" "${LEVELS_ARCHIVE}" \
+  "${EXCEL_REQUIRED}" "${LEVELS_REQUIRED}") <<'TS'
+import { basename } from "node:path";
+import { syncReleaseArchivePair } from "./src/data/sync.ts";
+
+const [, , excelRoot, levelsRoot, excelArchive, levelsArchive, excelRequired, levelsRequired] = process.argv;
+const results = await syncReleaseArchivePair(
+  {
+    owner: "3aKHP",
+    repo: "arknights-data-pipeline",
+    assetName: basename(excelArchive),
+    localZip: excelArchive,
+    localRoot: excelRoot,
+    requiredFiles: [excelRequired],
+  },
+  {
+    owner: "3aKHP",
+    repo: "arknights-data-pipeline",
+    assetName: basename(levelsArchive),
+    localZip: levelsArchive,
+    localRoot: levelsRoot,
+    requiredFiles: [levelsRequired],
+  },
+);
+if (results.some((result) => result.status !== "up_to_date")) {
+  throw new Error(`Unexpected unchanged sync status: ${results.map((result) => result.status).join(",")}`);
+}
+TS
+
+PAIR_IDENTITY_AFTER_TYPESCRIPT="$(stat -c '%i:%s:%Y:%Z' "${PAIR_PATH}")"
+if [[ "${PAIR_IDENTITY_AFTER_TYPESCRIPT}" != "${PAIR_IDENTITY_BEFORE}" ]]; then
+  echo "TypeScript rewrote unchanged Python-compatible pair metadata" >&2
+  exit 1
+fi
+
 uv run --directory "${REPO_ROOT}/python" --frozen --no-sync python - \
   "${SHARED_ROOT}" "${EXCEL_ROOT}" "${LEVELS_ROOT}" \
   "${EXCEL_REQUIRED}" "${LEVELS_REQUIRED}" <<'PY'

--- a/ts/src/data/sync.ts
+++ b/ts/src/data/sync.ts
@@ -1062,8 +1062,11 @@ async function loadGamedataPair(
   levelsSpec: ReleaseArchiveSpec,
 ): Promise<GamedataPairMeta | null> {
   try {
+    const path = gamedataPairPath(excelSpec, levelsSpec);
+    const pathInfo = await lstat(path);
+    if (!pathInfo.isFile() || pathInfo.isSymbolicLink()) return null;
     const value = JSON.parse(
-      await readFile(gamedataPairPath(excelSpec, levelsSpec), "utf-8"),
+      await readFile(path, "utf-8"),
     ) as {
       commit_sha?: unknown;
       excel_data_root?: unknown;
@@ -1096,6 +1099,15 @@ async function saveGamedataPair(
   levelsRoot: string,
 ): Promise<void> {
   const path = gamedataPairPath(excelSpec, levelsSpec);
+  const pathInfo = await lstat(path).catch(() => null);
+  const current = pathInfo?.isFile() && !pathInfo.isSymbolicLink()
+    ? await loadGamedataPair(excelSpec, levelsSpec)
+    : null;
+  if (
+    current?.commitSha === commitSha
+    && current.excelRoot === realpathSync(excelRoot)
+    && current.levelsRoot === realpathSync(levelsRoot)
+  ) return;
   const tmp = join(dirname(path), `.${basename(path)}.${randomUUID().replaceAll("-", "")}.tmp`);
   await mkdir(dirname(path), { recursive: true });
   await writeFile(tmp, JSON.stringify({
@@ -1113,13 +1125,26 @@ async function initializeGamedataPair(
   if (await loadGamedataPair(excelSpec, levelsSpec) !== null) return;
   const excelMeta = await loadExtractMeta(excelSpec);
   const levelsMeta = await loadExtractMeta(levelsSpec);
-  const excelRoot = excelMeta?.dataRoot ?? excelSpec.localRoot;
-  const levelsRoot = levelsMeta?.dataRoot ?? levelsSpec.localRoot;
+  let commitSha: string;
+  let excelRoot: string;
+  let levelsRoot: string;
+  if (excelMeta === null && levelsMeta === null) {
+    commitSha = "legacy";
+    excelRoot = excelSpec.localRoot;
+    levelsRoot = levelsSpec.localRoot;
+  } else if (
+    excelMeta !== null
+    && levelsMeta !== null
+    && excelMeta.commitSha === levelsMeta.commitSha
+  ) {
+    commitSha = excelMeta.commitSha;
+    excelRoot = excelMeta.dataRoot;
+    levelsRoot = levelsMeta.dataRoot;
+  } else {
+    return;
+  }
   if (!archiveFilesPresent(excelSpec, excelRoot)) return;
   if (!archiveFilesPresent(levelsSpec, levelsRoot)) return;
-  const commitSha = excelMeta?.commitSha === levelsMeta?.commitSha
-    ? (excelMeta?.commitSha ?? "legacy")
-    : "legacy-pair";
   await saveGamedataPair(
     excelSpec,
     levelsSpec,

--- a/ts/tests/sync.test.ts
+++ b/ts/tests/sync.test.ts
@@ -2,9 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  statSync,
   symlinkSync,
   unlinkSync,
   utimesSync,
@@ -178,6 +180,167 @@ function withFetchMock(
     else process.env["GITHUB_MIRRORS"] = originalMirrors;
   });
 }
+
+function pairSpecs(root: string): readonly [ReleaseArchiveSpec, ReleaseArchiveSpec] {
+  return [{
+    owner: "3aKHP",
+    repo: "arknights-data-pipeline",
+    assetName: "zh_CN-excel.zip",
+    localZip: join(root, "gamedata", "archives", "zh_CN-excel.zip"),
+    localRoot: join(root, "gamedata"),
+    requiredFiles: ["zh_CN/gamedata/excel/character_table.json"],
+  }, {
+    owner: "3aKHP",
+    repo: "arknights-data-pipeline",
+    assetName: "zh_CN-levels.zip",
+    localZip: join(root, "gamedata-levels", "archives", "zh_CN-levels.zip"),
+    localRoot: join(root, "gamedata-levels"),
+    requiredFiles: ["zh_CN/gamedata/levels/enemydata/enemy_database.json"],
+  }] as const;
+}
+
+function activatePairGeneration(
+  specs: readonly [ReleaseArchiveSpec, ReleaseArchiveSpec],
+  generation: string,
+): void {
+  for (const spec of specs) {
+    const required = spec.requiredFiles[0];
+    const dataRoot = join(spec.localRoot, ".releases", generation);
+    mkdirSync(dirname(join(dataRoot, required)), { recursive: true });
+    writeFileSync(join(dataRoot, required), generation, "utf-8");
+    writeZip(spec.localZip, { [required]: generation });
+    writeFileSync(join(dirname(spec.localZip), "release_meta.json"), JSON.stringify({
+      repo: `${spec.owner}/${spec.repo}`,
+      branch: "releases",
+      commit_sha: generation,
+      fetched_at: "2099-01-01T00:00:00.000Z",
+      files: [spec.assetName],
+    }), "utf-8");
+    writeFileSync(join(dirname(spec.localZip), "extract_meta.json"), JSON.stringify({
+      commit_sha: generation,
+      data_root: `.releases/${generation}`,
+    }), "utf-8");
+  }
+}
+
+test("pair manifest is stable until the generation changes", async () => {
+  const root = mkdtempSync(join(tmpdir(), "prts-sync-pair-stability-test-"));
+  const specs = pairSpecs(root);
+  activatePairGeneration(specs, "same");
+  const pairPath = join(root, ".gamedata_pair.json");
+  process.env["GAMEDATA_PATH"] = specs[0].localRoot;
+  try {
+    const config = await import(`../src/config.ts?pairStability=${Date.now()}-${Math.random()}`);
+    const first = await syncReleaseArchivePair(...specs);
+    assert.deepEqual(first.map((result) => result.status), ["up_to_date", "up_to_date"]);
+    config.checkActivationChange();
+    let clears = 0;
+    config.registerActivationListener(() => { clears += 1; });
+    const before = statSync(pairPath);
+
+    const second = await syncReleaseArchivePair(...specs);
+    const after = statSync(pairPath);
+    config.checkActivationChange();
+
+    assert.deepEqual(second.map((result) => result.status), ["up_to_date", "up_to_date"]);
+    assert.deepEqual(
+      [after.ino, after.mtimeMs, after.ctimeMs],
+      [before.ino, before.mtimeMs, before.ctimeMs],
+    );
+    assert.equal(clears, 0);
+
+    activatePairGeneration(specs, "next");
+    await syncReleaseArchivePair(...specs);
+    const changed = statSync(pairPath);
+    config.checkActivationChange();
+
+    assert.equal(JSON.parse(readFileSync(pairPath, "utf-8")).commit_sha, "next");
+    assert.notEqual(changed.ino, after.ino);
+    assert.equal(clears, 1);
+  } finally {
+    delete process.env["GAMEDATA_PATH"];
+  }
+});
+
+test("pair manifest is rebuilt when missing or invalid", async () => {
+  const root = mkdtempSync(join(tmpdir(), "prts-sync-pair-rebuild-test-"));
+  const specs = pairSpecs(root);
+  activatePairGeneration(specs, "same");
+  const pairPath = join(root, ".gamedata_pair.json");
+
+  await syncReleaseArchivePair(...specs);
+  unlinkSync(pairPath);
+  await syncReleaseArchivePair(...specs);
+  assert.equal(JSON.parse(readFileSync(pairPath, "utf-8")).commit_sha, "same");
+
+  writeFileSync(pairPath, "not json", "utf-8");
+  await syncReleaseArchivePair(...specs);
+  assert.equal(JSON.parse(readFileSync(pairPath, "utf-8")).commit_sha, "same");
+});
+
+test("pair manifest rebuild rejects mixed generations", async () => {
+  const root = mkdtempSync(join(tmpdir(), "prts-sync-pair-mixed-test-"));
+  const specs = pairSpecs(root);
+  activatePairGeneration(specs, "old");
+  const excelRoot = join(specs[0].localRoot, ".releases", "new");
+  const excelFile = join(excelRoot, specs[0].requiredFiles[0]);
+  mkdirSync(dirname(excelFile), { recursive: true });
+  writeFileSync(excelFile, "new", "utf-8");
+  writeFileSync(join(dirname(specs[0].localZip), "extract_meta.json"), JSON.stringify({
+    commit_sha: "new",
+    data_root: ".releases/new",
+  }), "utf-8");
+  for (const spec of specs) unlinkSync(spec.localZip);
+
+  await withFetchMock((async () => {
+    throw new Error("network down");
+  }) as typeof fetch, async () => {
+    const results = await syncReleaseArchivePair(...specs);
+    assert.deepEqual(results.map((result) => result.status), [
+      "offline_fallback",
+      "offline_fallback",
+    ]);
+  });
+
+  assert.equal(existsSync(join(root, ".gamedata_pair.json")), false);
+});
+
+test("pair manifest symlink is replaced", async () => {
+  const root = mkdtempSync(join(tmpdir(), "prts-sync-pair-symlink-test-"));
+  const specs = pairSpecs(root);
+  for (const spec of specs) {
+    const required = join(spec.localRoot, spec.requiredFiles[0]);
+    mkdirSync(dirname(required), { recursive: true });
+    writeFileSync(required, "legacy", "utf-8");
+  }
+  const pairPath = join(root, ".gamedata_pair.json");
+  const external = join(root, "external-pair.json");
+  writeFileSync(external, JSON.stringify({
+    commit_sha: "legacy",
+    excel_data_root: ".",
+    levels_data_root: ".",
+  }), "utf-8");
+  symlinkSync(external, pairPath);
+
+  await withFetchMock((async () => {
+    throw new Error("network down");
+  }) as typeof fetch, async () => {
+    const results = await syncReleaseArchivePair(...specs);
+    assert.deepEqual(results.map((result) => result.status), [
+      "offline_fallback",
+      "offline_fallback",
+    ]);
+  });
+
+  const info = lstatSync(pairPath);
+  assert.equal(info.isFile(), true);
+  assert.equal(info.isSymbolicLink(), false);
+  assert.deepEqual(
+    JSON.parse(readFileSync(external, "utf-8")),
+    JSON.parse(readFileSync(pairPath, "utf-8")),
+  );
+  assert.notEqual(statSync(external).ino, statSync(pairPath).ino);
+});
 
 test("syncRelease returns offline_fallback when network fails but zip exists", async () => {
   const spec = tempSpec();


### PR DESCRIPTION
## Summary

- forward-port the 2.6.2 GameData pair idempotency fix to the 2.7 development line
- preserve atomic generation changes, coherent metadata recovery, mixed-generation rejection, and symlink replacement in both implementations
- retain automated Python-to-TypeScript and TypeScript-to-Python shared-volume identity checks

Refs #152.

## Test plan

- `uv run --directory python --locked python -m pytest tests/test_sync_release.py -q` (39 passed)
- `cd ts && npm test -- --test-name-pattern="pair manifest|syncReleaseArchive|#102"` (280 passed, 2 skipped)
- `cd ts && npm run typecheck && npm run build`
- `./scripts/test-shared-volume-sync.sh`
- `git diff --check`

## Scope

Stable 2.6.2 version, changelog, README, STATUS, and roadmap metadata are intentionally excluded; `develop` remains on its 2.7.0 development version and planning state.