### PR TITLE
feat(sync): discover datarev revision releases with tuple ordering

### DIFF
--- a/.github/scripts/data-tag-selector.jq
+++ b/.github/scripts/data-tag-selector.jq
@@ -1,0 +1,5 @@
+# Newest data release tag across the data-/datarev- namespaces, ordered by the
+# (versionId, publicationRevision) tuple — mirrors the sync layer's
+# latest_data_release (ts/src/sync/releaseDiscovery.ts, python …/release_discovery.py).
+# All workflow sites must consume this file via: --jq "$(cat .github/scripts/data-tag-selector.jq)"
+[.[] | .tagName as $t | if ($t | test("^datarev-.+-r[0-9]+$")) then ($t | capture("^datarev-(?<vid>.+)-r(?<rev>[0-9]+)$")) as $m | {tagName: $t, vid: $m.vid, rev: ($m.rev | tonumber)} elif ($t | startswith("data-")) then {tagName: $t, vid: ($t | sub("^data-"; "")), rev: 1} else empty end] | max_by([.vid, .rev]) | .tagName

--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Download bundled storyjson zip
         run: |
           mkdir -p ts/data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq '[.[] | select(.tagName | startswith("data-"))] | max_by(.createdAt) | .tagName')
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Download storyjson zip for integration tests
         run: |
           mkdir -p .ci-data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq '[.[] | select(.tagName | startswith("data-"))] | max_by(.createdAt) | .tagName')
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
@@ -164,7 +164,7 @@ jobs:
       - name: Download bundled storyjson zip
         run: |
           mkdir -p data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq '[.[] | select(.tagName | startswith("data-"))] | max_by(.createdAt) | .tagName')
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Download storyjson zip for integration tests
         run: |
           mkdir -p .ci-data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq '[.[] | select(.tagName | startswith("data-"))] | max_by(.createdAt) | .tagName')
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
@@ -150,7 +150,7 @@ jobs:
       - name: Download bundled storyjson zip
         run: |
           mkdir -p data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq '[.[] | select(.tagName | startswith("data-"))] | max_by(.createdAt) | .tagName')
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
@@ -394,7 +394,7 @@ jobs:
       - name: Download bundled storyjson zip
         run: |
           mkdir -p data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq '[.[] | select(.tagName | startswith("data-"))] | max_by(.createdAt) | .tagName')
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
@@ -460,7 +460,7 @@ jobs:
       - name: Download bundled storyjson zip
         run: |
           mkdir -p data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq '[.[] | select(.tagName | startswith("data-"))] | max_by(.createdAt) | .tagName')
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \

--- a/docs/dev/LTS.md
+++ b/docs/dev/LTS.md
@@ -43,6 +43,8 @@ Until EOL, 1.7.x receives the fixes listed in [Scope](#scope). After EOL:
 
 **Data-source note:** 1.7 auto-sync reads the `3aKHP/ArknightsGameData` / `3aKHP/ArknightsStoryJson` forks via `/releases/latest`. These forks no longer track the original upstreams; their releases are projections of `3aKHP/arknights-data-pipeline` factory output, produced by each fork's own `sync-and-release.yml` workflow. Until EOL these forks must **not** be archived — archiving makes a repository read-only, which blocks new projection releases and would freeze 1.7 data.
 
+**Revision-release note:** from 2.8.0 the modern implementations additionally discover `datarev-<versionId>-r<N>` repair revisions directly from `3aKHP/arknights-data-pipeline` (ordered by `(versionId, publicationRevision)`). 1.7 never sees them: it follows `/releases/latest` on the projection forks, and `datarev-` releases are neither marked latest nor projected. Repair content reaches 1.7 only through the next normal `data-` release's projection.
+
 ## 1.7.x Fix Flow
 
 1. Branch from `lts/1.7` with `fix/v1.7.x-<topic>` or `docs/v1.7.x-<topic>`.

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Revision release discovery (`datarev-` namespace).** The data sync now understands the factory's immutable repair releases: `datarev-<versionId>-r<N>` tags are discovered alongside normal `data-<versionId>` releases and ordered by `(versionId, publicationRevision)` tuple instead of release creation time, so a repair revision outranks the release it fixes and a re-published older release can no longer win (rollback-by-republication protection; two releases claiming the same identity fail closed with a warning). Update decisions compare the same tuple over the stored release id — a bare `<versionId>` means revision 1 — while sentinel ids (`unknown`/`legacy`/`local-…`) keep the legacy string-equality semantics, and a refused downgrade reports the installed id. Manifest verification additionally requires `publicationRevision` on `datarev-` releases to match the tag. Stored metadata keeps the full tag suffix (`<versionId>-r<N>`), so the on-disk schemas and the cross-implementation meta interop are unchanged; 1.7-era deployments never see `datarev-` releases.
+
 ## [2.7.2] - 2026-08-22
 
 ### Fixed

--- a/python/src/prts_mcp/sync/release.py
+++ b/python/src/prts_mcp/sync/release.py
@@ -19,7 +19,9 @@ from prts_mcp.sync.release_activation import with_archive_activation_lock
 from prts_mcp.sync.primitives import atomic_write_json
 from prts_mcp.sync.release_discovery import (
     ReleaseSpec,
-    _TAG_PREFIX,
+    parse_data_tag,
+    parse_release_suffix,
+    tag_suffix,
     check_latest_release,
 )
 from prts_mcp.sync.transport import (
@@ -123,8 +125,8 @@ def download_release_asset(spec: ReleaseSpec, tag: str, url: str, timeout: float
             _verify_release_manifest(spec, tag, tmp, timeout=timeout)
         tmp.replace(spec.local_zip)
 
-        # Extract version identifier from tag (format: "data-<versionId>")
-        commit_sha = tag[len(_TAG_PREFIX):] if tag.startswith(_TAG_PREFIX) else tag
+        # Strip the namespace prefix: data-<vid> → <vid>, datarev-<vid>-rN → <vid>-rN
+        commit_sha = tag_suffix(tag)
         CacheMeta(
             repo=f"{spec.owner}/{spec.repo}",
             branch="releases",
@@ -176,13 +178,24 @@ def _verify_release_manifest(
         expected = manifest["assets"][spec.asset_name]
         expected_size = int(expected["size"])
         expected_sha = str(expected["sha256"])
-        expected_version = tag.removeprefix("data-")
+        parsed_tag = parse_data_tag(tag)
+        version_id, tag_revision = parsed_tag if parsed_tag else (None, None)
+        expected_version = version_id if version_id is not None else tag.removeprefix("data-")
         source = manifest.get("source", {})
         if not isinstance(source, dict):
             raise ValueError("manifest source must be an object")
         source_version = source.get("versionId")
-        if tag.startswith("data-") and source_version != expected_version:
+        if version_id is not None and source_version != expected_version:
             raise ValueError("manifest source version does not match release tag")
+        if tag_revision is not None and tag_revision > 1:
+            # datarev releases must declare their revision; a missing field
+            # means the manifest was not produced by the revision pipeline
+            revision = manifest.get("publicationRevision")
+            if revision != tag_revision:
+                raise ValueError(
+                    f"manifest publicationRevision {revision!r} does not "
+                    f"match tag revision {tag_revision}"
+                )
     except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
         raise ValueError(f"manifest for {tag} is invalid: {exc}") from exc
     actual_sha = hashlib.sha256(asset_path.read_bytes()).hexdigest()
@@ -192,6 +205,29 @@ def _verify_release_manifest(
             f"expected {expected_size}/{expected_sha}, "
             f"got {asset_path.stat().st_size}/{actual_sha}"
         )
+
+
+def _release_up_to_date(local_sha: str, upstream_sha: str) -> bool:
+    """Tuple-aware up-to-date decision over stored commit_sha values.
+
+    Both sides parse into (versionId, revision) → compare tuples: newer
+    upstream means stale, equal or older upstream means up to date (an older
+    upstream is refused loudly — rollback-by-republication protection).
+    Either side unparseable (sentinels like "unknown"/"legacy"/"local-…")
+    → plain string equality, preserving the legacy semantics.
+    """
+    local_version = parse_release_suffix(local_sha)
+    upstream_version = parse_release_suffix(upstream_sha)
+    if local_version is not None and upstream_version is not None:
+        if local_version < upstream_version:
+            return False
+        if local_version > upstream_version:
+            _logger.warning(
+                "upstream %s is not newer than installed %s; refusing downgrade",
+                upstream_sha, local_sha,
+            )
+        return True
+    return local_sha == upstream_sha
 
 
 def _sync_release_locked(spec: ReleaseSpec, *, force_check: bool = False) -> SyncResult:
@@ -250,9 +286,9 @@ def _sync_release_locked(spec: ReleaseSpec, *, force_check: bool = False) -> Syn
         return SyncResult(spec=_dummy_spec, status="no_data", commit_sha=None, error=error)
 
     tag, asset_url = result
-    upstream_sha = tag[len(_TAG_PREFIX):] if tag.startswith(_TAG_PREFIX) else tag
+    upstream_sha = tag_suffix(tag)
 
-    if cache is not None and cache.commit_sha == upstream_sha and zip_ok:
+    if cache is not None and zip_ok and _release_up_to_date(cache.commit_sha, upstream_sha):
         CacheMeta(
             repo=cache.repo,
             branch=cache.branch,
@@ -260,7 +296,9 @@ def _sync_release_locked(spec: ReleaseSpec, *, force_check: bool = False) -> Syn
             fetched_at=datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             files=cache.files,
         ).save(_release_cache_path(spec))
-        return SyncResult(spec=_dummy_spec, status="up_to_date", commit_sha=upstream_sha, error=None)
+        # report the *installed* sha: with tuple ordering this branch also
+        # covers refused downgrades, where upstream is older than installed
+        return SyncResult(spec=_dummy_spec, status="up_to_date", commit_sha=cache.commit_sha, error=None)
 
     try:
         download_release_asset(spec, tag, asset_url)

--- a/python/src/prts_mcp/sync/release_discovery.py
+++ b/python/src/prts_mcp/sync/release_discovery.py
@@ -9,6 +9,7 @@ filters by tag prefix instead. ``data/sync`` re-exports these and
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -18,6 +19,62 @@ from prts_mcp.sync.transport import get_cascading, github_headers
 _logger = logging.getLogger(__name__)
 
 _TAG_PREFIX = "data-"
+_DATAREV_TAG_PREFIX = "datarev-"
+
+#: a data versionId is fixed-width "YY-MM-DD-HH-MM-SS_hash", so lexicographic
+#: order is chronological order and (versionId, revision) tuples order
+#: without any date parsing
+_VID_RE = re.compile(r"^\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}_[0-9a-f]+$")
+_DATAREV_TAG_RE = re.compile(r"^datarev-(?P<vid>.+)-r(?P<rev>\d+)$")
+_DATAREV_SUFFIX_RE = re.compile(
+    r"^(?P<vid>\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}_[0-9a-f]+)-r(?P<rev>\d+)$"
+)
+
+
+def parse_data_tag(tag: str) -> tuple[str, int] | None:
+    """Parse a data release tag into ``(versionId, publicationRevision)``.
+
+    ``data-<versionId>`` is a normal release (revision 1);
+    ``datarev-<versionId>-r<N>`` is an immutable repair revision published
+    by the factory's manual SOP. Anything else (``images-*``, unknown tags)
+    is not a data release. Mirrors ``akdp.check.parse_release_tag``.
+    """
+    match = _DATAREV_TAG_RE.match(tag)
+    if match:
+        return match.group("vid"), int(match.group("rev"))
+    if tag.startswith(_TAG_PREFIX):
+        return tag[len(_TAG_PREFIX):], 1
+    return None
+
+
+def tag_suffix(tag: str) -> str:
+    """Strip the data/datarev namespace prefix from a release tag.
+
+    ``data-<vid>`` → ``<vid>``; ``datarev-<vid>-r<N>`` → ``<vid>-r<N>``.
+    The result is the canonical ``commit_sha`` value persisted in
+    release_meta/extract_meta/.gamedata_pair and shown in logs.
+    """
+    if tag.startswith(_DATAREV_TAG_PREFIX):
+        return tag[len(_DATAREV_TAG_PREFIX):]
+    if tag.startswith(_TAG_PREFIX):
+        return tag[len(_TAG_PREFIX):]
+    return tag
+
+
+def parse_release_suffix(suffix: str) -> tuple[str, int] | None:
+    """Parse a stored ``commit_sha`` (tag suffix) into ``(versionId, revision)``.
+
+    ``<vid>-r<N>`` (written for datarev releases) → ``(vid, N)``; a bare
+    versionId → ``(vid, 1)``. Sentinel values (``unknown``, ``legacy``,
+    ``local-<digest>``) and any future format return ``None`` so callers
+    fall back to plain string comparison.
+    """
+    match = _DATAREV_SUFFIX_RE.match(suffix)
+    if match:
+        return match.group("vid"), int(match.group("rev"))
+    if _VID_RE.match(suffix):
+        return suffix, 1
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -105,6 +162,37 @@ def latest_release_by_prefix(
     return candidates[0]
 
 
+def latest_data_release(releases: list[dict]) -> dict | None:
+    """Pick the newest data release across the ``data-``/``datarev-`` namespaces.
+
+    Orders by ``(versionId, publicationRevision)`` tuple instead of
+    ``created_at``, so a repair revision outranks the release it fixes and a
+    re-published older release can no longer win (rollback-by-republication).
+    Two releases claiming the same tuple is an upstream integrity violation:
+    log loudly and fail closed (returns None), mirroring the images pipeline's
+    duplicate-version rejection.
+    """
+    best: tuple[tuple[str, int], dict] | None = None
+    seen: set[tuple[str, int]] = set()
+    for release in releases:
+        tag = release.get("tag_name")
+        if not isinstance(tag, str):
+            continue
+        parsed = parse_data_tag(tag)
+        if parsed is None:
+            continue
+        if parsed in seen:
+            _logger.warning(
+                "duplicate data release identity (versionId=%s, revision=%d) "
+                "claimed by %r; failing closed", parsed[0], parsed[1], tag,
+            )
+            return None
+        seen.add(parsed)
+        if best is None or parsed > best[0]:
+            best = (parsed, release)
+    return best[1] if best is not None else None
+
+
 def asset_url(release: dict, asset_name: str) -> str | None:
     """Extract the ``browser_download_url`` for *asset_name* from a release dict."""
     for asset in release.get("assets", []):
@@ -128,19 +216,21 @@ class ReleaseSpec:
 
 
 def check_latest_release(spec: ReleaseSpec, timeout: float = 10.0) -> tuple[str, str] | None:
-    """Return ``(tag_name, asset_download_url)`` for the latest ``data-*`` release.
+    """Return ``(tag_name, asset_download_url)`` for the latest data release.
 
     Uses the releases list API with tag-prefix filtering instead of
     ``/releases/latest``, because the data-pipeline repo also hosts
-    ``images-*`` releases that may be promoted to "Latest" on GitHub.
-    Returns ``None`` on network failure or when no matching release/asset is found.
+    ``images-*`` releases that may be promoted to "Latest" on GitHub, and a
+    ``datarev-`` repair revision must outrank the ``data-`` release it fixes
+    even though it is never marked latest. Returns ``None`` on network
+    failure or when no matching release/asset is found.
     """
     releases = list_releases(spec.owner, spec.repo, timeout=timeout)
     if releases is None:
         return None
-    latest = latest_release_by_prefix(releases, _TAG_PREFIX)
+    latest = latest_data_release(releases)
     if latest is None:
-        _logger.debug("No release with prefix %s in %s/%s", _TAG_PREFIX, spec.owner, spec.repo)
+        _logger.debug("No data release found in %s/%s", spec.owner, spec.repo)
         return None
     tag = latest["tag_name"]
     url = asset_url(latest, spec.asset_name)

--- a/python/tests/test_sync_release.py
+++ b/python/tests/test_sync_release.py
@@ -1359,3 +1359,293 @@ class TestManifestAbsenceSemantics:
         ):
             with pytest.raises(ValueError, match="manifest unavailable"):
                 _verify_release_manifest(spec, "data-x", asset_path, timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# datarev revision discovery and activation (2.8.0)
+# ---------------------------------------------------------------------------
+
+_VID = "26-09-03-04-06-00_ed95a2"
+_VID2 = "26-10-01-11-22-33_aabbcc"
+
+
+def _mock_releases_response(releases: list[dict]) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = releases
+    return resp
+
+
+def _release_entry(tag: str, *, created: str = "2026-01-01T00:00:00Z",
+                   asset_name: str = "zh_CN.zip",
+                   url: str = "https://example/asset") -> dict:
+    return {
+        "tag_name": tag,
+        "created_at": created,
+        "assets": [{"name": asset_name, "browser_download_url": url}],
+    }
+
+
+class TestParseDataTag:
+    def test_matrix(self):
+        from prts_mcp.sync.release_discovery import parse_data_tag
+
+        assert parse_data_tag(f"data-{_VID}") == (_VID, 1)
+        assert parse_data_tag(f"datarev-{_VID}-r2") == (_VID, 2)
+        assert parse_data_tag(f"datarev-{_VID}-r10") == (_VID, 10)
+        assert parse_data_tag("images-v1") is None
+        assert parse_data_tag("datarev-x-r2-extra") is None
+        assert parse_data_tag("datarev-vid") is None
+
+
+class TestParseReleaseSuffixAndTagSuffix:
+    def test_matrix(self):
+        from prts_mcp.sync.release_discovery import parse_release_suffix, tag_suffix
+
+        assert parse_release_suffix(_VID) == (_VID, 1)
+        assert parse_release_suffix(f"{_VID}-r3") == (_VID, 3)
+        for sentinel in ("unknown", "legacy", "local-abc123", "manual"):
+            assert parse_release_suffix(sentinel) is None
+        assert parse_release_suffix("abc123") is None  # not a versionId shape
+        assert tag_suffix(f"data-{_VID}") == _VID
+        assert tag_suffix(f"datarev-{_VID}-r2") == f"{_VID}-r2"
+        assert tag_suffix("unknown") == "unknown"
+
+
+class TestLatestDataRelease:
+    def test_revision_outranks_normal_despite_created_at(self):
+        from prts_mcp.sync.release_discovery import latest_data_release
+
+        releases = [
+            _release_entry(f"data-{_VID}", created="2026-09-05T00:00:00Z"),
+            _release_entry(f"datarev-{_VID}-r2", created="2026-09-04T00:00:00Z"),
+        ]
+        assert latest_data_release(releases)["tag_name"] == f"datarev-{_VID}-r2"
+
+    def test_newer_version_outranks_older_revision(self):
+        from prts_mcp.sync.release_discovery import latest_data_release
+
+        releases = [
+            _release_entry(f"datarev-{_VID}-r9"),
+            _release_entry(f"data-{_VID2}"),
+        ]
+        assert latest_data_release(releases)["tag_name"] == f"data-{_VID2}"
+
+    def test_revision_compares_numerically(self):
+        from prts_mcp.sync.release_discovery import latest_data_release
+
+        releases = [
+            _release_entry(f"datarev-{_VID}-r2"),
+            _release_entry(f"datarev-{_VID}-r10"),
+        ]
+        assert latest_data_release(releases)["tag_name"] == f"datarev-{_VID}-r10"
+
+    def test_duplicate_tuple_fails_closed(self):
+        from prts_mcp.sync.release_discovery import latest_data_release
+
+        releases = [
+            _release_entry(f"data-{_VID}"),
+            _release_entry(f"datarev-{_VID}-r1"),
+        ]
+        assert latest_data_release(releases) is None
+
+    def test_no_data_tags_returns_none(self):
+        from prts_mcp.sync.release_discovery import latest_data_release
+
+        assert latest_data_release([_release_entry("images-v1")]) is None
+
+
+class TestCheckLatestReleaseRevision:
+    def test_datarev_selected_over_normal_release(self, tmp_path):
+        spec = _make_spec(tmp_path)
+        resp = _mock_releases_response([
+            _release_entry(f"data-{_VID}"),
+            _release_entry(f"datarev-{_VID}-r2", url="https://example/rev2"),
+        ])
+        with patch("httpx.get", return_value=resp):
+            result = check_latest_release(spec)
+        assert result == (f"datarev-{_VID}-r2", "https://example/rev2")
+
+
+class TestReleaseUpToDateDecision:
+    def test_matrix(self):
+        from prts_mcp.sync.release import _release_up_to_date as up_to_date
+
+        assert up_to_date(_VID, f"{_VID}-r2") is False       # newer revision → download
+        assert up_to_date(f"{_VID}-r2", f"{_VID}-r2") is True
+        assert up_to_date(f"{_VID}-r2", _VID) is True        # downgrade refused
+        assert up_to_date(_VID, _VID2) is False              # newer versionId → download
+        assert up_to_date(_VID2, _VID) is True
+        assert up_to_date("unknown", "unknown") is True      # sentinel: string fallback
+        assert up_to_date("unknown", _VID) is False
+        assert up_to_date("legacy", _VID) is False
+
+
+class TestSyncReleaseRevisionFlow:
+    def _install_cache(self, spec, commit_sha):
+        from prts_mcp.sync.release import CacheMeta, _release_cache_path
+
+        CacheMeta(
+            repo="3aKHP/arknights-data-pipeline",
+            branch="releases",
+            commit_sha=commit_sha,
+            fetched_at="2026-01-01T00:00:00Z",
+            files=["zh_CN.zip"],
+        ).save(_release_cache_path(spec))
+
+    def test_revision_downloads_and_stores_revision_suffix(self, tmp_path):
+        spec = _make_spec(tmp_path)
+        _write_zip(spec.local_zip)
+        self._install_cache(spec, _VID)
+
+        content = b"PK\x03\x04-rev2"
+        releases = _mock_releases_response([
+            _release_entry(f"data-{_VID}"),
+            _release_entry(f"datarev-{_VID}-r2"),
+        ])
+        with patch(
+            "prts_mcp.sync.release.get_cascading",
+            side_effect=[releases, _mock_asset_response(content)],
+        ) as cascading, patch(
+            "prts_mcp.sync.release_discovery.get_cascading", cascading,
+        ):
+            result = sync_release(spec, force_check=True)
+
+        assert result.status == "updated"
+        assert result.commit_sha == f"{_VID}-r2"
+        assert spec.local_zip.read_bytes() == content
+        meta = json.loads(
+            (spec.local_zip.parent / "release_meta.json").read_text(encoding="utf-8")
+        )
+        assert meta["commit_sha"] == f"{_VID}-r2"
+
+    def test_installed_revision_stays_up_to_date(self, tmp_path):
+        spec = _make_spec(tmp_path)
+        _write_zip(spec.local_zip)
+        self._install_cache(spec, f"{_VID}-r2")
+
+        releases = _mock_releases_response([
+            _release_entry(f"data-{_VID}"),
+            _release_entry(f"datarev-{_VID}-r2"),
+        ])
+        with patch(
+            "prts_mcp.sync.release.get_cascading",
+            side_effect=[releases],
+        ) as cascading, patch(
+            "prts_mcp.sync.release_discovery.get_cascading", cascading,
+        ):
+            result = sync_release(spec, force_check=True)
+
+        assert result.status == "up_to_date"
+        assert result.commit_sha == f"{_VID}-r2"
+
+    def test_manifest_revision_mismatch_fails_closed(self, tmp_path):
+        spec = ReleaseSpec(
+            owner="3aKHP",
+            repo="arknights-data-pipeline",
+            asset_name="zh_CN.zip",
+            local_zip=tmp_path / "storyjson" / "zh_CN.zip",
+            verify_manifest=True,
+        )
+        spec.local_zip.parent.mkdir(parents=True)
+        spec.local_zip.write_bytes(b"old")
+        content = b"PK\x03\x04-rev2"
+        manifest = _mock_asset_response()
+        manifest.json.return_value = {
+            "contractVersion": "prts-mcp-data/v1",
+            "source": {"versionId": _VID},
+            "publicationRevision": 3,
+            "assets": {"zh_CN.zip": {"size": len(content), "sha256": hashlib.sha256(content).hexdigest()}},
+        }
+        releases = _mock_releases_response([
+            _release_entry(f"datarev-{_VID}-r2"),
+        ])
+        with patch(
+            "prts_mcp.sync.release.get_cascading",
+            side_effect=[releases, _mock_asset_response(content), manifest],
+        ) as cascading, patch(
+            "prts_mcp.sync.release_discovery.get_cascading", cascading,
+        ):
+            result = sync_release(spec, force_check=True)
+        assert result.status == "offline_fallback"
+        assert spec.local_zip.read_bytes() == b"old"
+
+    def test_manifest_revision_missing_fails_closed(self, tmp_path):
+        spec = ReleaseSpec(
+            owner="3aKHP",
+            repo="arknights-data-pipeline",
+            asset_name="zh_CN.zip",
+            local_zip=tmp_path / "storyjson" / "zh_CN.zip",
+            verify_manifest=True,
+        )
+        spec.local_zip.parent.mkdir(parents=True)
+        spec.local_zip.write_bytes(b"old")
+        content = b"PK\x03\x04-rev2"
+        manifest = _mock_asset_response()
+        manifest.json.return_value = {
+            "contractVersion": "prts-mcp-data/v1",
+            "source": {"versionId": _VID},
+            "assets": {"zh_CN.zip": {"size": len(content), "sha256": hashlib.sha256(content).hexdigest()}},
+        }
+        releases = _mock_releases_response([
+            _release_entry(f"datarev-{_VID}-r2"),
+        ])
+        with patch(
+            "prts_mcp.sync.release.get_cascading",
+            side_effect=[releases, _mock_asset_response(content), manifest],
+        ) as cascading, patch(
+            "prts_mcp.sync.release_discovery.get_cascading", cascading,
+        ):
+            result = sync_release(spec, force_check=True)
+        assert result.status == "offline_fallback"
+
+    def test_manifest_matching_revision_updates(self, tmp_path):
+        spec = ReleaseSpec(
+            owner="3aKHP",
+            repo="arknights-data-pipeline",
+            asset_name="zh_CN.zip",
+            local_zip=tmp_path / "storyjson" / "zh_CN.zip",
+            verify_manifest=True,
+        )
+        content = b"PK\x03\x04-rev2"
+        manifest = _mock_asset_response()
+        manifest.json.return_value = {
+            "contractVersion": "prts-mcp-data/v1",
+            "source": {"versionId": _VID},
+            "publicationRevision": 2,
+            "assets": {"zh_CN.zip": {"size": len(content), "sha256": hashlib.sha256(content).hexdigest()}},
+        }
+        releases = _mock_releases_response([
+            _release_entry(f"datarev-{_VID}-r2"),
+        ])
+        with patch(
+            "prts_mcp.sync.release.get_cascading",
+            side_effect=[releases, _mock_asset_response(content), manifest],
+        ) as cascading, patch(
+            "prts_mcp.sync.release_discovery.get_cascading", cascading,
+        ):
+            result = sync_release(spec, force_check=True)
+        assert result.status == "updated"
+        assert result.commit_sha == f"{_VID}-r2"
+
+    def test_refuses_downgrade_and_reports_installed_sha(self, tmp_path):
+        spec = _make_spec(tmp_path)
+        _write_zip(spec.local_zip)
+        self._install_cache(spec, f"{_VID}-r2")
+
+        releases = _mock_releases_response([
+            _release_entry(f"data-{_VID}"),  # older than installed r2
+        ])
+        with patch(
+            "prts_mcp.sync.release.get_cascading",
+            side_effect=[releases],
+        ) as cascading, patch(
+            "prts_mcp.sync.release_discovery.get_cascading", cascading,
+        ):
+            result = sync_release(spec, force_check=True)
+
+        assert result.status == "up_to_date"
+        assert result.commit_sha == f"{_VID}-r2"
+        meta = json.loads(
+            (spec.local_zip.parent / "release_meta.json").read_text(encoding="utf-8")
+        )
+        assert meta["commit_sha"] == f"{_VID}-r2"

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Revision release discovery (`datarev-` namespace).** The data sync now understands the factory's immutable repair releases: `datarev-<versionId>-r<N>` tags are discovered alongside normal `data-<versionId>` releases and ordered by `(versionId, publicationRevision)` tuple instead of release creation time, so a repair revision outranks the release it fixes and a re-published older release can no longer win (rollback-by-republication protection; two releases claiming the same identity fail closed with a warning). Update decisions compare the same tuple over the stored release id — a bare `<versionId>` means revision 1 — while sentinel ids (`unknown`/`legacy`/`local-…`) keep the legacy string-equality semantics, and a refused downgrade reports the installed id. Manifest verification additionally requires `publicationRevision` on `datarev-` releases to match the tag. Stored metadata keeps the full tag suffix (`<versionId>-r<N>`), so the on-disk schemas and the cross-implementation meta interop are unchanged; 1.7-era deployments never see `datarev-` releases.
+
 ## [2.7.2] - 2026-08-22
 
 ### Fixed

--- a/ts/src/sync/release.ts
+++ b/ts/src/sync/release.ts
@@ -12,7 +12,13 @@ import { basename, dirname, join } from "node:path";
 
 import { type RepoSpec, type SyncResult, errorMessage } from "./types.js";
 import { atomicWriteJson } from "./primitives.js";
-import { type ReleaseSpec, TAG_PREFIX, checkLatestRelease } from "./releaseDiscovery.js";
+import {
+  type ReleaseSpec,
+  parseDataTag,
+  parseReleaseSuffix,
+  tagSuffix,
+  checkLatestRelease,
+} from "./releaseDiscovery.js";
 import {
   AssetNotFoundError,
   fetchCascading,
@@ -143,7 +149,8 @@ export async function downloadReleaseAsset(
     }
     await rename(tmp, spec.localZip);
 
-    const commitSha = tag.startsWith(TAG_PREFIX) ? tag.slice(TAG_PREFIX.length) : tag;
+    // Strip the namespace prefix: data-<vid> → <vid>, datarev-<vid>-rN → <vid>-rN
+    const commitSha = tagSuffix(tag);
     await saveReleaseMeta(spec, {
       repo: `${spec.owner}/${spec.repo}`,
       branch: "releases",
@@ -188,16 +195,28 @@ async function verifyReleaseManifest(
   const typedManifest = manifest as {
     assets?: Record<string, { size?: number; sha256?: string }>;
     contractVersion?: unknown;
+    publicationRevision?: unknown;
     source?: { versionId?: unknown };
   };
   if (typedManifest.contractVersion !== DATA_CONTRACT_VERSION) {
     throw new Error(`manifest for ${tag} has unsupported contractVersion`);
   }
+  const parsedTag = parseDataTag(tag);
   if (
-    tag.startsWith("data-")
-    && typedManifest.source?.versionId !== tag.slice("data-".length)
+    parsedTag
+    && typedManifest.source?.versionId !== parsedTag.versionId
   ) {
     throw new Error(`manifest source version does not match release tag ${tag}`);
+  }
+  if (parsedTag && parsedTag.revision > 1) {
+    // datarev releases must declare their revision; a missing field means
+    // the manifest was not produced by the revision pipeline
+    if (typedManifest.publicationRevision !== parsedTag.revision) {
+      throw new Error(
+        `manifest for ${tag} declares publicationRevision `
+        + `${String(typedManifest.publicationRevision)}, expected ${parsedTag.revision}`,
+      );
+    }
   }
   const expected = typedManifest.assets?.[spec.assetName];
   if (typeof expected?.size !== "number" || typeof expected.sha256 !== "string") {
@@ -211,6 +230,38 @@ async function verifyReleaseManifest(
       + `${expected.size}/${expected.sha256}, got ${bytes.byteLength}/${actualSha}`,
     );
   }
+}
+
+/**
+ * Tuple-aware up-to-date decision over stored commitSha values.
+ *
+ * Both sides parse into {versionId, revision} → compare tuples: newer
+ * upstream means stale, equal or older upstream means up to date (an older
+ * upstream is refused loudly — rollback-by-republication protection).
+ * Either side unparseable (sentinels like "unknown"/"legacy"/"local-…") →
+ * plain string equality, preserving the legacy semantics.
+ * Mirrors python's _release_up_to_date.
+ */
+function releaseUpToDate(localSha: string, upstreamSha: string): boolean {
+  const local = parseReleaseSuffix(localSha);
+  const upstream = parseReleaseSuffix(upstreamSha);
+  if (local && upstream) {
+    if (local.versionId !== upstream.versionId) {
+      if (upstream.versionId > local.versionId) return false;
+      console.warn(
+        `[sync] upstream ${upstreamSha} is not newer than installed ${localSha}; refusing downgrade`,
+      );
+      return true;
+    }
+    if (upstream.revision > local.revision) return false;
+    if (upstream.revision < local.revision) {
+      console.warn(
+        `[sync] upstream ${upstreamSha} is not newer than installed ${localSha}; refusing downgrade`,
+      );
+    }
+    return true;
+  }
+  return localSha === upstreamSha;
 }
 
 /**
@@ -267,13 +318,13 @@ async function syncReleaseLocked(
     return { spec: dummySpec, status: "no_data", commitSha: null, error };
   }
 
-  const commitSha = latest.tag.startsWith(TAG_PREFIX)
-    ? latest.tag.slice(TAG_PREFIX.length)
-    : latest.tag;
+  const commitSha = tagSuffix(latest.tag);
 
-  if (cache !== null && cache.commitSha === commitSha && zipOk) {
+  if (cache !== null && zipOk && releaseUpToDate(cache.commitSha, commitSha)) {
     await saveReleaseMeta(spec, { ...cache, fetchedAt: new Date().toISOString() });
-    return { spec: dummySpec, status: "up_to_date", commitSha, error: null };
+    // report the *installed* sha: with tuple ordering this branch also
+    // covers refused downgrades, where upstream is older than installed
+    return { spec: dummySpec, status: "up_to_date", commitSha: cache.commitSha, error: null };
   }
 
   try {

--- a/ts/src/sync/releaseDiscovery.ts
+++ b/ts/src/sync/releaseDiscovery.ts
@@ -10,6 +10,79 @@
 import { fetchCascading, githubHeaders } from "./transport.js";
 
 export const TAG_PREFIX = "data-";
+const DATAREV_TAG_PREFIX = "datarev-";
+
+// A data versionId is fixed-width "YY-MM-DD-HH-MM-SS_hash", so lexicographic
+// order is chronological order and (versionId, revision) tuples order without
+// any date parsing.
+const VID_RE = /^\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}_[0-9a-f]+$/;
+const DATAREV_TAG_RE = /^datarev-(?<vid>.+)-r(?<rev>\d+)$/;
+const DATAREV_SUFFIX_RE = /^(?<vid>\d{2}-\d{2}-\d{2}-\d{2}-\d{2}-\d{2}_[0-9a-f]+)-r(?<rev>\d+)$/;
+
+/** Parsed data release identity: versionId plus publication revision. */
+export interface DataTagVersion {
+  versionId: string;
+  revision: number;
+}
+
+/**
+ * Parse a data release tag into {versionId, revision}.
+ *
+ * `data-<versionId>` is a normal release (revision 1);
+ * `datarev-<versionId>-r<N>` is an immutable repair revision published by the
+ * factory's manual SOP. Anything else (images-*, unknown tags) is not a data
+ * release. Mirrors akdp.check.parse_release_tag.
+ */
+export function parseDataTag(tag: string): DataTagVersion | null {
+  const match = DATAREV_TAG_RE.exec(tag);
+  if (match?.groups) {
+    return { versionId: match.groups.vid, revision: Number(match.groups.rev) };
+  }
+  if (tag.startsWith(TAG_PREFIX)) {
+    return { versionId: tag.slice(TAG_PREFIX.length), revision: 1 };
+  }
+  return null;
+}
+
+/**
+ * Strip the data/datarev namespace prefix from a release tag.
+ *
+ * `data-<vid>` → `<vid>`; `datarev-<vid>-r<N>` → `<vid>-r<N>`. The result is
+ * the canonical commitSha persisted in release_meta/extract_meta/
+ * .gamedata_pair and shown in logs.
+ */
+export function tagSuffix(tag: string): string {
+  if (tag.startsWith(DATAREV_TAG_PREFIX)) return tag.slice(DATAREV_TAG_PREFIX.length);
+  if (tag.startsWith(TAG_PREFIX)) return tag.slice(TAG_PREFIX.length);
+  return tag;
+}
+
+/**
+ * Parse a stored commitSha (tag suffix) into {versionId, revision}.
+ *
+ * `<vid>-r<N>` (written for datarev releases) → revision N; a bare versionId
+ * → revision 1. Sentinel values ("unknown", "legacy", "local-<digest>") and
+ * any future format return null so callers fall back to plain string
+ * comparison.
+ */
+export function parseReleaseSuffix(suffix: string): DataTagVersion | null {
+  const match = DATAREV_SUFFIX_RE.exec(suffix);
+  if (match?.groups) {
+    return { versionId: match.groups.vid, revision: Number(match.groups.rev) };
+  }
+  if (VID_RE.test(suffix)) return { versionId: suffix, revision: 1 };
+  return null;
+}
+
+function tupleKey(v: DataTagVersion): string {
+  return `${v.versionId}\u0000${v.revision}`;
+}
+
+/** True when *b* is strictly newer than *a* (tuple order). */
+function isNewer(a: DataTagVersion, b: DataTagVersion): boolean {
+  if (a.versionId !== b.versionId) return b.versionId > a.versionId;
+  return b.revision > a.revision;
+}
 
 // ---------------------------------------------------------------------------
 // Release discovery (tag-prefix filtered)
@@ -106,6 +179,39 @@ export function latestReleaseByPrefix(
   return candidates[0];
 }
 
+/**
+ * Pick the newest data release across the data-/datarev- namespaces.
+ *
+ * Orders by (versionId, revision) tuple instead of created_at, so a repair
+ * revision outranks the release it fixes and a re-published older release
+ * can no longer win (rollback-by-republication). Two releases claiming the
+ * same tuple is an upstream integrity violation: log loudly and fail closed
+ * (returns null), mirroring the images pipeline's duplicate-version rejection.
+ */
+export function latestDataRelease(
+  releases: GithubRelease[],
+): GithubRelease | null {
+  let best: { key: DataTagVersion; release: GithubRelease } | null = null;
+  const seen = new Set<string>();
+  for (const release of releases) {
+    const tag = release["tag_name"];
+    if (typeof tag !== "string") continue;
+    const parsed = parseDataTag(tag);
+    if (!parsed) continue;
+    const key = tupleKey(parsed);
+    if (seen.has(key)) {
+      console.warn(
+        `[sync] duplicate data release identity (versionId=${parsed.versionId}, `
+        + `revision=${parsed.revision}) claimed by "${tag}"; failing closed`,
+      );
+      return null;
+    }
+    seen.add(key);
+    if (best === null || isNewer(best.key, parsed)) best = { key: parsed, release };
+  }
+  return best?.release ?? null;
+}
+
 /** Extract the browser_download_url for *assetName* from a release object. */
 export function assetUrl(release: GithubRelease, assetName: string): string | null {
   const assets = release["assets"];
@@ -134,12 +240,14 @@ export interface ReleaseSpec {
 }
 
 /**
- * Return the latest ``data-*`` release tag and asset download URL.
+ * Return the latest data release tag and asset download URL.
  *
  * Uses the releases list API with tag-prefix filtering instead of
  * ``/releases/latest``, because the data-pipeline repo also hosts
- * ``images-*`` releases that may be promoted to "Latest" on GitHub.
- * Returns null on network failure or when no matching release/asset is found.
+ * ``images-*`` releases that may be promoted to "Latest" on GitHub, and a
+ * ``datarev-`` repair revision must outrank the ``data-`` release it fixes
+ * even though it is never marked latest. Returns null on network failure or
+ * when no matching release/asset is found.
  */
 export async function checkLatestRelease(
   spec: ReleaseSpec,
@@ -147,7 +255,7 @@ export async function checkLatestRelease(
 ): Promise<{ tag: string; url: string } | null> {
   const releases = await listReleases(spec.owner, spec.repo, timeoutMs);
   if (releases === null) return null;
-  const latest = latestReleaseByPrefix(releases, TAG_PREFIX);
+  const latest = latestDataRelease(releases);
   if (!latest) return null;
   const tag = latest["tag_name"];
   if (typeof tag !== "string") return null;

--- a/ts/tests/sync.test.ts
+++ b/ts/tests/sync.test.ts
@@ -34,6 +34,12 @@ import {
   type ReleaseSpec,
 } from "../src/data/sync.ts";
 import { parseMirrors } from "../src/sync/transport.js";
+import {
+  latestDataRelease,
+  parseDataTag,
+  parseReleaseSuffix,
+  tagSuffix,
+} from "../src/sync/releaseDiscovery.js";
 
 test("fetchCascading raises AssetNotFoundError on a direct 404 (#100)", async () => {
   await withFetchMock((async () => new Response("missing", { status: 404 })) as typeof fetch, async () => {
@@ -991,4 +997,208 @@ test("concurrent archive activation keeps the authoritative tree", async () => {
     assert.equal(existsSync(join(dirname(spec.localZip), ".activation.lock")), false);
   });
   assert.equal(maxActiveChecks, 1);
+});
+
+// ---------------------------------------------------------------------------
+// datarev revision discovery and activation (2.8.0)
+// ---------------------------------------------------------------------------
+
+const REV_VID = "26-09-03-04-06-00_ed95a2";
+const REV_VID2 = "26-10-01-11-22-33_aabbcc";
+
+function releaseEntry(tag: string, created = "2026-01-01T00:00:00Z") {
+  return {
+    tag_name: tag,
+    created_at: created,
+    assets: [{ name: "zh_CN.zip", browser_download_url: "https://example.test/asset" }],
+  };
+}
+
+test("parseDataTag parses both data namespaces", () => {
+  assert.deepEqual(parseDataTag(`data-${REV_VID}`), { versionId: REV_VID, revision: 1 });
+  assert.deepEqual(parseDataTag(`datarev-${REV_VID}-r2`), { versionId: REV_VID, revision: 2 });
+  assert.deepEqual(parseDataTag(`datarev-${REV_VID}-r10`), { versionId: REV_VID, revision: 10 });
+  assert.equal(parseDataTag("images-v1"), null);
+  assert.equal(parseDataTag("datarev-x-r2-extra"), null);
+  assert.equal(parseDataTag("datarev-vid"), null);
+});
+
+test("parseReleaseSuffix and tagSuffix handle stored commitSha values", () => {
+  assert.deepEqual(parseReleaseSuffix(REV_VID), { versionId: REV_VID, revision: 1 });
+  assert.deepEqual(parseReleaseSuffix(`${REV_VID}-r3`), { versionId: REV_VID, revision: 3 });
+  for (const sentinel of ["unknown", "legacy", "local-abc123", "manual"]) {
+    assert.equal(parseReleaseSuffix(sentinel), null);
+  }
+  assert.equal(parseReleaseSuffix("abc123"), null);
+  assert.equal(tagSuffix(`data-${REV_VID}`), REV_VID);
+  assert.equal(tagSuffix(`datarev-${REV_VID}-r2`), `${REV_VID}-r2`);
+  assert.equal(tagSuffix("unknown"), "unknown");
+});
+
+test("latestDataRelease orders by (versionId, revision) tuple", () => {
+  const rev = latestDataRelease([
+    releaseEntry(`data-${REV_VID}`, "2026-09-05T00:00:00Z"),
+    releaseEntry(`datarev-${REV_VID}-r2`, "2026-09-04T00:00:00Z"),
+  ]);
+  assert.equal(rev?.["tag_name"], `datarev-${REV_VID}-r2`);
+
+  const newer = latestDataRelease([
+    releaseEntry(`datarev-${REV_VID}-r9`),
+    releaseEntry(`data-${REV_VID2}`),
+  ]);
+  assert.equal(newer?.["tag_name"], `data-${REV_VID2}`);
+
+  const numeric = latestDataRelease([
+    releaseEntry(`datarev-${REV_VID}-r2`),
+    releaseEntry(`datarev-${REV_VID}-r10`),
+  ]);
+  assert.equal(numeric?.["tag_name"], `datarev-${REV_VID}-r10`);
+
+  assert.equal(latestDataRelease([releaseEntry("images-v1")]), null);
+});
+
+test("latestDataRelease fails closed on duplicate release identity", () => {
+  assert.equal(latestDataRelease([
+    releaseEntry(`data-${REV_VID}`),
+    releaseEntry(`datarev-${REV_VID}-r1`),
+  ]), null);
+});
+
+function writeRevCache(spec: ReleaseSpec, commitSha: string): void {
+  mkdirSync(dirname(spec.localZip), { recursive: true });
+  writeFileSync(spec.localZip, "cached");
+  writeFileSync(
+    join(dirname(spec.localZip), "release_meta.json"),
+    JSON.stringify({
+      repo: "3aKHP/arknights-data-pipeline",
+      branch: "releases",
+      commitSha,
+      fetchedAt: "2026-01-01T00:00:00Z",
+      files: ["zh_CN.zip"],
+    }),
+    "utf-8",
+  );
+}
+
+test("syncRelease downloads a datarev revision and stores the revision suffix", async () => {
+  const spec = tempSpec();
+  writeRevCache(spec, REV_VID);
+  const content = "rev2-content";
+  let call = 0;
+  await withFetchMock((async () => {
+    call += 1;
+    if (call === 1) {
+      return new Response(JSON.stringify([
+        releaseEntry(`data-${REV_VID}`),
+        releaseEntry(`datarev-${REV_VID}-r2`),
+      ]), { headers: { "content-type": "application/json" } });
+    }
+    return new Response(content);
+  }) as typeof fetch, async () => {
+    const result = await syncRelease(spec, true);
+    assert.equal(result.status, "updated");
+    assert.equal(result.commitSha, `${REV_VID}-r2`);
+  });
+  assert.equal(call, 2);
+  assert.equal(readFileSync(spec.localZip, "utf-8"), content);
+  const meta = JSON.parse(
+    readFileSync(join(dirname(spec.localZip), "release_meta.json"), "utf-8"),
+  ) as { commit_sha: string };
+  assert.equal(meta.commit_sha, `${REV_VID}-r2`);
+});
+
+test("syncRelease stays up_to_date on the installed revision", async () => {
+  const spec = tempSpec();
+  writeRevCache(spec, `${REV_VID}-r2`);
+  let fetchCalls = 0;
+  await withFetchMock((async () => {
+    fetchCalls += 1;
+    return new Response(JSON.stringify([
+      releaseEntry(`data-${REV_VID}`),
+      releaseEntry(`datarev-${REV_VID}-r2`),
+    ]), { headers: { "content-type": "application/json" } });
+  }) as typeof fetch, async () => {
+    const result = await syncRelease(spec, true);
+    assert.equal(result.status, "up_to_date");
+    assert.equal(result.commitSha, `${REV_VID}-r2`);
+  });
+  assert.equal(fetchCalls, 1);
+  assert.equal(readFileSync(spec.localZip, "utf-8"), "cached");
+});
+
+test("syncRelease refuses downgrade to an older release", async () => {
+  const spec = tempSpec();
+  writeRevCache(spec, `${REV_VID}-r2`);
+  let fetchCalls = 0;
+  await withFetchMock((async () => {
+    fetchCalls += 1;
+    return new Response(JSON.stringify([
+      releaseEntry(`data-${REV_VID}`),
+    ]), { headers: { "content-type": "application/json" } });
+  }) as typeof fetch, async () => {
+    const result = await syncRelease(spec, true);
+    assert.equal(result.status, "up_to_date");
+    assert.equal(result.commitSha, `${REV_VID}-r2`);
+  });
+  assert.equal(fetchCalls, 1);
+});
+
+async function syncDatarevManifestCase(manifest: unknown): Promise<{ status: string; zip: string }> {
+  const spec = { ...tempSpec(), verifyManifest: true };
+  mkdirSync(dirname(spec.localZip), { recursive: true });
+  writeFileSync(spec.localZip, "old");
+  const content = Buffer.from("rev2-verified", "utf-8");
+  let call = 0;
+  let status = "";
+  await withFetchMock((async () => {
+    call += 1;
+    if (call === 1) {
+      return new Response(JSON.stringify([releaseEntry(`datarev-${REV_VID}-r2`)]),
+        { headers: { "content-type": "application/json" } });
+    }
+    if (call === 2) return new Response(content);
+    return new Response(JSON.stringify(manifest),
+      { headers: { "content-type": "application/json" } });
+  }) as typeof fetch, async () => {
+    const result = await syncRelease(spec, true);
+    status = result.status;
+  });
+  return { status, zip: readFileSync(spec.localZip, "utf-8") };
+}
+
+test("syncRelease fails closed when manifest revision mismatches the tag", async () => {
+  const content = Buffer.from("rev2-verified", "utf-8");
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  const { status, zip } = await syncDatarevManifestCase({
+    contractVersion: "prts-mcp-data/v1",
+    source: { versionId: REV_VID },
+    publicationRevision: 3,
+    assets: { "zh_CN.zip": { size: content.byteLength, sha256 } },
+  });
+  assert.equal(status, "offline_fallback");
+  assert.equal(zip, "old");
+});
+
+test("syncRelease fails closed when manifest revision is missing", async () => {
+  const content = Buffer.from("rev2-verified", "utf-8");
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  const { status, zip } = await syncDatarevManifestCase({
+    contractVersion: "prts-mcp-data/v1",
+    source: { versionId: REV_VID },
+    assets: { "zh_CN.zip": { size: content.byteLength, sha256 } },
+  });
+  assert.equal(status, "offline_fallback");
+  assert.equal(zip, "old");
+});
+
+test("syncRelease updates when manifest revision matches the tag", async () => {
+  const content = Buffer.from("rev2-verified", "utf-8");
+  const sha256 = createHash("sha256").update(content).digest("hex");
+  const { status } = await syncDatarevManifestCase({
+    contractVersion: "prts-mcp-data/v1",
+    source: { versionId: REV_VID },
+    publicationRevision: 2,
+    assets: { "zh_CN.zip": { size: content.byteLength, sha256 } },
+  });
+  assert.equal(status, "updated");
 });


### PR DESCRIPTION
## Summary

Two layers of one feature — runtime sync discovery + CI artifact selection for the factory's `datarev-<versionId>-r<N>` immutable repair releases — combined into a single PR. Both commits came from the two local branches `feat/sync-revision-discovery` and `chore/ci-datarev-tag-selection` (same base, disjoint files).

### feat(sync): revision release discovery

- `parse_data_tag` / `parse_release_suffix` / `tag_suffix` mirror akdp's tag contract across both implementations; sentinel commit ids (`unknown` / `legacy` / `local-…`) keep the legacy string-equality fallback.
- `latest_data_release` replaces `created_at` ordering for the data namespaces: `(versionId, publicationRevision)` tuples make a repair revision outrank the release it fixes, block rollback-by-republication, and fail closed (with a warning) on duplicate identity.
- Update decisions compare the same tuples; a refused downgrade reports the **installed** id so the archive layer never re-extracts in a loop and `extract_meta` never gets mislabeled with an older sha than the on-disk content. Both implementations warn on every refused-downgrade path.
- Manifest verification additionally requires `publicationRevision` on `datarev-` releases to match the tag. Stored metadata keeps the full tag suffix (`<versionId>-r<N>`), so on-disk schemas and cross-implementation meta interop are unchanged; 2.7.x/1.7-era deployments never see `datarev-` releases (documented in `docs/dev/LTS.md`).

### chore(ci): datarev-aware DATA_TAG selection

All **seven** `DATA_TAG` selectors (ci.yml ×4, cd.yml ×2, cd-ts.yml ×1) now take the max `(versionId, revision)` tuple instead of `max_by(.createdAt)`, so test runs, Docker builds, and the packed TS release artifact never bake in stale revision-1 data once datarev releases exist. The jq program lives in `.github/scripts/data-tag-selector.jq` and is consumed from every site via `--jq "$(cat …)"` — a single source of truth, no shellcheck disables needed. Unlike the sync layer, duplicate identities do not fail closed in CI (`max_by` picks one of the clashing tags) — acceptable for build inputs.

> Note: the original chore branch covered only six selectors and missed `cd-ts.yml` (the "Build and pack exact release artifact" job — the most production-facing one). Fixed here and folded into the chore commit.

## Review fixes (KHPilot round 2, all folded into the two commits)

- Extracted the 7× copy-pasted jq selector into `.github/scripts/data-tag-selector.jq` (bot's should-fix; implemented via `--jq "$(cat …)"` since gh has no `--jq-from-file`)
- Replaced the inverted ternary in `releaseUpToDate` (`x ? false : true` → explicit branch, bot's should-fix)
- TS now warns on versionId-level refused downgrades (parity with Python)
- Python `_verify_release_manifest` unpacks `version_id, tag_revision` instead of positional indexing
- Python "No release with prefix data-" debug log → "No data release found in owner/repo"
- Split the bundled TS manifest test into three named tests matching the Python suite

## Validation

- Python: `pytest tests -q` → **488 passed, 2 skipped**
- TS: `npm run typecheck` clean; `npm test` → **363 pass, 2 skipped**
- `actionlint` v1.7.12 (same command as CI) run locally against the final workflows → **no findings**
- Shared jq file verified byte-equivalent to the previous inline selector against the edge-case fixture (newer-vid-beats-revision, `r10 > r9`, revision-beats-createdAt, `images-` exclusion, empty set)
- Lightweight E2E real-machine pass per `docs/dev/E2E.md` (traffic-reduced scope: both implementations deployed production-style, tuple-aware sync decision exercised live, full MCP tool sweep; images domain skipped as untouched by this PR) — results in the PR discussion.

## Pre-merge checklist

- [x] Lightweight E2E pass (images domain excluded — untouched by this PR; full images pass deferred to the 2.8.0 release-milestone E2E)