### PR TITLE
docs(lts): 1.7 LTS lifecycle policy (EOL 2027-07-02) + gitignore backport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,9 @@ data/gamedata/**/*.7z
 data/gamedata-levels/archives/
 data/gamedata-levels/**/*.zip
 data/gamedata-levels/**/*.7z
+.release.lock/
+
+# Runtime sync artifacts
+data/*/.releases/
+data/*/release_meta.json
+data/*/zh_CN*.zip

--- a/docs/dev/LTS.md
+++ b/docs/dev/LTS.md
@@ -35,6 +35,18 @@ Not allowed in `1.7.x`:
 
 Do not push directly to any long-lived branch. Use PRs.
 
+## Lifecycle
+
+The `lts/1.7` line is maintained for **12 months from the 1.7.0 baseline** (released 2026-07-02): end of life is **2027-07-02**.
+
+Until EOL, 1.7.x receives the fixes listed in [Scope](#scope). After EOL:
+
+- No further 1.7.x releases. The `lts/1.7` branch and all `python/v1.7.*` / `ts/v1.7.*` tags remain available read-only and are not deleted.
+- The AKDP projection workflows in `3aKHP/ArknightsGameData` and `3aKHP/ArknightsStoryJson` are stopped. 1.7 clients keep working with the last published data but no longer receive game-data updates.
+- Users still on 1.x should follow [the 1.x → 2.0 migration guide](https://github.com/3aKHP/prts-mcp/blob/main/docs/migration-1.x-to-2.0.md) (maintained on the current release line).
+
+**Data-source note:** 1.7 auto-sync reads the `3aKHP/ArknightsGameData` / `3aKHP/ArknightsStoryJson` forks via `/releases/latest`. These forks no longer track the original upstreams; their releases are projections of `3aKHP/arknights-data-pipeline` factory output, produced by each fork's own `sync-and-release.yml` workflow. Until EOL these forks must **not** be archived — archiving makes a repository read-only, which blocks new projection releases and would freeze 1.7 data.
+
 ## 1.7.x Fix Flow
 
 1. Branch from `lts/1.7` with `fix/v1.7.x-<topic>` or `docs/v1.7.x-<topic>`.


### PR DESCRIPTION
## Summary

- `docs/dev/LTS.md` 新增 Lifecycle 一节：**1.7 LTS 维护期 12 个月，EOL 2027-07-02**（1.7.0 基线 2026-07-02）。此前全仓无任何 EOL 口径
- 写明 EOL 后机制：不再发 1.7.x；`lts/1.7` 分支与 `python/v1.7.*` / `ts/v1.7.*` tags 保留只读不删；fork 投影 workflow 停止，1.7 客户端以最后数据继续可用
- 首次书面记录 1.7 数据源的真实机制：fork 仓（3aKHP/ArknightsGameData / ArknightsStoryJson）的 Release 是工厂仓（arknights-data-pipeline）`data-*` Release 的投影，由各 fork 自身的 `sync-and-release.yml` 每天两班产生；并明确 **EOL 前两个 fork 不得 archive**
- 迁移指南链接指向 `main` 的绝对 URL（`lts/1.7` 上不存在 `migration-1.x-to-2.0.md`）
- `.gitignore` backport develop 的 4 条运行时产物规则（`data/storyjson/zh_CN.zip`、`.release.lock/` 等在 lts/1.7 上此前不被忽略，已有过一次误提交事故并修复）

## Test plan

- 纯 docs + gitignore；`git check-ignore` 验证两条新增规则覆盖本次事故文件
- 链接：迁移指南为绝对 URL（本分支无此文件）；其余无新增相对链接

## 未尽事宜

- 本 PR 不含代码变更，**不发 1.7.2 release tag**（路径 B 打 tag 步骤针对代码修复）
- 维护者已人工审查，本轮免双轨 CR；merge 后另开 develop 同步 PR（develop 的 LTS.md 为较新版本，Lifecycle 节适配移植）