### PR TITLE
feat(ci): verify PyPI published digests (#157)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -268,6 +268,14 @@ jobs:
           name: python-release-package
           path: python/dist
 
+      - name: Verify PyPI published digests
+        # Lives in github-release (not publish-pypi) so an indexing/propagation
+        # timeout fails only this job: re-run with `gh run rerun <run-id>
+        # --failed` re-checks the now-visible digests without re-publishing.
+        # Logic in python/scripts/verify_pypi_published.py (unit-tested in the
+        # verify-python pytest suite). See docs/admin/release-cd-recovery.md.
+        run: python3 python/scripts/verify_pypi_published.py python/dist
+
       - name: Extract changelog section
         env:
           VERSION: ${{ needs.build-and-push.outputs.version }}

--- a/docs/admin/release-cd-recovery.md
+++ b/docs/admin/release-cd-recovery.md
@@ -50,7 +50,24 @@ curl -fsSL "$(npm view prts-mcp-ts@${VERSION} dist.tarball)?ts=$(date +%s)" | sh
 - **声明 "registry tarball is intact … drifted"** → registry 制品完好（与它自报的 `dist.shasum` 一致），但与本地 artifact 不符：本地制品漂移（典型于 bundled 数据变化后的全量重跑）。npm 上的 tarball 才是正确的发布内容。恢复：直接以 registry tarball 创建 release；或对**最初发布该版本的 run** 做 `gh run rerun <id> --failed`（其 artifact 字节一致）。对当前（已漂移的）run 做 `--failed` 会重新下载漂移 artifact 而再次失败。
 - **声明 "does NOT match the registry's own declared hashes" 并附 downloaded sha1** → 下载到的字节与 registry 自己声明的哈希都不符（CDN/registry 异常或篡改）。**不要创建 GitHub Release**，先排查。
 
+## Python (PyPI) 校验
+
+`cd.yml` 的 `github-release` 同样有一个 Verify 步骤（`python/scripts/verify_pypi_published.py`），与 TS 版同构：传播/索引超时只失败 `github-release`，用 `gh run rerun <run-id> --failed` 恢复（不重发 PyPI）。
+
+差异：Python 版是**最小校验**——轮询 PyPI JSON API（`pypi.org/pypi/prts-mcp/<ver>/json`）直到版本可见，把本地 wheel/sdist 的 sha256 与 PyPI 自报的 `digests.sha256` 比对；**不下载文件**（PyPI 的 JSON digest 即“已索引内容”的权威来源，且制品本身很小）。
+
+- **"PyPI JSON not visible … propagation delay"** → PyPI 尚未完成索引，按主恢复路径重跑。
+- **"sha256 mismatch"** → 本地制品与 PyPI 已记录的 digest 不符，通常是全量重跑后本地漂移（PyPI 文件不可变，已发布的才是正确内容）。恢复：以 PyPI 上的文件重建 release，或对**最初发布该版本的 run** 做 `--failed`。
+
+手动回退：
+
+```bash
+VERSION=2.6.2
+curl -fsSL "https://pypi.org/pypi/prts-mcp/${VERSION}/json" | jq -r '.urls[] | "\(.filename)  \(.digests.sha256)"'
+# 与本地 python/dist/*.whl、*.tar.gz 的 sha256sum 比对
+```
+
 ## 范围说明
 
-- 本文目前仅覆盖 TypeScript CD。Python CD（`cd.yml` 的 `publish-pypi`）尚无对应的发布后字节校验步骤；parity 跟踪见 #157。
-- `environment: npm` 审批门挂在 `publish-npm`；任何让 `publish-npm` 重新运行的重跑都会再次要求审批。
+- 两套 CD（TypeScript `cd-ts.yml` 与 Python `cd.yml`）的 `github-release` 各有一个 Verify 步骤；TS 版下载 tarball 比对字节，Python 版比对 PyPI JSON 的 declared digest（最小校验，见上节）。
+- `environment: npm` / `environment: pypi` 审批门分别挂在 `publish-npm` / `publish-pypi`；任何让这两个 job 重新运行的重跑都会再次要求审批。

--- a/docs/admin/release-cd-recovery.md
+++ b/docs/admin/release-cd-recovery.md
@@ -58,12 +58,13 @@ curl -fsSL "$(npm view prts-mcp-ts@${VERSION} dist.tarball)?ts=$(date +%s)" | sh
 
 - **"PyPI JSON not visible … propagation delay"** → PyPI 尚未完成索引，按主恢复路径重跑。
 - **"sha256 mismatch"** → 本地制品与 PyPI 已记录的 digest 不符，通常是全量重跑后本地漂移（PyPI 文件不可变，已发布的才是正确内容）。恢复：以 PyPI 上的文件重建 release，或对**最初发布该版本的 run** 做 `--failed`。
+- **"local artifact(s) not present in PyPI JSON" / "PyPI JSON lists file(s) absent from local dist"** → 本地与 PyPI 的文件集合不一致（同样是全量重跑后本地漂移的典型表现）。已发布的 PyPI 文件才是正确内容；以 PyPI 文件重建 release，或对最初发布的 run 做 `--failed`。
 
-手动回退：
+手动回退（`VERSION` 用 PEP 440 形式：预发布写成 `2.7.0a1` 而非 git tag `2.7.0-alpha.1`——脚本会自动归一化）：
 
 ```bash
-VERSION=2.6.2
-curl -fsSL "https://pypi.org/pypi/prts-mcp/${VERSION}/json" | jq -r '.urls[] | "\(.filename)  \(.digests.sha256)"'
+VERSION=2.6.2   # 预发布示例：2.7.0a1
+python3 -c "import json,urllib.request as u; d=json.load(u.urlopen('https://pypi.org/pypi/prts-mcp/$VERSION/json')); [print(x['filename'], x['digests']['sha256']) for x in d['urls']]"
 # 与本地 python/dist/*.whl、*.tar.gz 的 sha256sum 比对
 ```
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **PyPI artifact verification in CD (#157).** The Python CD `github-release` job now verifies the published wheel and sdist sha256 against the digests PyPI recorded at upload (via the PyPI JSON API), polling through indexing delay, before creating the GitHub Release. Parity with the TypeScript npm-tarball verification added in #156.
+
 ## [2.6.1] - 2026-08-10
 
 ### Fixed

--- a/python/scripts/verify_pypi_published.py
+++ b/python/scripts/verify_pypi_published.py
@@ -118,8 +118,7 @@ def main() -> int:
             err(f"{name} {version}: sha256 mismatch for {fn}")
             err(f"  local (built):        {got}")
             err(f"  PyPI digests.sha256:  {want}")
-        if mismatches:
-            err("Recovery: the published files are the verified content; re-run the ORIGINAL run that published this version with `gh run rerun <run-id> --failed`, or rebuild the GitHub Release from the PyPI assets. A mismatch usually means the local dist drifted on a full rerun.")
+        err("Recovery: the published PyPI files are the verified content; re-run the ORIGINAL run that published this version with `gh run rerun <run-id> --failed`, or rebuild the GitHub Release from the PyPI assets. A difference here usually means the local dist drifted on a full rerun.")
         return 1
 
     err(f"{name} {version}: PyPI JSON not visible after {attempts} attempts (~{attempts*sleep//60} min); last HTTP {last}.")

--- a/python/scripts/verify_pypi_published.py
+++ b/python/scripts/verify_pypi_published.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Verify PyPI-published artifacts match the local release build (declared-hash).
+
+Polls the PyPI JSON API until the version document is visible, then compares
+each local wheel/sdist sha256 against the digest PyPI recorded at upload
+(`urls[].digests.sha256`). It does NOT download the files — the JSON digest is
+authoritative for "what PyPI indexed". Lives in cd.yml's github-release job so
+a propagation timeout fails only that job (recover with
+`gh run rerun <run-id> --failed`). Mirrors the TypeScript verify
+(ts/scripts/verify-npm-published.sh) at lower cost, since PyPI exposes the
+digest directly and the artifacts are small.
+
+Usage: verify_pypi_published.py [<dist-dir>]
+Env: VERSION          required if GITHUB_REF_NAME is unset; e.g. 2.7.0 / 2.7.0a1
+     PYPI_NAME        default prts-mcp
+     PYPI_BASE        default https://pypi.org
+     VERIFY_ATTEMPTS  default 40   (x VERIFY_SLEEP ~= 10 min polling budget)
+     VERIFY_SLEEP     default 15
+Exit 0: every local file matches its PyPI-declared digest.
+Exit 1: not yet indexed (propagation), or a retrievable mismatch.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+
+
+def err(msg: str) -> None:
+    print(f"::error::{msg}")
+
+
+def normalize_version(v: str) -> str:
+    # PEP 440 pre-release normalization for the PyPI JSON URL: a git tag spells
+    # `2.7.0-alpha.1` but PyPI stores/indexes `2.7.0a1`. Mirrors the version
+    # check in cd.yml's `verify` job.
+    return re.sub(
+        r"-(alpha|beta|rc|a|b)\.?",
+        lambda m: {"alpha": "a", "beta": "b"}.get(m.group(1), m.group(1)),
+        v,
+    )
+
+
+def local_digests(dist: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for fn in sorted(os.listdir(dist)):
+        if fn.endswith(".whl") or fn.endswith(".tar.gz"):
+            with open(os.path.join(dist, fn), "rb") as fh:
+                out[fn] = hashlib.sha256(fh.read()).hexdigest()
+    return out
+
+
+def main() -> int:
+    dist = sys.argv[1] if len(sys.argv) > 1 else os.environ.get("DIST", "python/dist")
+    name = os.environ.get("PYPI_NAME", "prts-mcp")
+    base = os.environ.get("PYPI_BASE", "https://pypi.org").rstrip("/")
+    attempts = int(os.environ.get("VERIFY_ATTEMPTS", "40"))
+    sleep = int(os.environ.get("VERIFY_SLEEP", "15"))
+
+    version = os.environ.get("VERSION", "").strip()
+    if not version:
+        ref = os.environ.get("GITHUB_REF_NAME", "")
+        if ref.startswith("python/v"):
+            version = ref[len("python/v"):]
+    if not version:
+        err("VERSION could not be determined (set VERSION or run under a python/v* tag)")
+        return 1
+
+    if not os.path.isdir(dist):
+        err(f"distribution directory not found: {dist}")
+        return 1
+    local = local_digests(dist)
+    if not local:
+        err(f"no wheel/sdist found in {dist}")
+        return 1
+
+    pypi_version = normalize_version(version)
+    url = f"{base}/pypi/{name}/{pypi_version}/json"
+    last = "000"
+    for attempt in range(1, attempts + 1):
+        # Cache-bust so a stale CDN copy cannot hide a version that just landed.
+        cachebusted = f"{url}?ts={int(time.time())}"
+        try:
+            with urllib.request.urlopen(cachebusted, timeout=30) as resp:
+                doc = json.load(resp)
+            last = str(getattr(resp, "status", 200))
+        except urllib.error.HTTPError as e:
+            last = str(e.code)
+            print(f"Waiting for PyPI JSON (attempt {attempt}/{attempts}, last HTTP {last})...")
+            time.sleep(sleep)
+            continue
+        except Exception as e:  # transient network / parse error
+            last = "err"
+            print(f"Waiting for PyPI JSON (attempt {attempt}/{attempts}, {e})...")
+            time.sleep(sleep)
+            continue
+
+        remote = {u["filename"]: u["digests"]["sha256"] for u in doc.get("urls", [])}
+        missing = [f for f in local if f not in remote]
+        extra = [f for f in remote if f not in local]
+        mismatches = [(f, local[f], remote[f]) for f in local if f in remote and local[f] != remote[f]]
+        if not missing and not extra and not mismatches:
+            print(f"PyPI digests verified for {len(local)} file(s) ({name} {version}).")
+            return 0
+
+        # PyPI files are immutable post-publish: any difference is permanent,
+        # so fail fast rather than retry.
+        if missing:
+            err(f"{name} {version}: local artifact(s) not present in PyPI JSON: {missing}")
+        if extra:
+            err(f"{name} {version}: PyPI JSON lists file(s) absent from local dist: {extra}")
+        for fn, got, want in mismatches:
+            err(f"{name} {version}: sha256 mismatch for {fn}")
+            err(f"  local (built):        {got}")
+            err(f"  PyPI digests.sha256:  {want}")
+        if mismatches:
+            err("Recovery: the published files are the verified content; re-run the ORIGINAL run that published this version with `gh run rerun <run-id> --failed`, or rebuild the GitHub Release from the PyPI assets. A mismatch usually means the local dist drifted on a full rerun.")
+        return 1
+
+    err(f"{name} {version}: PyPI JSON not visible after {attempts} attempts (~{attempts*sleep//60} min); last HTTP {last}.")
+    err("This is a registry propagation delay, not a byte mismatch.")
+    err("Recovery: wait for indexing, then re-run this github-release job (gh run rerun <run-id> --failed).")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/tests/test_verify_pypi_published.py
+++ b/python/tests/test_verify_pypi_published.py
@@ -1,0 +1,144 @@
+"""Tests for python/scripts/verify_pypi_published.py.
+
+Stands up a mock PyPI JSON endpoint on localhost and exercises the verify
+script as a subprocess across its contract: a digest match, a retrievable
+mismatch (fail-fast), and a propagation-delay-then-success retry. Plus a unit
+check of the PEP 440 pre-release normalization used to build the JSON URL.
+"""
+import hashlib
+import http.server
+import json
+import os
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "verify_pypi_published.py"
+NAME = "prts-mcp"
+VERSION = "9.9.9"
+WHL = "prts_mcp-9.9.9-py3-none-any.whl"
+SDIST = "prts_mcp-9.9.9.tar.gz"
+GOOD_WHL = b"wheel content original"
+GOOD_SDIST = b"sdist content original"
+
+# scenario is mutated per test; the server reads it.
+scenario: dict = {"first_404": 0, "digests": {}}
+_state: dict = {"calls": 0}
+
+
+class _Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        if path.startswith(f"/pypi/{NAME}/") and path.endswith("/json"):
+            _state["calls"] += 1
+            if _state["calls"] <= scenario["first_404"]:
+                self.send_response(404)
+                self.end_headers()
+                return
+            body = json.dumps(
+                {"urls": [{"filename": fn, "digests": {"sha256": d}} for fn, d in scenario["digests"].items()]}
+            ).encode()
+            self.send_response(200)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def log_message(self, *args):  # silence the test server
+        pass
+
+
+class _Server(threading.Thread):
+    def __init__(self):
+        super().__init__(daemon=True)
+        self.httpd = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+        self.port = self.httpd.server_address[1]
+
+    def run(self):
+        self.httpd.serve_forever()
+
+    def stop(self):
+        self.httpd.shutdown()
+
+
+@pytest.fixture
+def pypi():
+    _state["calls"] = 0
+    scenario["first_404"] = 0
+    scenario["digests"] = {}
+    s = _Server()
+    s.start()
+    yield f"http://127.0.0.1:{s.port}"
+    s.stop()
+
+
+def _write_dist(tmp_path: Path, contents: dict) -> Path:
+    d = tmp_path / "dist"
+    d.mkdir()
+    for fn, data in contents.items():
+        (d / fn).write_bytes(data)
+    return d
+
+
+def _run(dist: Path, base: str):
+    env = {
+        **os.environ,
+        "PYPI_BASE": base,
+        "VERSION": VERSION,
+        "VERIFY_ATTEMPTS": "3",
+        "VERIFY_SLEEP": "0",
+    }
+    return subprocess.run([sys.executable, str(SCRIPT), str(dist)], env=env, capture_output=True, text=True)
+
+
+def test_match(pypi, tmp_path):
+    dist = _write_dist(tmp_path, {WHL: GOOD_WHL, SDIST: GOOD_SDIST})
+    scenario["digests"] = {
+        WHL: hashlib.sha256(GOOD_WHL).hexdigest(),
+        SDIST: hashlib.sha256(GOOD_SDIST).hexdigest(),
+    }
+    r = _run(dist, pypi)
+    assert r.returncode == 0, r.stdout
+    assert "PyPI digests verified" in r.stdout
+
+
+def test_mismatch(pypi, tmp_path):
+    dist = _write_dist(tmp_path, {WHL: GOOD_WHL, SDIST: GOOD_SDIST})
+    scenario["digests"] = {
+        WHL: hashlib.sha256(GOOD_WHL).hexdigest(),
+        SDIST: hashlib.sha256(b"a different sdist").hexdigest(),
+    }
+    r = _run(dist, pypi)
+    assert r.returncode == 1
+    assert "sha256 mismatch" in r.stdout
+    assert SDIST in r.stdout
+    # fail-fast: must not be classified as a propagation delay
+    assert "propagation delay" not in r.stdout
+
+
+def test_propagation_then_ok(pypi, tmp_path):
+    dist = _write_dist(tmp_path, {WHL: GOOD_WHL, SDIST: GOOD_SDIST})
+    scenario["first_404"] = 1  # first request 404 (not yet indexed), then OK
+    scenario["digests"] = {
+        WHL: hashlib.sha256(GOOD_WHL).hexdigest(),
+        SDIST: hashlib.sha256(GOOD_SDIST).hexdigest(),
+    }
+    r = _run(dist, pypi)
+    assert r.returncode == 0, r.stdout
+    assert "PyPI digests verified" in r.stdout
+
+
+def test_normalize_version():
+    sys.path.insert(0, str(SCRIPT.parent))
+    from verify_pypi_published import normalize_version
+
+    assert normalize_version("2.7.0-alpha.1") == "2.7.0a1"
+    assert normalize_version("2.6.0-beta.2") == "2.6.0b2"
+    assert normalize_version("2.7.0-rc.1") == "2.7.0rc1"
+    assert normalize_version("2.7.0") == "2.7.0"

--- a/python/tests/test_verify_pypi_published.py
+++ b/python/tests/test_verify_pypi_published.py
@@ -134,6 +134,46 @@ def test_propagation_then_ok(pypi, tmp_path):
     assert "PyPI digests verified" in r.stdout
 
 
+def test_missing_on_pypi(pypi, tmp_path):
+    # local has a file PyPI's JSON omits -> fail-fast, not propagation delay
+    dist = _write_dist(tmp_path, {WHL: GOOD_WHL, SDIST: GOOD_SDIST})
+    scenario["digests"] = {WHL: hashlib.sha256(GOOD_WHL).hexdigest()}  # sdist missing
+    r = _run(dist, pypi)
+    assert r.returncode == 1
+    assert "not present in PyPI JSON" in r.stdout
+    assert SDIST in r.stdout
+    assert "propagation delay" not in r.stdout
+
+
+def test_extra_on_pypi(pypi, tmp_path):
+    # PyPI JSON lists a file absent from local dist -> fail-fast
+    extra = "prts_mcp-9.9.9-other.tar.gz"
+    dist = _write_dist(tmp_path, {WHL: GOOD_WHL, SDIST: GOOD_SDIST})
+    scenario["digests"] = {
+        WHL: hashlib.sha256(GOOD_WHL).hexdigest(),
+        SDIST: hashlib.sha256(GOOD_SDIST).hexdigest(),
+        extra: hashlib.sha256(b"an extra file on pypi").hexdigest(),
+    }
+    r = _run(dist, pypi)
+    assert r.returncode == 1
+    assert "absent from local dist" in r.stdout
+    assert extra in r.stdout
+
+
+def test_propagation_timeout(pypi, tmp_path):
+    # PyPI JSON never becomes visible -> timeout, classified as propagation delay
+    dist = _write_dist(tmp_path, {WHL: GOOD_WHL, SDIST: GOOD_SDIST})
+    scenario["first_404"] = 99  # always 404
+    scenario["digests"] = {
+        WHL: hashlib.sha256(GOOD_WHL).hexdigest(),
+        SDIST: hashlib.sha256(GOOD_SDIST).hexdigest(),
+    }
+    r = _run(dist, pypi)
+    assert r.returncode == 1
+    assert "PyPI JSON not visible" in r.stdout
+    assert "propagation delay" in r.stdout
+
+
 def test_normalize_version():
     sys.path.insert(0, str(SCRIPT.parent))
     from verify_pypi_published import normalize_version


### PR DESCRIPTION
## Summary

Closes #157. Adds a post-publish byte check to the Python CD, mirroring the TypeScript verify shipped in #158 — but **minimal**: PyPI exposes the digest directly (`urls[].digests.sha256`), so no file download is needed.

- `python/scripts/verify_pypi_published.py` polls the PyPI JSON API (cache-busted) until the version is visible, then compares each local wheel/sdist sha256 against the digest PyPI recorded at upload. Fails fast on a permanent mismatch (PyPI files are immutable post-publish); treats "JSON not yet visible" as a retryable indexing delay. Env-overridable; normalizes pre-release tags (`2.7.0-alpha.1` → `2.7.0a1`) for the JSON URL.
- `cd.yml` `github-release` gains a `Verify PyPI published digests` step after the artifact download (mirror of the TS placement), so an indexing timeout fails only that job — recover with `gh run rerun <run-id> --failed`, no re-publish.
- Runbook gains a Python (PyPI) section; scope note covers both CDs.

Deliberately minimal per the #157 decision: no file download (PyPI's JSON digest is authoritative; artifacts are small), no idempotent-publish guard (flagged below).

## Test plan

- [x] `actionlint@1.7.12` on `cd.yml` / `cd-ts.yml` / `ci.yml` → exit 0.
- [x] pytest: 4/4 (match / mismatch / propagation-retry / version-normalize).
- [x] End-to-end against live PyPI for 2.6.2: downloaded the real wheel+sdist → "verified" (exit 0); corrupted the sdist → `sha256 mismatch` with local/PyPI digests + recovery (exit 1).
- [ ] First real `python/v*` tag after merge confirms the Verify step passes on `github-release` (cannot exercise Trusted Publishing end-to-end pre-merge).

## 未尽事宜

- **Idempotent-publish guard** (skip `pypa/gh-action-pypi-publish` if the version already exists, mirroring the TS npm guard) intentionally omitted for the minimal scope; PyPI already rejects re-uploads (HTTP 400), so a full rerun fails loudly rather than double-publishing. Add if exact rerun-safety parity is wanted.
- No `python/CHANGELOG` entry (internal CD change, not user-visible); add if desired.
- The verify compares against PyPI's **declared** digest only (no download), so it confirms "PyPI indexed what we built" but not "files.pythonhosted.org serves those exact bytes" — a deliberate scope cut per #157 (download-and-hash is the TS-exact mirror but defends against a never-observed PyPI failure).