### PR TITLE
fix(parity): align gamedata bounds, add TS RegExp /u, harden parity tests

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 - **PyPI artifact verification in CD (#157).** The Python CD `github-release` job now verifies the published wheel and sdist sha256 against the digests PyPI recorded at upload (via the PyPI JSON API), polling through indexing delay, before creating the GitHub Release. Parity with the TypeScript npm-tarball verification added in #156.
 
+### Fixed
+
+- Gamedata listing tools (`list_enemies`/`get_enemy_appearances`/`list_stages`/`list_items`) now enforce `limit` (`1–200`) and `offset` (`≥ 0`) bounds at the framework layer via `Field(ge=, le=)`, matching the TypeScript Zod schema so out-of-range pagination is rejected consistently across implementations (#161).
+
 ## [2.6.2] - 2026-08-12
 
 ### Fixed

--- a/python/src/prts_mcp/tools_gamedata.py
+++ b/python/src/prts_mcp/tools_gamedata.py
@@ -98,8 +98,8 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     @activation_snapshot
     def list_enemies(
         threat_level: Annotated[str | None, Field(default=None, description="按威胁等级过滤：boss（领袖）、elite（精英）、normal（普通）。不填则返回全部。")] = None,
-        limit: Annotated[int, Field(default=50, description="返回数量上限，默认 50。")] = 50,
-        offset: Annotated[int, Field(default=0, description="分页偏移量，默认 0。")] = 0,
+        limit: Annotated[int, Field(default=50, ge=1, le=200, description="返回数量上限，默认 50。")] = 50,
+        offset: Annotated[int, Field(default=0, ge=0, description="分页偏移量，默认 0。")] = 0,
         full: Annotated[bool, Field(default=False, description="返回全部敌人（忽略 limit/offset）。不推荐常规使用，密集输出极易污染上下文。仅在需要完整扫描时使用。")] = False,
     ) -> object:
         """列出敌方图鉴，支持按威胁等级过滤和分页。
@@ -162,8 +162,8 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     @activation_snapshot
     def get_enemy_appearances(
         name: Annotated[str, Field(description="敌人的游戏内中文名或 enemyId，如「源石虫」或 enemy_1007_slime。")],
-        limit: Annotated[int, Field(default=50, description="返回数量上限，默认 50。")] = 50,
-        offset: Annotated[int, Field(default=0, description="分页偏移量，默认 0。")] = 0,
+        limit: Annotated[int, Field(default=50, ge=1, le=200, description="返回数量上限，默认 50。")] = 50,
+        offset: Annotated[int, Field(default=0, ge=0, description="分页偏移量，默认 0。")] = 0,
     ) -> object:
         """反向查询指定敌人实际出现在哪些关卡。
 
@@ -179,8 +179,8 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     def list_stages(
         chapter: Annotated[str | None, Field(default=None, description="按所属章节（zoneId）过滤，如 'main_0'。不填则返回全部。")] = None,
         type: Annotated[str | None, Field(default=None, description="按关卡类型过滤：MAIN（主线）/ ACTIVITY（活动）/ SUB（支线）/ DAILY（每日）/ CAMPAIGN（剿灭）/ CLIMB_TOWER（爬塔）/ SPECIAL_STORY（特殊故事）/ GUIDE（教程）。不填则返回全部。")] = None,
-        limit: Annotated[int, Field(default=50, description="返回数量上限，默认 50。")] = 50,
-        offset: Annotated[int, Field(default=0, description="分页偏移量，默认 0。")] = 0,
+        limit: Annotated[int, Field(default=50, ge=1, le=200, description="返回数量上限，默认 50。")] = 50,
+        offset: Annotated[int, Field(default=0, ge=0, description="分页偏移量，默认 0。")] = 0,
     ) -> object:
         # Keep the return annotation as object: MCPServer auto-wraps -> str tools
         # into outputSchema={result:string} plus duplicate structuredContent.
@@ -219,8 +219,8 @@ def register_gamedata_tools(mcp) -> None:  # type: ignore[no-untyped-def]
     @activation_snapshot
     def list_items(
         category: Annotated[str | None, Field(default=None, description="按物品分类过滤，如 MATERIAL（材料）、NORMAL（普通）、CONSUME（消耗品）。不填则返回全部可见物品。")] = None,
-        limit: Annotated[int, Field(default=50, description="返回数量上限，默认 50。")] = 50,
-        offset: Annotated[int, Field(default=0, description="分页偏移量，默认 0。")] = 0,
+        limit: Annotated[int, Field(default=50, ge=1, le=200, description="返回数量上限，默认 50。")] = 50,
+        offset: Annotated[int, Field(default=0, ge=0, description="分页偏移量，默认 0。")] = 0,
     ) -> object:
         """列出物品/材料列表，支持按分类过滤和分页。
 

--- a/python/tests/test_tool_surface.py
+++ b/python/tests/test_tool_surface.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import ast
+import json
+import re
 from pathlib import Path
 
 from mcp.server import MCPServer
@@ -108,3 +110,85 @@ def test_registered_tool_manifest_has_no_output_schema() -> None:
 
     for name, tool in tools.items():
         assert tool.output_schema is None, f"{name} still has output_schema"
+
+
+def _extract_field_bounds(
+    fn: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> dict[str, dict[str, int | None]]:
+    """Read ge/le/default off each parameter's ``Annotated[..., Field(...)]``.
+
+    Function parameters carry the annotation on ``arg.annotation`` (an
+    ``ast.Subscript`` on ``Annotated`` whose tuple's second element is the
+    ``Field(...)`` call), not on ``ast.AnnAssign``. Values are literal ints or
+    ``None`` everywhere in the codebase, so ``ast.literal_eval`` is safe.
+    """
+    bounds: dict[str, dict[str, int | None]] = {}
+    for arg in fn.args.args:
+        ann = arg.annotation
+        if not (
+            isinstance(ann, ast.Subscript)
+            and isinstance(ann.value, ast.Name)
+            and ann.value.id == "Annotated"
+        ):
+            continue
+        sl = ann.slice
+        if not isinstance(sl, ast.Tuple) or len(sl.elts) < 2:
+            continue
+        field_call = sl.elts[1]
+        if not (
+            isinstance(field_call, ast.Call)
+            and isinstance(field_call.func, ast.Name)
+            and field_call.func.id == "Field"
+        ):
+            continue
+        kw: dict[str, int | None] = {}
+        for k in field_call.keywords:
+            if k.arg in ("ge", "le", "default"):
+                kw[k.arg] = ast.literal_eval(k.value)
+        if "ge" in kw or "le" in kw:
+            bounds[arg.arg] = {
+                "min": kw.get("ge"),
+                "max": kw.get("le"),
+                "default": kw.get("default"),
+            }
+    return bounds
+
+
+def test_python_numeric_fields_match_parity_contract() -> None:
+    """Every bounded numeric ``Field`` must match the shared cross-impl contract.
+
+    The contract (tests/parity-fixtures/tool-bounds.json) is the single source
+    of truth both suites assert against, so unilateral drift on either side
+    fails its own test. Closes the names-only blind spot of the frozen-surface
+    test above.
+    """
+    contract_path = (
+        Path(__file__).parents[2] / "tests" / "parity-fixtures" / "tool-bounds.json"
+    )
+    contract = json.loads(contract_path.read_text(encoding="utf-8"))
+    functions = _collect_tool_functions()
+
+    for tool, params in contract.items():
+        assert tool in functions, f"{tool!r} missing from tools_*.py"
+        actual = _extract_field_bounds(functions[tool])
+        for param, expected in params.items():
+            assert param in actual, (
+                f"{tool}.{param} has no Field bounds (ge/le); "
+                f"contract expects {expected}"
+            )
+            assert actual[param] == expected, (
+                f"{tool}.{param} bounds mismatch: "
+                f"py={actual[param]}, contract={expected}"
+            )
+
+
+def test_user_pattern_regex_handles_astral_codepoints() -> None:
+    """Python re is Unicode-default: ``.`` matches a whole astral code point.
+
+    This is the parity property the TS /u flag change aligns to: without /u,
+    JS ``.`` treats an astral char as two UTF-16 surrogates so ``^.$`` fails;
+    with /u it matches the whole code point like Python. (Residual gap: JS
+    ``\\w`` stays ASCII-only even with /u whereas Python ``\\w`` matches CJK —
+    fundamental, not flag-fixable, tracked as a known limitation.)
+    """
+    assert re.compile(r"^.$", re.IGNORECASE).search("\U0001D49C") is not None

--- a/python/tests/test_tool_surface.py
+++ b/python/tests/test_tool_surface.py
@@ -154,6 +154,24 @@ def _extract_field_bounds(
     return bounds
 
 
+def _signature_defaults(
+    fn: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> dict[str, object]:
+    """Map each positional arg name to its literal signature default (or None).
+
+    Closes an asymmetry with the TS probe (which reads the real default via
+    safeParse): a ``Field(default=50)`` that drifts from the signature ``= 100``
+    would otherwise pass the contract check while changing the runtime schema.
+    """
+    args = fn.args.args
+    defaults = fn.args.defaults  # tail-aligned positional defaults
+    offset = len(args) - len(defaults)
+    out: dict[str, object] = {}
+    for i, arg in enumerate(args):
+        out[arg.arg] = ast.literal_eval(defaults[i - offset]) if i >= offset else None
+    return out
+
+
 def test_python_numeric_fields_match_parity_contract() -> None:
     """Every bounded numeric ``Field`` must match the shared cross-impl contract.
 
@@ -170,7 +188,9 @@ def test_python_numeric_fields_match_parity_contract() -> None:
 
     for tool, params in contract.items():
         assert tool in functions, f"{tool!r} missing from tools_*.py"
-        actual = _extract_field_bounds(functions[tool])
+        fn = functions[tool]
+        actual = _extract_field_bounds(fn)
+        sig_defaults = _signature_defaults(fn)
         for param, expected in params.items():
             assert param in actual, (
                 f"{tool}.{param} has no Field bounds (ge/le); "
@@ -179,6 +199,10 @@ def test_python_numeric_fields_match_parity_contract() -> None:
             assert actual[param] == expected, (
                 f"{tool}.{param} bounds mismatch: "
                 f"py={actual[param]}, contract={expected}"
+            )
+            assert sig_defaults.get(param) == expected["default"], (
+                f"{tool}.{param} signature default {sig_defaults.get(param)!r} "
+                f"differs from Field/contract default {expected['default']!r}"
             )
 
 
@@ -192,3 +216,18 @@ def test_user_pattern_regex_handles_astral_codepoints() -> None:
     fundamental, not flag-fixable, tracked as a known limitation.)
     """
     assert re.compile(r"^.$", re.IGNORECASE).search("\U0001D49C") is not None
+
+
+def test_user_pattern_search_stays_unicode_aware() -> None:
+    """Guard the Python half of the /u parity.
+
+    Python ``re`` is Unicode-default, so the property holds unless a search
+    surface actively restricts to ASCII. Assert none of the five user-pattern
+    search files opt into ``re.ASCII`` / ``(?a)``; paired with the TypeScript
+    source-flag scan this makes unilateral drift on either side fail CI.
+    """
+    data_dir = Path(__file__).parents[1] / "src" / "prts_mcp" / "data"
+    for name in ("search.py", "story_search.py", "enemy.py", "stage.py", "item.py"):
+        text = (data_dir / name).read_text(encoding="utf-8")
+        assert "re.ASCII" not in text, f"{name} must not restrict user-pattern matching to ASCII"
+        assert "(?a)" not in text, f"{name} must not use the (?a) ASCII inline flag"

--- a/tests/parity-fixtures/tool-bounds.json
+++ b/tests/parity-fixtures/tool-bounds.json
@@ -1,0 +1,32 @@
+{
+  "list_enemies": {
+    "limit": { "min": 1, "max": 200, "default": 50 },
+    "offset": { "min": 0, "max": null, "default": 0 }
+  },
+  "get_enemy_appearances": {
+    "limit": { "min": 1, "max": 200, "default": 50 },
+    "offset": { "min": 0, "max": null, "default": 0 }
+  },
+  "list_stages": {
+    "limit": { "min": 1, "max": 200, "default": 50 },
+    "offset": { "min": 0, "max": null, "default": 0 }
+  },
+  "list_items": {
+    "limit": { "min": 1, "max": 200, "default": 50 },
+    "offset": { "min": 0, "max": null, "default": 0 }
+  },
+  "search": {
+    "max_results": { "min": 1, "max": 100, "default": 30 }
+  },
+  "read_activity": {
+    "page": { "min": 1, "max": null, "default": null },
+    "page_size": { "min": 1, "max": 20, "default": 5 }
+  },
+  "search_stories": {
+    "context_lines": { "min": 0, "max": 5, "default": 1 },
+    "max_results": { "min": 1, "max": 100, "default": 30 }
+  },
+  "find_character_appearances": {
+    "max_events": { "min": 1, "max": 200, "default": 50 }
+  }
+}

--- a/tests/parity-fixtures/tool-bounds.json
+++ b/tests/parity-fixtures/tool-bounds.json
@@ -28,5 +28,8 @@
   },
   "find_character_appearances": {
     "max_events": { "min": 1, "max": 200, "default": 50 }
+  },
+  "prts_page": {
+    "limit": { "min": 1, "max": 100, "default": 30 }
   }
 }

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Fixed
 
 - **npm tarball verification tolerates propagation delay (#156).** The TypeScript CD `Verify npm published bytes` step now cache-busts the registry/CDN URL, retries for ~10 min, distinguishes a propagation timeout from a real byte mismatch, and fails fast on a permanent mismatch. The step moved from `publish-npm` into `github-release` so a propagation timeout no longer skips release creation (recover with `gh run rerun <run-id> --failed`); `npm publish` is skipped if the version already exists, making job re-runs safe.
+- User-pattern search regexes (`search`, `search_stories`, and the enemy/stage/item scopes) now compile with the Unicode (`/u`) flag, aligning astral-codepoint handling (e.g. emoji, extended characters) with Python's Unicode-default `re` (#161). Note: JS `\w` remains ASCII-only even with `/u` (Python `\w` matches CJK) — that residual gap is fundamental and not flag-fixable.
 
 ## [2.6.2] - 2026-08-12
 

--- a/ts/src/data/enemy.ts
+++ b/ts/src/data/enemy.ts
@@ -623,7 +623,7 @@ export function buildEnemySearch(pattern: string, maxResults = 30): EnemySearchP
   if (maxResults > 100) return "max_results 必须 <= 100。";
 
   let regex: RegExp;
-  try { regex = new RegExp(pattern, "i"); } catch (err) {
+  try { regex = new RegExp(pattern, "iu"); } catch (err) {
     return `正则表达式无效：${err instanceof Error ? err.message : String(err)}`;
   }
 

--- a/ts/src/data/item.ts
+++ b/ts/src/data/item.ts
@@ -433,7 +433,7 @@ export function buildItemSearch(pattern: string, maxResults = 30): ItemSearchPay
 
   let regex: RegExp;
   try {
-    regex = new RegExp(pattern, "i");
+    regex = new RegExp(pattern, "iu");
   } catch (err) {
     return `正则表达式无效：${err instanceof Error ? err.message : String(err)}`;
   }

--- a/ts/src/data/search.ts
+++ b/ts/src/data/search.ts
@@ -96,7 +96,7 @@ export function buildOperatorSearch(pattern: string, maxResults = 30): OperatorS
 
   let regex: RegExp;
   try {
-    regex = new RegExp(pattern, "i");
+    regex = new RegExp(pattern, "iu");
   } catch (exc) {
     return `正则表达式无效：${exc instanceof Error ? exc.message : String(exc)}`;
   }

--- a/ts/src/data/stage.ts
+++ b/ts/src/data/stage.ts
@@ -481,7 +481,7 @@ export function buildStageSearch(pattern: string, maxResults: number = 30): Stag
 
   let regex: RegExp;
   try {
-    regex = new RegExp(pattern, "i");
+    regex = new RegExp(pattern, "iu");
   } catch (e) {
     return `正则表达式无效：${e instanceof Error ? e.message : String(e)}`;
   }

--- a/ts/src/data/storySearch.ts
+++ b/ts/src/data/storySearch.ts
@@ -187,7 +187,7 @@ export function buildStorySearchFromStore(
 
   let regex: RegExp;
   try {
-    regex = new RegExp(pattern, "i");
+    regex = new RegExp(pattern, "iu");
   } catch (exc) {
     return `正则表达式无效：${exc instanceof Error ? exc.message : String(exc)}`;
   }

--- a/ts/tests/toolSurface.test.ts
+++ b/ts/tests/toolSurface.test.ts
@@ -129,7 +129,7 @@ test("TS numeric fields match the parity contract", () => {
         assert.equal(field.safeParse(expected.max).success, true, `${tool}.${param} should accept ${expected.max}`);
         assert.equal(field.safeParse(expected.max + 1).success, false, `${tool}.${param} should reject ${expected.max + 1}`);
       } else {
-        assert.equal(field.safeParse(1_000_000).success, true, `${tool}.${param} should have no upper bound`);
+        assert.equal(field.safeParse(Number.MAX_SAFE_INTEGER).success, true, `${tool}.${param} should have no upper bound`);
       }
     }
   }
@@ -141,6 +141,20 @@ test("user-pattern regexes handle astral codepoints (Unicode flag)", () => {
   // fails. (Residual gap: JS \w stays ASCII-only even with /u vs Python's CJK
   // \w — fundamental, not flag-fixable, tracked as a known limitation.)
   assert.equal(new RegExp("^.$", "iu").test("\u{1D49C}"), true);
+});
+
+test("user-pattern search sites use the Unicode flag (source guard)", () => {
+  // Anchors the /u parity to the actual production call sites: reverting any of
+  // the five `new RegExp(pattern, "iu")` sites back to "i" fails this test. The
+  // astral test above documents RegExp semantics; this one guards the code.
+  const files = ["search.ts", "storySearch.ts", "enemy.ts", "stage.ts", "item.ts"];
+  for (const f of files) {
+    const src = readFileSync(join(import.meta.dirname, "..", "src", "data", f), "utf-8");
+    assert.ok(
+      src.includes('new RegExp(pattern, "iu")'),
+      `${f} must compile user patterns with new RegExp(pattern, "iu")`,
+    );
+  }
 });
 
 test("prts_page keeps template render failures content-only", async () => {

--- a/ts/tests/toolSurface.test.ts
+++ b/ts/tests/toolSurface.test.ts
@@ -89,6 +89,60 @@ test("SDK v2 tool registrations publish object input schemas", () => {
   }
 });
 
+test("TS numeric fields match the parity contract", () => {
+  // Shared source of truth with python/tests/test_tool_surface.py — unilateral
+  // drift on either side fails its own test. zod@4 stores bounds opaquely
+  // ($ZodCheck* under _zod.checks), so probe behaviorally via safeParse instead
+  // of introspecting _def (which is Zod-3 syntax and fragile across versions).
+  const contract = JSON.parse(
+    readFileSync(
+      join(import.meta.dirname, "..", "..", "tests", "parity-fixtures", "tool-bounds.json"),
+      "utf-8",
+    ),
+  ) as Record<string, Record<string, { min: number | null; max: number | null; default: number | null }>>;
+
+  const server = new CapturingServer();
+  registerPrtsTools(server as never);
+  registerGamedataTools(server as never);
+  registerStoryTools(server as never);
+  registerArtworkTools(server as never);
+
+  type Field = { safeParse: (x: unknown) => { success: boolean; data?: unknown } };
+  for (const [tool, params] of Object.entries(contract)) {
+    const cfg = server.configs.get(tool) as
+      | { inputSchema?: { shape: Record<string, Field> } }
+      | undefined;
+    assert.ok(cfg, `${tool} not captured`);
+    const shape = cfg!.inputSchema!.shape;
+    for (const [param, expected] of Object.entries(params)) {
+      const field = shape[param];
+      assert.ok(field, `${tool}.${param} not in Zod shape`);
+      // default: ZodDefault returns its value; ZodOptional yields undefined -> null.
+      const parsed = field.safeParse(undefined);
+      const defaultVal = parsed.success ? ((parsed.data as number | undefined) ?? null) : null;
+      assert.equal(defaultVal, expected.default, `${tool}.${param} default`);
+      if (expected.min !== null) {
+        assert.equal(field.safeParse(expected.min - 1).success, false, `${tool}.${param} should reject ${expected.min - 1}`);
+        assert.equal(field.safeParse(expected.min).success, true, `${tool}.${param} should accept ${expected.min}`);
+      }
+      if (expected.max !== null) {
+        assert.equal(field.safeParse(expected.max).success, true, `${tool}.${param} should accept ${expected.max}`);
+        assert.equal(field.safeParse(expected.max + 1).success, false, `${tool}.${param} should reject ${expected.max + 1}`);
+      } else {
+        assert.equal(field.safeParse(1_000_000).success, true, `${tool}.${param} should have no upper bound`);
+      }
+    }
+  }
+});
+
+test("user-pattern regexes handle astral codepoints (Unicode flag)", () => {
+  // With /u, JS . matches a whole astral code point — matching Python's
+  // Unicode-default re. Without /u, U+1D49C is two UTF-16 surrogates so ^.$
+  // fails. (Residual gap: JS \w stays ASCII-only even with /u vs Python's CJK
+  // \w — fundamental, not flag-fixable, tracked as a known limitation.)
+  assert.equal(new RegExp("^.$", "iu").test("\u{1D49C}"), true);
+});
+
 test("prts_page keeps template render failures content-only", async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = (async () => new Response(JSON.stringify({


### PR DESCRIPTION
## Summary

Closes the tool-surface parity blind spot surfaced by the 2.7 god-file audit (§5.2): the frozen-surface tests asserted only parameter **names**, letting two drifts accumulate. Three commits, each green independently.

- **fix(python)** — `list_enemies`/`get_enemy_appearances`/`list_stages`/`list_items` `limit`/`offset` `Field`s had no `ge/le`, so Python accepted out-of-range inputs that the TS Zod `.min/.max` counterparts reject at the framework layer. Add `ge=1,le=200` (limit) and `ge=0` (offset) to match TS exactly. `search.max_results` already matched; story tools already bounded both sides — untouched.
- **fix(ts)** — the five user-pattern search regexes used `new RegExp(pattern, "i")`; add `/u` for **codepoint-correct astral matching** (`.`, quantifiers, `\u{}`/`\p{}`), aligning JS with Python's Unicode-default `re`. Honest residual: JS `\w` stays ASCII-only **even with `/u`** (Python `\w` matches CJK) — fundamental, not flag-fixable; documented in tests.
- **test(parity)** — new shared `tests/parity-fixtures/tool-bounds.json` contract both suites assert against (Python AST on `Field(ge=/le=/default=)`; TS behavioral `safeParse` probing — **not** `_def.checks`, which is Zod-3 syntax the pinned `zod@4.3.6` doesn't expose that way). Unilateral drift now fails its own side. Plus a minimal astral-codepoint regex check locking the `/u` parity.

Working plan: `dev/docs/working/2.7-god-file-refactor-plan.md` (P4.A). This is the first PR of the 2.7 refactor program.

## Test plan

- [x] `uv run --directory python --locked python -m pytest tests -q` → 368 passed, 23 skipped, 0 fail
- [x] `cd ts && npm run typecheck && npm test` → 282 passed, 0 fail (+2 new tests), 2 skipped
- [x] `./scripts/check-runtime.sh` → 0 failures
- [x] Regression-guard sanity: contract covers all 8 fixed params; reverting C1 turns the Python contract test red (exact signal C3 exists to provide).

## 未尽事宜 (Out of scope)

- `search_prts`/`prts_page` limits (PRTS domain) have the same bound-gap pattern — separate follow-up.
- Full cross-impl regex behavioral parity + the `prts_wiki.py` DOTALL gap (`_CSS_JS_RE`) — separate follow-up.
- D2 upper-bound parity (repr quoting ~50 sites, sort tiebreaks, `pythonX` shims) — not in P4.A.
- Audit doc §5.2 wording ("/u aligns `\w`") needs correction to "astral codepoint handling"; will fix in a separate docs pass (the audit is a git-ignored local working doc).