### PR TITLE
fix(sync): preserve repair identity and summary parity

### DIFF
--- a/.github/scripts/data-tag-selector.jq
+++ b/.github/scripts/data-tag-selector.jq
@@ -2,4 +2,14 @@
 # (versionId, publicationRevision) tuple — mirrors the sync layer's
 # latest_data_release (ts/src/sync/releaseDiscovery.ts, python …/release_discovery.py).
 # All workflow sites must consume this file via: --jq "$(cat .github/scripts/data-tag-selector.jq)"
-[.[] | .tagName as $t | if ($t | test("^datarev-.+-r[0-9]+$")) then ($t | capture("^datarev-(?<vid>.+)-r(?<rev>[0-9]+)$")) as $m | {tagName: $t, vid: $m.vid, rev: ($m.rev | tonumber)} elif ($t | startswith("data-")) then {tagName: $t, vid: ($t | sub("^data-"; "")), rev: 1} else empty end] | max_by([.vid, .rev]) | .tagName
+[.[] | select(.isDraft != true and .isPrerelease != true)
+ | .tagName as $t
+ | if ($t | test("^datarev-.+-r[0-9]+$")) then
+     ($t | capture("^datarev-(?<vid>.+)-r(?<rev>[0-9]+)$")) as $m
+     | {tagName: $t, vid: $m.vid, rev: ($m.rev | tonumber)}
+   elif ($t | startswith("data-")) then
+     {tagName: $t, vid: ($t | sub("^data-"; "")), rev: 1}
+   else empty end]
+| if (group_by([.vid, .rev]) | any(length > 1)) then
+    error("duplicate data release identity")
+  else max_by([.vid, .rev]) | .tagName end

--- a/.github/workflows/cd-ts.yml
+++ b/.github/workflows/cd-ts.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Download bundled storyjson zip
         run: |
           mkdir -p ts/data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,isDraft,isPrerelease --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Download storyjson zip for integration tests
         run: |
           mkdir -p .ci-data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,isDraft,isPrerelease --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
@@ -164,7 +164,7 @@ jobs:
       - name: Download bundled storyjson zip
         run: |
           mkdir -p data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,isDraft,isPrerelease --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Download storyjson zip for integration tests
         run: |
           mkdir -p .ci-data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,isDraft,isPrerelease --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
@@ -150,7 +150,7 @@ jobs:
       - name: Download bundled storyjson zip
         run: |
           mkdir -p data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,isDraft,isPrerelease --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
@@ -394,7 +394,7 @@ jobs:
       - name: Download bundled storyjson zip
         run: |
           mkdir -p data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,isDraft,isPrerelease --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \
@@ -460,7 +460,7 @@ jobs:
       - name: Download bundled storyjson zip
         run: |
           mkdir -p data/storyjson
-          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,createdAt --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
+          DATA_TAG=$(gh release list --repo 3aKHP/arknights-data-pipeline --json tagName,isDraft,isPrerelease --limit 100 --jq "$(cat .github/scripts/data-tag-selector.jq)")
           gh release download "$DATA_TAG" \
             --repo 3aKHP/arknights-data-pipeline \
             --pattern "zh_CN.zip" \

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- Chapter listings with summaries now prefer LLM summaries and share the single-chapter tool's official-summary fallback, including blank or invalid cached values.
+- Repair releases require a manifest even when its download returns 404. Duplicate release identities fail without a blind Latest download, and runtime and build selectors exclude drafts and prereleases.
+- Recorded release identities continue to prevent downgrades when a cached ZIP is missing or invalid; an unverified Latest fallback cannot replace them.
+
 ### Added
 
 - **Revision release discovery (`datarev-` namespace).** The data sync now understands the factory's immutable repair releases: `datarev-<versionId>-r<N>` tags are discovered alongside normal `data-<versionId>` releases and ordered by `(versionId, publicationRevision)` tuple instead of release creation time, so a repair revision outranks the release it fixes and a re-published older release can no longer win (rollback-by-republication protection; two releases claiming the same identity fail closed with a warning). Update decisions compare the same tuple over the stored release id — a bare `<versionId>` means revision 1 — while sentinel ids (`unknown`/`legacy`/`local-…`) keep the legacy string-equality semantics, and a refused downgrade reports the installed id. Manifest verification additionally requires `publicationRevision` on `datarev-` releases to match the tag. Stored metadata keeps the full tag suffix (`<versionId>-r<N>`), so the on-disk schemas and the cross-implementation meta interop are unchanged; 1.7-era deployments never see `datarev-` releases.

--- a/python/src/prts_mcp/data/story_reader.py
+++ b/python/src/prts_mcp/data/story_reader.py
@@ -413,6 +413,39 @@ def list_stories_from_store(store: JsonStore, event_id: str) -> list[ChapterSumm
     return chapters
 
 
+def load_chapter_summaries_from_store(store: JsonStore) -> dict[str, str]:
+    """Load usable chapter summaries, preferring LLM text over official text."""
+    summaries: dict[str, str] = {}
+    for path in (STORYINFO, SUMMARIES):
+        try:
+            if store.exists(path):
+                raw = load_json(store, path)
+                if isinstance(raw, dict):
+                    summaries.update({key: value.strip() for key, value in raw.items()
+                                      if isinstance(value, str) and value.strip()})
+        except Exception as exc:
+            _logger.debug("读取剧情摘要失败：%s", exc)
+    return summaries
+
+
+def chapter_summary_from_store(
+    store: JsonStore, story_key: str, summaries: dict[str, str],
+) -> str:
+    """Resolve one chapter, falling back to its embedded official summary."""
+    if story_key in summaries:
+        return summaries[story_key]
+    try:
+        path = story_zip_path(story_key)
+        if store.exists(path):
+            raw = load_json(store, path)
+            text = raw.get("storyInfo") if isinstance(raw, dict) else None
+            if isinstance(text, str):
+                return text.strip()
+    except Exception as exc:
+        _logger.debug("读取章节梗概失败：%s", exc)
+    return ""
+
+
 def build_stories_listing_from_store(
     store: JsonStore,
     event_id: str,
@@ -423,18 +456,16 @@ def build_stories_listing_from_store(
     chapter_summaries: dict[str, str] = {}
     event_summary_text = ""
     if include_summaries:
+        chapter_summaries = load_chapter_summaries_from_store(store)
         try:
-            if store.exists(STORYINFO):
-                raw = store.read_json(STORYINFO)
-                if isinstance(raw, dict):
-                    chapter_summaries = {str(k): str(v) for k, v in raw.items() if v}
             if store.exists(EVENT_SUMMARIES):
                 raw_events = store.read_json(EVENT_SUMMARIES)
                 if isinstance(raw_events, dict):
-                    event_summary_text = str(raw_events.get(event_id) or "").strip()
+                    text = raw_events.get(event_id)
+                    if isinstance(text, str):
+                        event_summary_text = text.strip()
         except Exception as exc:
             _logger.debug("读取剧情摘要失败，跳过摘要：%s", exc)
-            chapter_summaries = {}
             event_summary_text = ""
 
     data = {
@@ -448,7 +479,7 @@ def build_stories_listing_from_store(
                 "story_key": ch.story_key,
                 "avg_tag": ch.avg_tag,
                 **(
-                    {"summary": chapter_summaries.get(ch.story_key, "")}
+                    {"summary": chapter_summary_from_store(store, ch.story_key, chapter_summaries)}
                     if include_summaries
                     else {}
                 ),

--- a/python/src/prts_mcp/data/story_summary.py
+++ b/python/src/prts_mcp/data/story_summary.py
@@ -9,11 +9,9 @@ from pathlib import Path
 
 from prts_mcp.data.stores import JsonStore
 from prts_mcp.data.story_reader import (
-    STORYINFO,
-    SUMMARIES,
-    load_json,
+    chapter_summary_from_store,
+    load_chapter_summaries_from_store,
     story_store,
-    story_zip_path,
 )
 
 
@@ -35,42 +33,9 @@ def get_story_summary_from_store(store: JsonStore, story_key: str) -> str:
     """Return a summary for a single story chapter.
 
     Fallback chain:
-    1. zh_CN/summaries.json — LLM-generated long summary (future)
+    1. zh_CN/summaries.json — LLM-generated long summary
     2. zh_CN/storyinfo.json — official one-line summary
     3. Chapter JSON ``storyInfo`` field — identical to #2, last resort
     """
-    # --- tier 1: LLM summaries (future) ---
-    if store.exists(SUMMARIES):
-        try:
-            raw = load_json(store, SUMMARIES)
-            if isinstance(raw, dict):
-                text = raw.get(story_key)
-                if text and isinstance(text, str):
-                    return text.strip()
-        except Exception:
-            pass
-
-    # --- tier 2: storyinfo.json ---
-    if store.exists(STORYINFO):
-        try:
-            raw = load_json(store, STORYINFO)
-            if isinstance(raw, dict):
-                text = raw.get(story_key)
-                if text and isinstance(text, str):
-                    return text.strip()
-        except Exception:
-            pass
-
-    # --- tier 3: chapter JSON storyInfo ---
-    story_path = story_zip_path(story_key)
-    if store.exists(story_path):
-        try:
-            raw = load_json(store, story_path)
-            if isinstance(raw, dict):
-                text = raw.get("storyInfo")
-                if text and isinstance(text, str):
-                    return text.strip()
-        except Exception:
-            pass
-
-    return f"未找到剧情章节 '{story_key}' 的梗概。"
+    text = chapter_summary_from_store(store, story_key, load_chapter_summaries_from_store(store))
+    return text or f"未找到剧情章节 '{story_key}' 的梗概。"

--- a/python/src/prts_mcp/sync/release.py
+++ b/python/src/prts_mcp/sync/release.py
@@ -163,6 +163,8 @@ def _verify_release_manifest(
             manifest_url, timeout=timeout, headers=github_headers(), follow_redirects=True,
         )
     except _AssetNotFoundError:
+        if tag.startswith("datarev-"):
+            raise ValueError(f"manifest required for repair release {tag}") from None
         # Direct URL confirmed 404 → release predates the manifest asset.
         return
     except Exception as exc:
@@ -191,7 +193,7 @@ def _verify_release_manifest(
             # datarev releases must declare their revision; a missing field
             # means the manifest was not produced by the revision pipeline
             revision = manifest.get("publicationRevision")
-            if revision != tag_revision:
+            if type(revision) is not int or revision != tag_revision:
                 raise ValueError(
                     f"manifest publicationRevision {revision!r} does not "
                     f"match tag revision {tag_revision}"
@@ -273,6 +275,11 @@ def _sync_release_locked(spec: ReleaseSpec, *, force_check: bool = False) -> Syn
             )
         # No zip and API unreachable — attempt blind download via releases/latest/download/
         # (does not require the GitHub API; ghproxy and similar mirrors support this URL).
+        if cache is not None and parse_release_suffix(cache.commit_sha) is not None:
+            return SyncResult(
+                spec=_dummy_spec, status="no_data", commit_sha=cache.commit_sha,
+                error="Network unavailable; cannot verify replacement of recorded release",
+            )
         if _parse_mirrors():
             blind_url = f"https://github.com/{spec.owner}/{spec.repo}/releases/latest/download/{spec.asset_name}"
             try:
@@ -287,6 +294,15 @@ def _sync_release_locked(spec: ReleaseSpec, *, force_check: bool = False) -> Syn
 
     tag, asset_url = result
     upstream_sha = tag_suffix(tag)
+
+    if cache is not None and not zip_ok:
+        local_version = parse_release_suffix(cache.commit_sha)
+        upstream_version = parse_release_suffix(upstream_sha)
+        if local_version is not None and upstream_version is not None and local_version > upstream_version:
+            return SyncResult(
+                spec=_dummy_spec, status="no_data", commit_sha=cache.commit_sha,
+                error="Refusing downgrade of recorded release while cached zip is unavailable",
+            )
 
     if cache is not None and zip_ok and _release_up_to_date(cache.commit_sha, upstream_sha):
         CacheMeta(

--- a/python/src/prts_mcp/sync/release_discovery.py
+++ b/python/src/prts_mcp/sync/release_discovery.py
@@ -169,12 +169,13 @@ def latest_data_release(releases: list[dict]) -> dict | None:
     ``created_at``, so a repair revision outranks the release it fixes and a
     re-published older release can no longer win (rollback-by-republication).
     Two releases claiming the same tuple is an upstream integrity violation:
-    log loudly and fail closed (returns None), mirroring the images pipeline's
-    duplicate-version rejection.
+    raise an integrity error so callers cannot attempt a blind network fallback.
     """
     best: tuple[tuple[str, int], dict] | None = None
     seen: set[tuple[str, int]] = set()
     for release in releases:
+        if release.get("draft") or release.get("prerelease"):
+            continue
         tag = release.get("tag_name")
         if not isinstance(tag, str):
             continue
@@ -186,7 +187,7 @@ def latest_data_release(releases: list[dict]) -> dict | None:
                 "duplicate data release identity (versionId=%s, revision=%d) "
                 "claimed by %r; failing closed", parsed[0], parsed[1], tag,
             )
-            return None
+            raise ValueError("duplicate data release identity")
         seen.add(parsed)
         if best is None or parsed > best[0]:
             best = (parsed, release)

--- a/python/tests/test_data_release_selection.py
+++ b/python/tests/test_data_release_selection.py
@@ -1,0 +1,44 @@
+"""The runtime and build-time selectors share publication identity rules."""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from prts_mcp.sync.release_discovery import latest_data_release
+
+ROOT = Path(__file__).resolve().parents[2]
+CASES = json.loads((ROOT / "tests/parity-fixtures/data-release-selection.json").read_text())
+
+
+@pytest.mark.parametrize("case", CASES, ids=lambda case: case["name"])
+def test_runtime_and_ci_selection(case):
+    releases = [{"tag_name": tag, "draft": tag == case.get("draft"),
+                 "prerelease": tag == case.get("prerelease")} for tag in case["tags"]]
+    if case.get("error"):
+        with pytest.raises(ValueError, match="duplicate"):
+            latest_data_release(releases)
+    else:
+        selected = latest_data_release(releases)
+        assert (selected["tag_name"] if selected else None) == case["expected"]
+    if shutil.which("jq") is None:
+        pytest.skip("jq required to verify the CI selector")
+    selected = subprocess.run(
+        ["jq", "-f", str(ROOT / ".github/scripts/data-tag-selector.jq")],
+        input=json.dumps([{"tagName": tag, "isDraft": tag == case.get("draft"),
+                           "isPrerelease": tag == case.get("prerelease")} for tag in case["tags"]]),
+        text=True, capture_output=True,
+    )
+    if case.get("error"):
+        assert selected.returncode != 0 and "duplicate" in selected.stderr
+    else:
+        assert selected.returncode == 0, selected.stderr
+        assert json.loads(selected.stdout) == case["expected"]
+
+
+@pytest.mark.parametrize("flag", ["draft", "prerelease"])
+def test_unpublished_data_cannot_outrank_stable(flag):
+    assert latest_data_release([
+        {"tag_name": "data-V"}, {"tag_name": "datarev-V-r2", flag: True},
+    ])["tag_name"] == "data-V"

--- a/python/tests/test_story_output_channel.py
+++ b/python/tests/test_story_output_channel.py
@@ -28,6 +28,9 @@ from prts_mcp.tools_prts import (
     register_prts_tools,
 )
 from prts_mcp.tools_story import register_story_tools
+from prts_mcp.data.stores import DirectoryStore
+from prts_mcp.data.story_reader import build_stories_listing_from_store
+from prts_mcp.data.story_summary import get_story_summary_from_store
 
 STORY_REVIEW_PATH = "zh_CN/gamedata/excel/story_review_table.json"
 CHARDICT_PATH = "zh_CN/chardict.json"
@@ -40,6 +43,45 @@ NO_SUMMARY_STORY_KEY = "activities/act_no_summary/level_act_no_summary_01"
 NO_SUMMARY_SECOND_STORY_KEY = "activities/act_no_summary/level_act_no_summary_02"
 NARRATION_STORY_KEY = "activities/act_narration/level_act_narration_01"
 MEMOIR_STORY_KEY = "memory/amiya/level_amiya_01"
+
+
+@pytest.mark.parametrize("llm", [" LLM summary. ", " ", "", None, 42])
+def test_listing_and_summary_share_fallbacks(tmp_path, llm):
+    files = {
+        STORY_REVIEW_PATH: {"act": {"infoUnlockDatas": [{"storyTxt": "chapter"}]}},
+        "zh_CN/summaries.json": {"chapter": llm},
+        STORYINFO_PATH: {"chapter": " Official summary. "},
+        EVENT_SUMMARIES_PATH: {"act": "Event summary."},
+    }
+    for filename, value in files.items():
+        path = tmp_path / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value))
+    store = DirectoryStore(tmp_path)
+    result = build_stories_listing_from_store(store, "act", True)
+    expected = llm.strip() if isinstance(llm, str) and llm.strip() else "Official summary."
+    assert result["chapters"][0]["summary"] == expected
+    assert get_story_summary_from_store(store, "chapter") == expected
+    assert result["event_summary"] == "Event summary."
+
+
+def test_summary_sources_fail_independently_and_fall_back_to_chapter(tmp_path):
+    files = {
+        STORY_REVIEW_PATH: {"act": {"infoUnlockDatas": [{"storyTxt": "chapter"}]}},
+        "zh_CN/summaries.json": [],
+        "zh_CN/gamedata/story/chapter.json": {"storyInfo": " Embedded summary. "},
+        EVENT_SUMMARIES_PATH: {"act": "Event summary."},
+    }
+    for filename, value in files.items():
+        path = tmp_path / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(value))
+    (tmp_path / STORYINFO_PATH).write_text("{broken")
+    store = DirectoryStore(tmp_path)
+    result = build_stories_listing_from_store(store, "act", True)
+    assert result["chapters"][0]["summary"] == "Embedded summary."
+    assert get_story_summary_from_store(store, "chapter") == "Embedded summary."
+    assert result["event_summary"] == "Event summary."
 
 
 def _story_path(story_key: str) -> str:

--- a/python/tests/test_sync_release.py
+++ b/python/tests/test_sync_release.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import dataclasses
 import hashlib
 import os
 import subprocess
@@ -1446,7 +1447,8 @@ class TestLatestDataRelease:
             _release_entry(f"data-{_VID}"),
             _release_entry(f"datarev-{_VID}-r1"),
         ]
-        assert latest_data_release(releases) is None
+        with pytest.raises(ValueError, match="duplicate data release identity"):
+            latest_data_release(releases)
 
     def test_no_data_tags_returns_none(self):
         from prts_mcp.sync.release_discovery import latest_data_release
@@ -1627,6 +1629,7 @@ class TestSyncReleaseRevisionFlow:
         assert result.status == "updated"
         assert result.commit_sha == f"{_VID}-r2"
 
+
     def test_refuses_downgrade_and_reports_installed_sha(self, tmp_path):
         spec = _make_spec(tmp_path)
         _write_zip(spec.local_zip)
@@ -1649,3 +1652,80 @@ class TestSyncReleaseRevisionFlow:
             (spec.local_zip.parent / "release_meta.json").read_text(encoding="utf-8")
         )
         assert meta["commit_sha"] == f"{_VID}-r2"
+
+
+def test_datarev_manifest_404_keeps_old_archive(tmp_path):
+    spec = ReleaseSpec("3aKHP", "arknights-data-pipeline", "zh_CN.zip",
+                       tmp_path / "story.zip", verify_manifest=True)
+    spec.local_zip.write_bytes(b"old")
+    releases = _mock_releases_response([_release_entry(f"datarev-{_VID}-r2")])
+    with patch("prts_mcp.sync.release_discovery.list_releases", return_value=releases.json()), patch(
+        "prts_mcp.sync.release.get_cascading",
+        side_effect=[_mock_asset_response(b"new"), _AssetNotFoundError("not found")],
+    ):
+        result = sync_release(spec, force_check=True)
+    assert result.status == "offline_fallback"
+    assert spec.local_zip.read_bytes() == b"old"
+    assert "manifest" in result.error
+
+
+def test_duplicate_identity_never_uses_blind_download(tmp_path):
+    spec = _make_spec(tmp_path)
+    releases = [_release_entry(f"data-{_VID}"), _release_entry(f"datarev-{_VID}-r1")]
+    with patch("prts_mcp.sync.release_discovery.list_releases", return_value=releases), patch(
+        "prts_mcp.sync.release._parse_mirrors", return_value=["https://mirror.test"]
+    ), patch("prts_mcp.sync.release.download_release_asset") as download:
+        result = sync_release(spec, force_check=True)
+    assert result.status == "no_data"
+    assert "duplicate" in result.error
+    download.assert_not_called()
+
+
+@pytest.mark.parametrize("upstream", [None, f"data-{_VID}"])
+@pytest.mark.parametrize("invalid_zip", [False, True])
+def test_recorded_revision_prevents_downgrade_without_valid_zip(tmp_path, upstream, invalid_zip):
+    from prts_mcp.sync.release import CacheMeta
+
+    spec = _make_spec(tmp_path)
+    spec.local_zip.parent.mkdir(parents=True, exist_ok=True)
+    if invalid_zip:
+        spec.local_zip.write_bytes(b"broken")
+        spec = dataclasses.replace(spec, validate_zip=lambda path: ["invalid zip"])
+    meta_path = spec.local_zip.parent / "release_meta.json"
+    CacheMeta(
+        repo="3aKHP/arknights-data-pipeline", branch="releases",
+        commit_sha=f"{_VID}-r2", fetched_at="2000-01-01T00:00:00Z",
+        files=[spec.asset_name],
+    ).save(meta_path)
+    before = meta_path.read_bytes()
+    latest = (upstream, "https://example.test/old.zip") if upstream else None
+    with patch("prts_mcp.sync.release.check_latest_release", return_value=latest), patch(
+        "prts_mcp.sync.release._parse_mirrors", return_value=["https://mirror.test"]
+    ), patch("prts_mcp.sync.release.download_release_asset") as download:
+        result = sync_release(spec, force_check=True)
+    assert result.status == "no_data"
+    assert result.commit_sha == f"{_VID}-r2"
+    assert meta_path.read_bytes() == before
+    download.assert_not_called()
+
+
+@pytest.mark.parametrize("revision", [2, 3])
+def test_recorded_revision_allows_verified_replacement_without_zip(tmp_path, revision):
+    from prts_mcp.sync.release import CacheMeta
+
+    spec = _make_spec(tmp_path)
+    spec.local_zip.parent.mkdir(parents=True, exist_ok=True)
+    CacheMeta(
+        repo="3aKHP/arknights-data-pipeline", branch="releases",
+        commit_sha=f"{_VID}-r2", fetched_at="2000-01-01T00:00:00Z",
+        files=[spec.asset_name],
+    ).save(spec.local_zip.parent / "release_meta.json")
+    tag = f"datarev-{_VID}-r{revision}"
+    url = "https://example.test/current.zip"
+    with patch("prts_mcp.sync.release.check_latest_release", return_value=(tag, url)), patch(
+        "prts_mcp.sync.release.download_release_asset"
+    ) as download:
+        result = sync_release(spec, force_check=True)
+    assert result.status == "updated"
+    assert result.commit_sha == f"{_VID}-r{revision}"
+    download.assert_called_once_with(spec, tag, url)

--- a/tests/parity-fixtures/data-release-selection.json
+++ b/tests/parity-fixtures/data-release-selection.json
@@ -1,0 +1,9 @@
+[
+  {"name":"numeric revision", "tags":["data-V", "datarev-V-r2", "datarev-V-r10", "images-V"], "expected":"datarev-V-r10"},
+  {"name":"new source wins", "tags":["datarev-V-r10", "data-W"], "expected":"data-W"},
+  {"name":"duplicate identity", "tags":["data-V", "datarev-V-r1"], "error":true},
+  {"name":"duplicate revision", "tags":["datarev-V-r2", "datarev-V-r02"], "error":true},
+  {"name":"empty", "tags":["images-V"], "expected":null},
+  {"name":"draft excluded", "tags":["data-V", "datarev-V-r2"], "draft":"datarev-V-r2", "expected":"data-V"},
+  {"name":"prerelease excluded", "tags":["data-V", "datarev-V-r2"], "prerelease":"datarev-V-r2", "expected":"data-V"}
+]

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- Chapter listings with summaries now prefer LLM summaries and share the single-chapter tool's official-summary fallback, including blank or invalid cached values.
+- Repair releases require a manifest even when its download returns 404. Duplicate release identities fail without a blind Latest download, and runtime and build selectors exclude drafts and prereleases.
+- Recorded release identities continue to prevent downgrades when a cached ZIP is missing or invalid; an unverified Latest fallback cannot replace them.
+
 ### Added
 
 - **Revision release discovery (`datarev-` namespace).** The data sync now understands the factory's immutable repair releases: `datarev-<versionId>-r<N>` tags are discovered alongside normal `data-<versionId>` releases and ordered by `(versionId, publicationRevision)` tuple instead of release creation time, so a repair revision outranks the release it fixes and a re-published older release can no longer win (rollback-by-republication protection; two releases claiming the same identity fail closed with a warning). Update decisions compare the same tuple over the stored release id — a bare `<versionId>` means revision 1 — while sentinel ids (`unknown`/`legacy`/`local-…`) keep the legacy string-equality semantics, and a refused downgrade reports the installed id. Manifest verification additionally requires `publicationRevision` on `datarev-` releases to match the tag. Stored metadata keeps the full tag suffix (`<versionId>-r<N>`), so the on-disk schemas and the cross-implementation meta interop are unchanged; 1.7-era deployments never see `datarev-` releases.

--- a/ts/src/data/storyReader.ts
+++ b/ts/src/data/storyReader.ts
@@ -443,6 +443,41 @@ export function listStoriesFromStore(
   return chapters;
 }
 
+/** Load usable chapter summaries, preferring LLM text over official text. */
+export function loadChapterSummariesFromStore(store: JsonStore): Record<string, string> {
+  const summaries: Record<string, string> = {};
+  for (const path of [STORYINFO, SUMMARIES]) {
+    try {
+      if (!store.exists(path)) continue;
+      const raw = store.readJson<unknown>(path);
+      if (typeof raw !== "object" || raw === null || Array.isArray(raw)) continue;
+      for (const [key, value] of Object.entries(raw)) {
+        if (typeof value === "string" && value.trim()) summaries[key] = value.trim();
+      }
+    } catch {
+      // Keep the other summary source usable.
+    }
+  }
+  return summaries;
+}
+
+/** Resolve one chapter, falling back to its embedded official summary. */
+export function chapterSummaryFromStore(
+  store: JsonStore, storyKey: string, summaries: Record<string, string>,
+): string {
+  if (Object.hasOwn(summaries, storyKey)) return summaries[storyKey]!;
+  try {
+    const path = storyZipPath(storyKey);
+    if (store.exists(path)) {
+      const raw = store.readJson<{ storyInfo?: unknown }>(path);
+      if (typeof raw?.storyInfo === "string") return raw.storyInfo.trim();
+    }
+  } catch {
+    // No usable chapter summary.
+  }
+  return "";
+}
+
 export function buildStoriesListingFromStore(
   store: JsonStore,
   eventId: string,
@@ -453,22 +488,14 @@ export function buildStoriesListingFromStore(
   let eventSummaryText = "";
 
   if (includeSummaries) {
+    chapterSummaries = loadChapterSummariesFromStore(store);
     try {
-      if (store.exists(STORYINFO)) {
-        const raw = store.readJson<Record<string, unknown>>(STORYINFO);
-        chapterSummaries = Object.fromEntries(
-          Object.entries(raw)
-            .filter(([, value]) => Boolean(value))
-            .map(([key, value]) => [key, String(value)]),
-        );
-      }
       if (store.exists(EVENT_SUMMARIES)) {
         const rawEvents = store.readJson<Record<string, unknown>>(EVENT_SUMMARIES);
         const text = rawEvents[eventId];
         if (typeof text === "string") eventSummaryText = text.trim();
       }
     } catch {
-      chapterSummaries = {};
       eventSummaryText = "";
     }
   }
@@ -482,7 +509,7 @@ export function buildStoriesListingFromStore(
       story_name: ch.storyName,
       story_key: ch.storyKey,
       avg_tag: ch.avgTag,
-      ...(includeSummaries ? { summary: chapterSummaries[ch.storyKey] ?? "" } : {}),
+      ...(includeSummaries ? { summary: chapterSummaryFromStore(store, ch.storyKey, chapterSummaries) } : {}),
     })),
   };
   if (eventSummaryText) data.event_summary = eventSummaryText;

--- a/ts/src/data/storySummary.ts
+++ b/ts/src/data/storySummary.ts
@@ -8,9 +8,8 @@
 
 import type { JsonStore } from "./stores.js";
 import {
-  STORYINFO,
-  SUMMARIES,
-  storyZipPath,
+  chapterSummaryFromStore,
+  loadChapterSummariesFromStore,
   withStoryStore,
 } from "./storyReader.js";
 
@@ -23,39 +22,6 @@ export function getStorySummary(zipPath: string, storyKey: string): string {
 }
 
 export function getStorySummaryFromStore(store: JsonStore, storyKey: string): string {
-  // --- tier 1: LLM summaries (future) ---
-  if (store.exists(SUMMARIES)) {
-    try {
-      const raw = store.readJson<Record<string, unknown>>(SUMMARIES);
-      const text = raw[storyKey];
-      if (typeof text === "string" && text) return text.trim();
-    } catch {
-      // continue to next fallback
-    }
-  }
-
-  // --- tier 2: storyinfo.json ---
-  if (store.exists(STORYINFO)) {
-    try {
-      const raw = store.readJson<Record<string, unknown>>(STORYINFO);
-      const text = raw[storyKey];
-      if (typeof text === "string" && text) return text.trim();
-    } catch {
-      // continue to next fallback
-    }
-  }
-
-  // --- tier 3: chapter JSON storyInfo ---
-  const storyPath = storyZipPath(storyKey);
-  if (store.exists(storyPath)) {
-    try {
-      const raw = store.readJson<Record<string, unknown>>(storyPath);
-      const text = raw["storyInfo"];
-      if (typeof text === "string" && text) return text.trim();
-    } catch {
-      // continue to not-found
-    }
-  }
-
-  return `未找到剧情章节 '${storyKey}' 的梗概。`;
+  const text = chapterSummaryFromStore(store, storyKey, loadChapterSummariesFromStore(store));
+  return text || `未找到剧情章节 '${storyKey}' 的梗概。`;
 }

--- a/ts/src/sync/release.ts
+++ b/ts/src/sync/release.ts
@@ -180,7 +180,7 @@ async function verifyReleaseManifest(
     );
   } catch (err) {
     // Direct URL confirmed 404 → release predates the manifest asset.
-    if (err instanceof AssetNotFoundError) return;
+    if (err instanceof AssetNotFoundError && !tag.startsWith("datarev-")) return;
     throw new Error(`manifest unavailable for ${tag}: ${errorMessage(err)}`);
   }
   let manifest: unknown;
@@ -302,6 +302,12 @@ async function syncReleaseLocked(
     }
     // No zip and API unreachable — attempt blind download via releases/latest/download/
     // (does not require the GitHub API; ghproxy and similar mirrors support this URL).
+    if (cache !== null && parseReleaseSuffix(cache.commitSha) !== null) {
+      return {
+        spec: dummySpec, status: "no_data", commitSha: cache.commitSha,
+        error: "Network unavailable; cannot verify replacement of recorded release",
+      };
+    }
     if (parseMirrors().length > 0) {
       const blindUrl = `https://github.com/${spec.owner}/${spec.repo}/releases/latest/download/${spec.assetName}`;
       try {
@@ -319,6 +325,18 @@ async function syncReleaseLocked(
   }
 
   const commitSha = tagSuffix(latest.tag);
+
+  if (cache !== null && !zipOk) {
+    const local = parseReleaseSuffix(cache.commitSha);
+    const upstream = parseReleaseSuffix(commitSha);
+    if (local && upstream && (local.versionId > upstream.versionId
+      || (local.versionId === upstream.versionId && local.revision > upstream.revision))) {
+      return {
+        spec: dummySpec, status: "no_data", commitSha: cache.commitSha,
+        error: "Refusing downgrade of recorded release while cached zip is unavailable",
+      };
+    }
+  }
 
   if (cache !== null && zipOk && releaseUpToDate(cache.commitSha, commitSha)) {
     await saveReleaseMeta(spec, { ...cache, fetchedAt: new Date().toISOString() });

--- a/ts/src/sync/releaseDiscovery.ts
+++ b/ts/src/sync/releaseDiscovery.ts
@@ -185,8 +185,8 @@ export function latestReleaseByPrefix(
  * Orders by (versionId, revision) tuple instead of created_at, so a repair
  * revision outranks the release it fixes and a re-published older release
  * can no longer win (rollback-by-republication). Two releases claiming the
- * same tuple is an upstream integrity violation: log loudly and fail closed
- * (returns null), mirroring the images pipeline's duplicate-version rejection.
+ * same tuple is an upstream integrity violation: throw so callers cannot
+ * attempt a blind network fallback.
  */
 export function latestDataRelease(
   releases: GithubRelease[],
@@ -194,6 +194,7 @@ export function latestDataRelease(
   let best: { key: DataTagVersion; release: GithubRelease } | null = null;
   const seen = new Set<string>();
   for (const release of releases) {
+    if (release["draft"] || release["prerelease"]) continue;
     const tag = release["tag_name"];
     if (typeof tag !== "string") continue;
     const parsed = parseDataTag(tag);
@@ -204,7 +205,7 @@ export function latestDataRelease(
         `[sync] duplicate data release identity (versionId=${parsed.versionId}, `
         + `revision=${parsed.revision}) claimed by "${tag}"; failing closed`,
       );
-      return null;
+      throw new Error("duplicate data release identity");
     }
     seen.add(key);
     if (best === null || isNewer(best.key, parsed)) best = { key: parsed, release };

--- a/ts/tests/storyOutputChannel.test.ts
+++ b/ts/tests/storyOutputChannel.test.ts
@@ -4,6 +4,9 @@ import { mkdtempSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import AdmZip from "adm-zip";
+import { ZipStore } from "../src/data/stores.ts";
+import { buildStoriesListingFromStore } from "../src/data/storyReader.ts";
+import { getStorySummaryFromStore } from "../src/data/storySummary.ts";
 import {
   buildCharacterAppearances,
   buildOperatorMemoirs,
@@ -29,9 +32,57 @@ const NO_SUMMARY_SECOND_STORY_KEY = "activities/act_no_summary/level_act_no_summ
 const NARRATION_STORY_KEY = "activities/act_narration/level_act_narration_01";
 const MEMOIR_STORY_KEY = "memory/amiya/level_amiya_01";
 
+for (const llm of [" LLM summary. ", " ", "", null, 42]) {
+  test(`listing and summary share fallbacks: ${JSON.stringify(llm)}`, () => {
+    const zip = new AdmZip();
+    const files = {
+      [STORY_REVIEW_PATH]: { act: { infoUnlockDatas: [{ storyTxt: "chapter" }] } },
+      "zh_CN/summaries.json": { chapter: llm },
+      [STORYINFO_PATH]: { chapter: " Official summary. " },
+      [EVENT_SUMMARIES_PATH]: { act: "Event summary." },
+    };
+    for (const [name, value] of Object.entries(files)) zip.addFile(name, Buffer.from(JSON.stringify(value)));
+    const path = join(mkdtempSync(join(tmpdir(), "summary-fallback-")), "story.zip");
+    zip.writeZip(path);
+    const store = new ZipStore(path);
+    try {
+      const result = buildStoriesListingFromStore(store, "act", true);
+      const expected = typeof llm === "string" && llm.trim() ? llm.trim() : "Official summary.";
+      assert.equal(result.chapters[0]?.summary, expected);
+      assert.equal(getStorySummaryFromStore(store, "chapter"), expected);
+      assert.equal(result.event_summary, "Event summary.");
+    } finally {
+      store.close();
+    }
+  });
+}
+
 function storyPath(storyKey: string): string {
   return `zh_CN/gamedata/story/${storyKey}.json`;
 }
+
+test("summary sources fail independently and fall back to chapter", () => {
+  const zip = new AdmZip();
+  const files = {
+    [STORY_REVIEW_PATH]: { act: { infoUnlockDatas: [{ storyTxt: "chapter" }] } },
+    "zh_CN/summaries.json": [],
+    [storyPath("chapter")]: { storyInfo: " Embedded summary. " },
+    [EVENT_SUMMARIES_PATH]: { act: "Event summary." },
+  };
+  for (const [name, value] of Object.entries(files)) zip.addFile(name, Buffer.from(JSON.stringify(value)));
+  zip.addFile(STORYINFO_PATH, Buffer.from("{broken"));
+  const path = join(mkdtempSync(join(tmpdir(), "summary-embedded-")), "story.zip");
+  zip.writeZip(path);
+  const store = new ZipStore(path);
+  try {
+    const listing = buildStoriesListingFromStore(store, "act", true);
+    assert.equal(listing.chapters[0]?.summary, "Embedded summary.");
+    assert.equal(getStorySummaryFromStore(store, "chapter"), "Embedded summary.");
+    assert.equal(listing.event_summary, "Event summary.");
+  } finally {
+    store.close();
+  }
+});
 
 function loadParityFixture(name: string): unknown {
   return JSON.parse(

--- a/ts/tests/sync.test.ts
+++ b/ts/tests/sync.test.ts
@@ -1058,10 +1058,29 @@ test("latestDataRelease orders by (versionId, revision) tuple", () => {
 });
 
 test("latestDataRelease fails closed on duplicate release identity", () => {
-  assert.equal(latestDataRelease([
+  assert.throws(() => latestDataRelease([
     releaseEntry(`data-${REV_VID}`),
     releaseEntry(`datarev-${REV_VID}-r1`),
-  ]), null);
+  ]), /duplicate data release identity/);
+});
+
+test("data release selector matches shared publication cases", () => {
+  const cases = JSON.parse(readFileSync(
+    join(import.meta.dirname, "../../tests/parity-fixtures/data-release-selection.json"), "utf8",
+  )) as { name: string; tags: string[]; expected?: string | null; error?: boolean;
+    draft?: string; prerelease?: string }[];
+  for (const entry of cases) {
+    const select = () => latestDataRelease(entry.tags.map(tag => ({
+      ...releaseEntry(tag), draft: tag === entry.draft, prerelease: tag === entry.prerelease,
+    })));
+    if (entry.error) assert.throws(select, /duplicate/, entry.name);
+    else assert.equal(select()?.["tag_name"] ?? null, entry.expected, entry.name);
+  }
+  for (const flag of ["draft", "prerelease"]) {
+    assert.equal(latestDataRelease([
+      releaseEntry("data-V"), { ...releaseEntry("datarev-V-r2"), [flag]: true },
+    ])?.["tag_name"], "data-V");
+  }
 });
 
 function writeRevCache(spec: ReleaseSpec, commitSha: string): void {
@@ -1157,6 +1176,7 @@ async function syncDatarevManifestCase(manifest: unknown): Promise<{ status: str
         { headers: { "content-type": "application/json" } });
     }
     if (call === 2) return new Response(content);
+    if (manifest === undefined) return new Response("not found", { status: 404 });
     return new Response(JSON.stringify(manifest),
       { headers: { "content-type": "application/json" } });
   }) as typeof fetch, async () => {
@@ -1164,6 +1184,56 @@ async function syncDatarevManifestCase(manifest: unknown): Promise<{ status: str
     status = result.status;
   });
   return { status, zip: readFileSync(spec.localZip, "utf-8") };
+}
+
+for (const upstream of [null, `data-${REV_VID}`]) {
+  for (const invalidZip of [false, true]) {
+    test(`recorded revision prevents downgrade without valid zip: ${upstream}/${invalidZip}`, async () => {
+      const spec = { ...tempSpec(), ...(invalidZip ? { validateZip: () => ["invalid zip"] } : {}) };
+      writeRevCache(spec, `${REV_VID}-r2`);
+      if (!invalidZip) unlinkSync(spec.localZip);
+      const metaPath = join(dirname(spec.localZip), "release_meta.json");
+      const before = readFileSync(metaPath, "utf-8");
+      const oldMirrors = process.env["GITHUB_MIRRORS"];
+      process.env["GITHUB_MIRRORS"] = "https://mirror.test";
+      const urls: string[] = [];
+      try {
+        await withFetchMock((async (input) => {
+          const url = String(input);
+          urls.push(url);
+          if (upstream === null) throw new Error("offline");
+          return new Response(JSON.stringify([releaseEntry(upstream)]));
+        }) as typeof fetch, async () => {
+          const result = await syncRelease(spec, true);
+          assert.equal(result.status, "no_data");
+          assert.equal(result.commitSha, `${REV_VID}-r2`);
+        });
+      } finally {
+        if (oldMirrors === undefined) delete process.env["GITHUB_MIRRORS"];
+        else process.env["GITHUB_MIRRORS"] = oldMirrors;
+      }
+      assert(urls.every(url => url.includes("api.github.com")), JSON.stringify(urls));
+      assert.equal(readFileSync(metaPath, "utf-8"), before);
+    });
+  }
+}
+
+for (const revision of [2, 3]) {
+  test(`recorded revision permits replacement without zip: r${revision}`, async () => {
+    const spec = tempSpec();
+    writeRevCache(spec, `${REV_VID}-r2`);
+    unlinkSync(spec.localZip);
+    await withFetchMock((async (input) => {
+      return String(input).includes("api.github.com")
+        ? new Response(JSON.stringify([releaseEntry(`datarev-${REV_VID}-r${revision}`)]))
+        : new Response("replacement");
+    }) as typeof fetch, async () => {
+      const result = await syncRelease(spec, true);
+      assert.equal(result.status, "updated");
+      assert.equal(result.commitSha, `${REV_VID}-r${revision}`);
+    });
+    assert.equal(readFileSync(spec.localZip, "utf-8"), "replacement");
+  });
 }
 
 test("syncRelease fails closed when manifest revision mismatches the tag", async () => {
@@ -1189,6 +1259,34 @@ test("syncRelease fails closed when manifest revision is missing", async () => {
   });
   assert.equal(status, "offline_fallback");
   assert.equal(zip, "old");
+});
+
+test("syncRelease rejects a datarev manifest 404", async () => {
+  const { status, zip } = await syncDatarevManifestCase(undefined);
+  assert.equal(status, "offline_fallback");
+  assert.equal(zip, "old");
+});
+
+test("duplicate data identity never uses blind download", async () => {
+  const previousMirrors = process.env["GITHUB_MIRRORS"];
+  process.env["GITHUB_MIRRORS"] = "https://mirror.test";
+  let calls = 0;
+  try {
+    await withFetchMock((async () => {
+      calls += 1;
+      return new Response(JSON.stringify([
+        releaseEntry(`data-${REV_VID}`), releaseEntry(`datarev-${REV_VID}-r1`),
+      ]), { headers: { "content-type": "application/json" } });
+    }) as typeof fetch, async () => {
+      const result = await syncRelease(tempSpec(), true);
+      assert.equal(result.status, "no_data");
+      assert.match(result.error ?? "", /duplicate/);
+    });
+    assert.equal(calls, 1);
+  } finally {
+    if (previousMirrors === undefined) delete process.env["GITHUB_MIRRORS"];
+    else process.env["GITHUB_MIRRORS"] = previousMirrors;
+  }
 });
 
 test("syncRelease updates when manifest revision matches the tag", async () => {


### PR DESCRIPTION
## Summary

Chapter listings and single-chapter summaries now share the same valid LLM and official fallback sources in Python and TypeScript. Repair discovery requires the revision manifest, rejects ambiguous identities, and uses the same publication filtering in runtime and CI/CD selectors. Recorded versions remain protected when a cached archive needs recovery.

## Test Plan

- Full runtime check passed: Python 511 passed / 2 skipped; TypeScript 378 passed / 2 skipped, build, typecheck, shared-volume sync, and Bun HTTP smoke.
- Shared publication fixtures cover both implementations and the jq selector.
- Real r2 E2E covered 24 tools / 38 calls per runtime, 13 chapter-summary comparisons, manifest hashes, and MediaWiki/local image paths.
- Additional recovery regression tests first reproduced the failures, then passed in both runtimes; same or newer revision downloads remain supported.
- Clean-context independent review found no blocking issues.

## Remaining Work

Integrate into develop only. The package release and maintenance SOP will be handled separately; this PR does not change package versions or publish a release.
