### PR TITLE
docs(style): archive 2.7 god-file audit healthy-unit verdicts (P5.1)

### DIFF
--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -16,6 +16,19 @@
 - **文件长度预警线**：源文件超过 ~300 行就要问"这能不能拆"
 - **模块边界**：`data/` 的数据读取模块只做数据读写和格式化，不混进 HTTP 请求；HTTP 传输统一收敛到 `sync/` 层；`api/` 只做 PRTS Wiki API 调用；`server.py` 只做工具注册和启动编排
 
+**已审健康的大文件（2.7.0 上帝文件审计归档，P5.1）**：预警线以耦合度为准，不是行数。以下单元在 2.7.0 周期审计中按 STYLE 耦合规则逐个判为单一职责/抽取得当，**不要为行数机械拆分**；表中"可选辅助"是审计记录的文件内抽取候选，仅在利于测试/复用时再做，不欠账：
+
+| 模块（PY / TS 行数@2026-08） | 审计结论 | 可选辅助（非必须） |
+|---|---|---|
+| `data/operator`（311 / 402） | 🟢 单一职责（干员数据读+格式化）；TS 大 ~90 行是 JSON-shape interface + per-cache CacheMetrics 的结构不对称，非上帝文件 | `resolve_operator_or_error`（收 3 处重复前置解析） |
+| `data/item`（475 / 496） | 🟢 镜像 operator 的 build/render/entry 形态 | `itemLabels`（纯 label 表 + 格式化，无 IO 可单测） |
+| `data/stage`（526 / 554） | 🟢 validate→load→filter→paginate→shape 线性管线，最大嵌套 2 | `stage_render`（纯 markdown；`stage_search` 契合 ROADMAP 决策原则 7 的统一 search 入口） |
+| `data/story_search`（398 / 356） | 🟢 内聚 | `_validate_search_params`（集中 6 个参数 guard） |
+| `data/story_reader`（540 / 561） | 🟡 临界：默认不拆，可选 `story_types`（纯数据形状）+ `story_format`（payload+markdown），仅在利于测试时 | 同左 |
+| `data/images`（227 / 233） | 🟢 免检：单域、抽取得当（sync 在 `sync/images_sync`、缓存生命周期合惯例） | — |
+
+
+
 ### 分层纪律
 
 ```

--- a/docs/dev/STYLE.md
+++ b/docs/dev/STYLE.md
@@ -16,7 +16,7 @@
 - **文件长度预警线**：源文件超过 ~300 行就要问"这能不能拆"
 - **模块边界**：`data/` 的数据读取模块只做数据读写和格式化，不混进 HTTP 请求；HTTP 传输统一收敛到 `sync/` 层；`api/` 只做 PRTS Wiki API 调用；`server.py` 只做工具注册和启动编排
 
-**已审健康的大文件（2.7.0 上帝文件审计归档，P5.1）**：预警线以耦合度为准，不是行数。以下单元在 2.7.0 周期审计中按 STYLE 耦合规则逐个判为单一职责/抽取得当，**不要为行数机械拆分**；表中"可选辅助"是审计记录的文件内抽取候选，仅在利于测试/复用时再做，不欠账：
+> **已审健康的大文件（2.7.0 上帝文件审计归档，P5.1）**：预警线以耦合度为准，不是行数。以下单元在 2.7.0 周期审计中按 STYLE 耦合规则逐个判为单一职责/抽取得当（story_reader 为临界），**不要为行数机械拆分**；表中行数是归档时的快照，结论以耦合度为准；"可选辅助"是审计记录的文件内抽取候选，仅在利于测试/复用时再做，不欠账：
 
 | 模块（PY / TS 行数@2026-08） | 审计结论 | 可选辅助（非必须） |
 |---|---|---|
@@ -24,10 +24,8 @@
 | `data/item`（475 / 496） | 🟢 镜像 operator 的 build/render/entry 形态 | `itemLabels`（纯 label 表 + 格式化，无 IO 可单测） |
 | `data/stage`（526 / 554） | 🟢 validate→load→filter→paginate→shape 线性管线，最大嵌套 2 | `stage_render`（纯 markdown；`stage_search` 契合 ROADMAP 决策原则 7 的统一 search 入口） |
 | `data/story_search`（398 / 356） | 🟢 内聚 | `_validate_search_params`（集中 6 个参数 guard） |
-| `data/story_reader`（540 / 561） | 🟡 临界：默认不拆，可选 `story_types`（纯数据形状）+ `story_format`（payload+markdown），仅在利于测试时 | 同左 |
+| `data/story_reader`（540 / 561） | 🟡 临界：默认不拆，仅在利于测试时抽取 | `story_types`（纯数据形状）+ `story_format`（payload+markdown） |
 | `data/images`（227 / 233） | 🟢 免检：单域、抽取得当（sync 在 `sync/images_sync`、缓存生命周期合惯例） | — |
-
-
 
 ### 分层纪律
 


### PR DESCRIPTION
## Summary

- Final item of the 2.7 god-file refactor program (execution slot 9/9): records the audit's healthy-unit verdicts into `docs/dev/STYLE.md`, closing the audit loop.
- A short "已审健康的大文件" table follows the ~300-line warning line so the threshold is read as a **coupling prompt, not a mechanical split trigger**: `operator` / `item` / `stage` / `story_search` are 🟢 single-responsibility by the STYLE coupling rules; `story_reader` is honestly marked 🟡 borderline (unsplit by default, optional `story_types`/`story_format` extraction noted); `images` is fully acquitted. Line counts refreshed to 2026-08 reality (audit-time counts drifted slightly across the P1–P3 refactors).
- The audit's file-internal helper candidates (e.g. `itemLabels`, `stage_render`, `_validate_search_params`) are logged as **optional, not owed** — only worth doing when they serve testing/reuse.
- Docs-only: no code, no CHANGELOG entry (per STYLE's docs-exemption).

## Test plan

- Targeted verification per the docs-only row of the verification matrix: all referenced module paths exist on both implementations; the ROADMAP decision-principle 7 cross-reference verified verbatim (`ROADMAP.md:208`); table renders in the natural-semantic-wrap convention (one physical line per cell).
- Full suites unaffected (no code change): last runs on this base — PY 424 passed / TS 325 passed / check-runtime --full 0 failures.

## 未尽事宜

- With this PR the 2.7 refactor program is complete (9/9 execution items: #161–#170 + this). The audit/plan working documents remain git-ignored under `dev/docs/working/` as the program's archive.