### PR TITLE
refactor(sync): extract sync/ transport + release_discovery tier (P2.A)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -102,7 +102,7 @@ PRTS-MCP/
 │   │   │   ├── items.py         # 物品/材料数据
 │   │   │   ├── stores.py        # 存储抽象 (Directory/Zip/Fallback)
 │   │   │   └── sync.py          # 同步状态机（release/archive/pair 编排；P2.B 迁出中）
-│   │   ├── sync/            # GitHub Release 传输+发现（HTTP 归此层；P2.A 抽出）
+│   │   ├── sync/            # GitHub Release 传输+发现（数据同步 HTTP 归此层；P2.A 抽出）
 │   │   └── utils/          # wikitext 清洗等工具
 │   ├── tests/              # pytest 测试
 │   ├── pyproject.toml      # 包元数据、依赖
@@ -122,7 +122,7 @@ PRTS-MCP/
 │   │       ├── operators.ts / enemies.ts / stages.ts / items.ts
 │   │       ├── stores.ts / sync.ts
 │   │       └── ...
-│   │   └── sync/           # GitHub Release 传输+发现（HTTP 归此层）
+│   │   └── sync/           # GitHub Release 传输+发现（数据同步 HTTP 归此层）
 │   ├── tests/              # node --test 测试
 │   ├── package.json
 │   └── CHANGELOG.md

--- a/STATUS.md
+++ b/STATUS.md
@@ -101,7 +101,8 @@ PRTS-MCP/
 │   │   │   ├── stages.py        # 关卡数据
 │   │   │   ├── items.py         # 物品/材料数据
 │   │   │   ├── stores.py        # 存储抽象 (Directory/Zip/Fallback)
-│   │   │   └── sync.py          # GitHub Release 同步
+│   │   │   └── sync.py          # 同步状态机（release/archive/pair 编排；P2.B 迁出中）
+│   │   ├── sync/            # GitHub Release 传输+发现（HTTP 归此层；P2.A 抽出）
 │   │   └── utils/          # wikitext 清洗等工具
 │   ├── tests/              # pytest 测试
 │   ├── pyproject.toml      # 包元数据、依赖
@@ -115,12 +116,13 @@ PRTS-MCP/
 │   │   │   ├── prtsTools.ts
 │   │   │   ├── gamedataTools.ts
 │   │   │   └── storyTools.ts
-│   │   └── data/           # 数据抽象层（对齐 python/src/prts_mcp/data/）
+│   │   ├── data/           # 数据抽象层（对齐 python/src/prts_mcp/data/）
 │   │       ├── story.ts        # 兼容性垫片
 │   │       ├── storyReader.ts / storySearch.ts / storyMemoir.ts / storySummary.ts
 │   │       ├── operators.ts / enemies.ts / stages.ts / items.ts
 │   │       ├── stores.ts / sync.ts
 │   │       └── ...
+│   │   └── sync/           # GitHub Release 传输+发现（HTTP 归此层）
 │   ├── tests/              # node --test 测试
 │   ├── package.json
 │   └── CHANGELOG.md

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -23,12 +23,12 @@ server.py/ts          ←  MCP 工具注册、启动同步编排
 api/                  ←  PRTS Wiki MediaWiki API 客户端
 data/                 ←  干员/剧情/搜索/store 抽象
 data/stores           ←  DirectoryStore / ZipStore 底层读写
-sync/                 ←  GitHub Release 数据同步（传输：HTTP/镜像/级联 fetch；发现：release 列表）；仓库唯一允许发 HTTP 的层
+sync/                 ←  GitHub Release 数据同步（传输：HTTP/镜像/级联 fetch；发现：release 列表）；数据同步 HTTP 归此层（PRTS Wiki HTTP 归 api/）
 utils/                ←  跨领域纯函数（wikitext 清洗等）
 config.py/ts          ←  路径解析、环境变量
 ```
 
-**允许的依赖方向**：`server → api, data, sync, config` / `data → stores, utils, config` / `sync → stores, utils, config` / `api → utils`。 **禁止**：`stores` 依赖 `data`；`utils` 依赖 `api` 或 `data`；`config` 依赖任何其他模块；`data` 的数据读取模块直接发 HTTP（HTTP 只归 `sync/`）。
+**允许的依赖方向**：`server → api, data, sync, config` / `data → stores, utils, config` / `sync → stores, utils, config` / `api → utils`。 **禁止**：`stores` 依赖 `data`；`utils` 依赖 `api` 或 `data`；`config` 依赖任何其他模块；`data` 的数据读取模块直接发 HTTP（数据同步 HTTP 归 `sync/`、PRTS Wiki HTTP 归 `api/`）。
 
 > 迁移期注记：`data/sync.*` 的状态机在 P2.A→P2.B 期间临时 `data → sync` 反向依赖新抽出的 `sync/transport`、`sync/release_discovery`（经 re-export shim），状态机迁出 `data/` 后该过渡边消失。`data/images_sync.py` 仍直接发 HTTP（`_download_large`），是 sync 层模块暂居 `data/` 的历史残留，随 images_sync 迁入 `sync/` 层时清除（P3.B）。
 

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -14,20 +14,23 @@
 
 - **单一职责**：一个文件只干一件事。`operator.py` 只负责干员数据读取，不混进搜索逻辑；`sanitizer.py` 只管 wikitext 清洗，不放 API 调用
 - **文件长度预警线**：源文件超过 ~300 行就要问"这能不能拆"
-- **模块边界**：`data/` 只做数据读写和格式化，不混进 HTTP 请求；`api/` 只做 PRTS Wiki API 调用；`server.py` 只做工具注册和启动编排
+- **模块边界**：`data/` 的数据读取模块只做数据读写和格式化，不混进 HTTP 请求；HTTP 传输统一收敛到 `sync/` 层；`api/` 只做 PRTS Wiki API 调用；`server.py` 只做工具注册和启动编排
 
 ### 分层纪律
 
 ```
 server.py/ts          ←  MCP 工具注册、启动同步编排
 api/                  ←  PRTS Wiki MediaWiki API 客户端
-data/                 ←  干员/剧情/搜索/同步/store 抽象
+data/                 ←  干员/剧情/搜索/store 抽象
 data/stores           ←  DirectoryStore / ZipStore 底层读写
+sync/                 ←  GitHub Release 数据同步（传输：HTTP/镜像/级联 fetch；发现：release 列表）；仓库唯一允许发 HTTP 的层
 utils/                ←  跨领域纯函数（wikitext 清洗等）
 config.py/ts          ←  路径解析、环境变量
 ```
 
-**允许的依赖方向**：`server → api, data, config` / `data → stores, utils, config` / `api → utils`。 **禁止**：`stores` 依赖 `data`；`utils` 依赖 `api` 或 `data`；`config` 依赖任何其他模块。
+**允许的依赖方向**：`server → api, data, sync, config` / `data → stores, utils, config` / `sync → stores, utils, config` / `api → utils`。 **禁止**：`stores` 依赖 `data`；`utils` 依赖 `api` 或 `data`；`config` 依赖任何其他模块；`data` 的数据读取模块直接发 HTTP（HTTP 只归 `sync/`）。
+
+> 迁移期注记：`data/sync.*` 的状态机在 P2.A→P2.B 期间临时 `data → sync` 反向依赖新抽出的 `sync/transport`、`sync/release_discovery`（经 re-export shim），状态机迁出 `data/` 后该过渡边消失。`data/images_sync.py` 仍直接发 HTTP（`_download_large`），是 sync 层模块暂居 `data/` 的历史残留，随 images_sync 迁入 `sync/` 层时清除（P3.B）。
 
 ### 抽象层
 
@@ -104,7 +107,7 @@ MCP 工具描述（Python `@mcp.tool()` 的 docstring / TS `server.tool()` 的�
 - 工具函数里直接读文件（绕过 store 抽象）
 - `Utils.py` / `helpers.ts` 杂物堆——按主题拆专用模块
 - 同一份常量在多个文件散落（必须走 config 或顶层常量）
-- 跨层调用（data 模块里直接发起 HTTP 请求）
+- 跨层调用（data 数据读取模块里直接发起 HTTP 请求；HTTP 传输只归 `sync/` 层）
 - 两套实现的行为不一致（工具名、参数、输出格式）
 - 为每个新数据域机械复制 `list_X` / `get_X` / `search_X` 三件套——优先扩 `search(scope)` 等统一入口的 enum（见 ROADMAP 决策原则 7）
 
@@ -238,7 +241,9 @@ Python 和 TypeScript 不是翻译关系，但文件结构和模块职责应保�
 | `data/operator.py` | `data/operator.ts` | 干员数据读取和格式化 |
 | `data/story.py` | `data/story.ts` | 剧情数据读取和格式化 |
 | `data/search.py` | `data/search.ts` | 全文搜索 |
-| `data/sync.py` | `data/sync.ts` | GitHub Release 同步 |
+| `data/sync.py` | `data/sync.ts` | 同步状态机（release/archive/pair 编排；P2.B 迁出中） |
+| `sync/transport.py` | `sync/transport.ts` | GitHub Release HTTP 传输（镜像/级联 fetch） |
+| `sync/release_discovery.py` | `sync/releaseDiscovery.ts` | Release 发现（list/latest-by-prefix/asset_url/check_latest） |
 | `data/datasets.py` | `data/datasets.ts` | 数据集 spec 定义 |
 | `api/prts_wiki.py` | `api/prtsWiki.ts` | PRTS MediaWiki API 客户端 |
 | `utils/sanitizer.py` | `utils/sanitizer.ts` | Wikitext 清洗 |

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Changed
 
 - Internal activation and cache-instrumentation symbols moved out of `prts_mcp.config` into dedicated modules — a visible import-path change for anyone importing these internals from `prts_mcp.config`: `activation_aware_cache`/`cache_stat` → `prts_mcp.cache_stats`; `activation_snapshot`/`check_activation_change`/`register_activation_listener` → `prts_mcp.activation`. The MCP tool surface (names/params/output) is unchanged (#162).
+- HTTP transport and release-discovery leaves extracted from `prts_mcp.data.sync` into a new `prts_mcp.sync` tier (`sync.transport`, `sync.release_discovery`) — the repository's only HTTP-issuing layer. `data/sync` re-exports them during the P2.A→P2.B migration, so existing `prts_mcp.data.sync.*` import paths keep working; the release/archive/pair state machine remains in `data/sync` until P2.B. `check_latest_release` log lines now originate from `prts_mcp.sync.release_discovery`. The MCP tool surface is unchanged.
 
 ### Fixed
 

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Changed
 
 - Internal activation and cache-instrumentation symbols moved out of `prts_mcp.config` into dedicated modules — a visible import-path change for anyone importing these internals from `prts_mcp.config`: `activation_aware_cache`/`cache_stat` → `prts_mcp.cache_stats`; `activation_snapshot`/`check_activation_change`/`register_activation_listener` → `prts_mcp.activation`. The MCP tool surface (names/params/output) is unchanged (#162).
-- HTTP transport and release-discovery leaves extracted from `prts_mcp.data.sync` into a new `prts_mcp.sync` tier (`sync.transport`, `sync.release_discovery`) — the repository's only HTTP-issuing layer. `data/sync` re-exports them during the P2.A→P2.B migration, so existing `prts_mcp.data.sync.*` import paths keep working; the release/archive/pair state machine remains in `data/sync` until P2.B. `check_latest_release` log lines now originate from `prts_mcp.sync.release_discovery`. The MCP tool surface is unchanged.
+- HTTP transport and release-discovery leaves extracted from `prts_mcp.data.sync` into a new `prts_mcp.sync` tier (`sync.transport`, `sync.release_discovery`) — the only layer that issues data-sync HTTP (the PRTS Wiki API client in `api/` is unaffected). `data/sync` re-exports them during the P2.A→P2.B migration, so existing `prts_mcp.data.sync.*` import paths keep working; the release/archive/pair state machine remains in `data/sync` until P2.B. `check_latest_release` log lines now originate from `prts_mcp.sync.release_discovery`. The MCP tool surface is unchanged.
 
 ### Fixed
 

--- a/python/src/prts_mcp/data/sync.py
+++ b/python/src/prts_mcp/data/sync.py
@@ -18,10 +18,8 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Iterator, Literal
+from typing import Iterator, Literal
 from uuid import uuid4
-
-import httpx
 
 _logger = logging.getLogger(__name__)
 
@@ -44,73 +42,18 @@ GAMEDATA_FILES: tuple[str, ...] = (
 # remain readable during the migration to the self-built pipeline.
 DATA_CONTRACT_VERSION = "prts-mcp-data/v1"
 
-_GITHUB_UA = "PRTS-MCP-Bot/0.1 (Arknights fan-creation helper)"
-
-
-def _github_headers() -> dict[str, str]:
-    headers: dict[str, str] = {"User-Agent": _GITHUB_UA}
-    token = os.environ.get("GITHUB_TOKEN")
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
-
-
-def _parse_mirrors() -> list[str]:
-    """Parse GITHUB_MIRRORS env var into a list of proxy base URLs (trailing slash stripped).
-
-    Unset / empty → [] (direct only, no cascade)
-    "https://ghproxy.net" → ["https://ghproxy.net"]
-    "https://a.example,https://b.example" → ["https://a.example", "https://b.example"]
-
-    Mirror URL format (ghproxy-style): <mirror>/<original_url>
-    e.g. "https://ghproxy.net/https://raw.githubusercontent.com/..."
-    """
-    raw = os.environ.get("GITHUB_MIRRORS", "")
-    return [m.rstrip("/") for m in raw.split(",") if m.strip()]
-
-
-def _url_candidates(url: str) -> list[str]:
-    """Return [url, mirror1/url, mirror2/url, ...]."""
-    return [url] + [f"{m}/{url}" for m in _parse_mirrors()]
-
-
-class _AssetNotFoundError(Exception):
-    """Direct release URL returned 404 — asset confirmed absent.
-
-    Distinguished from a mirror 404 (mirror lacks the asset; the release
-    may still exist upstream) so manifest verification skips only on a
-    confirmed upstream 404 and stays fail-closed otherwise (#100).
-    """
-
-
-def _get_cascading(url: str, *, timeout: float, **kwargs: object) -> httpx.Response:
-    """httpx.get() wrapper that cascades through URL candidates on failure.
-
-    - HTTP 4xx from the direct URL propagates immediately (resource missing).
-    - Network error or HTTP 5xx from any candidate → try the next one.
-    """
-    candidates = _url_candidates(url)
-    last_exc: BaseException = RuntimeError("All URL candidates failed")
-    for i, candidate in enumerate(candidates):
-        try:
-            response = httpx.get(candidate, timeout=timeout, **kwargs)  # type: ignore[arg-type]
-            if response.is_success:
-                return response
-            # Direct 404 → asset confirmed absent; record the typed error and
-            # stop without trying mirrors. last_exc + break (not raise) so the
-            # typed error survives to the caller even with GITHUB_MIRRORS (#100).
-            if i == 0 and response.status_code == 404:
-                last_exc = _AssetNotFoundError(f"HTTP 404: {candidate}")
-                break
-            last_exc = Exception(f"HTTP {response.status_code}")
-            # Other direct 4xx → resource genuinely missing; mirrors cannot help.
-            if i == 0 and 400 <= response.status_code < 500:
-                break
-        except httpx.HTTPStatusError:
-            raise  # only reached for direct 4xx via raise_for_status(); propagate as-is
-        except Exception as exc:  # noqa: BLE001
-            last_exc = exc
-    raise last_exc
+# HTTP transport (mirrors / headers / cascading fetch) lives in the sync/
+# transport tier — the only layer allowed to issue HTTP. Re-imported here so
+# the state machine below and existing ``prts_mcp.data.sync.*`` references
+# keep resolving during the P2.A→P2.B migration.
+from prts_mcp.sync.transport import (  # noqa: F401  (re-exported to preserve the data/sync namespace)
+    _AssetNotFoundError,
+    _GITHUB_UA,
+    _get_cascading,
+    _github_headers,
+    _parse_mirrors,
+    _url_candidates,
+)
 
 
 # Skip the upstream SHA check if cached data is fresher than this many seconds.
@@ -220,75 +163,18 @@ def _cache_is_fresh(cache: CacheMeta) -> bool:
 # Release-based sync (for storyjson zip)
 # ---------------------------------------------------------------------------
 
-_TAG_PREFIX = "data-"
-
-
-# ---------------------------------------------------------------------------
-# Release discovery (tag-prefix filtered)
-#
-# The arknights-data-pipeline repo hosts both ``data-*`` and ``images-*``
-# GitHub Releases.  ``/releases/latest`` may point at an ``images-*`` release
-# if GitHub auto-promotes it, so data sync must filter by tag prefix instead.
-# (images_sync reuses these helpers for its own prefix filtering.)
-# ---------------------------------------------------------------------------
-
-
-def _list_releases(owner: str, repo: str, *, timeout: float = 10.0) -> list[dict] | None:
-    """List all non-draft releases. Returns None on any network/API failure."""
-    url = f"https://api.github.com/repos/{owner}/{repo}/releases?per_page=100"
-    try:
-        response = _get_cascading(url, timeout=timeout, headers=_github_headers())
-        data = response.json()
-        return data if isinstance(data, list) else None
-    except Exception:  # noqa: BLE001
-        return None
-
-
-def _latest_release_by_prefix(
-    releases: list[dict],
-    prefix: str,
-    *,
-    exclude_prefix: str | None = None,
-) -> dict | None:
-    """Pick the newest release whose tag starts with *prefix*.
-
-    Sorts by ``created_at`` (GitHub release creation timestamp) descending,
-    which is robust across baseline/delta tag formats.
-    """
-    candidates: list[dict] = []
-    for release in releases:
-        tag = release.get("tag_name")
-        if not isinstance(tag, str) or not tag.startswith(prefix):
-            continue
-        if exclude_prefix and tag.startswith(exclude_prefix):
-            continue
-        candidates.append(release)
-    if not candidates:
-        return None
-    candidates.sort(key=lambda r: str(r.get("created_at", "")), reverse=True)
-    return candidates[0]
-
-
-def _asset_url(release: dict, asset_name: str) -> str | None:
-    """Extract the ``browser_download_url`` for *asset_name* from a release dict."""
-    for asset in release.get("assets", []):
-        if isinstance(asset, dict) and asset.get("name") == asset_name:
-            url = asset.get("browser_download_url")
-            if isinstance(url, str):
-                return url
-    return None
-
-
-@dataclass(frozen=True)
-class ReleaseSpec:
-    """Describes a GitHub Release asset to download as a local zip."""
-
-    owner: str
-    repo: str
-    asset_name: str   # e.g. "zh_CN.zip"
-    local_zip: Path   # destination path on disk
-    validate_zip: Callable[[Path], list[str]] | None = None
-    verify_manifest: bool = False
+# Release discovery (tag-prefix-filtered list / latest / asset_url /
+# check_latest) + the ReleaseSpec type live in the sync/release_discovery
+# tier. Re-imported here so the state machine below and existing
+# ``prts_mcp.data.sync.*`` references keep resolving during P2.A→P2.B.
+from prts_mcp.sync.release_discovery import (  # noqa: F401  (re-exported to preserve the data/sync namespace)
+    ReleaseSpec,
+    _TAG_PREFIX,
+    _asset_url,
+    _latest_release_by_prefix,
+    _list_releases,
+    check_latest_release,
+)
 
 
 @dataclass(frozen=True)
@@ -310,29 +196,6 @@ def _release_cache_path(spec: ReleaseSpec) -> Path:
 
 def _release_cache_is_fresh(cache: CacheMeta) -> bool:
     return _cache_is_fresh(cache)
-
-
-def check_latest_release(spec: ReleaseSpec, timeout: float = 10.0) -> tuple[str, str] | None:
-    """Return ``(tag_name, asset_download_url)`` for the latest ``data-*`` release.
-
-    Uses the releases list API with tag-prefix filtering instead of
-    ``/releases/latest``, because the data-pipeline repo also hosts
-    ``images-*`` releases that may be promoted to "Latest" on GitHub.
-    Returns ``None`` on network failure or when no matching release/asset is found.
-    """
-    releases = _list_releases(spec.owner, spec.repo, timeout=timeout)
-    if releases is None:
-        return None
-    latest = _latest_release_by_prefix(releases, _TAG_PREFIX)
-    if latest is None:
-        _logger.debug("No release with prefix %s in %s/%s", _TAG_PREFIX, spec.owner, spec.repo)
-        return None
-    tag = latest["tag_name"]
-    url = _asset_url(latest, spec.asset_name)
-    if url is None:
-        _logger.debug("Asset %s not found in release %s", spec.asset_name, tag)
-        return None
-    return tag, url
 
 
 def download_release_asset(spec: ReleaseSpec, tag: str, url: str, timeout: float = 120.0) -> None:

--- a/python/src/prts_mcp/sync/__init__.py
+++ b/python/src/prts_mcp/sync/__init__.py
@@ -1,0 +1,6 @@
+"""GitHub Release data-sync tier.
+
+The only layer permitted to issue HTTP. Holds the transport (HTTP / mirror
+cascade) and release-discovery leaves extracted from ``data/sync``; the
+release/archive/pair state machine still lives in ``data/sync`` until P2.B.
+"""

--- a/python/src/prts_mcp/sync/release_discovery.py
+++ b/python/src/prts_mcp/sync/release_discovery.py
@@ -1,0 +1,111 @@
+"""GitHub Release discovery: tag-prefix-filtered list / latest / asset_url.
+
+Extracted from ``data/sync`` (P2.A). The arknights-data-pipeline repo hosts
+both ``data-*`` and ``images-*`` GitHub Releases; ``/releases/latest`` may
+point at an ``images-*`` release if GitHub auto-promotes it, so data sync
+filters by tag prefix instead. ``data/sync`` re-exports these and
+``ReleaseSpec`` during the P2.A→P2.B migration.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+from prts_mcp.sync.transport import _get_cascading, _github_headers
+
+_logger = logging.getLogger(__name__)
+
+_TAG_PREFIX = "data-"
+
+
+# ---------------------------------------------------------------------------
+# Release discovery (tag-prefix filtered)
+#
+# The arknights-data-pipeline repo hosts both ``data-*`` and ``images-*``
+# GitHub Releases.  ``/releases/latest`` may point at an ``images-*`` release
+# if GitHub auto-promotes it, so data sync must filter by tag prefix instead.
+# (images_sync reuses these helpers for its own prefix filtering.)
+# ---------------------------------------------------------------------------
+
+
+def _list_releases(owner: str, repo: str, *, timeout: float = 10.0) -> list[dict] | None:
+    """List all non-draft releases. Returns None on any network/API failure."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/releases?per_page=100"
+    try:
+        response = _get_cascading(url, timeout=timeout, headers=_github_headers())
+        data = response.json()
+        return data if isinstance(data, list) else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _latest_release_by_prefix(
+    releases: list[dict],
+    prefix: str,
+    *,
+    exclude_prefix: str | None = None,
+) -> dict | None:
+    """Pick the newest release whose tag starts with *prefix*.
+
+    Sorts by ``created_at`` (GitHub release creation timestamp) descending,
+    which is robust across baseline/delta tag formats.
+    """
+    candidates: list[dict] = []
+    for release in releases:
+        tag = release.get("tag_name")
+        if not isinstance(tag, str) or not tag.startswith(prefix):
+            continue
+        if exclude_prefix and tag.startswith(exclude_prefix):
+            continue
+        candidates.append(release)
+    if not candidates:
+        return None
+    candidates.sort(key=lambda r: str(r.get("created_at", "")), reverse=True)
+    return candidates[0]
+
+
+def _asset_url(release: dict, asset_name: str) -> str | None:
+    """Extract the ``browser_download_url`` for *asset_name* from a release dict."""
+    for asset in release.get("assets", []):
+        if isinstance(asset, dict) and asset.get("name") == asset_name:
+            url = asset.get("browser_download_url")
+            if isinstance(url, str):
+                return url
+    return None
+
+
+@dataclass(frozen=True)
+class ReleaseSpec:
+    """Describes a GitHub Release asset to download as a local zip."""
+
+    owner: str
+    repo: str
+    asset_name: str   # e.g. "zh_CN.zip"
+    local_zip: Path   # destination path on disk
+    validate_zip: Callable[[Path], list[str]] | None = None
+    verify_manifest: bool = False
+
+
+def check_latest_release(spec: ReleaseSpec, timeout: float = 10.0) -> tuple[str, str] | None:
+    """Return ``(tag_name, asset_download_url)`` for the latest ``data-*`` release.
+
+    Uses the releases list API with tag-prefix filtering instead of
+    ``/releases/latest``, because the data-pipeline repo also hosts
+    ``images-*`` releases that may be promoted to "Latest" on GitHub.
+    Returns ``None`` on network failure or when no matching release/asset is found.
+    """
+    releases = _list_releases(spec.owner, spec.repo, timeout=timeout)
+    if releases is None:
+        return None
+    latest = _latest_release_by_prefix(releases, _TAG_PREFIX)
+    if latest is None:
+        _logger.debug("No release with prefix %s in %s/%s", _TAG_PREFIX, spec.owner, spec.repo)
+        return None
+    tag = latest["tag_name"]
+    url = _asset_url(latest, spec.asset_name)
+    if url is None:
+        _logger.debug("Asset %s not found in release %s", spec.asset_name, tag)
+        return None
+    return tag, url

--- a/python/src/prts_mcp/sync/transport.py
+++ b/python/src/prts_mcp/sync/transport.py
@@ -1,0 +1,79 @@
+"""HTTP transport for GitHub Release sync: mirrors, headers, cascading fetch.
+
+Extracted from ``data/sync`` (P2.A). This is the repo's only HTTP-issuing
+tier; the release/archive/pair state machine still in ``data/sync`` consumes
+it. ``data/sync`` re-exports these symbols during the P2.A→P2.B migration.
+"""
+from __future__ import annotations
+
+import os
+
+import httpx
+
+_GITHUB_UA = "PRTS-MCP-Bot/0.1 (Arknights fan-creation helper)"
+
+
+def _github_headers() -> dict[str, str]:
+    headers: dict[str, str] = {"User-Agent": _GITHUB_UA}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _parse_mirrors() -> list[str]:
+    """Parse GITHUB_MIRRORS env var into a list of proxy base URLs (trailing slash stripped).
+
+    Unset / empty → [] (direct only, no cascade)
+    "https://ghproxy.net" → ["https://ghproxy.net"]
+    "https://a.example,https://b.example" → ["https://a.example", "https://b.example"]
+
+    Mirror URL format (ghproxy-style): <mirror>/<original_url>
+    e.g. "https://ghproxy.net/https://raw.githubusercontent.com/..."
+    """
+    raw = os.environ.get("GITHUB_MIRRORS", "")
+    return [m.rstrip("/") for m in raw.split(",") if m.strip()]
+
+
+def _url_candidates(url: str) -> list[str]:
+    """Return [url, mirror1/url, mirror2/url, ...]."""
+    return [url] + [f"{m}/{url}" for m in _parse_mirrors()]
+
+
+class _AssetNotFoundError(Exception):
+    """Direct release URL returned 404 — asset confirmed absent.
+
+    Distinguished from a mirror 404 (mirror lacks the asset; the release
+    may still exist upstream) so manifest verification skips only on a
+    confirmed upstream 404 and stays fail-closed otherwise (#100).
+    """
+
+
+def _get_cascading(url: str, *, timeout: float, **kwargs: object) -> httpx.Response:
+    """httpx.get() wrapper that cascades through URL candidates on failure.
+
+    - HTTP 4xx from the direct URL propagates immediately (resource missing).
+    - Network error or HTTP 5xx from any candidate → try the next one.
+    """
+    candidates = _url_candidates(url)
+    last_exc: BaseException = RuntimeError("All URL candidates failed")
+    for i, candidate in enumerate(candidates):
+        try:
+            response = httpx.get(candidate, timeout=timeout, **kwargs)  # type: ignore[arg-type]
+            if response.is_success:
+                return response
+            # Direct 404 → asset confirmed absent; record the typed error and
+            # stop without trying mirrors. last_exc + break (not raise) so the
+            # typed error survives to the caller even with GITHUB_MIRRORS (#100).
+            if i == 0 and response.status_code == 404:
+                last_exc = _AssetNotFoundError(f"HTTP 404: {candidate}")
+                break
+            last_exc = Exception(f"HTTP {response.status_code}")
+            # Other direct 4xx → resource genuinely missing; mirrors cannot help.
+            if i == 0 and 400 <= response.status_code < 500:
+                break
+        except httpx.HTTPStatusError:
+            raise  # only reached for direct 4xx via raise_for_status(); propagate as-is
+        except Exception as exc:  # noqa: BLE001
+            last_exc = exc
+    raise last_exc

--- a/python/tests/test_sync_release.py
+++ b/python/tests/test_sync_release.py
@@ -132,6 +132,10 @@ class TestSyncRelease:
                 },
             },
         }
+        # check_latest_release moved to release_discovery (P2.A), so its
+        # _get_cascading call resolves there, not in data.sync. One shared mock
+        # patches both namespaces; side_effect is consumed in call order:
+        # release list (discovery) -> asset download -> manifest (state machine).
         with patch(
             "prts_mcp.data.sync._get_cascading",
             side_effect=[release, asset, manifest],

--- a/python/tests/test_sync_release.py
+++ b/python/tests/test_sync_release.py
@@ -135,6 +135,9 @@ class TestSyncRelease:
         with patch(
             "prts_mcp.data.sync._get_cascading",
             side_effect=[release, asset, manifest],
+        ) as cascading, patch(
+            "prts_mcp.sync.release_discovery._get_cascading",
+            cascading,
         ):
             result = sync_release(spec, force_check=True)
         assert result.status == "updated"
@@ -161,6 +164,9 @@ class TestSyncRelease:
         with patch(
             "prts_mcp.data.sync._get_cascading",
             side_effect=[release, asset, manifest],
+        ) as cascading, patch(
+            "prts_mcp.sync.release_discovery._get_cascading",
+            cascading,
         ):
             result = sync_release(spec, force_check=True)
         assert result.status == "offline_fallback"
@@ -179,6 +185,9 @@ class TestSyncRelease:
         with patch(
             "prts_mcp.data.sync._get_cascading",
             side_effect=[release, asset, _AssetNotFoundError("HTTP 404")],
+        ) as cascading, patch(
+            "prts_mcp.sync.release_discovery._get_cascading",
+            cascading,
         ):
             result = sync_release(spec, force_check=True)
         assert result.status == "updated"
@@ -203,6 +212,9 @@ class TestSyncRelease:
                 _mock_asset_response(b"new"),
                 manifest,
             ],
+        ) as cascading, patch(
+            "prts_mcp.sync.release_discovery._get_cascading",
+            cascading,
         ):
             result = sync_release(spec, force_check=True)
         assert result.status == "offline_fallback"

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Changed
 
 - Internal activation symbols (`withActivationSnapshot`/`checkActivationChange`/`registerActivationListener`) moved from `config.js` into a dedicated `activation.js` module — import them from `activation.js` instead of `config.js`. The MCP tool surface is unchanged (#162).
+- HTTP transport and release-discovery leaves extracted from `data/sync.ts` into a new `sync/` tier (`sync/transport.ts`, `sync/releaseDiscovery.ts`) — the repository's only HTTP-issuing layer. `data/sync.ts` re-exports them during the P2.A→P2.B migration, so existing `./sync.js` import paths keep working; the release/archive/pair state machine remains in `data/sync.ts` until P2.B. The MCP tool surface is unchanged.
 
 ### Fixed
 

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 ### Changed
 
 - Internal activation symbols (`withActivationSnapshot`/`checkActivationChange`/`registerActivationListener`) moved from `config.js` into a dedicated `activation.js` module — import them from `activation.js` instead of `config.js`. The MCP tool surface is unchanged (#162).
-- HTTP transport and release-discovery leaves extracted from `data/sync.ts` into a new `sync/` tier (`sync/transport.ts`, `sync/releaseDiscovery.ts`) — the repository's only HTTP-issuing layer. `data/sync.ts` re-exports them during the P2.A→P2.B migration, so existing `./sync.js` import paths keep working; the release/archive/pair state machine remains in `data/sync.ts` until P2.B. The MCP tool surface is unchanged.
+- HTTP transport and release-discovery leaves extracted from `data/sync.ts` into a new `sync/` tier (`sync/transport.ts`, `sync/releaseDiscovery.ts`) — the only layer that issues data-sync HTTP (the PRTS Wiki API client in `api/` is unaffected). `data/sync.ts` re-exports them during the P2.A→P2.B migration, so existing `./sync.js` import paths keep working; the release/archive/pair state machine remains in `data/sync.ts` until P2.B. The MCP tool surface is unchanged.
 
 ### Fixed
 

--- a/ts/src/data/sync.ts
+++ b/ts/src/data/sync.ts
@@ -25,18 +25,17 @@ import {
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import AdmZip from "adm-zip";
-import type { Dispatcher } from "undici";
+import {
+  AssetNotFoundError,
+  fetchCascading,
+  githubHeaders,
+  parseMirrors,
+  type FetchResponse,
+} from "../sync/transport.js";
 
-const NATIVE_FETCH = globalThis.fetch;
-let envProxyAgent: Dispatcher | undefined;
-
-/** The response surface shared by the global and Undici fetch runtimes. */
-interface FetchResponse {
-  readonly ok: boolean;
-  readonly status: number;
-  json(): Promise<unknown>;
-  arrayBuffer(): Promise<ArrayBuffer>;
-}
+// Re-exported so existing `./sync.js` consumers (imagesSync, sync.test) keep
+// resolving these during the P2.A→P2.B migration.
+export { AssetNotFoundError, fetchCascading, githubHeaders };
 
 /** Versioned contract shared with the arknights-data-pipeline manifest. */
 export const DATA_CONTRACT_VERSION = "prts-mcp-data/v1";
@@ -55,8 +54,6 @@ export const GAMEDATA_FILES: readonly string[] = [
   "zh_CN/gamedata/excel/zone_table.json",
   "zh_CN/gamedata/excel/item_table.json",
 ];
-
-const GITHUB_UA = "PRTS-MCP-Bot/0.1 (Arknights fan-creation helper)";
 
 /** Skip the upstream SHA check if cached data is fresher than this (seconds). */
 const CACHE_TTL_SECONDS = 3600;
@@ -108,115 +105,8 @@ export interface SyncResult {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-export function githubHeaders(): Record<string, string> {
-  const headers: Record<string, string> = { "User-Agent": GITHUB_UA };
-  const token = process.env["GITHUB_TOKEN"];
-  if (token) headers["Authorization"] = `Bearer ${token}`;
-  return headers;
-}
-
-/**
- * Parse GITHUB_MIRRORS env var into a list of proxy base URLs (trailing slash stripped).
- *
- * Unset / empty  → [] (direct only, no cascade)
- * "https://ghproxy.net"              → ["https://ghproxy.net"]
- * "https://a.example,https://b.example" → ["https://a.example", "https://b.example"]
- *
- * Mirror URL format (ghproxy-style): <mirror>/<original_url>
- * e.g. "https://ghproxy.net/https://raw.githubusercontent.com/..."
- */
-function parseMirrors(): string[] {
-  return (process.env["GITHUB_MIRRORS"] ?? "")
-    .split(",")
-    .map((s) => s.trim().replace(/\/$/, ""))
-    .filter(Boolean);
-}
-
-/** Return [url, mirroredUrl1, mirroredUrl2, ...] */
-function urlCandidates(url: string): string[] {
-  return [url, ...parseMirrors().map((m) => `${m}/${url}`)];
-}
-
-async function fetchWithRuntimeProxy(
-  url: string,
-  options: Omit<RequestInit, "signal">,
-  signal: AbortSignal,
-): Promise<FetchResponse> {
-  // Preserve test/in-process fetch overrides and Bun's native proxy support.
-  if (
-    globalThis.fetch !== NATIVE_FETCH
-    || process.versions.bun
-    || !(
-      process.env["HTTP_PROXY"] || process.env["HTTPS_PROXY"]
-      || process.env["http_proxy"] || process.env["https_proxy"]
-    )
-  ) {
-    return globalThis.fetch(url, { ...options, signal });
-  }
-  const { EnvHttpProxyAgent, fetch: undiciFetch } = await import("undici");
-  if (envProxyAgent === undefined) envProxyAgent = new EnvHttpProxyAgent();
-  const response = await undiciFetch(url, {
-    ...options,
-    signal,
-    dispatcher: envProxyAgent,
-  } as Parameters<typeof undiciFetch>[1]);
-  return response;
-}
-
-/**
- * fetch() wrapper that cascades through URL candidates on failure.
- *
- * - A fresh AbortSignal.timeout is created per attempt so an earlier
- *   timeout does not consume the budget for later candidates.
- * - HTTP 4xx from the direct URL propagates immediately (resource is
- *   genuinely missing — mirrors won't help).
- * - Network error or HTTP 5xx from any candidate → try the next one.
- */
-export async function fetchCascading(
-  url: string,
-  options: Omit<RequestInit, "signal">,
-  timeoutMs: number,
-): Promise<FetchResponse> {
-  const candidates = urlCandidates(url);
-  let lastErr: unknown = new Error("All URL candidates failed");
-  for (let i = 0; i < candidates.length; i++) {
-    try {
-      const res = await fetchWithRuntimeProxy(
-        candidates[i], options, AbortSignal.timeout(timeoutMs),
-      );
-      if (res.ok) return res;
-      // Direct 404 → asset confirmed absent; record the typed error and stop
-      // without trying mirrors. lastErr + break (not throw) so the typed
-      // error survives to the caller even with GITHUB_MIRRORS (#100).
-      if (i === 0 && res.status === 404) {
-        lastErr = new AssetNotFoundError(`HTTP 404: ${candidates[i]}`);
-        break;
-      }
-      lastErr = new Error(`HTTP ${res.status}`);
-      // Other direct 4xx → the resource does not exist; mirrors cannot help.
-      if (i === 0 && res.status >= 400 && res.status < 500) break;
-    } catch (err) {
-      lastErr = err;
-    }
-  }
-  throw lastErr;
-}
-
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
-}
-
-/**
- * The direct release URL returned 404 — the asset genuinely does not exist.
- * Distinguished from a mirror 404 (mirror lacks the asset; the release may
- * still exist upstream) so manifest verification skips only on a confirmed
- * upstream 404 and stays fail-closed otherwise (#100).
- */
-export class AssetNotFoundError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "AssetNotFoundError";
-  }
 }
 
 function cacheIsFresh(cache: CacheMeta): boolean {
@@ -243,87 +133,23 @@ function releaseZipError(spec: ReleaseSpec): string | null {
 // Release-based sync (for zh_CN.zip from GitHub Releases)
 // ---------------------------------------------------------------------------
 
-const TAG_PREFIX = "data-";
-
-// ---------------------------------------------------------------------------
-// Release discovery (tag-prefix filtered)
-//
-// The arknights-data-pipeline repo hosts both ``data-*`` and ``images-*``
-// GitHub Releases.  ``/releases/latest`` may point at an ``images-*`` release
-// if GitHub auto-promotes it, so data sync must filter by tag prefix instead.
-// (imagesSync reuses these helpers for its own prefix filtering.)
-// ---------------------------------------------------------------------------
-
-/** Minimal shape of a GitHub Release object (only the fields we read). */
-export interface GithubRelease {
-  tag_name?: unknown;
-  created_at?: unknown;
-  assets?: unknown;
-  [key: string]: unknown;
-}
-
-/** List all non-draft releases. Returns null on any network/API failure. */
-export async function listReleases(
-  owner: string,
-  repo: string,
-  timeoutMs = 10_000,
-): Promise<GithubRelease[] | null> {
-  const url = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=100`;
-  try {
-    const res = await fetchCascading(url, { headers: githubHeaders() }, timeoutMs);
-    const data = await res.json();
-    return Array.isArray(data) ? (data as GithubRelease[]) : null;
-  } catch {
-    return null;
-  }
-}
-
-/** Pick the newest release whose tag starts with *prefix*, sorting by created_at desc. */
-export function latestReleaseByPrefix(
-  releases: GithubRelease[],
-  prefix: string,
-  opts: { excludePrefix?: string } = {},
-): GithubRelease | null {
-  const candidates: GithubRelease[] = [];
-  for (const release of releases) {
-    const tag = release["tag_name"];
-    if (typeof tag !== "string" || !tag.startsWith(prefix)) continue;
-    if (opts.excludePrefix && tag.startsWith(opts.excludePrefix)) continue;
-    candidates.push(release);
-  }
-  if (candidates.length === 0) return null;
-  candidates.sort((a, b) =>
-    String(b["created_at"] ?? "").localeCompare(String(a["created_at"] ?? "")),
-  );
-  return candidates[0];
-}
-
-/** Extract the browser_download_url for *assetName* from a release object. */
-export function assetUrl(release: GithubRelease, assetName: string): string | null {
-  const assets = release["assets"];
-  if (!Array.isArray(assets)) return null;
-  for (const a of assets) {
-    if (typeof a === "object" && a !== null && (a as Record<string, unknown>)["name"] === assetName) {
-      const url = (a as Record<string, unknown>)["browser_download_url"];
-      if (typeof url === "string") return url;
-    }
-  }
-  return null;
-}
-
-/** Describes a GitHub Release asset to download as a local zip. */
-export interface ReleaseSpec {
-  owner: string;
-  repo: string;
-  /** Asset filename in the release, e.g. "zh_CN.zip". */
-  assetName: string;
-  /** Absolute destination path for the downloaded zip. */
-  localZip: string;
-  /** Optional validator returning missing or invalid zip entries. */
-  validateZip?: (zipPath: string) => string[];
-  /** Verify the optional factory manifest when the release provides it. */
-  verifyManifest?: boolean;
-}
+// Release discovery (tag-prefix-filtered list / latest / asset_url /
+// checkLatestRelease) + the ReleaseSpec type live in the
+// sync/releaseDiscovery tier. Re-imported here so the state machine below
+// and existing `./sync.js` consumers keep resolving during P2.A→P2.B.
+import {
+  type ReleaseSpec,
+  TAG_PREFIX,
+  checkLatestRelease,
+} from "../sync/releaseDiscovery.js";
+export {
+  type GithubRelease,
+  type ReleaseSpec,
+  assetUrl,
+  checkLatestRelease,
+  latestReleaseByPrefix,
+  listReleases,
+} from "../sync/releaseDiscovery.js";
 
 /** Describes a GitHub Release zip asset that should be extracted locally. */
 export interface ReleaseArchiveSpec {
@@ -390,29 +216,6 @@ async function saveReleaseMeta(
     files: meta.files,
   }, null, 2), "utf-8");
   await rename(tmp, p);
-}
-
-/**
- * Return the latest ``data-*`` release tag and asset download URL.
- *
- * Uses the releases list API with tag-prefix filtering instead of
- * ``/releases/latest``, because the data-pipeline repo also hosts
- * ``images-*`` releases that may be promoted to "Latest" on GitHub.
- * Returns null on network failure or when no matching release/asset is found.
- */
-export async function checkLatestRelease(
-  spec: ReleaseSpec,
-  timeoutMs = 10_000
-): Promise<{ tag: string; url: string } | null> {
-  const releases = await listReleases(spec.owner, spec.repo, timeoutMs);
-  if (releases === null) return null;
-  const latest = latestReleaseByPrefix(releases, TAG_PREFIX);
-  if (!latest) return null;
-  const tag = latest["tag_name"];
-  if (typeof tag !== "string") return null;
-  const url = assetUrl(latest, spec.assetName);
-  if (!url) return null;
-  return { tag, url };
 }
 
 /**

--- a/ts/src/sync/releaseDiscovery.ts
+++ b/ts/src/sync/releaseDiscovery.ts
@@ -1,0 +1,115 @@
+/**
+ * GitHub Release discovery: tag-prefix-filtered list / latest / asset_url.
+ *
+ * Mirrors python/src/prts_mcp/sync/release_discovery.py. Extracted from
+ * data/sync (P2.A): the arknights-data-pipeline repo hosts both ``data-*``
+ * and ``images-*`` releases, so data sync filters by tag prefix instead of
+ * using /releases/latest. data/sync re-exports these and ReleaseSpec during
+ * the P2.A→P2.B migration.
+ */
+import { fetchCascading, githubHeaders } from "./transport.js";
+
+export const TAG_PREFIX = "data-";
+
+// ---------------------------------------------------------------------------
+// Release discovery (tag-prefix filtered)
+//
+// The arknights-data-pipeline repo hosts both ``data-*`` and ``images-*``
+// GitHub Releases.  ``/releases/latest`` may point at an ``images-*`` release
+// if GitHub auto-promotes it, so data sync must filter by tag prefix instead.
+// (imagesSync reuses these helpers for its own prefix filtering.)
+// ---------------------------------------------------------------------------
+
+/** Minimal shape of a GitHub Release object (only the fields we read). */
+export interface GithubRelease {
+  tag_name?: unknown;
+  created_at?: unknown;
+  assets?: unknown;
+  [key: string]: unknown;
+}
+
+/** List all non-draft releases. Returns null on any network/API failure. */
+export async function listReleases(
+  owner: string,
+  repo: string,
+  timeoutMs = 10_000,
+): Promise<GithubRelease[] | null> {
+  const url = `https://api.github.com/repos/${owner}/${repo}/releases?per_page=100`;
+  try {
+    const res = await fetchCascading(url, { headers: githubHeaders() }, timeoutMs);
+    const data = await res.json();
+    return Array.isArray(data) ? (data as GithubRelease[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Pick the newest release whose tag starts with *prefix*, sorting by created_at desc. */
+export function latestReleaseByPrefix(
+  releases: GithubRelease[],
+  prefix: string,
+  opts: { excludePrefix?: string } = {},
+): GithubRelease | null {
+  const candidates: GithubRelease[] = [];
+  for (const release of releases) {
+    const tag = release["tag_name"];
+    if (typeof tag !== "string" || !tag.startsWith(prefix)) continue;
+    if (opts.excludePrefix && tag.startsWith(opts.excludePrefix)) continue;
+    candidates.push(release);
+  }
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) =>
+    String(b["created_at"] ?? "").localeCompare(String(a["created_at"] ?? "")),
+  );
+  return candidates[0];
+}
+
+/** Extract the browser_download_url for *assetName* from a release object. */
+export function assetUrl(release: GithubRelease, assetName: string): string | null {
+  const assets = release["assets"];
+  if (!Array.isArray(assets)) return null;
+  for (const a of assets) {
+    if (typeof a === "object" && a !== null && (a as Record<string, unknown>)["name"] === assetName) {
+      const url = (a as Record<string, unknown>)["browser_download_url"];
+      if (typeof url === "string") return url;
+    }
+  }
+  return null;
+}
+
+/** Describes a GitHub Release asset to download as a local zip. */
+export interface ReleaseSpec {
+  owner: string;
+  repo: string;
+  /** Asset filename in the release, e.g. "zh_CN.zip". */
+  assetName: string;
+  /** Absolute destination path for the downloaded zip. */
+  localZip: string;
+  /** Optional validator returning missing or invalid zip entries. */
+  validateZip?: (zipPath: string) => string[];
+  /** Verify the optional factory manifest when the release provides it. */
+  verifyManifest?: boolean;
+}
+
+/**
+ * Return the latest ``data-*`` release tag and asset download URL.
+ *
+ * Uses the releases list API with tag-prefix filtering instead of
+ * ``/releases/latest``, because the data-pipeline repo also hosts
+ * ``images-*`` releases that may be promoted to "Latest" on GitHub.
+ * Returns null on network failure or when no matching release/asset is found.
+ */
+export async function checkLatestRelease(
+  spec: ReleaseSpec,
+  timeoutMs = 10_000
+): Promise<{ tag: string; url: string } | null> {
+  const releases = await listReleases(spec.owner, spec.repo, timeoutMs);
+  if (releases === null) return null;
+  const latest = latestReleaseByPrefix(releases, TAG_PREFIX);
+  if (!latest) return null;
+  const tag = latest["tag_name"];
+  if (typeof tag !== "string") return null;
+  const url = assetUrl(latest, spec.assetName);
+  if (!url) return null;
+  return { tag, url };
+}

--- a/ts/src/sync/transport.ts
+++ b/ts/src/sync/transport.ts
@@ -1,0 +1,128 @@
+/**
+ * HTTP transport for GitHub Release sync: mirrors, headers, cascading fetch.
+ *
+ * Mirrors python/src/prts_mcp/sync/transport.py. Extracted from data/sync
+ * (P2.A): this is the repo's only HTTP-issuing tier. data/sync re-exports
+ * these symbols during the P2.A→P2.B migration.
+ */
+import type { Dispatcher } from "undici";
+
+const NATIVE_FETCH = globalThis.fetch;
+let envProxyAgent: Dispatcher | undefined;
+
+/** The response surface shared by the global and Undici fetch runtimes. */
+export interface FetchResponse {
+  readonly ok: boolean;
+  readonly status: number;
+  json(): Promise<unknown>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+const GITHUB_UA = "PRTS-MCP-Bot/0.1 (Arknights fan-creation helper)";
+
+export function githubHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { "User-Agent": GITHUB_UA };
+  const token = process.env["GITHUB_TOKEN"];
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  return headers;
+}
+
+/**
+ * Parse GITHUB_MIRRORS env var into a list of proxy base URLs (trailing slash stripped).
+ *
+ * Unset / empty  → [] (direct only, no cascade)
+ * "https://ghproxy.net"              → ["https://ghproxy.net"]
+ * "https://a.example,https://b.example" → ["https://a.example", "https://b.example"]
+ *
+ * Mirror URL format (ghproxy-style): <mirror>/<original_url>
+ * e.g. "https://ghproxy.net/https://raw.githubusercontent.com/..."
+ */
+export function parseMirrors(): string[] {
+  return (process.env["GITHUB_MIRRORS"] ?? "")
+    .split(",")
+    .map((s) => s.trim().replace(/\/$/, ""))
+    .filter(Boolean);
+}
+
+/** Return [url, mirroredUrl1, mirroredUrl2, ...] */
+function urlCandidates(url: string): string[] {
+  return [url, ...parseMirrors().map((m) => `${m}/${url}`)];
+}
+
+async function fetchWithRuntimeProxy(
+  url: string,
+  options: Omit<RequestInit, "signal">,
+  signal: AbortSignal,
+): Promise<FetchResponse> {
+  // Preserve test/in-process fetch overrides and Bun's native proxy support.
+  if (
+    globalThis.fetch !== NATIVE_FETCH
+    || process.versions.bun
+    || !(
+      process.env["HTTP_PROXY"] || process.env["HTTPS_PROXY"]
+      || process.env["http_proxy"] || process.env["https_proxy"]
+    )
+  ) {
+    return globalThis.fetch(url, { ...options, signal });
+  }
+  const { EnvHttpProxyAgent, fetch: undiciFetch } = await import("undici");
+  if (envProxyAgent === undefined) envProxyAgent = new EnvHttpProxyAgent();
+  const response = await undiciFetch(url, {
+    ...options,
+    signal,
+    dispatcher: envProxyAgent,
+  } as Parameters<typeof undiciFetch>[1]);
+  return response;
+}
+
+/**
+ * fetch() wrapper that cascades through URL candidates on failure.
+ *
+ * - A fresh AbortSignal.timeout is created per attempt so an earlier
+ *   timeout does not consume the budget for later candidates.
+ * - HTTP 4xx from the direct URL propagates immediately (resource is
+ *   genuinely missing — mirrors won't help).
+ * - Network error or HTTP 5xx from any candidate → try the next one.
+ */
+export async function fetchCascading(
+  url: string,
+  options: Omit<RequestInit, "signal">,
+  timeoutMs: number,
+): Promise<FetchResponse> {
+  const candidates = urlCandidates(url);
+  let lastErr: unknown = new Error("All URL candidates failed");
+  for (let i = 0; i < candidates.length; i++) {
+    try {
+      const res = await fetchWithRuntimeProxy(
+        candidates[i], options, AbortSignal.timeout(timeoutMs),
+      );
+      if (res.ok) return res;
+      // Direct 404 → asset confirmed absent; record the typed error and stop
+      // without trying mirrors. lastErr + break (not throw) so the typed
+      // error survives to the caller even with GITHUB_MIRRORS (#100).
+      if (i === 0 && res.status === 404) {
+        lastErr = new AssetNotFoundError(`HTTP 404: ${candidates[i]}`);
+        break;
+      }
+      lastErr = new Error(`HTTP ${res.status}`);
+      // Other direct 4xx → the resource does not exist; mirrors cannot help.
+      if (i === 0 && res.status >= 400 && res.status < 500) break;
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * The direct release URL returned 404 — the asset genuinely does not exist.
+ * Distinguished from a mirror 404 (mirror lacks the asset; the release may
+ * still exist upstream) so manifest verification skips only on a confirmed
+ * upstream 404 and stays fail-closed otherwise (#100).
+ */
+export class AssetNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AssetNotFoundError";
+  }
+}


### PR DESCRIPTION
## Summary

P2.A of the 2.7 god-file refactor (`dev/docs/working/2.7-god-file-refactor-plan.md`). Extracts the two clean leaf clusters — **transport** (HTTP / mirrors / cascading fetch) and **release_discovery** (list / latest-by-prefix / asset_url / check_latest) — out of the `data/sync.*` god files into a new top-level `sync/` tier — the only layer that issues **data-sync** HTTP (`api/` handles PRTS Wiki HTTP). Clears the primary layering fault the audit flagged (STYLE forbade HTTP in `data/`, yet `data/sync` issued it).

- New `python/src/prts_mcp/sync/{transport,release_discovery}.py` + `ts/src/sync/{transport,releaseDiscovery}.ts`. `data/sync.*` re-exports the moved symbols (incl. `ReleaseSpec` and the TS transport singleton) so all existing import paths + the 25 test patch sites keep resolving — a transitional shim removed when the state machine migrates in P2.B.
- STYLE.md amended (C1): `sync/` tier row + `sync → stores,utils,config` arrow; the `data/` HTTP prohibition scoped to data-reading modules, with `images_sync._download_large` documented as a tracked transient for P3.B.
- **`ReleaseSpec` (not `RepoSpec`) moves with discovery** — it is `check_latest_release`'s param type and is self-contained, so no `sync → data` back-edge. `RepoSpec` stays (state-machine only). The release/archive/pair **state machine stays in `data/sync.*`** until P2.B.

### Deviations from the validated plan (transparent)
- **4 test edits, not "zero".** Moving `check_latest_release` / `_list_releases` to `release_discovery` shifted their internal `_get_cascading` lookup out of the `data.sync` namespace; 4 `test_sync_release` patches that feed that call now also patch `release_discovery._get_cascading` (shared mock). Two of the four were silently passing for the wrong reason before (cache-luck `offline_fallback`) — now exercised correctly.
- **Commits folded to 2** (docs / code) instead of the planned 3: `data/sync.*` carries intermingled transport+discovery hunks and interactive hunk staging isn't available in this environment, so the code lands as one bisectable move commit with docs isolated. (+1 follow-up commit addressing CR nits.)

## Test plan
- [x] `uv run --directory python --locked python -m pytest tests -q` → 369 passed, 23 skipped
- [x] `cd ts && npm run build && npm run typecheck && npm test` → build + typecheck clean, 283 passed, 2 skipped
- [x] `./scripts/check-runtime.sh --full` → 0 failures (typecheck + cross-runtime shared-volume sync + Bun HTTP smoke)
- [x] Stale-term scan clean; no stale `data/sync` layering claims

## 未尽事宜 (deferred — not this PR)
- Visibility rename (`_get_cascading` → public, etc.) + `images_sync` direct-import migration + the 2 remaining underscore-private symbols → **P2.B** (with the state-machine move).
- `_download_large` / `downloadLarge` relocation + streaming/buffered cascade unification → **P3.B / P4.B**.
- `download_release_asset` / `verifyReleaseManifest` release module → **P2.B**.
- Removing the `data/sync.*` re-export shim → **P2.B** (when the state machine moves out and `data/sync.*` is deleted).