### PR TITLE
chore(release): reopen 2.8.0 development

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.7.3] - 2026-09-05
 
 ### Fixed

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "prts-mcp"
-version = "2.7.3"
+version = "2.8.0.dev0"
 description = "MCP Server for Arknights PRTS Wiki & game data"
 readme = "README.md"
 license = { text = "MIT" }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "prts-mcp"
-version = "2.7.3"
+version = "2.8.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/ts/CHANGELOG.md
+++ b/ts/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
 ## [2.7.3] - 2026-09-05
 
 ### Fixed

--- a/ts/package-lock.json
+++ b/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.7.3",
+  "version": "2.8.0-dev.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "prts-mcp-ts",
-      "version": "2.7.3",
+      "version": "2.8.0-dev.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "2.0.0",

--- a/ts/package.json
+++ b/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prts-mcp-ts",
-  "version": "2.7.3",
+  "version": "2.8.0-dev.0",
   "description": "MCP Server for Arknights PRTS Wiki & game data (TypeScript / Streamable HTTP + stdio)",
   "type": "module",
   "main": "dist/server.js",


### PR DESCRIPTION
## Summary

Reopen development after 2.7.3: set Python to 2.8.0.dev0 and TypeScript to 2.8.0-dev.0, synchronize lockfiles, and restore empty Unreleased changelog sections. Stable-release documentation remains at 2.7.3.

## Test plan

- Runtime environment audit and lock consistency checks.
- Version-only diff; no runtime or dependency changes.
- CI and independent clean-context review before merge.

## Outstanding items

None for reopening development.
