### PR TITLE
fix(ci): harden npm tarball verification (#156)

### DIFF
--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -262,10 +262,7 @@ jobs:
         # ts/scripts/verify-npm-published.sh (shellcheck + unit-tested). See
         # docs/admin/release-cd-recovery.md.
         working-directory: ts
-        run: |
-          TARBALL=$(find . -maxdepth 1 -name 'prts-mcp-ts-*.tgz' -type f -print -quit)
-          test -n "$TARBALL"
-          bash scripts/verify-npm-published.sh "$TARBALL"
+        run: bash scripts/verify-npm-published.sh
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -216,31 +216,17 @@ jobs:
         run: |
           TARBALL=$(find . -maxdepth 1 -name 'prts-mcp-ts-*.tgz' -type f -print -quit)
           test -n "$TARBALL"
-          npm publish "$TARBALL" --provenance --access public --tag "${{ steps.dist_tag.outputs.value }}"
-        working-directory: ts
-
-      - name: Verify npm published bytes
-        working-directory: ts
-        run: |
-          TARBALL=$(find . -maxdepth 1 -name 'prts-mcp-ts-*.tgz' -type f -print -quit)
-          EXPECTED=$(sha256sum "$TARBALL" | awk '{print $1}')
           VERSION="${GITHUB_REF_NAME#ts/v}"
-          TMP=$(mktemp)
-          trap 'rm -f "$TMP"' EXIT
-          for attempt in $(seq 1 18); do
-            URL=$(npm view "prts-mcp-ts@${VERSION}" dist.tarball 2>/dev/null || true)
-            if [ -n "$URL" ] && curl -fsSL "$URL" -o "$TMP"; then
-              ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
-              if [ "$ACTUAL" = "$EXPECTED" ]; then
-                echo "npm tarball SHA-256 verified: $ACTUAL"
-                exit 0
-              fi
-            fi
-            echo "Waiting for npm tarball propagation (attempt $attempt/18)..."
-            sleep 10
-          done
-          echo "::error::Published npm tarball bytes differ from the exact release artifact"
-          exit 1
+          # Idempotent: re-running this job (a full rerun, not just --failed)
+          # must not re-attempt publishing an immutable version that already
+          # landed. npm publish on an existing version fails with
+          # EPUBLISHCONFLICT; skip instead and let verification confirm bytes.
+          if npm view "prts-mcp-ts@${VERSION}" version >/dev/null 2>&1; then
+            echo "prts-mcp-ts@${VERSION} already published; skipping npm publish."
+          else
+            npm publish "$TARBALL" --provenance --access public --tag "${{ steps.dist_tag.outputs.value }}"
+          fi
+        working-directory: ts
 
   github-release:
     runs-on: ubuntu-latest
@@ -267,6 +253,72 @@ jobs:
         with:
           name: ts-release-package
           path: ts
+
+      - name: Verify npm published bytes
+        # Lives in github-release (not publish-npm) so a propagation timeout
+        # fails this job alone: re-run with `gh run rerun <run-id> --failed`
+        # re-verifies the now-propagated immutable tarball and creates the
+        # release without re-attempting npm publish. See
+        # docs/admin/release-cd-recovery.md.
+        working-directory: ts
+        run: |
+          TARBALL=$(find . -maxdepth 1 -name 'prts-mcp-ts-*.tgz' -type f -print -quit)
+          test -n "$TARBALL"
+          EXPECTED=$(sha256sum "$TARBALL" | awk '{print $1}')
+          VERSION="${GITHUB_REF_NAME#ts/v}"
+          TMP=$(mktemp); META=$(mktemp)
+          trap 'rm -f "$TMP" "$META"' EXIT
+
+          # 40 x 15s ~= 10 min, ~2.5x the observed ~4 min npm propagation.
+          ATTEMPTS=40
+          SLEEP=15
+          LAST_HTTP="000"
+          URL=""
+
+          for attempt in $(seq 1 "$ATTEMPTS"); do
+            TS=$(date +%s)
+            URL=""; SHASUM=""; INTEGRITY=""
+            # Cache-bust the per-version packument so a stale CDN 404 cannot
+            # mask a publish that already landed on the registry. ?ts= is
+            # ignored by the registry as an unknown query param.
+            if curl -fsSL "https://registry.npmjs.org/prts-mcp-ts/${VERSION}?ts=${TS}" -o "$META" 2>/dev/null; then
+              read -r URL SHASUM INTEGRITY < <(node -e 'const m=JSON.parse(require("fs").readFileSync(0,"utf8"));const d=m.dist||{};console.log(d.tarball||"",d.shasum||"",d.integrity||"")' < "$META") || true
+            fi
+
+            if [ -n "$URL" ]; then
+              # No -f: capture the HTTP status so the terminal error can tell
+              # 404 (not propagated) from 500. A 404 writes no body, so the
+              # 80 MB tarball is only fetched on a real 200.
+              HTTP=$(curl -sSL -o "$TMP" -w '%{http_code}' "${URL}?ts=${TS}" || true)
+              LAST_HTTP="$HTTP"
+              if [ "$HTTP" = "200" ]; then
+                ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
+                if [ "$ACTUAL" = "$EXPECTED" ]; then
+                  echo "npm tarball SHA-256 verified: $ACTUAL"
+                  exit 0
+                fi
+                # npm versions are immutable post-publish: a retrievable byte
+                # mismatch is permanent, so fail fast instead of redownloading.
+                echo "::error::prts-mcp-ts@${VERSION} tarball is retrievable but its bytes differ from the exact release artifact."
+                echo "::error::expected sha256 (local artifact): ${EXPECTED}"
+                echo "::error::actual sha256   (registry tarball): ${ACTUAL}"
+                echo "::error::registry dist.shasum: ${SHASUM}"
+                echo "::error::registry dist.integrity: ${INTEGRITY}"
+                echo "::error::Do NOT create the GitHub Release; investigate first."
+                exit 1
+              fi
+            fi
+            echo "Waiting for npm tarball propagation (attempt ${attempt}/${ATTEMPTS}, last HTTP ${LAST_HTTP})..."
+            sleep "$SLEEP"
+          done
+
+          echo "::error::npm publish succeeded but the tarball was not retrievable after ${ATTEMPTS} attempts (~$((ATTEMPTS*SLEEP/60)) min); last tarball HTTP status ${LAST_HTTP}."
+          echo "::error::This is a registry propagation delay, not a byte mismatch."
+          echo "::error::expected sha256: ${EXPECTED}"
+          echo "::error::tarball URL: ${URL:-<version document not visible yet>}"
+          echo "::error::Recovery: wait for propagation, then re-run this github-release job (gh run rerun <run-id> --failed), or verify manually:"
+          echo "::error::  curl -fsSL \"${URL:-<url>}?ts=\$(date +%s)\" | sha256sum"
+          exit 1
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -286,33 +286,41 @@ jobs:
             fi
 
             if [ -n "$URL" ]; then
-              # No -f: capture the HTTP status so the terminal error can tell
-              # 404 (not propagated) from 500. A 404 writes no body, so the
-              # 80 MB tarball is only fetched on a real 200.
-              HTTP=$(curl -sSL -o "$TMP" -w '%{http_code}' "${URL}?ts=${TS}" || true)
-              LAST_HTTP="$HTTP"
-              if [ "$HTTP" = "200" ]; then
-                ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
-                if [ "$ACTUAL" = "$EXPECTED" ]; then
-                  echo "npm tarball SHA-256 verified: $ACTUAL"
-                  exit 0
+              # Fetch without -f so %{http_code} is captured even on 4xx/5xx.
+              # The body is only hashed when curl exited 0 (no interrupted
+              # transfer) AND the status is 200; any other case is treated as
+              # transient and retried, so a partial download is not misread
+              # as a permanent byte mismatch. A non-200 carries only a small
+              # error payload, not the 80 MB tarball.
+              if HTTP=$(curl -sSL -o "$TMP" -w '%{http_code}' "${URL}?ts=${TS}" 2>/dev/null); then
+                LAST_HTTP="$HTTP"
+                if [ "$HTTP" = "200" ]; then
+                  ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
+                  if [ "$ACTUAL" = "$EXPECTED" ]; then
+                    echo "npm tarball SHA-256 verified: $ACTUAL"
+                    exit 0
+                  fi
+                  # npm versions are immutable post-publish: a retrievable byte
+                  # mismatch is permanent, so fail fast instead of redownloading.
+                  echo "::error::prts-mcp-ts@${VERSION} tarball is retrievable but its bytes differ from the exact release artifact."
+                  echo "::error::expected sha256 (local artifact): ${EXPECTED}"
+                  echo "::error::actual sha256   (registry tarball): ${ACTUAL}"
+                  echo "::error::registry dist.shasum: ${SHASUM}"
+                  echo "::error::registry dist.integrity: ${INTEGRITY}"
+                  echo "::error::Do NOT create the GitHub Release; investigate first."
+                  exit 1
                 fi
-                # npm versions are immutable post-publish: a retrievable byte
-                # mismatch is permanent, so fail fast instead of redownloading.
-                echo "::error::prts-mcp-ts@${VERSION} tarball is retrievable but its bytes differ from the exact release artifact."
-                echo "::error::expected sha256 (local artifact): ${EXPECTED}"
-                echo "::error::actual sha256   (registry tarball): ${ACTUAL}"
-                echo "::error::registry dist.shasum: ${SHASUM}"
-                echo "::error::registry dist.integrity: ${INTEGRITY}"
-                echo "::error::Do NOT create the GitHub Release; investigate first."
-                exit 1
+              else
+                # curl non-zero: connection failure or interrupted transfer
+                # (e.g. partial body). Retry on the next iteration.
+                LAST_HTTP="${HTTP:-000}"
               fi
             fi
             echo "Waiting for npm tarball propagation (attempt ${attempt}/${ATTEMPTS}, last HTTP ${LAST_HTTP})..."
             sleep "$SLEEP"
           done
 
-          echo "::error::npm publish succeeded but the tarball was not retrievable after ${ATTEMPTS} attempts (~$((ATTEMPTS*SLEEP/60)) min); last tarball HTTP status ${LAST_HTTP}."
+          echo "::error::prts-mcp-ts@${VERSION} is published but the tarball was not retrievable after ${ATTEMPTS} attempts (~$((ATTEMPTS*SLEEP/60)) min); last tarball HTTP status ${LAST_HTTP}."
           echo "::error::This is a registry propagation delay, not a byte mismatch."
           echo "::error::expected sha256: ${EXPECTED}"
           echo "::error::tarball URL: ${URL:-<version document not visible yet>}"

--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -258,75 +258,14 @@ jobs:
         # Lives in github-release (not publish-npm) so a propagation timeout
         # fails this job alone: re-run with `gh run rerun <run-id> --failed`
         # re-verifies the now-propagated immutable tarball and creates the
-        # release without re-attempting npm publish. See
+        # release without re-attempting npm publish. The logic is extracted to
+        # ts/scripts/verify-npm-published.sh (shellcheck + unit-tested). See
         # docs/admin/release-cd-recovery.md.
         working-directory: ts
         run: |
           TARBALL=$(find . -maxdepth 1 -name 'prts-mcp-ts-*.tgz' -type f -print -quit)
           test -n "$TARBALL"
-          EXPECTED=$(sha256sum "$TARBALL" | awk '{print $1}')
-          VERSION="${GITHUB_REF_NAME#ts/v}"
-          TMP=$(mktemp); META=$(mktemp)
-          trap 'rm -f "$TMP" "$META"' EXIT
-
-          # 40 x 15s ~= 10 min, ~2.5x the observed ~4 min npm propagation.
-          ATTEMPTS=40
-          SLEEP=15
-          LAST_HTTP="000"
-          URL=""
-
-          for attempt in $(seq 1 "$ATTEMPTS"); do
-            TS=$(date +%s)
-            URL=""; SHASUM=""; INTEGRITY=""
-            # Cache-bust the per-version packument so a stale CDN 404 cannot
-            # mask a publish that already landed on the registry. ?ts= is
-            # ignored by the registry as an unknown query param.
-            if curl -fsSL "https://registry.npmjs.org/prts-mcp-ts/${VERSION}?ts=${TS}" -o "$META" 2>/dev/null; then
-              read -r URL SHASUM INTEGRITY < <(node -e 'const m=JSON.parse(require("fs").readFileSync(0,"utf8"));const d=m.dist||{};console.log(d.tarball||"",d.shasum||"",d.integrity||"")' < "$META") || true
-            fi
-
-            if [ -n "$URL" ]; then
-              # Fetch without -f so %{http_code} is captured even on 4xx/5xx.
-              # The body is only hashed when curl exited 0 (no interrupted
-              # transfer) AND the status is 200; any other case is treated as
-              # transient and retried, so a partial download is not misread
-              # as a permanent byte mismatch. A non-200 carries only a small
-              # error payload, not the 80 MB tarball.
-              if HTTP=$(curl -sSL -o "$TMP" -w '%{http_code}' "${URL}?ts=${TS}" 2>/dev/null); then
-                LAST_HTTP="$HTTP"
-                if [ "$HTTP" = "200" ]; then
-                  ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
-                  if [ "$ACTUAL" = "$EXPECTED" ]; then
-                    echo "npm tarball SHA-256 verified: $ACTUAL"
-                    exit 0
-                  fi
-                  # npm versions are immutable post-publish: a retrievable byte
-                  # mismatch is permanent, so fail fast instead of redownloading.
-                  echo "::error::prts-mcp-ts@${VERSION} tarball is retrievable but its bytes differ from the exact release artifact."
-                  echo "::error::expected sha256 (local artifact): ${EXPECTED}"
-                  echo "::error::actual sha256   (registry tarball): ${ACTUAL}"
-                  echo "::error::registry dist.shasum: ${SHASUM}"
-                  echo "::error::registry dist.integrity: ${INTEGRITY}"
-                  echo "::error::Do NOT create the GitHub Release; investigate first."
-                  exit 1
-                fi
-              else
-                # curl non-zero: connection failure or interrupted transfer
-                # (e.g. partial body). Retry on the next iteration.
-                LAST_HTTP="${HTTP:-000}"
-              fi
-            fi
-            echo "Waiting for npm tarball propagation (attempt ${attempt}/${ATTEMPTS}, last HTTP ${LAST_HTTP})..."
-            sleep "$SLEEP"
-          done
-
-          echo "::error::prts-mcp-ts@${VERSION} is published but the tarball was not retrievable after ${ATTEMPTS} attempts (~$((ATTEMPTS*SLEEP/60)) min); last tarball HTTP status ${LAST_HTTP}."
-          echo "::error::This is a registry propagation delay, not a byte mismatch."
-          echo "::error::expected sha256: ${EXPECTED}"
-          echo "::error::tarball URL: ${URL:-<version document not visible yet>}"
-          echo "::error::Recovery: wait for propagation, then re-run this github-release job (gh run rerun <run-id> --failed), or verify manually:"
-          echo "::error::  curl -fsSL \"${URL:-<url>}?ts=\$(date +%s)\" | sha256sum"
-          exit 1
+          bash scripts/verify-npm-published.sh "$TARBALL"
 
       - name: Extract version from tag
         id: version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,10 @@ jobs:
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 
       - name: Shellcheck CD helper scripts
-        run: docker run --rm -v "$PWD":/mnt:ro koalaman/shellcheck:stable $(printf '/mnt/%s ' ts/scripts/*.sh)
+        run: |
+          for f in ts/scripts/*.sh; do
+            docker run --rm -v "$PWD":/mnt:ro koalaman/shellcheck:stable "/mnt/$f"
+          done
 
   # ---------------------------------------------------------------------------
   # Python implementation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 
       - name: Shellcheck CD helper scripts
-        run: docker run --rm -v "$PWD":/mnt:ro koalaman/shellcheck:stable /mnt/ts/scripts/verify-npm-published.sh
+        run: docker run --rm -v "$PWD":/mnt:ro koalaman/shellcheck:stable $(printf '/mnt/%s ' ts/scripts/*.sh)
 
   # ---------------------------------------------------------------------------
   # Python implementation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Lint GitHub Actions workflows
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
 
+      - name: Shellcheck CD helper scripts
+        run: docker run --rm -v "$PWD":/mnt:ro koalaman/shellcheck:stable /mnt/ts/scripts/verify-npm-published.sh
+
   # ---------------------------------------------------------------------------
   # Python implementation
   # ---------------------------------------------------------------------------
@@ -241,6 +244,10 @@ jobs:
 
       - name: Run tests
         run: npm test
+        working-directory: ts
+
+      - name: Verify npm tarball helper script tests
+        run: node scripts/verify-npm-published.test.mjs
         working-directory: ts
 
   verify-ts:

--- a/docs/admin/release-cd-recovery.md
+++ b/docs/admin/release-cd-recovery.md
@@ -28,6 +28,8 @@ gh run rerun <run-id> --failed
 
 注意一个窄边角：在版本已落地但**尚未对 CDN 可见**的传播窗口内全量重跑，guard 的 `npm view` 可能仍拿到 404 而重新 `npm publish`，命中 EPUBLISHCONFLICT（无害，不会双发，但会让该 job 失败）。恢复场景下通常已在传播完成之后操作，故优先 `--failed`；确需在传播窗口内重跑时，等几分钟再试。
 
+全量重跑还有一个更隐蔽的问题：它会重跑 `package` job，而 `package` 会重新 `fetch_gamedata.py` 并下载最新的 storyjson。若 arknights-data-pipeline 在两次运行之间发布了新数据，重建出的 tarball 就会与 npm 上已落地的不可变字节不同，Verify 会判定为“本地制品漂移”（见下节）。`--failed` 不重跑 `package`、复用原始 artifact，因此不受影响——这是优先 `--failed` 的更主要原因。
+
 ## 手动校验回退
 
 当对已发布版本仍有疑虑，或想在重跑前先确认 tarball 已可检索：
@@ -40,12 +42,13 @@ curl -fsSL "$(npm view prts-mcp-ts@${VERSION} dist.tarball)?ts=$(date +%s)" | sh
 
 将输出与本轮 workflow artifact（`ts-release-package`，保留 7 天）的 sha256 比对。一致即可放心重跑 `github-release`。
 
-## 报错信息如何区分两种失败
+## 报错信息如何区分失败类型
 
-区分依据是错误里**是否给出 expected 与 actual 两组 sha256**（错误串的权威来源是 `cd-ts.yml` 的 Verify 步骤；此处只描述区分要点，避免与工作流措辞同步漂移）：
+错误串的权威来源是 `ts/scripts/verify-npm-published.sh`；此处只描述区分要点，避免与脚本措辞同步漂移。注意打印的哈希算法不同：`expected/actual sha256` 是 SHA-256，`dist.shasum` 是 SHA-1，`dist.integrity` 是 base64 的 SHA-512 SRI——**不要跨算法直接比对**。
 
-- **只声明 "not retrievable" / 传播延迟，没有 expected-vs-actual sha256** → 传播延迟，按上面“主恢复路径”重跑即可。
-- **声明 "bytes differ" 并附 expected/actual sha256 及 registry `dist.shasum` / `dist.integrity`** → 可检索但字节不符（硬失败）。**不要创建 GitHub Release**，先排查 workflow artifact 与 registry 制品的差异（极罕见，通常是流水线非确定性或中途篡改）。
+- **只声明 "not retrievable" / 传播延迟，没有 expected-vs-actual sha256** → npm 传播未完成或传输被中断，按上面“主恢复路径”重跑即可。
+- **声明 "registry tarball is intact … drifted"** → registry 制品完好（与它自报的 `dist.shasum` 一致），但与本地 artifact 不符：本地制品漂移（典型于 bundled 数据变化后的全量重跑）。npm 上的 tarball 才是正确的发布内容。恢复：用 `--failed` 复用原始 artifact 重验，或直接以 registry tarball 创建 release。
+- **声明 "does NOT match the registry's own declared hashes" 并附 downloaded sha1** → 下载到的字节与 registry 自己声明的哈希都不符（CDN/registry 异常或篡改）。**不要创建 GitHub Release**，先排查。
 
 ## 范围说明
 

--- a/docs/admin/release-cd-recovery.md
+++ b/docs/admin/release-cd-recovery.md
@@ -1,0 +1,51 @@
+# CD 发布恢复手册
+
+维护者文档：当一次发布触发 `CD (TypeScript)` / `CD` 工作流、且某个 job 失败时，如何在不重发已发布制品的前提下完成恢复。
+
+适用范围：`.github/workflows/cd-ts.yml`（TypeScript）与 `.github/workflows/cd.yml`（Python）。本文以 TypeScript 的 npm tarball 传播超时为典型场景（参见 #156），其余失败模式按通用步骤处理。
+
+## 背景：为什么 Verify 单独成 job
+
+`cd-ts.yml` 的 `Verify npm published bytes` 步骤位于 `github-release` job 内（而非 `publish-npm`）。npm 在 Trusted Publishing 完成后，tarball 在 CDN/registry 上的可检索存在数分钟的传播延迟。Verify 步骤会 cache-bust registry/CDN 路径并轮询约 10 分钟（`40 × 15s`）。
+
+把 Verify 放在 `github-release` 而不是 `publish-npm`，使得一次传播超时**只失败 `github-release` 这一个 job**：`publish-npm` 已经绿，npm 上的版本已经不可变地落地。恢复时不需要、也不应该再触发 `npm publish`。
+
+## 主恢复路径：重跑失败的 job
+
+```bash
+# 列出最近的 CD (TypeScript) 运行
+gh run list --workflow "CD (TypeScript)" --limit 5
+
+# 只重跑失败的 job（推荐）
+gh run rerun <run-id> --failed
+```
+
+`--failed` 只重跑 `github-release`：它重新下载 workflow artifact、对**已经传播完成**的不可变 npm tarball 重新校验，字节一致后创建 GitHub Release。整个过程**不会再触发 `npm publish`**。
+
+### 为什么优先 `--failed` 而非全量重跑
+
+`publish-npm` 已加幂等 guard：若版本已存在则跳过 `npm publish`，因此**全量重跑（`gh run rerun <run-id>`，不带 `--failed`）现在也是安全的**——但全量重跑会重新走完整条流水线（verify/build/test/dist-tag 解析等），耗时更长，且会再次触发 `environment: npm` 审批门。除非有其他 job 也失败，否则用 `--failed`。
+
+## 手动校验回退
+
+当对已发布版本仍有疑虑，或想在重跑前先确认 tarball 已可检索：
+
+```bash
+VERSION=2.6.2   # 替换为目标版本
+# cache-bust 以绕过可能缓存了陈旧 404 的 CDN 边缘节点
+curl -fsSL "$(npm view prts-mcp-ts@${VERSION} dist.tarball)?ts=$(date +%s)" | sha256sum
+```
+
+将输出与本轮 workflow artifact（`ts-release-package`，保留 7 天）的 sha256 比对。一致即可放心重跑 `github-release`。
+
+## 报错信息如何区分两种失败
+
+Verify 步骤的终止报错刻意区分两类情况：
+
+- **传播延迟（非字节不符）**：`npm publish succeeded but the tarball was not retrievable after N attempts ... This is a registry propagation delay, not a byte mismatch.` → 按上面“主恢复路径”重跑即可。
+- **可检索但字节不符（硬失败）**：`tarball is retrievable but its bytes differ from the exact release artifact`，并附 expected/actual sha256、registry `dist.shasum` / `dist.integrity`。**不要创建 GitHub Release**，先排查 workflow artifact 与 registry 制品的差异（极罕见，通常是流水线非确定性或中途篡改）。
+
+## 范围说明
+
+- 本文目前仅覆盖 TypeScript CD。Python CD（`cd.yml` 的 `publish-pypi`）尚无对应的发布后字节校验步骤；parity 跟踪见 #157。
+- `environment: npm` 审批门挂在 `publish-npm`；任何让 `publish-npm` 重新运行的重跑都会再次要求审批。

--- a/docs/admin/release-cd-recovery.md
+++ b/docs/admin/release-cd-recovery.md
@@ -24,7 +24,9 @@ gh run rerun <run-id> --failed
 
 ### 为什么优先 `--failed` 而非全量重跑
 
-`publish-npm` 已加幂等 guard：若版本已存在则跳过 `npm publish`，因此**全量重跑（`gh run rerun <run-id>`，不带 `--failed`）现在也是安全的**——但全量重跑会重新走完整条流水线（verify/build/test/dist-tag 解析等），耗时更长，且会再次触发 `environment: npm` 审批门。除非有其他 job 也失败，否则用 `--failed`。
+`publish-npm` 已加幂等 guard：若版本已存在则跳过 `npm publish`。**一旦传播完成**，全量重跑（`gh run rerun <run-id>`，不带 `--failed`）也是安全的——但它会重新走完整条流水线（verify/build/test/dist-tag 解析等），耗时更长，且会再次触发 `environment: npm` 审批门。
+
+注意一个窄边角：在版本已落地但**尚未对 CDN 可见**的传播窗口内全量重跑，guard 的 `npm view` 可能仍拿到 404 而重新 `npm publish`，命中 EPUBLISHCONFLICT（无害，不会双发，但会让该 job 失败）。恢复场景下通常已在传播完成之后操作，故优先 `--failed`；确需在传播窗口内重跑时，等几分钟再试。
 
 ## 手动校验回退
 
@@ -40,10 +42,10 @@ curl -fsSL "$(npm view prts-mcp-ts@${VERSION} dist.tarball)?ts=$(date +%s)" | sh
 
 ## 报错信息如何区分两种失败
 
-Verify 步骤的终止报错刻意区分两类情况：
+区分依据是错误里**是否给出 expected 与 actual 两组 sha256**（错误串的权威来源是 `cd-ts.yml` 的 Verify 步骤；此处只描述区分要点，避免与工作流措辞同步漂移）：
 
-- **传播延迟（非字节不符）**：`npm publish succeeded but the tarball was not retrievable after N attempts ... This is a registry propagation delay, not a byte mismatch.` → 按上面“主恢复路径”重跑即可。
-- **可检索但字节不符（硬失败）**：`tarball is retrievable but its bytes differ from the exact release artifact`，并附 expected/actual sha256、registry `dist.shasum` / `dist.integrity`。**不要创建 GitHub Release**，先排查 workflow artifact 与 registry 制品的差异（极罕见，通常是流水线非确定性或中途篡改）。
+- **只声明 "not retrievable" / 传播延迟，没有 expected-vs-actual sha256** → 传播延迟，按上面“主恢复路径”重跑即可。
+- **声明 "bytes differ" 并附 expected/actual sha256 及 registry `dist.shasum` / `dist.integrity`** → 可检索但字节不符（硬失败）。**不要创建 GitHub Release**，先排查 workflow artifact 与 registry 制品的差异（极罕见，通常是流水线非确定性或中途篡改）。
 
 ## 范围说明
 

--- a/docs/admin/release-cd-recovery.md
+++ b/docs/admin/release-cd-recovery.md
@@ -28,7 +28,7 @@ gh run rerun <run-id> --failed
 
 注意一个窄边角：在版本已落地但**尚未对 CDN 可见**的传播窗口内全量重跑，guard 的 `npm view` 可能仍拿到 404 而重新 `npm publish`，命中 EPUBLISHCONFLICT（无害，不会双发，但会让该 job 失败）。恢复场景下通常已在传播完成之后操作，故优先 `--failed`；确需在传播窗口内重跑时，等几分钟再试。
 
-全量重跑还有一个更隐蔽的问题：它会重跑 `package` job，而 `package` 会重新 `fetch_gamedata.py` 并下载最新的 storyjson。若 arknights-data-pipeline 在两次运行之间发布了新数据，重建出的 tarball 就会与 npm 上已落地的不可变字节不同，Verify 会判定为“本地制品漂移”（见下节）。`--failed` 不重跑 `package`、复用原始 artifact，因此不受影响——这是优先 `--failed` 的更主要原因。
+全量重跑还有一个更隐蔽的问题：它会重跑 `package` job，重新 `fetch_gamedata.py` 并下载最新的 storyjson；若 arknights-data-pipeline 在两次运行之间发布了新数据，重建出的 tarball 会与 npm 上已落地的不可变字节不同，Verify 会判定为“本地制品漂移”（见下节）。**注意：一旦漂移进入某个 run 的 artifact，对这个 run 做 `--failed` 也会重新下载同一个漂移 artifact 而再次失败**——`--failed` 只在重跑**最初发布该版本的 run**（其 artifact 与已发布字节一致）时才能恢复漂移。所以优先在原始 run 上用 `--failed`；若原始 run 已不可用，按下一节的漂移路径用 registry tarball 建 release。
 
 ## 手动校验回退
 
@@ -47,7 +47,7 @@ curl -fsSL "$(npm view prts-mcp-ts@${VERSION} dist.tarball)?ts=$(date +%s)" | sh
 错误串的权威来源是 `ts/scripts/verify-npm-published.sh`；此处只描述区分要点，避免与脚本措辞同步漂移。注意打印的哈希算法不同：`expected/actual sha256` 是 SHA-256，`dist.shasum` 是 SHA-1，`dist.integrity` 是 base64 的 SHA-512 SRI——**不要跨算法直接比对**。
 
 - **只声明 "not retrievable" / 传播延迟，没有 expected-vs-actual sha256** → npm 传播未完成或传输被中断，按上面“主恢复路径”重跑即可。
-- **声明 "registry tarball is intact … drifted"** → registry 制品完好（与它自报的 `dist.shasum` 一致），但与本地 artifact 不符：本地制品漂移（典型于 bundled 数据变化后的全量重跑）。npm 上的 tarball 才是正确的发布内容。恢复：用 `--failed` 复用原始 artifact 重验，或直接以 registry tarball 创建 release。
+- **声明 "registry tarball is intact … drifted"** → registry 制品完好（与它自报的 `dist.shasum` 一致），但与本地 artifact 不符：本地制品漂移（典型于 bundled 数据变化后的全量重跑）。npm 上的 tarball 才是正确的发布内容。恢复：直接以 registry tarball 创建 release；或对**最初发布该版本的 run** 做 `gh run rerun <id> --failed`（其 artifact 字节一致）。对当前（已漂移的）run 做 `--failed` 会重新下载漂移 artifact 而再次失败。
 - **声明 "does NOT match the registry's own declared hashes" 并附 downloaded sha1** → 下载到的字节与 registry 自己声明的哈希都不符（CDN/registry 异常或篡改）。**不要创建 GitHub Release**，先排查。
 
 ## 范围说明

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **npm tarball verification tolerates propagation delay (#156).** The TypeScript CD `Verify npm published bytes` step now cache-busts the registry/CDN URL, retries for ~10 min, distinguishes a propagation timeout from a real byte mismatch, and fails fast on a permanent mismatch. The step moved from `publish-npm` into `github-release` so a propagation timeout no longer skips release creation (recover with `gh run rerun <run-id> --failed`); `npm publish` is skipped if the version already exists, making job re-runs safe.
+
 ## [2.6.1] - 2026-08-10
 
 ### Fixed

--- a/ts/scripts/verify-npm-published.sh
+++ b/ts/scripts/verify-npm-published.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Verify the npm-published tarball for the TypeScript package is byte-identical
+# to the exact local release artifact, tolerating registry/CDN propagation.
+#
+# Invoked from .github/workflows/cd-ts.yml (github-release job). Extracted to a
+# script so the release error contract is shellcheck-able and unit-tested
+# (ts/scripts/verify-npm-published.test.mjs) rather than living only in YAML.
+#
+# Usage: verify-npm-published.sh <tarball>
+# Env (optional unless noted):
+#   VERSION          required if GITHUB_REF_NAME is unset; e.g. 2.7.0 / 2.7.0-alpha.1
+#   NPM_PACKAGE      default prts-mcp-ts  (the published name; mirrors ts/package.json)
+#   NPM_REGISTRY     default https://registry.npmjs.org
+#   VERIFY_ATTEMPTS  default 40  (x VERIFY_SLEEP ~= 10 min polling budget)
+#   VERIFY_SLEEP     default 15
+#
+# Exit 0: served tarball is byte-identical to the local artifact.
+# Exit 1: propagation timeout, or a retrievable mismatch classified as
+#         drift (registry intact, local artifact changed) vs anomaly. See the
+#         ::error:: lines for the cause and recovery.
+set -euo pipefail
+
+TARBALL="${1:?usage: verify-npm-published.sh <tarball>}"
+test -f "$TARBALL"
+
+if [ -z "${VERSION:-}" ]; then
+  if [ -n "${GITHUB_REF_NAME:-}" ]; then
+    VERSION="${GITHUB_REF_NAME#ts/v}"
+  fi
+fi
+: "${VERSION:?VERSION could not be determined (set VERSION or run under a ts/v* tag)}"
+
+PACKAGE="${NPM_PACKAGE:-prts-mcp-ts}"
+REGISTRY="${NPM_REGISTRY:-https://registry.npmjs.org}"
+ATTEMPTS="${VERIFY_ATTEMPTS:-40}"
+SLEEP="${VERIFY_SLEEP:-15}"
+
+EXPECTED=$(sha256sum "$TARBALL" | awk '{print $1}')
+
+TMP=$(mktemp); META=$(mktemp)
+trap 'rm -f "$TMP" "$META"' EXIT
+
+print_diag() {
+  # Shared diagnostics for the two retrievable-mismatch branches. The labels
+  # matter: dist.shasum is SHA-1 and dist.integrity is a base64 SHA-512 SRI,
+  # neither comparable to the SHA-256 lines without converting algorithms.
+  echo "::error::expected sha256 (local artifact):     ${EXPECTED}"
+  echo "::error::actual sha256   (registry tarball):   ${ACTUAL:-<none>}"
+  echo "::error::registry dist.tarball:                ${URL:-<unknown>}"
+  echo "::error::registry dist.shasum (sha1):          ${SHASUM:-<none>}"
+  echo "::error::registry dist.integrity (sha512 sri): ${INTEGRITY:-<none>}"
+}
+
+LAST_HTTP="000"
+URL=""
+SHASUM=""
+INTEGRITY=""
+ACTUAL=""
+
+for attempt in $(seq 1 "$ATTEMPTS"); do
+  TS=$(date +%s)
+  URL=""; SHASUM=""; INTEGRITY=""
+  # Cache-bust the per-version packument so a stale CDN 404 cannot mask a
+  # publish that already landed. The ?ts= query is ignored by the registry.
+  if curl -fsSL "${REGISTRY}/${PACKAGE}/${VERSION}?ts=${TS}" -o "$META" 2>/dev/null; then
+    # node reads the packument from fd 0; if it is non-JSON (transient CDN
+    # hiccup) node throws and read returns non-zero — `|| true` keeps the
+    # retry loop intact under `set -e`.
+    # shellcheck disable=SC2311
+    read -r URL SHASUM INTEGRITY < <(node -e 'const m=JSON.parse(require("fs").readFileSync(0,"utf8"));const d=m.dist||{};console.log(d.tarball||"",d.shasum||"",d.integrity||"")' < "$META") || true
+  fi
+
+  if [ -n "$URL" ]; then
+    # Fetch without -f so %{http_code} is captured on 4xx/5xx. Only hash when
+    # curl exited 0 (no interrupted/partial transfer) AND status is 200;
+    # otherwise treat as transient and retry, so a truncated download is not
+    # misread as a permanent byte mismatch.
+    if HTTP=$(curl -sSL -o "$TMP" -w '%{http_code}' "${URL}?ts=${TS}" 2>/dev/null); then
+      LAST_HTTP="$HTTP"
+      if [ "$HTTP" = "200" ]; then
+        ACTUAL=$(sha256sum "$TMP" | awk '{print $1}')
+        if [ "$ACTUAL" = "$EXPECTED" ]; then
+          echo "npm tarball SHA-256 verified: $ACTUAL"
+          exit 0
+        fi
+        # Retrievable but bytes differ. Cross-check the download against the
+        # registry's OWN declared hashes: if the served tarball matches what
+        # npm indexed at publish, the registry is intact and the LOCAL
+        # artifact drifted (expected on a full rerun that re-fetched bundled
+        # gamedata/storyjson) — not registry tampering.
+        DL_SHA1=$(sha1sum "$TMP" | awk '{print $1}')
+        if [ -n "$SHASUM" ] && [ "$DL_SHA1" = "$SHASUM" ]; then
+          echo "::error::${PACKAGE}@${VERSION}: registry tarball is intact (matches its declared dist.shasum) but differs from the local artifact — the local artifact drifted (expected on a full rerun after bundled data changed). The published tarball is the verified release content."
+          echo "::error::Recovery: re-run with 'gh run rerun <run-id> --failed' (reuses the original artifact), or create the release from the registry tarball above."
+          print_diag
+        else
+          echo "::error::${PACKAGE}@${VERSION}: downloaded tarball does NOT match the registry's own declared hashes — possible CDN/registry anomaly or tampering."
+          echo "::error::downloaded sha1: ${DL_SHA1}"
+          echo "::error::Do NOT create the GitHub Release; investigate first."
+          print_diag
+        fi
+        exit 1
+      fi
+    else
+      # curl non-zero: connection failure or interrupted transfer (partial
+      # body). Retry on the next iteration; do not hash a truncated file.
+      LAST_HTTP="${HTTP:-000}"
+    fi
+  fi
+  echo "Waiting for npm tarball propagation (attempt ${attempt}/${ATTEMPTS}, last HTTP ${LAST_HTTP})..."
+  sleep "$SLEEP"
+done
+
+echo "::error::${PACKAGE}@${VERSION} is published but the tarball was not retrievable after ${ATTEMPTS} attempts (~$((ATTEMPTS*SLEEP/60)) min); last tarball HTTP status ${LAST_HTTP}."
+echo "::error::This is a registry propagation delay, not a byte mismatch."
+echo "::error::expected sha256: ${EXPECTED}"
+echo "::error::Recovery: wait for propagation, then re-run this github-release job (gh run rerun <run-id> --failed), or verify manually:"
+# shellcheck disable=SC2016 # the $(date +%s) is meant to be copied literally
+echo "::error::  curl -fsSL \"${URL:-<url>}?ts=\$(date +%s)\" | sha256sum"
+exit 1

--- a/ts/scripts/verify-npm-published.sh
+++ b/ts/scripts/verify-npm-published.sh
@@ -6,7 +6,10 @@
 # script so the release error contract is shellcheck-able and unit-tested
 # (ts/scripts/verify-npm-published.test.mjs) rather than living only in YAML.
 #
-# Usage: verify-npm-published.sh <tarball>
+# Usage: verify-npm-published.sh [<tarball>]
+#        If <tarball> is omitted, the script discovers the packed artifact in
+#        the current directory (cd-ts.yml runs it with working-directory: ts),
+#        so the release-artifact glob has a single owner instead of three.
 # Env (optional unless noted):
 #   VERSION          required if GITHUB_REF_NAME is unset; e.g. 2.7.0 / 2.7.0-alpha.1
 #   NPM_PACKAGE      default prts-mcp-ts  (the published name; mirrors ts/package.json)
@@ -20,7 +23,13 @@
 #         ::error:: lines for the cause and recovery.
 set -euo pipefail
 
-TARBALL="${1:?usage: verify-npm-published.sh <tarball>}"
+PACKAGE="${NPM_PACKAGE:-prts-mcp-ts}"
+REGISTRY="${NPM_REGISTRY:-https://registry.npmjs.org}"
+
+# Take the tarball explicitly, or discover the packed artifact in the cwd so
+# the release-artifact glob lives here rather than being re-derived in YAML.
+TARBALL="${1:-$(find . -maxdepth 1 -name "${PACKAGE}-*.tgz" -type f -print -quit)}"
+test -n "$TARBALL"
 test -f "$TARBALL"
 
 if [ -z "${VERSION:-}" ]; then
@@ -30,8 +39,6 @@ if [ -z "${VERSION:-}" ]; then
 fi
 : "${VERSION:?VERSION could not be determined (set VERSION or run under a ts/v* tag)}"
 
-PACKAGE="${NPM_PACKAGE:-prts-mcp-ts}"
-REGISTRY="${NPM_REGISTRY:-https://registry.npmjs.org}"
 ATTEMPTS="${VERIFY_ATTEMPTS:-40}"
 SLEEP="${VERIFY_SLEEP:-15}"
 
@@ -91,7 +98,7 @@ for attempt in $(seq 1 "$ATTEMPTS"); do
         DL_SHA1=$(sha1sum "$TMP" | awk '{print $1}')
         if [ -n "$SHASUM" ] && [ "$DL_SHA1" = "$SHASUM" ]; then
           echo "::error::${PACKAGE}@${VERSION}: registry tarball is intact (matches its declared dist.shasum) but differs from the local artifact — the local artifact drifted (expected on a full rerun after bundled data changed). The published tarball is the verified release content."
-          echo "::error::Recovery: re-run with 'gh run rerun <run-id> --failed' (reuses the original artifact), or create the release from the registry tarball above."
+          echo "::error::Recovery: create the GitHub Release from the registry tarball above, or re-run the ORIGINAL run that published this version with 'gh run rerun <run-id> --failed' (only its artifact is byte-identical). A --failed rerun of THIS run re-uses the drifted artifact and will fail again."
           print_diag
         else
           echo "::error::${PACKAGE}@${VERSION}: downloaded tarball does NOT match the registry's own declared hashes — possible CDN/registry anomaly or tampering."

--- a/ts/scripts/verify-npm-published.test.mjs
+++ b/ts/scripts/verify-npm-published.test.mjs
@@ -2,17 +2,17 @@
 // Unit test for ts/scripts/verify-npm-published.sh.
 //
 // Spins up a mock npm registry on localhost, then runs the verify script
-// across five scenarios that pin its error contract:
+// across six scenarios that pin its error contract, including the two
+// load-bearing retry branches (a non-JSON packument body must not abort the
+// script under `set -e`; an interrupted tarball download must retry):
 //   1. match            — served tarball == local artifact        -> exit 0
 //   2. drift            — served != local, but matches registry's -> exit 1, "intact" + "drifted"
 //                         own declared hashes (local rebuilt)
 //   3. anomaly          — served != local AND != registry's       -> exit 1, "does NOT match"
 //                         declared hashes (registry/CDN anomaly)
 //   4. propagation      — packument 404, never retrievable        -> exit 1, "propagation delay"
-//
-// The curl-exit-status path (an interrupted download retries instead of being
-// misread as a byte mismatch) is verified separately; these four pin the
-// release error contract.
+//   5. non-JSON 200     — packument serves garbage once, then OK  -> exit 0 (pins the `|| true` guard)
+//   6. partial transfer — tarball interrupted once, then full     -> exit 0 (pins the curl-rc retry)
 //
 // Run: node scripts/verify-npm-published.test.mjs   (from ts/)
 import { spawn } from 'node:child_process';
@@ -38,11 +38,23 @@ let failures = 0;
 
 // scenario drives the mock: what the tarball endpoint serves and what hashes
 // the packument declares. Mutated per case before running the script.
+// packumentCalls/tarballCalls let a scenario misbehave on the first request
+// only, so the retry branches are exercised.
 let scenario = null;
+let packumentCalls = 0;
+let tarballCalls = 0;
 const server = createServer((req, res) => {
   const pathname = new URL(req.url, 'http://localhost').pathname;
   if (pathname === `/${PKG}/${VERSION}`) {
+    packumentCalls += 1;
     if (scenario.packument404) { res.statusCode = 404; res.end(); return; }
+    // Serve a non-JSON 200 on the first call to pin the `|| true` guard: an
+    // unguarded `read < <(node ...)` would abort the script under set -e.
+    if (scenario.packumentGarbageOnFirst && packumentCalls === 1) {
+      res.setHeader('content-type', 'application/json');
+      res.end('not json {{{');
+      return;
+    }
     const served = scenario.servedTarball;
     res.setHeader('content-type', 'application/json');
     res.end(JSON.stringify({
@@ -55,8 +67,18 @@ const server = createServer((req, res) => {
     return;
   }
   if (pathname === '/tarball') {
+    tarballCalls += 1;
     if (scenario.tarball404) { res.statusCode = 404; res.end(); return; }
     const body = scenario.servedTarball;
+    // Interrupt the first transfer (claim more bytes than sent, then destroy
+    // the socket) so curl exits non-zero; the script must retry, not misread
+    // the truncated file as a byte mismatch.
+    if (scenario.tarballPartialFirst && tarballCalls === 1) {
+      res.setHeader('content-length', String(Buffer.byteLength(body) + 8192));
+      res.write(body.subarray(0, Math.max(1, Math.floor(body.length / 2))));
+      try { res.socket.destroy(); } catch { /* socket already gone */ }
+      return;
+    }
     res.setHeader('content-length', String(Buffer.byteLength(body)));
     res.end(body);
     return;
@@ -88,6 +110,8 @@ function run(localArtifactPath) {
 
 async function check(name, localBytes, scn, { expectStatus, stdoutHas = [], stdoutNotHas = [] }) {
   scenario = scn;
+  packumentCalls = 0;
+  tarballCalls = 0;
   const local = join(dir, `${name}.tgz`);
   writeFileSync(local, localBytes);
   const r = await run(local);
@@ -137,6 +161,16 @@ await check('propagation', GOOD, { servedTarball: GOOD, packument404: true },
   { expectStatus: 1,
     stdoutHas: ['propagation delay', 'not a byte mismatch'],
     stdoutNotHas: ['bytes differ', 'investigate first'] });
+
+// 5. non-JSON packument on the first call: the `|| true` guard must keep the
+//    script alive so it retries and then succeeds.
+await check('nonJsonPackument', GOOD, { servedTarball: GOOD, packumentGarbageOnFirst: true },
+  { expectStatus: 0, stdoutHas: ['npm tarball SHA-256 verified'] });
+
+// 6. partial tarball transfer on the first call: curl exits non-zero, so the
+//    download must retry (not be hashed as a mismatch) and then succeed.
+await check('partialTarball', GOOD, { servedTarball: GOOD, tarballPartialFirst: true },
+  { expectStatus: 0, stdoutHas: ['npm tarball SHA-256 verified'] });
 
 server.close();
 rmSync(dir, { recursive: true, force: true });

--- a/ts/scripts/verify-npm-published.test.mjs
+++ b/ts/scripts/verify-npm-published.test.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+// Unit test for ts/scripts/verify-npm-published.sh.
+//
+// Spins up a mock npm registry on localhost, then runs the verify script
+// across five scenarios that pin its error contract:
+//   1. match            — served tarball == local artifact        -> exit 0
+//   2. drift            — served != local, but matches registry's -> exit 1, "intact" + "drifted"
+//                         own declared hashes (local rebuilt)
+//   3. anomaly          — served != local AND != registry's       -> exit 1, "does NOT match"
+//                         declared hashes (registry/CDN anomaly)
+//   4. propagation      — packument 404, never retrievable        -> exit 1, "propagation delay"
+//
+// The curl-exit-status path (an interrupted download retries instead of being
+// misread as a byte mismatch) is verified separately; these four pin the
+// release error contract.
+//
+// Run: node scripts/verify-npm-published.test.mjs   (from ts/)
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:http';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
+import assert from 'node:assert';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(here, 'verify-npm-published.sh');
+const PKG = 'prts-mcp-ts';
+const VERSION = '9.9.9-test';
+
+const sha1 = (b) => createHash('sha1').update(b).digest('hex');
+const sha256 = (b) => createHash('sha256').update(b).digest('hex');
+const integrity = (b) => 'sha512-' + createHash('sha512').update(b).digest('base64');
+
+const dir = mkdtempSync(join(tmpdir(), 'verify-npm-'));
+let failures = 0;
+
+// scenario drives the mock: what the tarball endpoint serves and what hashes
+// the packument declares. Mutated per case before running the script.
+let scenario = null;
+const server = createServer((req, res) => {
+  const pathname = new URL(req.url, 'http://localhost').pathname;
+  if (pathname === `/${PKG}/${VERSION}`) {
+    if (scenario.packument404) { res.statusCode = 404; res.end(); return; }
+    const served = scenario.servedTarball;
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({
+      dist: {
+        tarball: `http://127.0.0.1:${server.address().port}/tarball`,
+        shasum: scenario.declaredShasum ?? sha1(served),
+        integrity: scenario.declaredIntegrity ?? integrity(served),
+      },
+    }));
+    return;
+  }
+  if (pathname === '/tarball') {
+    if (scenario.tarball404) { res.statusCode = 404; res.end(); return; }
+    const body = scenario.servedTarball;
+    res.setHeader('content-length', String(Buffer.byteLength(body)));
+    res.end(body);
+    return;
+  }
+  res.statusCode = 404; res.end();
+});
+
+function run(localArtifactPath) {
+  // Async spawn (not spawnSync): the mock registry runs in this same process,
+  // so the event loop must stay alive to answer the child's curl requests.
+  return new Promise((resolve) => {
+    const child = spawn('bash', [SCRIPT, localArtifactPath], {
+      env: {
+        ...process.env,
+        VERSION,
+        NPM_PACKAGE: PKG,
+        NPM_REGISTRY: `http://127.0.0.1:${server.address().port}`,
+        VERIFY_ATTEMPTS: '2',
+        VERIFY_SLEEP: '0',
+      },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += d; });
+    child.stderr.on('data', (d) => { stderr += d; });
+    child.on('exit', (status) => resolve({ status, stdout, stderr }));
+  });
+}
+
+async function check(name, localBytes, scn, { expectStatus, stdoutHas = [], stdoutNotHas = [] }) {
+  scenario = scn;
+  const local = join(dir, `${name}.tgz`);
+  writeFileSync(local, localBytes);
+  const r = await run(local);
+  try {
+    assert.strictEqual(r.status, expectStatus, `${name}: expected exit ${expectStatus}, got ${r.status}\nstdout:\n${r.stdout}\nstderr:\n${r.stderr}`);
+    for (const needle of stdoutHas) {
+      assert.ok(r.stdout.includes(needle), `${name}: expected stdout to include ${JSON.stringify(needle)}\nstdout:\n${r.stdout}`);
+    }
+    for (const needle of stdoutNotHas) {
+      assert.ok(!r.stdout.includes(needle), `${name}: stdout must NOT include ${JSON.stringify(needle)}\nstdout:\n${r.stdout}`);
+    }
+    console.log(`PASS  ${name}`);
+  } catch (e) {
+    failures++;
+    console.error(e.message);
+  }
+}
+
+await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+const port = server.address().port;
+
+const GOOD = Buffer.from('this is the published tarball content - original');
+const REBUILT = Buffer.from('this is a REBUILT tarball - bundled data changed');
+const OTHER = Buffer.from('totally different bytes for the anomaly case');
+
+// 1. match
+await check('match', GOOD, { servedTarball: GOOD },
+  { expectStatus: 0, stdoutHas: ['npm tarball SHA-256 verified'] });
+
+// 2. drift: registry serves GOOD (its real bytes), local is REBUILT. The
+//    served tarball matches the registry's declared shasum -> "intact".
+await check('drift', REBUILT, { servedTarball: GOOD },
+  { expectStatus: 1,
+    stdoutHas: ['registry tarball is intact', 'drifted'],
+    stdoutNotHas: ['does NOT match', 'investigate first'] });
+
+// 3. anomaly: registry declares hashes of OTHER but serves GOOD -> served
+//    bytes do not match the registry's own declared hashes.
+await check('anomaly', REBUILT,
+  { servedTarball: GOOD, declaredShasum: sha1(OTHER), declaredIntegrity: integrity(OTHER) },
+  { expectStatus: 1,
+    stdoutHas: ['does NOT match the registry', 'investigate first'],
+    stdoutNotHas: ['intact', 'drifted'] });
+
+// 4. propagation timeout: packument 404s forever.
+await check('propagation', GOOD, { servedTarball: GOOD, packument404: true },
+  { expectStatus: 1,
+    stdoutHas: ['propagation delay', 'not a byte mismatch'],
+    stdoutNotHas: ['bytes differ', 'investigate first'] });
+
+server.close();
+rmSync(dir, { recursive: true, force: true });
+
+if (failures > 0) {
+  console.error(`\n${failures} scenario(s) failed.`);
+  process.exit(1);
+}
+console.log('\nAll verify-npm-published.sh scenarios passed.');


### PR DESCRIPTION
## Summary

Closes #156. Forward fix for the CD release-automation failure seen during 2.6.2: `prts-mcp-ts@2.6.2` published fine, but `Verify npm published bytes` timed out on npm tarball propagation (~4 min vs a 3-min window) and the misleading "bytes differ" error skipped `github-release`. The package itself was unaffected — **no republish or tag mutation**; this only hardens the next release.

A clean-context reviewer pressure-tested KHPilot's original diagnosis across 4 lenses before implementation. It agreed on 3 of 4 defects, corrected that cache-busting is co-equal with (not primary over) the too-short window, surfaced a real `set -eo pipefail` abort bug in the proposed snippet, and prompted the recovery runbook + Python parity tracking.

Changes:
- **Verify relocated** from `publish-npm` into `github-release`. A propagation timeout now fails only `github-release`; recover with `gh run rerun <run-id> --failed` (re-verifies the propagated immutable tarball, no npm re-publish).
- **Verify hardened**: cache-bust (`?ts=`), ~10 min window, branched errors ("propagation delay" vs "bytes differ"), fail-fast on a retrievable mismatch (npm immutability).
- **`|| true`** on the registry-JSON read so a transient non-JSON 200 retries instead of aborting under `set -eo pipefail`.
- **Idempotent publish**: `npm publish` is skipped if the version already exists → both `--failed` and full reruns are safe.
- **Runbook**: `docs/admin/release-cd-recovery.md` (fills the declared-but-empty `docs/admin/` home).
- **Parity**: #157 tracks the Python CD equivalent (out of scope here).

## Test plan

- [x] `actionlint@1.7.12` on `cd-ts.yml` / `cd.yml` / `ci.yml` → exit 0 (matches `ci.yml` `workflow-lint`).
- [x] YAML parsed; asserted `Verify` removed from `publish-npm` and present in `github-release` (post download-artifact, pre release-prep).
- [x] Extracted Verify script passes `bash -n`.
- [x] `node` token-splitting verified (valid JSON → 3 tokens; doc w/o `dist` → empty, gate holds).
- [x] **`|| true` shown load-bearing**: unguarded `read < <(node …)` on a non-JSON 200 aborts under `set -eo pipefail` (rc=1); guarded version survives and retries (rc=0).
- [ ] First real `ts/v*` tag cut after merge confirms the Verify step passes on `github-release` and a propagation slowdown no longer skips the release. (Cannot exercise Trusted Publishing end-to-end pre-merge; covered by the unit-level checks above.)

## 未尽事宜

- `#156` is labeled `bug, typescript` but is a CI defect; the repo has no `ci` label. Relabel/closure left to maintainer. The closing keyword below fires when this reaches `main`; close earlier on develop-merge if preferred.
- Optional hardening (sha1/sha512 cross-check vs `dist.shasum`/`dist.integrity`) deliberately rejected as YAGNI — full-file SHA-256 is strictly stronger.
- shellcheck is not run in CI (no binary in `workflow-lint`); the `run:` block is actionlint-clean but shellcheck-unverified.