### PR TITLE
docs: global env-var reference + Streamable HTTP deployment chapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The `operator_artwork` tool (2.5.0+) is **enabled by default**. Two data source 
 | `ORIGINAL_IMAGE` | `false` | Also sync original-resolution shards; only effective when `LOCAL_IMAGE=true`. |
 | `PRTS_IMAGE_DIR` | `~/.local/share/prts-mcp/images/` | AKDP asset sync target; only effective when `LOCAL_IMAGE=true`. Docker: `/data/images`. |
 
-Zero-config: the tool works immediately via MediaWiki with caching. For the full offline AKDP experience, set `LOCAL_IMAGE=true` (triggers ~1.5 GB background sync).
+Zero-config: the tool works immediately via MediaWiki with caching. For the full offline AKDP experience, set `LOCAL_IMAGE=true` (triggers ~1.5 GB background sync). For the complete environment-variable list, see [docs/user/environment-variables.md](docs/user/environment-variables.md).
 
 ### Quick Start
 
@@ -231,7 +231,7 @@ See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contribution workflow and [`doc
 | `ORIGINAL_IMAGE` | `false` | 额外同步原图分辨率分片；仅在 `LOCAL_IMAGE=true` 时生效。 |
 | `PRTS_IMAGE_DIR` | `~/.local/share/prts-mcp/images/` | AKDP 资产同步目标；仅在 `LOCAL_IMAGE=true` 时生效。Docker：`/data/images`。 |
 
-零配置即可使用：默认走 MediaWiki + 缓存。若需离线全量体验，设置 `LOCAL_IMAGE=true`（触发 ~1.5 GB 后台同步）。
+零配置即可使用：默认走 MediaWiki + 缓存。若需离线全量体验，设置 `LOCAL_IMAGE=true`（触发 ~1.5 GB 后台同步）。完整环境变量清单见[环境变量参考](docs/user/environment-variables.md)。
 
 ### 快速开始
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -134,7 +134,7 @@ PRTS-MCP/
 │   │       ├── building.ts / artworkFormat.ts / artworkLocal.ts / artworkMediawiki.ts / images.ts
 │   │       ├── stores.ts / sync.ts
 │   │       └── ...
-│   │   └── sync/           # GitHub Release 传输+发现（数据同步 HTTP 归此层）
+│   │   └── sync/           # GitHub Release 传输+发现+激活（数据同步 HTTP 归此层）
 │   ├── tests/              # node --test 测试
 │   ├── package.json
 │   └── CHANGELOG.md
@@ -161,9 +161,9 @@ PRTS-MCP/
 
 | 数据源 | 用途 | 同步方式 |
 |--------|------|----------|
-| [arknights-data-pipeline](https://github.com/3aKHP/arknights-data-pipeline) | 干员/敌人/关卡/物品表格 | GitHub Release `zh_CN-excel.zip` |
-| [arknights-data-pipeline](https://github.com/3aKHP/arknights-data-pipeline) | 关卡实际出怪与关卡级敌人数值 | GitHub Release `zh_CN-levels.zip` |
-| [arknights-data-pipeline](https://github.com/3aKHP/arknights-data-pipeline) | 剧情台词 + LLM 摘要 | GitHub Release `zh_CN.zip` |
+| [arknights-data-pipeline](https://github.com/3aKHP/arknights-data-pipeline) | 干员/敌人/关卡/物品表格 | GitHub Release `zh_CN-excel.zip`（→ `gamedata` volume） |
+| [arknights-data-pipeline](https://github.com/3aKHP/arknights-data-pipeline) | 关卡实际出怪与关卡级敌人数值 | GitHub Release `zh_CN-levels.zip`（→ `gamedata-levels` volume） |
+| [arknights-data-pipeline](https://github.com/3aKHP/arknights-data-pipeline) | 剧情台词 + LLM 摘要 | GitHub Release `zh_CN.zip`（→ `storyjson` volume） |
 | [PRTS Wiki API](https://prts.wiki/api.php) | 世界观词条/阵营设定 | 实时 HTTP 请求 |
 
 ## 工具清单 (24, 2.x 发布线)

--- a/docs/user/environment-variables.md
+++ b/docs/user/environment-variables.md
@@ -24,7 +24,7 @@
 | `GITHUB_TOKEN` | 空 | 双实现 | 提高 GitHub API 限额，降低 Release 检查被限流的风险 |
 | `GITHUB_MIRRORS` | 空 | 双实现 | 逗号分隔的 ghproxy 风格代理前缀列表（如 `https://ghproxy.net`），直连失败后依次尝试；首尾空白与尾部斜杠自动归一化 |
 | `PRTS_AUTO_SYNC_INTERVAL_SECONDS` | `3600` | 双实现 | GitHub Release 周期检查间隔（秒）；有效范围 `60..604800`（7 天），`0` 表示只执行启动同步；非法值回落默认值 |
-| `HTTP_PROXY` / `HTTPS_PROXY` | 未设置 | 双实现 | 同步与 Wiki 请求的 HTTP 代理。TS 侧显式读取；Python 侧由 httpx 默认 `trust_env` 隐式支持（含 `NO_PROXY`） |
+| `HTTP_PROXY` / `HTTPS_PROXY` | 未设置 | 双实现 | 同步与 Wiki 请求的 HTTP 代理（大小写形式均支持，`NO_PROXY` 排除列表两实现均生效）。TS 侧由 sync 传输显式读取；Python 侧由 httpx 默认 `trust_env` 隐式支持 |
 
 ## 立绘（`operator_artwork`）
 
@@ -39,10 +39,10 @@
 
 | 变量 | 默认值 | 实现 | 说明 |
 |------|--------|------|------|
-| `PRTS_OUTPUT_CHANNEL` | `content` | 双实现 | 结构化输出通道：`content`（默认，与 1.x 行为一致）/ `structured` / `both`；非法值回退 `content`。TS 另支持查询字符串 `?output_channel=` 与请求头 `x-prts-output-channel` 按连接覆盖 |
+| `PRTS_OUTPUT_CHANNEL` | `content` | 双实现 | 结构化输出通道：`content`（默认，与 1.x 行为一致）/ `structured` / `both`；非法值回退 `content`。TS 另支持查询字符串 `?output_channel=` 与请求头 `x-prts-output-channel` 覆盖 |
 | `PRTS_TRANSPORT` | `stdio` | 仅 Python | 传输选择：`stdio`（默认）/ `http`。TS 无此变量，经 bin 选择（`prts-mcp-ts`[-bun] = HTTP，`prts-mcp-ts-stdio` = stdio） |
 | `HOST` | `0.0.0.0` | 双实现 | HTTP 模式监听地址 |
-| `PORT` | `3000` | 双实现 | HTTP 模式监听端口；非数字值报错退出。HTTP 端点为 `/mcp`，探活为 `/health` |
+| `PORT` | `3000` | 双实现 | HTTP 模式监听端口；非法值导致启动失败。HTTP 端点为 `/mcp`，探活为 `/health` |
 
 ## 诊断端点
 
@@ -61,4 +61,4 @@
 | `PRTS_BENCH_ISOLATED` | TS 内存 bench 的隔离确认开关（`bench:memory`） |
 | `PRTS_BENCH_ORIGIN` | bench 目标地址，仅接受 loopback |
 | `PRTS_BENCH_MAX_RSS_BYTES` / `PRTS_BENCH_MAX_RSS_GROWTH_BYTES` | bench 的 RSS 上限与相对增长上限 |
-| `E2E_PRTS_API` | E2E 测试覆盖 PRTS API 基址 |
+| `E2E_PRTS_API` | E2E 测试 opt-in 开关：设为 `1` 时启用依赖真实 PRTS API 的网络用例（不是 URL 基址覆盖） |

--- a/docs/user/environment-variables.md
+++ b/docs/user/environment-variables.md
@@ -1,0 +1,64 @@
+# 环境变量参考
+
+本文档是 PRTS-MCP 双实现（Python / TypeScript）环境变量的**单一来源**。各 README 与部署指南只保留常用项快表并链接到此页；新增或修改变量时请先更新本页。
+
+- "实现"列标注变量在哪些实现中生效：**双实现** / **仅 Python** / **仅 TS**。
+- 布尔变量的合法真值为 `1` / `true` / `yes` / `on`（大小写不敏感），其余值视为假；未设置时取默认值。两实现解析规则一致。
+- 标注"HTTP 模式"的变量仅在以 Streamable HTTP 运行时生效（Python：`PRTS_TRANSPORT=http`；TS：`prts-mcp-ts` / `prts-mcp-ts-bun` bin）。
+
+## 数据路径
+
+| 变量 | 默认值 | 实现 | 说明 |
+|------|--------|------|------|
+| `GAMEDATA_PATH` | 未设置 | 双实现 | 指向自定义游戏数据目录。**设置后 GameData excel/levels 的 auto-sync 被禁用**。若指向完整 ArknightsGameData 仓库根目录，其内 `zh_CN/gamedata/levels` 直接用作关卡战斗数据；否则在相邻目录维护 `gamedata-levels` |
+| `STORYJSON_PATH` | 未设置 | 双实现 | 指向本地 `zh_CN.zip`（剧情数据）。**设置后剧情 auto-sync 被禁用** |
+| `XDG_DATA_HOME` | `~/.local/share` | 双实现 | Linux/macOS 的默认数据根；非 Docker 安装时 gamedata、storyjson、images 依次落在 `$XDG_DATA_HOME/prts-mcp/` 下 |
+| `LOCALAPPDATA` | `~/AppData/Local` | 双实现 | Windows 的默认数据根，作用同上（`%LOCALAPPDATA%\prts-mcp\`） |
+| `PRTS_MCP_ROOT` | 镜像内置 `/app` | 双实现 | 标识 Docker 环境，使默认路径切到固定卷挂载点（`/data/gamedata` 等）。**不要在容器外设置** |
+| `PRTS_IMAGE_DIR` | `/data/images`（Docker）/ 数据根下 `images/` | 双实现 | AKDP 立绘资产同步目标；仅 `LOCAL_IMAGE=true` 时生效 |
+
+## 数据同步
+
+| 变量 | 默认值 | 实现 | 说明 |
+|------|--------|------|------|
+| `GITHUB_TOKEN` | 空 | 双实现 | 提高 GitHub API 限额，降低 Release 检查被限流的风险 |
+| `GITHUB_MIRRORS` | 空 | 双实现 | 逗号分隔的 ghproxy 风格代理前缀列表（如 `https://ghproxy.net`），直连失败后依次尝试；首尾空白与尾部斜杠自动归一化 |
+| `PRTS_AUTO_SYNC_INTERVAL_SECONDS` | `3600` | 双实现 | GitHub Release 周期检查间隔（秒）；有效范围 `60..604800`（7 天），`0` 表示只执行启动同步；非法值回落默认值 |
+| `HTTP_PROXY` / `HTTPS_PROXY` | 未设置 | 双实现 | 同步与 Wiki 请求的 HTTP 代理。TS 侧显式读取；Python 侧由 httpx 默认 `trust_env` 隐式支持（含 `NO_PROXY`） |
+
+## 立绘（`operator_artwork`）
+
+| 变量 | 默认值 | 实现 | 说明 |
+|------|--------|------|------|
+| `IMAGES_ENABLED` | `true` | 双实现 | 立绘工具主开关；`false` 时不注册 `operator_artwork`（工具面 24 → 23） |
+| `LOCAL_IMAGE` | `false` | 双实现 | `true` = 同步 AKDP 本地 PNG 资产（~1.5 GB，需挂载/预留 `PRTS_IMAGE_DIR`）；`false` = 从 PRTS MediaWiki 按需获取（零下载） |
+| `ORIGINAL_IMAGE` | `false` | 双实现 | 额外同步原图分辨率分片（总量 ~3 GB）；仅 `LOCAL_IMAGE=true` 时生效 |
+| `PRTS_IMAGE_CACHE` | `true` | 双实现 | MediaWiki 图片的内存 LRU 缓存（256 MiB）；仅 `LOCAL_IMAGE=false` 时生效 |
+
+## 输出与传输
+
+| 变量 | 默认值 | 实现 | 说明 |
+|------|--------|------|------|
+| `PRTS_OUTPUT_CHANNEL` | `content` | 双实现 | 结构化输出通道：`content`（默认，与 1.x 行为一致）/ `structured` / `both`；非法值回退 `content`。TS 另支持查询字符串 `?output_channel=` 与请求头 `x-prts-output-channel` 按连接覆盖 |
+| `PRTS_TRANSPORT` | `stdio` | 仅 Python | 传输选择：`stdio`（默认）/ `http`。TS 无此变量，经 bin 选择（`prts-mcp-ts`[-bun] = HTTP，`prts-mcp-ts-stdio` = stdio） |
+| `HOST` | `0.0.0.0` | 双实现 | HTTP 模式监听地址 |
+| `PORT` | `3000` | 双实现 | HTTP 模式监听端口；非数字值报错退出。HTTP 端点为 `/mcp`，探活为 `/health` |
+
+## 诊断端点
+
+| 变量 | 默认值 | 实现 | 说明 |
+|------|--------|------|------|
+| `PRTS_DEBUG_TOKEN` | 未设置 | 双实现 | `/debug/cache`（及 TS 的 `/debug/metrics`）的必需 Bearer 令牌；未设置或不匹配时返回 404（等于默认关闭）。不要公开反代这些路径，也不要把令牌写入日志或客户端配置 |
+| `PRTS_METRICS_ENABLED` | `false` | 仅 TS | 设为严格的 `true` 才启用 `/debug/metrics`；响应只含聚合指标，不含 MCP 参数、结果或会话 ID |
+| `SESSION_IDLE_TIMEOUT_MS` | `86400000`（24h） | 仅 TS | HTTP 会话空闲超时（毫秒）；非法值或 ≤0 表示禁用空闲清理 |
+
+## 附录：非运行时变量（bench / 测试）
+
+以下变量不属于运行时配置，仅供本机隔离环境使用，**不得用于生产服务**：
+
+| 变量 | 用途 |
+|------|------|
+| `PRTS_BENCH_ISOLATED` | TS 内存 bench 的隔离确认开关（`bench:memory`） |
+| `PRTS_BENCH_ORIGIN` | bench 目标地址，仅接受 loopback |
+| `PRTS_BENCH_MAX_RSS_BYTES` / `PRTS_BENCH_MAX_RSS_GROWTH_BYTES` | bench 的 RSS 上限与相对增长上限 |
+| `E2E_PRTS_API` | E2E 测试覆盖 PRTS API 基址 |

--- a/python/README.md
+++ b/python/README.md
@@ -76,4 +76,5 @@ GAMEDATA_PATH=/path/to/ArknightsGameData prts-mcp
 
 ## 详细文档
 
-→ [docs/deployment.md](docs/deployment.md)：完整部署方式、MCP 客户端配置、环境变量参考
+→ [docs/deployment.md](docs/deployment.md)：完整部署方式、MCP 客户端配置
+→ [环境变量参考](../docs/user/environment-variables.md)：双实现全部环境变量的单一来源

--- a/python/docs/deployment.md
+++ b/python/docs/deployment.md
@@ -182,7 +182,11 @@ docker run -i --rm `
         "read_story",
         "read_activity",
         "search",
-        "search_stories"
+        "search_stories",
+        "get_operator_memoirs",
+        "find_character_appearances",
+        "find_speakers_in",
+        "operator_artwork"
     ]
 }
 ```

--- a/python/docs/deployment.md
+++ b/python/docs/deployment.md
@@ -298,16 +298,17 @@ Remove-Item "$env:LOCALAPPDATA\prts-mcp\gamedata-levels\archives\extract_meta.js
 
 ## 环境变量参考
 
+完整清单与语义以 [docs/user/environment-variables.md](../../docs/user/environment-variables.md) 为单一来源（双实现共用）。Docker 部署最常用：
+
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
-| `GAMEDATA_PATH` | 未设置（使用 `/data/gamedata`） | 设置后指向自定义游戏数据目录，**GameData excel/levels auto-sync 被禁用**；若该路径是完整 ArknightsGameData 仓库根目录，`zh_CN/gamedata/levels` 会直接用于关卡战斗数据 |
-| `STORYJSON_PATH` | 未设置（使用 `/data/storyjson/zh_CN.zip`） | 设置后指向本地 `zh_CN.zip`，**剧情 auto-sync 被禁用** |
-| `GITHUB_TOKEN` | 空 | 用于提高 GitHub API 限额，降低限流风险 |
-| `GITHUB_MIRRORS` | 空 | 逗号分隔的 ghproxy 风格代理前缀列表（如 `https://ghproxy.net`），依次在直连失败后尝试；首尾空白与尾部斜杠自动归一化；适用于 GitHub 被 GFW 封锁的服务器 |
-| `PRTS_AUTO_SYNC_INTERVAL_SECONDS` | `3600` | GitHub Release 周期检查间隔（秒）；有效范围 `60..604800`，`0` 表示只执行启动同步；非法值回落到默认值 |
-| `IMAGES_ENABLED` | `true` | 立绘工具主开关；`false` 隐藏 `operator_artwork` |
-| `LOCAL_IMAGE` | `false` | `true` = 同步 AKDP 本地 PNG 资产（~1.5 GB，需挂载 `/data/images` 卷）；`false` = 从 PRTS MediaWiki 按需获取（零下载） |
-| `ORIGINAL_IMAGE` | `false` | 额外同步原图分辨率分片（总量 ~3 GB）；仅在 `LOCAL_IMAGE=true` 时生效 |
-| `PRTS_IMAGE_CACHE` | `true` | MediaWiki 图片的内存 LRU 缓存（256 MiB）；仅在 `LOCAL_IMAGE=false` 时生效 |
-| `PRTS_IMAGE_DIR` | `/data/images`（Docker） | AKDP 资产同步目标；仅在 `LOCAL_IMAGE=true` 时生效 |
-| `PRTS_MCP_ROOT` | `/app`（Docker 内） | 标识 Docker 环境，供 config.py 选择正确的默认路径 |
+| `GAMEDATA_PATH` | 未设置 | 自有 gamedata 目录；**设置后 GameData excel/levels auto-sync 被禁用** |
+| `STORYJSON_PATH` | 未设置 | 本地剧情 `zh_CN.zip`；**设置后剧情 auto-sync 被禁用** |
+| `PRTS_TRANSPORT` | `stdio` | `http` = Streamable HTTP 模式（见上方「Streamable HTTP 模式」） |
+| `HOST` / `PORT` | `0.0.0.0` / `3000` | HTTP 模式监听地址与端口 |
+| `GITHUB_TOKEN` | 空 | 提高 GitHub API 限额，降低限流风险 |
+| `GITHUB_MIRRORS` | 空 | 代理前缀列表，直连失败后依次尝试 |
+| `PRTS_AUTO_SYNC_INTERVAL_SECONDS` | `3600` | Release 周期检查间隔（秒）；`0` 表示只执行启动同步 |
+| `IMAGES_ENABLED` | `true` | `false` 隐藏 `operator_artwork` |
+| `LOCAL_IMAGE` | `false` | `true` = 同步 AKDP 本地立绘资产（~1.5 GB，需 images 卷） |
+| `ORIGINAL_IMAGE` | `false` | 额外同步原图分辨率分片（~3 GB）；仅 `LOCAL_IMAGE=true` 时生效 |

--- a/python/docs/deployment.md
+++ b/python/docs/deployment.md
@@ -34,6 +34,25 @@ Named volume 由 Docker 自动管理，无需关心宿主机路径，**在所有
 
 > 如需降低 GitHub 匿名 API 限流风险，可追加 `-e GITHUB_TOKEN=ghp_xxx`。
 
+### Streamable HTTP 模式（作为 HTTP 服务部署）
+
+以上方式均为默认的 stdio 传输（MCP 客户端直接拉起容器进程）。如需作为独立 HTTP 服务长期运行、供远程 MCP 客户端接入，设置 `PRTS_TRANSPORT=http` 并发布端口：
+
+```bash
+docker run -d --name prts-mcp \
+  -p 3000:3000 \
+  -v prts-mcp-data:/data/gamedata \
+  -v prts-mcp-levels:/data/gamedata-levels \
+  -v prts-mcp-storyjson:/data/storyjson \
+  -e PRTS_TRANSPORT=http \
+  prts-mcp
+```
+
+- HTTP 端点为 `http://<host>:3000/mcp`，探活端点为 `/health`；监听地址与端口可用 `HOST` / `PORT` 调整（默认 `0.0.0.0:3000`）。
+- HTTP 模式不需要 `-i`（无 stdio 交互），用 `-d` 常驻；数据卷挂法与 stdio 模式完全一致。
+- 非 Docker 运行同样适用：`PRTS_TRANSPORT=http prts-mcp`。
+- 诊断端点 `/debug/cache` 需要 `PRTS_DEBUG_TOKEN` 的 Bearer 令牌，未设置时恒返回 404（等于默认关闭）；不要公开反代该路径。完整变量说明见[环境变量参考](../../docs/user/environment-variables.md)。
+
 ### 本地全量立绘模式（LOCAL_IMAGE=true）
 
 默认的 MediaWiki 按需模式不需要 images 卷。如需使用 AKDP 本地全量立绘资产（~1.5 GB），追加 images 卷和相关环境变量：
@@ -227,6 +246,12 @@ npx @modelcontextprotocol/inspector docker run -i --rm -v prts-mcp-data:/data/ga
 | `search` | `scope`: `operators`, `pattern`: `阿米娅` | 干员数据 |
 | `search_stories` | `pattern`: `博士`, `event_id`: `act31side` | 剧情数据 |
 | `operator_artwork` | `operator_name`: `阿米娅`, `action`: `list` | 网络 |
+
+Streamable HTTP 模式下可先做一次不依赖 MCP 客户端的探活：
+
+```bash
+curl -s http://127.0.0.1:3000/health   # 期望返回 {"status":"ok"}
+```
 
 ---
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -137,7 +137,7 @@ docker run -d -p 3000:3000 -v prts-mcp-ts-data:/data/gamedata -v prts-mcp-ts-lev
 - **关卡战斗数据**（`/data/gamedata-levels` volume）：从同一 Release 下载 `zh_CN-levels.zip`，用于关卡实际出怪和关卡级敌人数值
 - **剧情数据**（`/data/storyjson` volume）：从同一 Release 下载 `zh_CN.zip`（含剧情 JSON 和 LLM 摘要）
 
-立绘图片默认走 PRTS MediaWiki 按需获取（零下载）。设置 `LOCAL_IMAGE=true` 时额外同步 AKDP 本地 PNG 资产到 `/data/images`（~1.5 GB）；环境变量详见 `python/docs/deployment.md`。
+立绘图片默认走 PRTS MediaWiki 按需获取（零下载）。设置 `LOCAL_IMAGE=true` 时额外同步 AKDP 本地 PNG 资产到 `/data/images`（~1.5 GB）；环境变量详见 [环境变量参考](../docs/user/environment-variables.md)。
 
 镜像内置 bundled 数据作为网络不可用时的离线保底。
 
@@ -151,19 +151,19 @@ docker run -d -p 3000:3000 -v prts-mcp-ts-data:/data/gamedata -v prts-mcp-ts-lev
 
 ## 环境变量
 
+常用项快表；完整清单与语义以 [docs/user/environment-variables.md](../docs/user/environment-variables.md) 为单一来源。
+
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
-| `PORT` | `3000` | 监听端口 |
-| `HOST` | `0.0.0.0` | 监听地址 |
-| `GAMEDATA_PATH` | 未设置 | 设置后指向自定义游戏数据目录，**GameData excel/levels auto-sync 被禁用**；若该路径是完整 ArknightsGameData 仓库根目录，`zh_CN/gamedata/levels` 会直接用于关卡战斗数据 |
-| `STORYJSON_PATH` | 未设置 | 设置后指向本地 `zh_CN.zip`，**剧情 auto-sync 被禁用** |
-| `GITHUB_TOKEN` | 空 | 用于提高 GitHub API 限额，降低限流风险 |
-| `GITHUB_MIRRORS` | 空 | 逗号分隔的 ghproxy 风格代理前缀列表（如 `https://ghproxy.net`），依次在直连失败后尝试；首尾空白与尾部斜杠自动归一化 |
-| `PRTS_AUTO_SYNC_INTERVAL_SECONDS` | `3600` | GitHub Release 周期检查间隔（秒）；有效范围 `60..604800`，`0` 表示只执行启动同步；非法值回落到默认值 |
-| `PRTS_OUTPUT_CHANNEL` | `content` | 2.0 输出通道：`content`（默认，仅 markdown，与 1.x 一致）/ `structured`（仅 structuredContent）/ `both`。也可经查询字符串 `?output_channel=` 或请求头 `x-prts-output-channel` 按请求覆盖。仅在客户端确认支持 `structuredContent` 时才用非默认值 |
-| `SESSION_IDLE_TIMEOUT_MS` | `86400000` | Streamable HTTP 会话空闲超时（毫秒）。设为非正数时禁用超时；会话活跃时间、有效值与淘汰计数可由已启用的 `/debug/metrics` 读取。`closed_total` 包含被空闲淘汰而关闭的会话，`evicted_total` 是其中的原因子集。 |
-| `PRTS_METRICS_ENABLED` | `false` | 设为严格的 `true` 才启用 `/debug/metrics`；仍需有效的 `PRTS_DEBUG_TOKEN` Bearer 请求头。响应只含进程、缓存、请求、工具和会话的聚合指标，不含 MCP 参数、结果或会话 ID。工具维度只接受内置工具名，避免把调用方输入变成指标标签。 |
-| `PRTS_DEBUG_TOKEN` | 未设置 | `/debug/cache` 和 `/debug/metrics` 的必需 Bearer token；未设置或不匹配时返回 404。不要公开反向代理这两个路径，也不要把 token 写入日志、请求正文或客户端配置。 |
+| `PORT` / `HOST` | `3000` / `0.0.0.0` | HTTP 模式监听端口与地址 |
+| `GAMEDATA_PATH` | 未设置 | 指向自定义游戏数据目录，**GameData excel/levels auto-sync 被禁用** |
+| `STORYJSON_PATH` | 未设置 | 指向本地 `zh_CN.zip`，**剧情 auto-sync 被禁用** |
+| `GITHUB_TOKEN` / `GITHUB_MIRRORS` | 空 | GitHub API 限额 / 代理前缀列表 |
+| `PRTS_AUTO_SYNC_INTERVAL_SECONDS` | `3600` | Release 周期检查间隔（秒）；`0` 表示只执行启动同步 |
+| `PRTS_OUTPUT_CHANNEL` | `content` | 2.0 输出通道；也可经查询字符串 `?output_channel=` 或请求头 `x-prts-output-channel` 按请求覆盖 |
+| `PRTS_DEBUG_TOKEN` | 未设置 | `/debug/cache` 和 `/debug/metrics` 的必需 Bearer token；未设置或不匹配时返回 404。不要公开反代这两个路径 |
+| `PRTS_METRICS_ENABLED` | `false` | 设为严格的 `true` 才启用 `/debug/metrics`（仅 TS）；仍需有效 token |
+| `SESSION_IDLE_TIMEOUT_MS` | `86400000` | HTTP 会话空闲超时（毫秒，仅 TS）；非正数禁用 |
 
 需要验证重复负载与并发会话时，只能在隔离的本机实例上执行 `PRTS_BENCH_ISOLATED=true PRTS_BENCH_ORIGIN=http://127.0.0.1:<port> PRTS_DEBUG_TOKEN=... npm run bench:memory`。脚本要求指标端点、有效诊断 token 和可读剧情/本地图片数据均已启用：它会先发现一个活动、章节和阿米娅立绘，然后以 **6 个并发会话** 执行档案、基础资料、数据搜索、剧情搜索、单章、活动分页和实际图片 get。除重复负载不能新增 cache miss 外，它还要求并发后至少 7 个会话仍在、请求已静止、RSS 不超过 1 GiB、相对冷缓存增长不超过 256 MiB（可用 `PRTS_BENCH_MAX_RSS_BYTES` / `PRTS_BENCH_MAX_RSS_GROWTH_BYTES` 调整）。它拒绝非 loopback 目标，不得在生产正式服务执行。
 

--- a/ts/README.md
+++ b/ts/README.md
@@ -160,7 +160,7 @@ docker run -d -p 3000:3000 -v prts-mcp-ts-data:/data/gamedata -v prts-mcp-ts-lev
 | `STORYJSON_PATH` | 未设置 | 指向本地 `zh_CN.zip`，**剧情 auto-sync 被禁用** |
 | `GITHUB_TOKEN` / `GITHUB_MIRRORS` | 空 | GitHub API 限额 / 代理前缀列表 |
 | `PRTS_AUTO_SYNC_INTERVAL_SECONDS` | `3600` | Release 周期检查间隔（秒）；`0` 表示只执行启动同步 |
-| `PRTS_OUTPUT_CHANNEL` | `content` | 2.0 输出通道；也可经查询字符串 `?output_channel=` 或请求头 `x-prts-output-channel` 按请求覆盖 |
+| `PRTS_OUTPUT_CHANNEL` | `content` | 2.0 输出通道；也可经查询字符串 `?output_channel=` 或请求头 `x-prts-output-channel` 覆盖 |
 | `PRTS_DEBUG_TOKEN` | 未设置 | `/debug/cache` 和 `/debug/metrics` 的必需 Bearer token；未设置或不匹配时返回 404。不要公开反代这两个路径 |
 | `PRTS_METRICS_ENABLED` | `false` | 设为严格的 `true` 才启用 `/debug/metrics`（仅 TS）；仍需有效 token |
 | `SESSION_IDLE_TIMEOUT_MS` | `86400000` | HTTP 会话空闲超时（毫秒，仅 TS）；非正数禁用 |


### PR DESCRIPTION
## Summary

- **新建 `docs/user/environment-variables.md`**：双实现环境变量单一来源（共享 17 + 仅 Python 1 + 仅 TS 3 + bench/test 附录 5），每个变量的默认值与语义逐项对照 `python/src` / `ts/src` 源码核实；此前 `XDG_DATA_HOME` / `LOCALAPPDATA` / `SESSION_IDLE_TIMEOUT_MS` 等在任何 README 均未记录
- **`python/docs/deployment.md` 补 Streamable HTTP 部署章**（原 B6 遗留）：`PRTS_TRANSPORT=http`、`HOST`/`PORT`、`/mcp` 端点、`/health` 探活、`PRTS_DEBUG_TOKEN` 门控的 `/debug/cache`；docker daemon 与非 Docker 两种示例；「验证」节补 curl 探活
- **三处既有 env 表降级为常用快表 + 链接全局文档**（deployment.md、ts/README、python/README），消除三处各自残缺漂移的维护模式；顺带修正 ts/README 立绘段原指向 Python 部署文档的错误链接
- **deployment.md `alwaysAllow` 示例补齐到 24 工具**（+`get_operator_memoirs` / `find_character_appearances` / `find_speakers_in` / `operator_artwork`）
- **STATUS.md**：TS `sync/` 树注释加"激活"（修 #182 引入的 PY/TS 不对称）；数据源表三行标注目标 docker volume

## Test plan

文档类改动，按验证矩阵最小集执行：

- 环境变量清单为源码穷举：`rg` 提取 `python/src` 与 `ts/src` 全部 env 读取点（`os.environ` / `process.env` / 字面量三模式），默认值与解析语义对照 `config.py` / `config.ts` / `server.py` / `server.ts` / `output.py` / `startup_sync.py` 逐条核实
- 新增 3 处相对链接（→ `docs/user/environment-variables.md`）已实测可解析
- CLAUDE.md stale-term 扫描（工具名 / transport / 数据源 / env 词汇）无过期命中
- 完整 diff 逐行自查，无代码改动；CI 走 docs-only 路径

## 未尽事宜

- KHPilot 在 #182 的 NIT 3（STATUS 树状图恢复一行一模块）经评估**不做**：斜杠合并行是该节改动前就有的排版风格，一行一模块会放大未来 diff 噪音；已获维护者认可
- ts/README 快表删去的 metrics 细节（`closed_total`/`evicted_total`、指标标签安全性）要点已保留在全局文档对应行
- python/CHANGELOG 两处历史条目（0.2.1 日期倒挂、2.5.2 误入 npm 条目）按维护者决定保持原样